### PR TITLE
Fix CLI issues - wrong output types, string params not escaped, incorrect docs, DateTime does not support a timezone parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ pnpm add @hypequery/clickhouse
 
 ```typescript
 import { createQueryBuilder } from '@hypequery/clickhouse';
-import type { Schema } from './generated-schema';
+import type { IntrospectedSchema } from './generated-schema';
 
 // Initialize the query builder
-const db = createQueryBuilder<Schema>({
+const db = createQueryBuilder<IntrospectedSchema>({
   host: 'your-clickhouse-host',
   username: 'default',
   password: '',
@@ -72,7 +72,7 @@ HypeQuery provides a CLI tool to generate TypeScript types from your ClickHouse 
 npm install -g @hypequery/clickhouse
 
 # Generate schema types
-npx hypequery-generate --host your-clickhouse-host --database your-database
+npx hypequery-generate-types --host your-clickhouse-host --database your-database
 ```
 
 This creates a `generated-schema.ts` file that you can import in your application:

--- a/packages/clickhouse/src/cli/generate-types.js
+++ b/packages/clickhouse/src/cli/generate-types.js
@@ -118,7 +118,8 @@ export interface IntrospectedSchema {`;
 
     typeDefinitions += `\n  ${table.name}: {`;
     for (const column of columns) {
-      typeDefinitions += `\n    ${column.name}: '${clickhouseToTsType(column.type)}';`;
+      const clickHouseType = column.type.replace.replace(/'/g, "\\'"); // Escape single quotes, e.g. `DateTime('UTC')`
+      typeDefinitions += `\n    ${column.name}: '${clickHouseType}';`;
     }
     typeDefinitions += '\n  };';
   }

--- a/packages/clickhouse/src/types/clickhouse-types.ts
+++ b/packages/clickhouse/src/types/clickhouse-types.ts
@@ -13,6 +13,7 @@ export type ClickHouseDecimal =
 export type ClickHouseDateTime =
   | 'Date' | 'Date32'
   | 'DateTime'
+  | `DateTime('${string}')` // With timezone
   | `DateTime64(${number})` // For subsecond precision
   | `DateTime64(${number}, '${string}')`; // With timezone
 

--- a/website/src/pages/docs/installation.mdx
+++ b/website/src/pages/docs/installation.mdx
@@ -13,7 +13,7 @@ Get started using hypequery in your project by following these simple steps.
 Before installing hypequery, make sure you have:
 
  <ul>
-     <li>Node.js 16 or higher</li>
+     <li>Node.js v20 or higher</li>
      <li>npm or yarn package manager</li>
      <li>A ClickHouse instance to connect to</li>
    </ul>


### PR DESCRIPTION
- generate-types.js: fix output of ClickHouse type, escape single quotes (in e.g. string parameters)
- clickhouse-types.ts: add support for `DateTime` with a timezone parameter
- README.md: rename `Schema` -> `IntrospectedSchema`, `hypequery-generate` -> `hypequery-generate-types`
- installation.mdx: update the lowest supported NodeJS to v20
  - In NodeJS v18, the CLI errors with an error, saying it can't find `crypto`.

Closes #2 