### PR TITLE
fix: support star syntax in select queries

### DIFF
--- a/examples/node-starter/src/index.ts
+++ b/examples/node-starter/src/index.ts
@@ -7,4 +7,5 @@ const db = createQueryBuilder<IntrospectedSchema>({
 
 const table = db.table('otel_logs')
 const validResults = await table.select(['ResourceAttributes', 'Body', 'ScopeVersion']).limit(100).execute();
-console.log('Valid SQL Query:', validResults);
+const validResults2 = await table.select('*').limit(100).execute();
+console.log('Valid SQL Query:', validResults, validResults2);

--- a/packages/clickhouse/package.json
+++ b/packages/clickhouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hypequery/clickhouse",
-  "version": "1.3.0",
+  "version": "1.2.7",
   "description": "ClickHouse typescript query builder",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -182,32 +182,58 @@ export class QueryBuilder<
     return this;
   }
 
+
   /**
    * Selects specific columns from the table.
    * @template K - The keys/columns to select
-   * @param {K[]} columns - Array of column names to select
+   * @param {K[] | '*'} columnsOrAsterisk - Array of column names to select or '*' for all columns
    * @returns {QueryBuilder} A new QueryBuilder instance with updated types
    * @example
    * ```ts
    * builder.select(['id', 'name'])
+   * builder.select('*')
    * ```
    */
-  select<K extends keyof T | TableColumn<Schema> | SqlExpression>(
-    columns: K[]
-  ): QueryBuilder<
-    Schema,
-    {
-      [P in Extract<K, keyof T | TableColumn<Schema>> as P extends `${string}.${infer C}` ? C : P]:
-      P extends keyof T
-      ? T[P] extends ColumnType
-      ? InferClickHouseType<T[P]>
-      : unknown
-      : string
-    },
-    true,
-    Aggregations,
-    OriginalT
-  > {
+  select<K extends keyof T | TableColumn<Schema> | SqlExpression = keyof T | TableColumn<Schema> | SqlExpression>(
+    columnsOrAsterisk: K[] | '*'
+  ): K[] extends typeof columnsOrAsterisk
+    ? QueryBuilder<
+      Schema,
+      {
+        [P in Extract<K, keyof T | TableColumn<Schema>> as P extends `${string}.${infer C}` ? C : P]:
+        P extends keyof T
+        ? T[P] extends ColumnType
+        ? InferClickHouseType<T[P]>
+        : unknown
+        : string
+      },
+      true,
+      Aggregations,
+      OriginalT
+    >
+    : QueryBuilder<Schema, T, true, Aggregations, OriginalT> {
+    // Handle '*' case - return all columns with original type
+    if (columnsOrAsterisk === '*') {
+      const newBuilder = new QueryBuilder<Schema, T, true, Aggregations, OriginalT>(
+        this.tableName,
+        this.schema,
+        this.originalSchema
+      );
+
+      newBuilder.config = {
+        ...this.config,
+        select: ['*'],
+        orderBy: this.config.orderBy?.map(({ column, direction }) => ({
+          column: String(column) as any,
+          direction
+        }))
+      };
+      return newBuilder as any;
+    }
+
+    // Handle array case - select specific columns
+    const columns = columnsOrAsterisk as K[];
+
     // Create a new builder with the appropriate type parameters
     const newBuilder = new QueryBuilder<
       Schema,

--- a/packages/clickhouse/src/core/tests/query-builder.basic.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.basic.test.ts
@@ -20,6 +20,22 @@ describe('QueryBuilder - Basic Operations', () => {
       const sql = builder.toSQL();
       expect(sql).toBe('SELECT * FROM test_table');
     });
+
+    it('should handle select("*") for all columns', () => {
+      const sql = builder
+        .select('*')
+        .toSQL();
+      expect(sql).toBe('SELECT * FROM test_table');
+    });
+
+    it('should handle select("*") with additional clauses', () => {
+      const sql = builder
+        .select('*')
+        .where('id', 'gt', 1)
+        .limit(10)
+        .toSQL();
+      expect(sql).toBe('SELECT * FROM test_table WHERE id > 1 LIMIT 10');
+    });
   });
 
   describe('distinct', () => {


### PR DESCRIPTION
This PR resolves https://github.com/hypequery/hypequery/issues/42 by adding support for select '*' syntax