### PR TITLE
fix: tuple type inference in CLI generated types

### DIFF
--- a/.changeset/cli-tuple-fix.md
+++ b/.changeset/cli-tuple-fix.md
@@ -1,0 +1,11 @@
+---
+"@hypequery/cli": patch
+---
+
+Fix tuple type inference in generated types from the `hypequery generate` command to properly render positional tuple types instead of falling back to `string`. This includes:
+
+- Added helper functions `splitTopLevelArgs`, `unwrapType`, and `getPrimitiveTsType` for better maintainability
+- Added support for `Tuple(...)` types to render as positional TypeScript tuple types
+- Added support for `LowCardinality` wrapper types
+- Added support for nested tuple types within `Array`, `Map`, and `Nullable` wrappers
+- Added test coverage for tuple type inference scenarios

--- a/packages/cli/src/generators/clickhouse.test.ts
+++ b/packages/cli/src/generators/clickhouse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { generateClickHouseTypes } from './clickhouse.js';
+import { generateClickHouseTypes, clickhouseToTsType } from './clickhouse.js';
 
 const mkdir = vi.hoisted(() => vi.fn());
 const writeFile = vi.hoisted(() => vi.fn());
@@ -42,5 +42,31 @@ describe('generateClickHouseTypes', () => {
     const [writtenPath, contents] = writeFile.mock.calls[0];
     expect(writtenPath).toContain('analytics/schema.ts');
     expect(contents).toContain('export interface IntrospectedSchema');
+  });
+});
+
+describe('clickhouseToTsType', () => {
+  it('renders tuple types positionally', () => {
+    expect(
+      clickhouseToTsType('Tuple(UInt32, LowCardinality(String), String, String, LowCardinality(String))')
+    ).toBe('[number, string, string, string, string]');
+    expect(
+      clickhouseToTsType('Array(Tuple(UInt32, LowCardinality(String), String, String, LowCardinality(String)))')
+    ).toBe('Array<[number, string, string, string, string]>');
+  });
+
+  it('handles nested tuple values inside maps and nullable wrappers', () => {
+    expect(
+      clickhouseToTsType('Map(String, Tuple(UInt64, Nullable(String)))')
+    ).toBe('Record<string, [string, string | null]>');
+    expect(
+      clickhouseToTsType('LowCardinality(Nullable(String))')
+    ).toBe('string | null');
+    expect(
+      clickhouseToTsType('Nullable(Array(Tuple(UInt32, String)))')
+    ).toBe('Array<[number, string]> | null');
+    expect(
+      clickhouseToTsType('Map(String, Array(Tuple(UInt32, String)))')
+    ).toBe('Record<string, Array<[number, string]>>');
   });
 });

--- a/packages/cli/src/generators/clickhouse.ts
+++ b/packages/cli/src/generators/clickhouse.ts
@@ -22,62 +22,61 @@ const DEFAULT_WARNING =
 
 const capitalizeFirstLetter = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
 
-const clickhouseToTsType = (type: string): string => {
-  if (type.startsWith('Array(')) {
-    const innerType = type.slice(6, -1);
-    return `Array<${clickhouseToTsType(innerType)}>`;
-  }
+function splitTopLevelArgs(value: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let depth = 0;
 
-  if (type.startsWith('Nullable(')) {
-    const innerType = type.slice(9, -1);
-    return `${clickhouseToTsType(innerType)} | null`;
-  }
-
-  if (type.startsWith('Map(')) {
-    const mapContent = type.slice(4, -1);
-    const commaIndex = mapContent.lastIndexOf(',');
-
-    if (commaIndex !== -1) {
-      const keyType = mapContent.substring(0, commaIndex).trim();
-      const valueType = mapContent.substring(commaIndex + 1).trim();
-
-      let keyTsType = 'string';
-      if (keyType === 'LowCardinality(String)') {
-        keyTsType = 'string';
-      } else if (keyType.includes('Int') || keyType.includes('UInt')) {
-        keyTsType = 'number';
-      }
-
-      let valueTsType = 'unknown';
-      if (valueType.startsWith('Array(')) {
-        const innerType = valueType.slice(6, -1);
-        valueTsType = `Array<${clickhouseToTsType(innerType)}>`;
-      } else if (valueType.startsWith('Nullable(')) {
-        const innerType = valueType.slice(9, -1);
-        valueTsType = `${clickhouseToTsType(innerType)} | null`;
-      } else {
-        valueTsType = clickhouseToTsType(valueType);
-      }
-
-      return `Record<${keyTsType}, ${valueTsType}>`;
+  for (const char of value) {
+    if (char === '(') {
+      depth += 1;
+      current += char;
+      continue;
     }
 
-    return 'Record<string, unknown>';
+    if (char === ')') {
+      depth -= 1;
+      current += char;
+      continue;
+    }
+
+    if (char === ',' && depth === 0) {
+      parts.push(current.trim());
+      current = '';
+      continue;
+    }
+
+    current += char;
   }
 
-  switch (type.toLowerCase()) {
+  if (current.trim()) {
+    parts.push(current.trim());
+  }
+
+  return parts;
+}
+
+function unwrapType(type: string, wrapperName: string): string | null {
+  const prefix = `${wrapperName}(`;
+  return type.startsWith(prefix) && type.endsWith(')') ? type.slice(prefix.length, -1) : null;
+}
+
+function getPrimitiveTsType(type: string): string | null {
+  const lowerType = type.toLowerCase();
+
+  switch (lowerType) {
     case 'string':
-    case 'fixedstring':
+    case 'uuid':
       return 'string';
     case 'int8':
     case 'int16':
     case 'int32':
     case 'uint8':
-    case 'int64':
     case 'uint16':
     case 'uint32':
-    case 'uint64':
       return 'number';
+    case 'int64':
+    case 'uint64':
     case 'uint128':
     case 'uint256':
     case 'int128':
@@ -96,9 +95,57 @@ const clickhouseToTsType = (type: string): string => {
     case 'boolean':
       return 'boolean';
     default:
-      return 'string';
+      if (type.startsWith('FixedString(')) return 'string';
+      if (type.startsWith('Decimal(')) return 'number';
+      if (type.startsWith('DateTime64(')) return 'string';
+      if (type.startsWith('DateTime(')) return 'string';
+      if (type.startsWith('Enum8(')) return 'string';
+      if (type.startsWith('Enum16(')) return 'string';
+      return null;
   }
+}
+
+const clickhouseToTsType = (type: string): string => {
+  const wrappedArrayType = unwrapType(type, 'Array');
+  if (wrappedArrayType) {
+    return `Array<${clickhouseToTsType(wrappedArrayType)}>`;
+  }
+
+  const wrappedNullableType = unwrapType(type, 'Nullable');
+  if (wrappedNullableType) {
+    return `${clickhouseToTsType(wrappedNullableType)} | null`;
+  }
+
+  const wrappedLowCardinalityType = unwrapType(type, 'LowCardinality');
+  if (wrappedLowCardinalityType) {
+    return clickhouseToTsType(wrappedLowCardinalityType);
+  }
+
+  const wrappedTupleType = unwrapType(type, 'Tuple');
+  if (wrappedTupleType) {
+    const tupleParts = splitTopLevelArgs(wrappedTupleType);
+    return `[${tupleParts.map(clickhouseToTsType).join(', ')}]`;
+  }
+
+  const wrappedMapType = unwrapType(type, 'Map');
+  if (wrappedMapType) {
+    const mapParts = splitTopLevelArgs(wrappedMapType);
+    if (mapParts.length === 2) {
+      const [, valueType] = mapParts;
+      // JSON object keys are strings even when ClickHouse map keys are numeric.
+      return `Record<string, ${clickhouseToTsType(valueType)}>`;
+    }
+    return 'Record<string, unknown>';
+  }
+
+  const primitiveType = getPrimitiveTsType(type);
+  if (primitiveType) return primitiveType;
+
+  // Unsupported or more complex ClickHouse types currently preserve the historical fallback.
+  return 'string';
 };
+
+export { clickhouseToTsType };
 
 async function fetchTables(includeTables?: string[], excludeTables?: string[]) {
   const client = getClickHouseClient();


### PR DESCRIPTION
## Summary
Fixes tuple type inference in the hypequery generate command to properly render positional tuple types instead of falling back to string.

Mirrors the last PR but fixes the CLI package

##  Problem

  Previously, when using the hypequery generate command to introspect a ClickHouse database schema, columns with
  Tuple(...) types would be incorrectly generated as string types in the TypeScript interfaces.

  For example, a ClickHouse column with type:
  Tuple(UInt32, LowCardinality(String), String)

  Would be incorrectly generated as:
  columnName: string

 ## Solution

  This PR adds proper tuple type parsing support to the CLI's type generation logic, mirroring the fix recently
  applied to @hypequery/clickhouse:

  - Added Tuple(...) support - Now correctly renders as [number, string, string]
  - Added LowCardinality support - Properly unwraps LowCardinality types
  - Enhanced nested types - Handles tuples within Array, Map, and Nullable wrappers
  - Refactored type parsing - Extracted helper functions for better maintainability:
    - splitTopLevelArgs() - Parses comma-separated type arguments while preserving nested parentheses
    - unwrapType() - Extracts inner types from wrapper types
    - getPrimitiveTsType() - Handles primitive ClickHouse types

  Examples

  Before

  // ClickHouse: Tuple(UInt32, String, String)
  columnName: string  // ❌ Lost type information

  After

  // ClickHouse: Tuple(UInt32, String, String)
  columnName: [number, string, string]  // ✅ Proper positional tuple type
