### PR TITLE
Fix: Unsafe integers represented as strings and preserve rawAs() aliases in mixed selects

### DIFF
--- a/packages/clickhouse/src/cli/generate-types.js
+++ b/packages/clickhouse/src/cli/generate-types.js
@@ -23,7 +23,7 @@ dotenv.config();
  * @param {string} type - The ClickHouse type to convert
  * @returns {string} - The corresponding TypeScript type
  */
-const clickhouseToTsType = (type) => {
+export const clickhouseToTsType = (type) => {
   if (type.startsWith('Array(')) {
     const innerType = type.slice(6, -1);
     return `Array<${clickhouseToTsType(innerType)}>`;
@@ -44,14 +44,6 @@ const clickhouseToTsType = (type) => {
       const keyType = mapContent.substring(0, commaIndex).trim();
       const valueType = mapContent.substring(commaIndex + 1).trim();
 
-      // Handle different key types
-      let keyTsType = 'string';
-      if (keyType === 'LowCardinality(String)') {
-        keyTsType = 'string';
-      } else if (keyType.includes('Int') || keyType.includes('UInt')) {
-        keyTsType = 'number';
-      }
-
       // Handle different value types
       let valueTsType = 'unknown';
       if (valueType.startsWith('Array(')) {
@@ -64,7 +56,12 @@ const clickhouseToTsType = (type) => {
         valueTsType = clickhouseToTsType(valueType);
       }
 
-      return `Record<${keyTsType}, ${valueTsType}>`;
+      // JSON object keys are strings even when ClickHouse map keys are numeric.
+      if (keyType === 'LowCardinality(String)' || keyType.includes('Int') || keyType.includes('UInt') || keyType === 'String') {
+        return `Record<string, ${valueTsType}>`;
+      }
+
+      return `Record<string, ${valueTsType}>`;
     }
     return 'Record<string, unknown>';
   }
@@ -77,11 +74,11 @@ const clickhouseToTsType = (type) => {
     case 'int16':
     case 'int32':
     case 'uint8':
-    case 'int64':
     case 'uint16':
     case 'uint32':
-    case 'uint64':
       return 'number';
+    case 'int64':
+    case 'uint64':
     case 'uint128':
     case 'uint256':
     case 'int128':

--- a/packages/clickhouse/src/cli/generate-types.js
+++ b/packages/clickhouse/src/cli/generate-types.js
@@ -57,10 +57,6 @@ export const clickhouseToTsType = (type) => {
       }
 
       // JSON object keys are strings even when ClickHouse map keys are numeric.
-      if (keyType === 'LowCardinality(String)' || keyType.includes('Int') || keyType.includes('UInt') || keyType === 'String') {
-        return `Record<string, ${valueTsType}>`;
-      }
-
       return `Record<string, ${valueTsType}>`;
     }
     return 'Record<string, unknown>';

--- a/packages/clickhouse/src/core/tests/generate-types.test.ts
+++ b/packages/clickhouse/src/core/tests/generate-types.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { clickhouseToTsType } from '../../cli/generate-types.js';
+
+describe('clickhouseToTsType', () => {
+  it('maps 64-bit and wider integers to string', () => {
+    expect(clickhouseToTsType('UInt64')).toBe('string');
+    expect(clickhouseToTsType('Int64')).toBe('string');
+    expect(clickhouseToTsType('UInt128')).toBe('string');
+    expect(clickhouseToTsType('Int256')).toBe('string');
+  });
+
+  it('keeps 32-bit and smaller integers as number', () => {
+    expect(clickhouseToTsType('UInt32')).toBe('number');
+    expect(clickhouseToTsType('Int32')).toBe('number');
+  });
+
+  it('propagates wide integer mapping through nested types', () => {
+    expect(clickhouseToTsType('Array(UInt64)')).toBe('Array<string>');
+    expect(clickhouseToTsType('Nullable(Int128)')).toBe('string | null');
+    expect(clickhouseToTsType('Map(String, UInt64)')).toBe('Record<string, string>');
+  });
+
+  it('renders map keys as strings for numeric ClickHouse maps', () => {
+    expect(clickhouseToTsType('Map(UInt64, String)')).toBe('Record<string, string>');
+    expect(clickhouseToTsType('Map(UInt32, UInt64)')).toBe('Record<string, string>');
+  });
+});

--- a/packages/clickhouse/src/core/types/select-types.ts
+++ b/packages/clickhouse/src/core/types/select-types.ts
@@ -31,7 +31,8 @@ type AliasedColumnString<State extends AnyBuilderState> = `${StringSelectableCol
 export type SelectableItem<State extends AnyBuilderState> =
   | SelectableColumn<State>
   | AliasedColumnString<State>
-  | SqlExpression;
+  | AliasedExpression<any, string>
+  | SqlExpression<any>;
 
 export type ColumnSelectionKey<P> = P extends `${string}.${infer C}` ? C : P;
 

--- a/packages/clickhouse/src/types/clickhouse-types.ts
+++ b/packages/clickhouse/src/types/clickhouse-types.ts
@@ -2,6 +2,13 @@ export type ClickHouseInteger =
   | 'Int8' | 'Int16' | 'Int32' | 'Int64' | 'Int128' | 'Int256'
   | 'UInt8' | 'UInt16' | 'UInt32' | 'UInt64' | 'UInt128' | 'UInt256';
 
+export type ClickHouseJsSafeInteger =
+  | 'Int8' | 'Int16' | 'Int32'
+  | 'UInt8' | 'UInt16' | 'UInt32';
+
+export type ClickHouseJsUnsafeInteger =
+  Exclude<ClickHouseInteger, ClickHouseJsSafeInteger>;
+
 export type ClickHouseFloat = 'Float32' | 'Float64';
 
 export type ClickHouseDecimal =
@@ -65,7 +72,8 @@ export type ClickHouseType =
 export type InferClickHouseType<T extends ClickHouseType, Depth extends number = 0> =
   Depth extends 5
   ? unknown
-  : T extends ClickHouseInteger ? number
+  : T extends ClickHouseJsSafeInteger ? number
+  : T extends ClickHouseJsUnsafeInteger ? string
   : T extends ClickHouseFloat ? number
   : T extends ClickHouseDecimal ? number
   : T extends ClickHouseDateTime ? string

--- a/packages/clickhouse/type-tests/query-builder-types.test.ts
+++ b/packages/clickhouse/type-tests/query-builder-types.test.ts
@@ -131,6 +131,22 @@ type AssertAliasRowKeys = Expect<Equal<AliasRowKeys, 'avg_total'>>;
 type AliasValue = AliasRow['avg_total'];
 type AssertAliasValue = Expect<Equal<AliasValue, number>>;
 
+const mixedAliasSelection = builder.select([
+  'id',
+  rawAs('COUNT(*)', 'value_count'),
+]);
+type MixedAliasSelectionResult = Awaited<ReturnType<typeof mixedAliasSelection.execute>>;
+type ExpectedMixedAliasSelectionResult = { id: number; value_count: unknown }[];
+type AssertMixedAliasSelection = Expect<Equal<MixedAliasSelectionResult, ExpectedMixedAliasSelectionResult>>;
+
+const typedMixedAliasSelection = builder.select([
+  'id',
+  rawAs<number, 'value_count'>('COUNT(*)', 'value_count'),
+]);
+type TypedMixedAliasSelectionResult = Awaited<ReturnType<typeof typedMixedAliasSelection.execute>>;
+type ExpectedTypedMixedAliasSelectionResult = { id: number; value_count: number }[];
+type AssertTypedMixedAliasSelection = Expect<Equal<TypedMixedAliasSelectionResult, ExpectedTypedMixedAliasSelectionResult>>;
+
 const joinedColumnsQuery = builder
   .innerJoin('users', 'created_by', 'users.id')
   .select(['users.email', 'name']);

--- a/packages/clickhouse/type-tests/schema-and-querybuilder.test.ts
+++ b/packages/clickhouse/type-tests/schema-and-querybuilder.test.ts
@@ -2,6 +2,7 @@ import { QueryBuilder } from '../src/core/query-builder.js';
 import type { DatabaseAdapter } from '../src/core/adapters/database-adapter.js';
 import { ClickHouseDialect } from '../src/core/dialects/clickhouse-dialect.js';
 import type { BuilderState } from '../src/core/types/builder-state.js';
+import type { InferClickHouseType } from '../src/types/clickhouse-types.js';
 import type { TableColumn, TableRecord } from '../src/types/schema.js';
 import { buildRuntimeContext, resolveCacheConfig } from '../src/core/cache/runtime-context.js';
 import { substituteParameters } from '../src/core/utils.js';
@@ -32,6 +33,12 @@ type EventsRecord = TableRecord<AppSchema['events']>;
 type _UsersIdIsNumber = Expect<Equal<UsersRecord['id'], number>>;
 type _UsersCreatedAtIsString = Expect<Equal<UsersRecord['created_at'], string>>;
 type _EventsTimestampIsString = Expect<Equal<EventsRecord['ts'], string>>;
+type _UInt64InfersToString = Expect<Equal<InferClickHouseType<'UInt64'>, string>>;
+type _Int128InfersToString = Expect<Equal<InferClickHouseType<'Int128'>, string>>;
+type _UInt32InfersToNumber = Expect<Equal<InferClickHouseType<'UInt32'>, number>>;
+type _NullableUInt64InfersToStringOrNull = Expect<Equal<InferClickHouseType<'Nullable(UInt64)'>, string | null>>;
+type _ArrayUInt64InfersToStringArray = Expect<Equal<InferClickHouseType<'Array(UInt64)'>, string[]>>;
+type _MapUInt64InfersToStringValues = Expect<Equal<InferClickHouseType<'Map(String, UInt64)'>, Record<string, string>>>;
 
 // Validate TableColumn helper emits both qualified + bare column unions
 type ExpectedColumns =


### PR DESCRIPTION
Fixes #77 and #143. ClickHouse integer type inference for 64-bit+ widths and preserve rawAs() aliases in mixed selects

## Summary

This PR fixes two type-safety issues in `@hypequery/clickhouse`:

1. ClickHouse integer widths `Int64`/`UInt64` and above were inferred/generated as TypeScript `number`, even though they are not safely representable in JS numbers and commonly arrive as strings in the package's `JSONEachRow` execution path.

2. `rawAs()` selections could lose their alias in mixed `select([...])` calls, causing aliased raw expressions to disappear from the inferred `execute()` result type unless the caller forced a narrower type.

---

## Fixes

### 1. Correct integer width mapping

Updated core type inference and CLI-generated record types so integer widths map as follows:

- `Int8` / `Int16` / `Int32` / `UInt8` / `UInt16` / `UInt32` -> `number`
- `Int64` / `UInt64` / `Int128` / `UInt128` / `Int256` / `UInt256` -> `string`

This aligns with:
- JavaScript numeric safety limits
- the package's default query path (`JSONEachRow`)
- observed runtime behavior for 64-bit+ integers

Also renamed the internal helper split to make intent explicit:
- `ClickHouseJsSafeInteger`
- `ClickHouseJsUnsafeInteger`

### 2. Preserve rawAs() alias inference in mixed selects

Fixed `SelectableItem` typing so `AliasedExpression` is represented explicitly instead of only via `SqlExpression`.

**Before:**

```ts
builder.select([
  'product_id',
  rawAs('COUNT(*)', 'value_count'),
]);
```

could infer:

```ts
{ product_id: string }[]
```

**Now it correctly infers:**

```ts
{ product_id: string; value_count: unknown }[]
```

And still supports explicit typing:

```ts
rawAs<number, 'value_count'>('COUNT(*)', 'value_count')
```

which infers:

```ts
{ product_id: string; value_count: number }[]
```

---

## Implementation notes

- Updated `InferClickHouseType` in `src/types/clickhouse-types.ts`
- Updated CLI generator mapping in `src/cli/generate-types.js`
- Aligned generated `Map(...)` record key types to `Record<string, ...>` for numeric ClickHouse map keys, matching JSON/object behavior
- Updated select item typing in `src/core/types/select-types.ts` so aliased raw expressions keep alias metadata during contextual typing

---

## Tests

Added/updated coverage for:

**Compile-time inference of:**
- `UInt64`
- `Int128`
- `Nullable(UInt64)`
- `Array(UInt64)`
- `Map(String, UInt64)`

**CLI generator output mapping for:**
- safe vs unsafe integer widths
- nested array/nullable forms
- numeric `Map(...)` keys

**Mixed `rawAs()` selections:**
- default alias type as `unknown`
- explicit alias type propagation