### PR TITLE
fix: add per-query ClickHouse settings forwarding

### DIFF
--- a/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
+++ b/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
@@ -1,4 +1,4 @@
-import type { DatabaseAdapter } from './database-adapter.js';
+import type { DatabaseAdapter, QueryExecutionOptions } from './database-adapter.js';
 import type { ClickHouseClient as NodeClickHouseClient } from '@clickhouse/client';
 import type { ClickHouseClient as WebClickHouseClient } from '@clickhouse/client-web';
 import type { ClickHouseConfig } from '../query-builder.js';
@@ -38,20 +38,24 @@ export class ClickHouseAdapter implements DatabaseAdapter {
     this.client = createClickHouseClient(config);
   }
 
-  async query<T>(sql: string, params: unknown[] = []): Promise<T[]> {
+  async query<T>(sql: string, params: unknown[] = [], options?: QueryExecutionOptions): Promise<T[]> {
     const finalSQL = substituteParameters(sql, params);
     const result = await this.client.query({
       query: finalSQL,
-      format: 'JSONEachRow'
+      format: 'JSONEachRow',
+      clickhouse_settings: options?.clickhouseSettings,
+      query_id: options?.queryId,
     });
     return result.json<T>();
   }
 
-  async stream<T>(sql: string, params: unknown[] = []): Promise<ReadableStream<T[]>> {
+  async stream<T>(sql: string, params: unknown[] = [], options?: QueryExecutionOptions): Promise<ReadableStream<T[]>> {
     const finalSQL = substituteParameters(sql, params);
     const result = await this.client.query({
       query: finalSQL,
-      format: 'JSONEachRow'
+      format: 'JSONEachRow',
+      clickhouse_settings: options?.clickhouseSettings,
+      query_id: options?.queryId,
     });
     const stream = result.stream();
     return createJsonEachRowStream<T>(stream as NodeJS.ReadableStream);

--- a/packages/clickhouse/src/core/adapters/database-adapter.ts
+++ b/packages/clickhouse/src/core/adapters/database-adapter.ts
@@ -1,7 +1,14 @@
+import type { ClickHouseSettings } from '@clickhouse/client-common';
+
+export interface QueryExecutionOptions {
+  clickhouseSettings?: ClickHouseSettings;
+  queryId?: string;
+}
+
 export interface DatabaseAdapter {
   readonly name: string;
   readonly namespace?: string;
-  query<T>(sql: string, params?: unknown[]): Promise<T[]>;
-  stream?<T>(sql: string, params?: unknown[]): Promise<ReadableStream<T[]>>;
+  query<T>(sql: string, params?: unknown[], options?: QueryExecutionOptions): Promise<T[]>;
+  stream?<T>(sql: string, params?: unknown[], options?: QueryExecutionOptions): Promise<ReadableStream<T[]>>;
   render?(sql: string, params?: unknown[]): string;
 }

--- a/packages/clickhouse/src/core/cache/cache-manager.ts
+++ b/packages/clickhouse/src/core/cache/cache-manager.ts
@@ -89,7 +89,7 @@ export async function executeWithCache<
     namespace,
     sql,
     parameters,
-    settings: builder.getConfig().settings ? { settings: builder.getConfig().settings } : undefined,
+    settings: builder.getConfig().settings,
     version: runtime.versionTag,
     tableName
   });

--- a/packages/clickhouse/src/core/features/analytics.ts
+++ b/packages/clickhouse/src/core/features/analytics.ts
@@ -46,11 +46,14 @@ export class AnalyticsFeature<
     };
   }
 
-  addSettings(opts: ClickHouseSettings, dialect: SqlDialect) {
+  addSettings(opts: ClickHouseSettings) {
     const config = this.builder.getConfig();
     return {
       ...config,
-      settings: dialect.formatSettings(opts)
+      settings: {
+        ...(config.settings || {}),
+        ...opts,
+      }
     };
   }
 }

--- a/packages/clickhouse/src/core/features/executor.ts
+++ b/packages/clickhouse/src/core/features/executor.ts
@@ -30,6 +30,7 @@ export class ExecutorFeature<
   async execute(options?: ExecutorRunOptions): Promise<State['output'][]> {
     const adapter = this.builder.getAdapter();
     const { sql, parameters } = this.toSQLWithParams();
+    const config = this.builder.getConfig();
     const renderSql = adapter.render ? adapter.render(sql, parameters) : substituteParameters(sql, parameters);
 
     const startTime = Date.now();
@@ -43,7 +44,10 @@ export class ExecutorFeature<
     });
 
     try {
-      const rows = await adapter.query<State['output']>(sql, parameters);
+      const rows = await adapter.query<State['output']>(sql, parameters, {
+        clickhouseSettings: config.settings,
+        queryId: options?.queryId,
+      });
       const endTime = Date.now();
 
       logger.logQuery({
@@ -80,6 +84,7 @@ export class ExecutorFeature<
   async stream(): Promise<ReadableStream<State['output'][]>> {
     const adapter = this.builder.getAdapter();
     const { sql, parameters } = this.toSQLWithParams();
+    const config = this.builder.getConfig();
     const renderSql = adapter.render ? adapter.render(sql, parameters) : substituteParameters(sql, parameters);
 
     const startTime = Date.now();
@@ -94,7 +99,9 @@ export class ExecutorFeature<
       if (!adapter.stream) {
         throw new Error(`Streaming is not supported by adapter "${adapter.name}".`);
       }
-      const webStream = await adapter.stream<State['output']>(sql, parameters);
+      const webStream = await adapter.stream<State['output']>(sql, parameters, {
+        clickhouseSettings: config.settings,
+      });
 
       const endTime = Date.now();
       logger.logQuery({

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -1,4 +1,4 @@
-import type { DatabaseAdapter } from './adapters/database-adapter.js';
+import type { DatabaseAdapter, QueryExecutionOptions } from './adapters/database-adapter.js';
 import { createClickHouseAdapter } from './adapters/clickhouse-adapter.js';
 import { ClickHouseDialect } from './dialects/clickhouse-dialect.js';
 import type { SqlDialect } from './dialects/sql-dialect.js';
@@ -253,7 +253,7 @@ export class QueryBuilder<
 
   // --- Analytics Helper: Add query settings.
   settings(opts: ClickHouseSettings): this {
-    this.config = this.analytics.addSettings(opts, this.dialect);
+    this.config = this.analytics.addSettings(opts);
     return this;
   }
 
@@ -876,8 +876,12 @@ export function createQueryBuilder<Schema extends SchemaDefinition<Schema>>(
     cache: cacheController,
     adapter: resolvedAdapter,
     dialect: resolvedDialect,
-    async rawQuery<TResult = any>(sql: string, params: unknown[] = []) {
-      return resolvedAdapter.query<TResult>(sql, params);
+    async rawQuery<TResult = any>(
+      sql: string,
+      params: unknown[] = [],
+      options?: QueryExecutionOptions
+    ) {
+      return resolvedAdapter.query<TResult>(sql, params, options);
     },
     table<TableName extends Extract<keyof Schema, string>>(tableName: TableName): SelectQB<
       Schema,

--- a/packages/clickhouse/src/core/tests/clickhouse-adapter.test.ts
+++ b/packages/clickhouse/src/core/tests/clickhouse-adapter.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ClickHouseAdapter } from '../adapters/clickhouse-adapter.js';
+import { createQueryBuilder } from '../query-builder.js';
+
+describe('ClickHouseAdapter', () => {
+  it('forwards per-query settings and query ids to the ClickHouse client', async () => {
+    const jsonMock = vi.fn().mockResolvedValue([{ id: 1 }]);
+    const clientQueryMock = vi.fn().mockResolvedValue({
+      json: jsonMock,
+    });
+
+    const adapter = new ClickHouseAdapter({
+      client: {
+        query: clientQueryMock,
+      } as any,
+    });
+
+    const result = await adapter.query<{ id: number }>(
+      'SELECT ?',
+      [1],
+      {
+        clickhouseSettings: { final: 1, max_execution_time: 10 },
+        queryId: 'query-123',
+      },
+    );
+
+    expect(result).toEqual([{ id: 1 }]);
+    expect(clientQueryMock).toHaveBeenCalledWith({
+      query: 'SELECT 1',
+      format: 'JSONEachRow',
+      clickhouse_settings: { final: 1, max_execution_time: 10 },
+      query_id: 'query-123',
+    });
+    expect(jsonMock).toHaveBeenCalled();
+  });
+
+  it('executes builder settings through clickhouse_settings without mutating SQL text', async () => {
+    const jsonMock = vi.fn().mockResolvedValue([{ id: 1 }]);
+    const clientQueryMock = vi.fn().mockResolvedValue({
+      json: jsonMock,
+    });
+
+    const db = createQueryBuilder<{
+      events: {
+        id: 'UInt32';
+      };
+    }>({
+      adapter: new ClickHouseAdapter({
+        client: {
+          query: clientQueryMock,
+        } as any,
+      }),
+    });
+
+    const query = db
+      .table('events')
+      .settings({ final: 1, max_execution_time: 10 })
+      .select(['id']);
+
+    expect(query.toSQL()).toBe('SELECT id FROM events');
+
+    await query.execute({ queryId: 'query-456' });
+
+    expect(clientQueryMock).toHaveBeenCalledWith({
+      query: 'SELECT id FROM events',
+      format: 'JSONEachRow',
+      clickhouse_settings: { final: 1, max_execution_time: 10 },
+      query_id: 'query-456',
+    });
+  });
+});

--- a/packages/clickhouse/src/core/tests/dialect-seam.test.ts
+++ b/packages/clickhouse/src/core/tests/dialect-seam.test.ts
@@ -16,11 +16,10 @@ describe('dialect seam', () => {
   const renderMock = vi.fn();
   const compileQueryMock = vi.fn();
   const formatTimeIntervalMock = vi.fn();
-  const formatSettingsMock = vi.fn();
 
   const adapter: DatabaseAdapter = {
     name: 'test-adapter',
-    query: (sql, params = []) => queryMock(sql, params),
+    query: (sql, params = [], options) => queryMock(sql, params, options),
     render: (sql, params = []) => renderMock(sql, params),
   };
 
@@ -29,7 +28,7 @@ describe('dialect seam', () => {
     compileQuery: (config, context) => compileQueryMock(config, context),
     formatTimeInterval: (column, interval, method) =>
       formatTimeIntervalMock(column, interval, method),
-    formatSettings: (settings) => formatSettingsMock(settings),
+    formatSettings: () => '',
   };
 
   beforeEach(() => {
@@ -37,12 +36,10 @@ describe('dialect seam', () => {
     renderMock.mockReset();
     compileQueryMock.mockReset();
     formatTimeIntervalMock.mockReset();
-    formatSettingsMock.mockReset();
 
     formatTimeIntervalMock.mockReturnValue('bucket(created_at, 1 day)');
-    formatSettingsMock.mockReturnValue('max_execution_time=10');
     compileQueryMock.mockImplementation((config, context) => (
-      `compiled:${context.tableName}:${config.groupBy?.join('|') ?? 'none'}:${config.settings ?? 'none'}`
+      `compiled:${context.tableName}:${config.groupBy?.join('|') ?? 'none'}:${JSON.stringify(config.settings ?? null)}`
     ));
     renderMock.mockImplementation((sql, params = []) => `rendered:${sql}:${params.join(',')}`);
     queryMock.mockResolvedValue([{ id: 1 }]);
@@ -67,7 +64,7 @@ describe('dialect seam', () => {
       .settings({ max_execution_time: 10 });
 
     expect(query.toSQL()).toBe(
-      'rendered:compiled:users:bucket(created_at, 1 day):max_execution_time=10:42'
+      'rendered:compiled:users:bucket(created_at, 1 day):{"max_execution_time":10}:42'
     );
 
     const first = await query.execute();
@@ -80,15 +77,23 @@ describe('dialect seam', () => {
       '1 day',
       'toStartOfInterval',
     );
-    expect(formatSettingsMock).toHaveBeenCalledWith({ max_execution_time: 10 });
-    expect(compileQueryMock).toHaveBeenCalled();
+    expect(compileQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        settings: { max_execution_time: 10 },
+      }),
+      expect.anything(),
+    );
     expect(queryMock).toHaveBeenCalledTimes(1);
     expect(queryMock).toHaveBeenCalledWith(
-      'compiled:users:bucket(created_at, 1 day):max_execution_time=10',
+      'compiled:users:bucket(created_at, 1 day):{"max_execution_time":10}',
       [42],
+      {
+        clickhouseSettings: { max_execution_time: 10 },
+        queryId: undefined,
+      },
     );
     expect(renderMock).toHaveBeenCalledWith(
-      'compiled:users:bucket(created_at, 1 day):max_execution_time=10',
+      'compiled:users:bucket(created_at, 1 day):{"max_execution_time":10}',
       [42],
     );
   });

--- a/packages/clickhouse/src/core/tests/query-builder-analytics.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder-analytics.test.ts
@@ -89,6 +89,31 @@ describe('QueryBuilder Analytics Features', () => {
     });
   });
 
+  describe('settings', () => {
+    it('should not change rendered SQL', () => {
+      const sql = queryBuilder
+        .select(['id'])
+        .settings({ max_execution_time: 10, final: 1 })
+        .toSQL();
+
+      expect(sql).toBe(
+        'SELECT id FROM test_table'
+      );
+    });
+
+    it('should merge settings across repeated calls without affecting rendered SQL', () => {
+      const query = queryBuilder
+        .settings({ max_execution_time: 10 })
+        .settings({ final: 1 });
+
+      expect(query.toSQL()).toBe('SELECT * FROM test_table');
+      expect(query.getConfig().settings).toEqual({
+        max_execution_time: 10,
+        final: 1,
+      });
+    });
+  });
+
   describe('withCTE', () => {
     it('should add CTE using a subquery', () => {
       const subquery = builderUsers

--- a/packages/clickhouse/src/core/tests/raw-query.test.ts
+++ b/packages/clickhouse/src/core/tests/raw-query.test.ts
@@ -6,7 +6,7 @@ const queryMock = vi.fn();
 
 const testAdapter: DatabaseAdapter = {
   name: 'test',
-  query: (sql, params = []) => queryMock(sql, params)
+  query: (sql, params = [], options) => queryMock(sql, params, options)
 };
 
 type TestSchema = {
@@ -30,7 +30,33 @@ describe('rawQuery helper', () => {
     expect(result).toEqual(rows);
     expect(queryMock).toHaveBeenCalledWith(
       'SELECT * FROM users WHERE id = ? AND status = ?',
-      [42, 'active']
+      [42, 'active'],
+      undefined,
+    );
+  });
+
+  it('forwards per-query execution options', async () => {
+    const rows = [{ id: 1 }];
+    queryMock.mockResolvedValue(rows);
+
+    const db = createQueryBuilder<TestSchema>({ adapter: testAdapter });
+    const result = await db.rawQuery(
+      'SELECT * FROM users WHERE id = ?',
+      [42],
+      {
+        clickhouseSettings: { final: 1 },
+        queryId: 'raw-123',
+      },
+    );
+
+    expect(result).toEqual(rows);
+    expect(queryMock).toHaveBeenCalledWith(
+      'SELECT * FROM users WHERE id = ?',
+      [42],
+      {
+        clickhouseSettings: { final: 1 },
+        queryId: 'raw-123',
+      },
     );
   });
 });

--- a/packages/clickhouse/src/types/base.ts
+++ b/packages/clickhouse/src/types/base.ts
@@ -1,3 +1,4 @@
+import type { ClickHouseSettings } from '@clickhouse/client-common';
 import { FilterOperator } from "./filters.js";
 import type { TableColumn } from './schema.js';
 
@@ -17,7 +18,7 @@ export interface QueryConfig<T, Schema> {
   parameters?: any[];
   ctes?: string[];
   unionQueries?: string[];
-  settings?: string;
+  settings?: ClickHouseSettings;
 }
 
 export type { ColumnType, TableSchema, DatabaseSchema, TableRecord, InferColumnType, TableColumn } from './schema.js';


### PR DESCRIPTION


# Summary
Fixes #142. Per-query ClickHouse settings forwarding and add rawQuery execution options.

This fixes a bug in `@hypequery/clickhouse` where builder-level .settings(...) had no effect on executed queries. I have also passed on `query_id` and added to the rawQuery function

**Before this change:**
.settings(...) was stored on builder config but never applied by the real ClickHouse execution path
toSQL() and executed requests ignored those settings
execute({ queryId }) only affected local logging and was not forwarded to ClickHouse
rawQuery() had no way to pass per-query execution options

**After this change:**
builder .settings(...) is preserved in structured form and forwarded at execution time via clickhouse_settings
repeated .settings(...) calls merge
builder SQL rendering remains unchanged; settings are execution-only
queryId is forwarded to ClickHouse as query_id
rawQuery() now accepts the same per-query execution options

**Behaviour change**
Builder queries:
```
db.table('events')
  .settings({ final: 1, max_execution_time: 10 })
  .select(['id'])
  .execute({ queryId: 'q-123' });
```

Now sends:
`SQL text: SELECT id FROM events`

ClickHouse client options:
```
clickhouse_settings: { final: 1, max_execution_time: 10 }
query_id: 'q-123'
```

rawQuery() now supports the same pattern:
```
tsdb.rawQuery(
  'SELECT * FROM events WHERE id = ?',
  [42],
  { clickhouseSettings: { final: 1 }, queryId: 'raw-123' }
);
```

# Implementation notes

Kept query settings out of SQL rendering and applied them only at execution time.
Updated the adapter interface to accept per-query execution options.

Forwarded execution options through:
execute()
stream()
rawQuery()

Preserved settings in builder config as structured data instead of flattening early.
Merged repeated .settings(...) calls instead of overwriting prior values.
Kept cache keying sensitive to per-query settings.

# Tests
Added/updated coverage for:
builder settings merging without mutating rendered SQL
ClickHouse adapter forwarding clickhouse_settings and query_id
end-to-end builder execution using transport-only settings
rawQuery() forwarding execution options