### PR TITLE
fix: ClickHouse tuple type inference in generated types

### DIFF
--- a/.changeset/tuple-type-fix.md
+++ b/.changeset/tuple-type-fix.md
@@ -1,0 +1,11 @@
+---
+"@hypequery/clickhouse": patch
+---
+
+Fix tuple type inference in generated types to properly render positional tuple types instead of falling back to `unknown`. This includes:
+
+- Added `ParseTopLevelArgs` type helper to correctly parse comma-separated type arguments while preserving nested parentheses
+- Updated `InferClickHouseType` to handle `Tuple(...)` types by inferring positional TypeScript tuple types
+- Refactored CLI type-parsing logic to extract `clickhouseToTsType` into a separate module with improved tuple handling
+- Added support for nested tuple types within `Array`, `Map`, and `Nullable` wrappers
+- Added test coverage for tuple type inference scenarios

--- a/packages/clickhouse/scripts/handle-cli-files.js
+++ b/packages/clickhouse/scripts/handle-cli-files.js
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'url';
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const srcCliDir = path.join(rootDir, 'src', 'cli');
 const distCliDir = path.join(rootDir, 'dist', 'cli');
-const files = ['bin.js', 'generate-types.js', 'index.js', 'generate-types.d.ts', 'index.d.ts'];
+const files = ['bin.js', 'generate-types.js', 'index.js', 'type-parsing.js', 'generate-types.d.ts', 'index.d.ts'];
 
 fs.mkdirSync(distCliDir, { recursive: true });
 

--- a/packages/clickhouse/src/cli/generate-types.js
+++ b/packages/clickhouse/src/cli/generate-types.js
@@ -2,6 +2,9 @@ import { ClickHouseConnection } from '../core/connection.js';
 import fs from 'fs/promises';
 import path from 'path';
 import dotenv from 'dotenv';
+import { clickhouseToTsType } from './type-parsing.js';
+
+export { clickhouseToTsType } from './type-parsing.js';
 
 // Load environment variables from the current directory
 dotenv.config();
@@ -17,87 +20,6 @@ dotenv.config();
  * @property {string[]} [includeTables] - List of tables to include
  * @property {string[]} [excludeTables] - List of tables to exclude
  */
-
-/**
- * Converts ClickHouse types to TypeScript types
- * @param {string} type - The ClickHouse type to convert
- * @returns {string} - The corresponding TypeScript type
- */
-export const clickhouseToTsType = (type) => {
-  if (type.startsWith('Array(')) {
-    const innerType = type.slice(6, -1);
-    return `Array<${clickhouseToTsType(innerType)}>`;
-  }
-
-  // Handle Nullable types
-  if (type.startsWith('Nullable(')) {
-    const innerType = type.slice(9, -1);
-    return `${clickhouseToTsType(innerType)} | null`;
-  }
-
-  // Handle Map types
-  if (type.startsWith('Map(')) {
-    // Extract key and value types from Map(KeyType, ValueType)
-    const mapContent = type.slice(4, -1); // Remove 'Map(' and ')'
-    const commaIndex = mapContent.lastIndexOf(',');
-    if (commaIndex !== -1) {
-      const keyType = mapContent.substring(0, commaIndex).trim();
-      const valueType = mapContent.substring(commaIndex + 1).trim();
-
-      // Handle different value types
-      let valueTsType = 'unknown';
-      if (valueType.startsWith('Array(')) {
-        const innerType = valueType.slice(6, -1);
-        valueTsType = `Array<${clickhouseToTsType(innerType)}>`;
-      } else if (valueType.startsWith('Nullable(')) {
-        const innerType = valueType.slice(9, -1);
-        valueTsType = `${clickhouseToTsType(innerType)} | null`;
-      } else {
-        valueTsType = clickhouseToTsType(valueType);
-      }
-
-      // JSON object keys are strings even when ClickHouse map keys are numeric.
-      return `Record<string, ${valueTsType}>`;
-    }
-    return 'Record<string, unknown>';
-  }
-
-  switch (type.toLowerCase()) {
-    case 'string':
-    case 'fixedstring':
-      return 'string';
-    case 'int8':
-    case 'int16':
-    case 'int32':
-    case 'uint8':
-    case 'uint16':
-    case 'uint32':
-      return 'number';
-    case 'int64':
-    case 'uint64':
-    case 'uint128':
-    case 'uint256':
-    case 'int128':
-    case 'int256':
-      return 'string';
-    case 'float32':
-    case 'float64':
-    case 'decimal':
-      return 'number';
-    case 'datetime':
-    case 'datetime64':
-      return 'string'; // Use string for datetime
-    case 'date':
-    case 'date32':
-      return 'string'; // Use string for date
-    case 'bool':
-    case 'boolean':
-      return 'boolean';
-    default:
-      // For complex types or unknown types, return string as a safe default
-      return 'string';
-  }
-};
 
 /**
  * Generates TypeScript type definitions from the ClickHouse database schema

--- a/packages/clickhouse/src/cli/type-parsing.js
+++ b/packages/clickhouse/src/cli/type-parsing.js
@@ -1,0 +1,124 @@
+function splitTopLevelArgs(value) {
+  const parts = [];
+  let current = '';
+  let depth = 0;
+
+  for (const char of value) {
+    if (char === '(') {
+      depth += 1;
+      current += char;
+      continue;
+    }
+
+    if (char === ')') {
+      depth -= 1;
+      current += char;
+      continue;
+    }
+
+    if (char === ',' && depth === 0) {
+      parts.push(current.trim());
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.trim()) {
+    parts.push(current.trim());
+  }
+
+  return parts;
+}
+
+function unwrapType(type, wrapperName) {
+  const prefix = `${wrapperName}(`;
+  return type.startsWith(prefix) && type.endsWith(')')
+    ? type.slice(prefix.length, -1)
+    : null;
+}
+
+function getPrimitiveTsType(type) {
+  const lowerType = type.toLowerCase();
+
+  switch (lowerType) {
+    case 'string':
+    case 'uuid':
+      return 'string';
+    case 'int8':
+    case 'int16':
+    case 'int32':
+    case 'uint8':
+    case 'uint16':
+    case 'uint32':
+      return 'number';
+    case 'int64':
+    case 'uint64':
+    case 'uint128':
+    case 'uint256':
+    case 'int128':
+    case 'int256':
+      return 'string';
+    case 'float32':
+    case 'float64':
+    case 'decimal':
+      return 'number';
+    case 'datetime':
+    case 'datetime64':
+    case 'date':
+    case 'date32':
+      return 'string';
+    case 'bool':
+    case 'boolean':
+      return 'boolean';
+    default:
+      if (type.startsWith('FixedString(')) return 'string';
+      if (type.startsWith('Decimal(')) return 'number';
+      if (type.startsWith('DateTime64(')) return 'string';
+      if (type.startsWith('DateTime(')) return 'string';
+      if (type.startsWith('Enum8(')) return 'string';
+      if (type.startsWith('Enum16(')) return 'string';
+      return null;
+  }
+}
+
+export const clickhouseToTsType = (type) => {
+  const wrappedArrayType = unwrapType(type, 'Array');
+  if (wrappedArrayType) {
+    return `Array<${clickhouseToTsType(wrappedArrayType)}>`;
+  }
+
+  const wrappedNullableType = unwrapType(type, 'Nullable');
+  if (wrappedNullableType) {
+    return `${clickhouseToTsType(wrappedNullableType)} | null`;
+  }
+
+  const wrappedLowCardinalityType = unwrapType(type, 'LowCardinality');
+  if (wrappedLowCardinalityType) {
+    return clickhouseToTsType(wrappedLowCardinalityType);
+  }
+
+  const wrappedTupleType = unwrapType(type, 'Tuple');
+  if (wrappedTupleType) {
+    const tupleParts = splitTopLevelArgs(wrappedTupleType);
+    return `[${tupleParts.map(clickhouseToTsType).join(', ')}]`;
+  }
+
+  const wrappedMapType = unwrapType(type, 'Map');
+  if (wrappedMapType) {
+    const mapParts = splitTopLevelArgs(wrappedMapType);
+    if (mapParts.length === 2) {
+      const [, valueType] = mapParts;
+      // JSON object keys are strings even when ClickHouse map keys are numeric.
+      return `Record<string, ${clickhouseToTsType(valueType)}>`;
+    }
+    return 'Record<string, unknown>';
+  }
+
+  const primitiveType = getPrimitiveTsType(type);
+  if (primitiveType) return primitiveType;
+
+  // Unsupported or more complex ClickHouse types currently preserve the historical fallback.
+  return 'string';
+};

--- a/packages/clickhouse/src/core/tests/generate-types.test.ts
+++ b/packages/clickhouse/src/core/tests/generate-types.test.ts
@@ -24,4 +24,28 @@ describe('clickhouseToTsType', () => {
     expect(clickhouseToTsType('Map(UInt64, String)')).toBe('Record<string, string>');
     expect(clickhouseToTsType('Map(UInt32, UInt64)')).toBe('Record<string, string>');
   });
+
+  it('renders tuple types positionally', () => {
+    expect(
+      clickhouseToTsType('Tuple(UInt32, LowCardinality(String), String, String, LowCardinality(String))')
+    ).toBe('[number, string, string, string, string]');
+    expect(
+      clickhouseToTsType('Array(Tuple(UInt32, LowCardinality(String), String, String, LowCardinality(String)))')
+    ).toBe('Array<[number, string, string, string, string]>');
+  });
+
+  it('handles nested tuple values inside maps and nullable wrappers', () => {
+    expect(
+      clickhouseToTsType('Map(String, Tuple(UInt64, Nullable(String)))')
+    ).toBe('Record<string, [string, string | null]>');
+    expect(
+      clickhouseToTsType('LowCardinality(Nullable(String))')
+    ).toBe('string | null');
+    expect(
+      clickhouseToTsType('Nullable(Array(Tuple(UInt32, String)))')
+    ).toBe('Array<[number, string]> | null');
+    expect(
+      clickhouseToTsType('Map(String, Array(Tuple(UInt32, String)))')
+    ).toBe('Record<string, Array<[number, string]>>');
+  });
 });

--- a/packages/clickhouse/src/types/clickhouse-types.ts
+++ b/packages/clickhouse/src/types/clickhouse-types.ts
@@ -1,3 +1,5 @@
+import type { ParseTopLevelArgs } from './type-helpers.js';
+
 export type ClickHouseInteger =
   | 'Int8' | 'Int16' | 'Int32' | 'Int64' | 'Int128' | 'Int256'
   | 'UInt8' | 'UInt16' | 'UInt32' | 'UInt64' | 'UInt128' | 'UInt256';
@@ -48,8 +50,11 @@ export type ClickHouseType =
   | `Array(Nullable(${ClickHouseBaseType}))`
   | `Array(LowCardinality(String))`
   | `Array(LowCardinality(${ClickHouseEnum}))`
+  | `Array(Tuple(${string}))`
   | `Nullable(${ClickHouseBaseType})`
   | `Nullable(Array(${ClickHouseBaseType}))`
+  | `Nullable(Array(Tuple(${string})))`
+  | `Nullable(Tuple(${string}))`
   | `LowCardinality(${ClickHouseString})`
   | `LowCardinality(${ClickHouseEnum})`
   | `LowCardinality(Nullable(${ClickHouseString}))`
@@ -57,19 +62,32 @@ export type ClickHouseType =
   | `Map(String, ${ClickHouseBaseType})`
   | `Map(String, Array(${ClickHouseBaseType}))`
   | `Map(String, Nullable(${ClickHouseBaseType}))`
+  | `Map(String, Tuple(${string}))`
+  | `Map(String, Array(Tuple(${string})))`
   | `Map(LowCardinality(String), ${ClickHouseBaseType})`
   | `Map(LowCardinality(String), Array(${ClickHouseBaseType}))`
   | `Map(LowCardinality(String), Nullable(${ClickHouseBaseType}))`
+  | `Map(LowCardinality(String), Tuple(${string}))`
+  | `Map(LowCardinality(String), Array(Tuple(${string})))`
   | `Map(${ClickHouseInteger}, ${ClickHouseBaseType})`
   | `Map(${ClickHouseInteger}, Array(${ClickHouseBaseType}))`
   | `Map(${ClickHouseInteger}, Nullable(${ClickHouseBaseType}))`
+  | `Map(${ClickHouseInteger}, Tuple(${string}))`
+  | `Map(${ClickHouseInteger}, Array(Tuple(${string})))`
   | `Array(Map(String, ${ClickHouseBaseType}))`
+  | `Array(Map(String, Tuple(${string})))`
   | `Array(Map(LowCardinality(String), ${ClickHouseBaseType}))`
+  | `Array(Map(LowCardinality(String), Tuple(${string})))`
   | `Array(Map(${ClickHouseInteger}, ${ClickHouseBaseType}))`
+  | `Array(Map(${ClickHouseInteger}, Tuple(${string})))`
   | `Nullable(Map(String, ${ClickHouseBaseType}))`
-  | `Nullable(Map(LowCardinality(String), ${ClickHouseBaseType}))`;
+  | `Nullable(Map(String, Tuple(${string})))`
+  | `Nullable(Map(LowCardinality(String), ${ClickHouseBaseType}))`
+  | `Nullable(Map(LowCardinality(String), Tuple(${string})))`
+  | `Tuple(${string})`;
 
-export type InferClickHouseType<T extends ClickHouseType, Depth extends number = 0> =
+// Cap recursive expansion for nested ClickHouse wrappers to keep type instantiation bounded.
+export type InferClickHouseType<T extends string, Depth extends number = 0> =
   Depth extends 5
   ? unknown
   : T extends ClickHouseJsSafeInteger ? number
@@ -84,6 +102,10 @@ export type InferClickHouseType<T extends ClickHouseType, Depth extends number =
   ? U extends ClickHouseType
   ? Array<InferClickHouseType<U, Add1<Depth>>>
   : unknown[]
+  : T extends `Tuple(${infer U})`
+  ? ParseTopLevelArgs<U> extends infer Parts extends string[]
+    ? { [K in keyof Parts]: InferClickHouseType<Parts[K] & ClickHouseType, Add1<Depth>> }
+    : unknown[]
   : T extends `Nullable(${infer U})`
   ? U extends ClickHouseType
   ? InferClickHouseType<U, Add1<Depth>> | null

--- a/packages/clickhouse/src/types/index.ts
+++ b/packages/clickhouse/src/types/index.ts
@@ -2,3 +2,4 @@ export * from './base.js';
 export * from './filters.js';
 export * from './clickhouse-types.js';
 export * from './schema.js';
+export * from './type-helpers.js';

--- a/packages/clickhouse/src/types/type-helpers.ts
+++ b/packages/clickhouse/src/types/type-helpers.ts
@@ -1,0 +1,26 @@
+type TrimLeft<S extends string> = S extends ` ${infer R}` ? TrimLeft<R> : S;
+type TrimRight<S extends string> = S extends `${infer R} ` ? TrimRight<R> : S;
+type Trim<S extends string> = TrimLeft<TrimRight<S>>;
+type Push<T extends string[], V extends string> = [...T, V];
+
+// Split a comma-separated argument list while preserving nested (...) groups.
+export type ParseTopLevelArgs<
+  S extends string,
+  Current extends string = '',
+  Depth extends string[] = [],
+  Result extends string[] = []
+> = S extends `${infer First}${infer Rest}`
+  ? First extends '('
+    ? ParseTopLevelArgs<Rest, `${Current}${First}`, Push<Depth, First>, Result>
+    : First extends ')'
+      ? Depth extends [...infer Remaining extends string[], string]
+        ? ParseTopLevelArgs<Rest, `${Current}${First}`, Remaining, Result>
+        : ParseTopLevelArgs<Rest, `${Current}${First}`, Depth, Result>
+      : First extends ','
+        ? Depth['length'] extends 0
+          ? ParseTopLevelArgs<Rest, '', Depth, Push<Result, Trim<Current>>>
+          : ParseTopLevelArgs<Rest, `${Current}${First}`, Depth, Result>
+        : ParseTopLevelArgs<Rest, `${Current}${First}`, Depth, Result>
+  : Current extends ''
+    ? Result
+    : Push<Result, Trim<Current>>;

--- a/packages/clickhouse/type-tests/schema-and-querybuilder.test.ts
+++ b/packages/clickhouse/type-tests/schema-and-querybuilder.test.ts
@@ -39,6 +39,24 @@ type _UInt32InfersToNumber = Expect<Equal<InferClickHouseType<'UInt32'>, number>
 type _NullableUInt64InfersToStringOrNull = Expect<Equal<InferClickHouseType<'Nullable(UInt64)'>, string | null>>;
 type _ArrayUInt64InfersToStringArray = Expect<Equal<InferClickHouseType<'Array(UInt64)'>, string[]>>;
 type _MapUInt64InfersToStringValues = Expect<Equal<InferClickHouseType<'Map(String, UInt64)'>, Record<string, string>>>;
+type _TupleInfersPositionally = Expect<
+  Equal<
+    InferClickHouseType<'Tuple(UInt32, LowCardinality(String), String, String, LowCardinality(String))'>,
+    [number, string, string, string, string]
+  >
+>;
+type _ArrayOfTupleInfersNestedTupleRows = Expect<
+  Equal<
+    InferClickHouseType<'Array(Tuple(UInt32, LowCardinality(String), String, String, LowCardinality(String)))'>,
+    Array<[number, string, string, string, string]>
+  >
+>;
+type _MapTupleValuesInferPositionally = Expect<
+  Equal<
+    InferClickHouseType<'Map(String, Tuple(UInt64, Nullable(String)))'>,
+    Record<string, [string, string | null]>
+  >
+>;
 
 // Validate TableColumn helper emits both qualified + bare column unions
 type ExpectedColumns =


### PR DESCRIPTION
 ## Description

 This fixes (#149) incorrect TypeScript generation for ClickHouse tuple-valued columns, especially Array(Tuple(...)), which was being emitted as Array<string> even though the ClickHouse HTTP client returns nested JSON arrays.

Changes in this PR:
  - add positional tuple inference to InferClickHouseType
  - fix `hypequery-generate-types` to emit tuple shapes correctly for:
      - Tuple(...)
      - Array(Tuple(...))
      - Map(..., Tuple(...))
      - supported nested wrapper combinations
  - improve nested type argument parsing so composite types are split safely at top-level commas
  - add regression coverage for tuple inference in both type-level and runtime generator tests
  - keep overall ClickHouse type support scope unchanged; this PR does not introduce broader
    support for new ClickHouse type families


