### PR TITLE
task: improve query builder internals

### DIFF
--- a/packages/clickhouse/dist-file-index.txt
+++ b/packages/clickhouse/dist-file-index.txt
@@ -84,6 +84,9 @@ core/join-relationships.js
 core/query-builder.d.ts
 core/query-builder.d.ts.map
 core/query-builder.js
+core/query-node.d.ts
+core/query-node.d.ts.map
+core/query-node.js
 core/tests/index.d.ts
 core/tests/index.d.ts.map
 core/tests/index.js
@@ -166,6 +169,15 @@ migrations/diff/index.js
 migrations/diff/types.d.ts
 migrations/diff/types.d.ts.map
 migrations/diff/types.js
+migrations/plan/index.d.ts
+migrations/plan/index.d.ts.map
+migrations/plan/index.js
+migrations/plan/plan.d.ts
+migrations/plan/plan.d.ts.map
+migrations/plan/plan.js
+migrations/plan/types.d.ts
+migrations/plan/types.d.ts.map
+migrations/plan/types.js
 migrations/schema/column.d.ts
 migrations/schema/column.d.ts.map
 migrations/schema/column.js

--- a/packages/clickhouse/dist-file-index.txt
+++ b/packages/clickhouse/dist-file-index.txt
@@ -3,6 +3,7 @@ cli/generate-types.d.ts
 cli/generate-types.js
 cli/index.d.ts
 cli/index.js
+cli/type-parsing.js
 core/adapters/clickhouse-adapter.d.ts
 core/adapters/clickhouse-adapter.d.ts.map
 core/adapters/clickhouse-adapter.js
@@ -226,3 +227,6 @@ types/index.js
 types/schema.d.ts
 types/schema.d.ts.map
 types/schema.js
+types/type-helpers.d.ts
+types/type-helpers.d.ts.map
+types/type-helpers.js

--- a/packages/clickhouse/src/core/cache/cache-manager.ts
+++ b/packages/clickhouse/src/core/cache/cache-manager.ts
@@ -13,9 +13,10 @@ function isCacheable(options: CacheOptions): boolean {
 }
 
 function deriveTags<Schema extends SchemaDefinition<Schema>, State extends AnyBuilderState>(builder: QueryBuilder<Schema, State>): string[] {
+  const queryNode = builder.toQueryNode();
   const tags = new Set<string>();
-  tags.add(builder.getTableName());
-  const joins = builder.getConfig().joins || [];
+  tags.add(queryNode.from?.kind === 'table' ? queryNode.from.name : builder.getTableName());
+  const joins = queryNode.joins || [];
   joins.forEach(join => tags.add(join.table));
   return Array.from(tags);
 }
@@ -85,11 +86,12 @@ export async function executeWithCache<
   const renderSql = adapter.render ? adapter.render(sql, parameters) : substituteParameters(sql, parameters);
   const tableName = builder.getTableName();
   const namespace = mergedOptions.namespace || runtime.namespace;
+  const queryNode = builder.toQueryNode();
   const key = mergedOptions.key || computeCacheKey({
     namespace,
     sql,
     parameters,
-    settings: builder.getConfig().settings,
+    settings: queryNode.settings,
     version: runtime.versionTag,
     tableName
   });

--- a/packages/clickhouse/src/core/cross-filter.ts
+++ b/packages/clickhouse/src/core/cross-filter.ts
@@ -193,7 +193,7 @@ export class CrossFilter<
   private isGroup(
     item: FilterConditionInput<any, Schema, Schema[TableName]> | FilterGroup<Schema, Schema[TableName]>
   ): item is FilterGroup<Schema, Schema[TableName]> {
-    return typeof (item as any).conditions !== 'undefined';
+    return 'conditions' in item;
   }
 
   /**

--- a/packages/clickhouse/src/core/dialects/clickhouse-dialect.ts
+++ b/packages/clickhouse/src/core/dialects/clickhouse-dialect.ts
@@ -1,4 +1,4 @@
-import type { QueryConfig } from '../../types/index.js';
+import type { CompiledQuery, SelectQueryNode } from '../../types/index.js';
 import { SQLFormatter } from '../formatters/sql-formatter.js';
 import type { CompileQueryContext, SqlDialect } from './sql-dialect.js';
 
@@ -6,45 +6,56 @@ export class ClickHouseDialect implements SqlDialect {
   readonly name = 'clickhouse';
   private formatter = new SQLFormatter();
 
-  compileQuery(config: QueryConfig<any, any>, context: CompileQueryContext): string {
+  compileQuery(query: SelectQueryNode<any, any>, context: CompileQueryContext): CompiledQuery {
     const parts: string[] = [];
+    const parameters: unknown[] = [];
 
-    if (config.ctes?.length) {
-      parts.push(`WITH ${config.ctes.join(', ')}`);
+    if (query.ctes?.length) {
+      parts.push(`WITH ${this.formatter.formatCtes(query)}`);
     }
 
-    parts.push(`SELECT ${this.formatter.formatSelect(config)}`);
-    parts.push(`FROM ${context.tableName}`);
+    parts.push(`SELECT ${this.formatter.formatSelect(query)}`);
+    parts.push(`FROM ${this.formatter.formatFrom(query.from ?? { kind: 'table', name: context.tableName })}`);
 
-    if (config.joins?.length) {
-      parts.push(this.formatter.formatJoins(config));
+    if (query.joins?.length) {
+      parts.push(this.formatter.formatJoins(query));
     }
 
-    if (config.where?.length) {
-      parts.push(`WHERE ${this.formatter.formatWhere(config)}`);
+    if (query.prewhere) {
+      const compiled = this.formatter.compileExpr(query.prewhere);
+      parts.push(`PREWHERE ${compiled.query}`);
+      parameters.push(...compiled.parameters);
     }
 
-    if (config.groupBy?.length) {
-      parts.push(`GROUP BY ${this.formatter.formatGroupBy(config)}`);
+    if (query.where) {
+      const compiled = this.formatter.compileExpr(query.where);
+      parts.push(`WHERE ${compiled.query}`);
+      parameters.push(...compiled.parameters);
     }
 
-    if (config.having?.length) {
-      parts.push(`HAVING ${config.having.join(' AND ')}`);
+    if (query.groupBy?.length) {
+      parts.push(`GROUP BY ${this.formatter.formatGroupBy(query)}`);
     }
 
-    if (config.orderBy?.length) {
-      const orderBy = config.orderBy
-        .map(({ column, direction }) => `${String(column)} ${direction}`.trim())
-        .join(', ');
-      parts.push(`ORDER BY ${orderBy}`);
+    if (query.having?.length) {
+      const compiled = this.formatter.compileHaving(query);
+      parts.push(`HAVING ${compiled.query}`);
+      parameters.push(...compiled.parameters);
     }
 
-    if (config.limit) {
-      const offsetClause = config.offset ? `OFFSET ${config.offset}` : '';
-      parts.push(`LIMIT ${config.limit} ${offsetClause}`);
+    if (query.orderBy?.length) {
+      parts.push(`ORDER BY ${this.formatter.formatOrderBy(query)}`);
     }
 
-    return parts.join(' ').trim();
+    if (query.limit) {
+      const offsetClause = query.offset ? `OFFSET ${query.offset}` : '';
+      parts.push(`LIMIT ${query.limit} ${offsetClause}`);
+    }
+
+    return {
+      query: parts.join(' ').trim(),
+      parameters,
+    };
   }
 
   formatTimeInterval(column: string, interval: string, method: string): string {

--- a/packages/clickhouse/src/core/dialects/sql-dialect.ts
+++ b/packages/clickhouse/src/core/dialects/sql-dialect.ts
@@ -1,4 +1,4 @@
-import type { QueryConfig } from '../../types/index.js';
+import type { CompiledQuery, SelectQueryNode } from '../../types/index.js';
 
 export interface CompileQueryContext {
   tableName: string;
@@ -6,7 +6,7 @@ export interface CompileQueryContext {
 
 export interface SqlDialect {
   readonly name: string;
-  compileQuery(config: QueryConfig<any, any>, context: CompileQueryContext): string;
+  compileQuery(query: SelectQueryNode<any, any>, context: CompileQueryContext): CompiledQuery;
   formatTimeInterval(
     column: string,
     interval: string,

--- a/packages/clickhouse/src/core/features/aggregations.ts
+++ b/packages/clickhouse/src/core/features/aggregations.ts
@@ -1,5 +1,6 @@
 import type { BuilderState, SchemaDefinition } from '../types/builder-state.js';
 import { QueryBuilder } from '../query-builder.js';
+import type { SelectQueryNode } from '../../types/index.js';
 
 export class AggregationFeature<
   Schema extends SchemaDefinition<Schema>,
@@ -11,15 +12,15 @@ export class AggregationFeature<
     column: string,
     fn: 'COUNT' | 'SUM' | 'AVG' | 'MIN' | 'MAX',
     alias: string
-  ) {
+  ): SelectQueryNode<State['output'], Schema> {
     const aggregationSQL = `${fn}(${column}) AS ${alias}`;
-    const config = this.builder.getConfig();
+    const query = this.builder.getQueryNode();
 
-    if (config.select) {
-      const selections = config.select.map(item => item.selection);
+    if (query.select) {
+      const selections = query.select.map(item => item.selection);
       return {
-        ...config,
-        select: [...config.select, { kind: 'selection' as const, selection: aggregationSQL }],
+        ...query,
+        select: [...query.select, { kind: 'selection' as const, selection: aggregationSQL }],
         groupBy: selections
           .filter(col => !col.includes(' AS '))
           .map(expression => ({ kind: 'group-by-item' as const, expression }))
@@ -27,7 +28,7 @@ export class AggregationFeature<
     }
 
     return {
-      ...config,
+      ...query,
       select: [{ kind: 'selection' as const, selection: aggregationSQL }]
     };
   }

--- a/packages/clickhouse/src/core/features/aggregations.ts
+++ b/packages/clickhouse/src/core/features/aggregations.ts
@@ -16,16 +16,19 @@ export class AggregationFeature<
     const config = this.builder.getConfig();
 
     if (config.select) {
+      const selections = config.select.map(item => item.selection);
       return {
         ...config,
-        select: [...(config.select || []).map(String), aggregationSQL],
-        groupBy: (config.select || []).map(String).filter(col => !col.includes(' AS '))
+        select: [...config.select, { kind: 'selection' as const, selection: aggregationSQL }],
+        groupBy: selections
+          .filter(col => !col.includes(' AS '))
+          .map(expression => ({ kind: 'group-by-item' as const, expression }))
       };
     }
 
     return {
       ...config,
-      select: [aggregationSQL]
+      select: [{ kind: 'selection' as const, selection: aggregationSQL }]
     };
   }
 

--- a/packages/clickhouse/src/core/features/analytics.ts
+++ b/packages/clickhouse/src/core/features/analytics.ts
@@ -4,7 +4,7 @@ import { QueryBuilder } from '../query-builder.js';
 import type { SqlDialect } from '../dialects/sql-dialect.js';
 import type { PredicateExpression } from '../utils/predicate-builder.js';
 import { substituteParameters } from '../utils.js';
-import type { QueryConfig } from '../../types/index.js';
+import type { SelectQueryNode } from '../../types/index.js';
 
 export class AnalyticsFeature<
   Schema extends SchemaDefinition<Schema>,
@@ -12,21 +12,21 @@ export class AnalyticsFeature<
 > {
   constructor(private builder: QueryBuilder<Schema, State>) { }
 
-  addCTE(alias: string, subquery: QueryBuilder<any, AnyBuilderState> | string): QueryConfig<State['output'], Schema> {
-    const config = this.builder.getConfig();
+  addCTE(alias: string, subquery: QueryBuilder<any, AnyBuilderState> | string): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
     const cte = typeof subquery === 'string' ? subquery : subquery.toSQL();
     return {
-      ...config,
-      ctes: [...(config.ctes || []), { kind: 'cte' as const, expression: `${alias} AS (${cte})` }]
+      ...query,
+      ctes: [...(query.ctes || []), { kind: 'cte' as const, expression: `${alias} AS (${cte})` }]
     };
   }
 
-  addScalar(alias: string, expression: PredicateExpression): QueryConfig<State['output'], Schema> {
-    const config = this.builder.getConfig();
+  addScalar(alias: string, expression: PredicateExpression): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
     const scalarExpression = substituteParameters(expression.sql, expression.parameters);
     return {
-      ...config,
-      ctes: [...(config.ctes || []), { kind: 'cte' as const, expression: `${scalarExpression} AS ${alias}` }]
+      ...query,
+      ctes: [...(query.ctes || []), { kind: 'cte' as const, expression: `${scalarExpression} AS ${alias}` }]
     };
   }
 
@@ -35,25 +35,25 @@ export class AnalyticsFeature<
     interval: string,
     method: 'toStartOfInterval' | 'toStartOfMinute' | 'toStartOfHour' | 'toStartOfDay' | 'toStartOfWeek' | 'toStartOfMonth' | 'toStartOfQuarter' | 'toStartOfYear',
     dialect: SqlDialect,
-  ): QueryConfig<State['output'], Schema> {
-    const config = this.builder.getConfig();
+  ): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
     const groupBy = [
-      ...(config.groupBy || []),
+      ...(query.groupBy || []),
       { kind: 'group-by-item' as const, expression: dialect.formatTimeInterval(column, interval, method) }
     ];
 
     return {
-      ...config,
+      ...query,
       groupBy
     };
   }
 
-  addSettings(opts: ClickHouseSettings): QueryConfig<State['output'], Schema> {
-    const config = this.builder.getConfig();
+  addSettings(opts: ClickHouseSettings): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
     return {
-      ...config,
+      ...query,
       settings: {
-        ...(config.settings || {}),
+        ...(query.settings || {}),
         ...opts,
       }
     };

--- a/packages/clickhouse/src/core/features/analytics.ts
+++ b/packages/clickhouse/src/core/features/analytics.ts
@@ -4,6 +4,7 @@ import { QueryBuilder } from '../query-builder.js';
 import type { SqlDialect } from '../dialects/sql-dialect.js';
 import type { PredicateExpression } from '../utils/predicate-builder.js';
 import { substituteParameters } from '../utils.js';
+import type { QueryConfig } from '../../types/index.js';
 
 export class AnalyticsFeature<
   Schema extends SchemaDefinition<Schema>,
@@ -11,21 +12,21 @@ export class AnalyticsFeature<
 > {
   constructor(private builder: QueryBuilder<Schema, State>) { }
 
-  addCTE(alias: string, subquery: QueryBuilder<any, AnyBuilderState> | string) {
+  addCTE(alias: string, subquery: QueryBuilder<any, AnyBuilderState> | string): QueryConfig<State['output'], Schema> {
     const config = this.builder.getConfig();
     const cte = typeof subquery === 'string' ? subquery : subquery.toSQL();
     return {
       ...config,
-      ctes: [...(config.ctes || []), `${alias} AS (${cte})`]
+      ctes: [...(config.ctes || []), { kind: 'cte' as const, expression: `${alias} AS (${cte})` }]
     };
   }
 
-  addScalar(alias: string, expression: PredicateExpression) {
+  addScalar(alias: string, expression: PredicateExpression): QueryConfig<State['output'], Schema> {
     const config = this.builder.getConfig();
     const scalarExpression = substituteParameters(expression.sql, expression.parameters);
     return {
       ...config,
-      ctes: [...(config.ctes || []), `${scalarExpression} AS ${alias}`]
+      ctes: [...(config.ctes || []), { kind: 'cte' as const, expression: `${scalarExpression} AS ${alias}` }]
     };
   }
 
@@ -34,11 +35,12 @@ export class AnalyticsFeature<
     interval: string,
     method: 'toStartOfInterval' | 'toStartOfMinute' | 'toStartOfHour' | 'toStartOfDay' | 'toStartOfWeek' | 'toStartOfMonth' | 'toStartOfQuarter' | 'toStartOfYear',
     dialect: SqlDialect,
-  ) {
+  ): QueryConfig<State['output'], Schema> {
     const config = this.builder.getConfig();
-    const groupBy = config.groupBy || [];
-
-    groupBy.push(dialect.formatTimeInterval(column, interval, method));
+    const groupBy = [
+      ...(config.groupBy || []),
+      { kind: 'group-by-item' as const, expression: dialect.formatTimeInterval(column, interval, method) }
+    ];
 
     return {
       ...config,
@@ -46,7 +48,7 @@ export class AnalyticsFeature<
     };
   }
 
-  addSettings(opts: ClickHouseSettings) {
+  addSettings(opts: ClickHouseSettings): QueryConfig<State['output'], Schema> {
     const config = this.builder.getConfig();
     return {
       ...config,

--- a/packages/clickhouse/src/core/features/cross-filtering.ts
+++ b/packages/clickhouse/src/core/features/cross-filtering.ts
@@ -1,15 +1,17 @@
 
 import type { BuilderState, SchemaDefinition } from '../types/builder-state.js';
 import { QueryBuilder } from '../query-builder.js';
-import { CrossFilter, FilterGroup } from '../cross-filter.js';
-import { FilterConditionInput } from '../../types/index.js';
+import { CrossFilter, type FilterGroup } from '../cross-filter.js';
+import type { FilterConditionInput } from '../../types/index.js';
 
-function isFilterCondition(obj: any): obj is FilterConditionInput<any, any, any> {
-  return obj && 'column' in obj && 'operator' in obj && 'value' in obj;
-}
+type CrossFilterNode<Schema extends SchemaDefinition<Schema>> =
+  | FilterConditionInput<any, Schema, any>
+  | FilterGroup<Schema, any>;
 
-function isFilterGroup(obj: any): obj is FilterGroup<any, any> {
-  return obj && 'conditions' in obj && 'operator' in obj;
+function isFilterCondition<Schema extends SchemaDefinition<Schema>>(
+  node: CrossFilterNode<Schema>
+): node is FilterConditionInput<any, Schema, any> {
+  return 'column' in node;
 }
 
 export class CrossFilteringFeature<
@@ -19,95 +21,52 @@ export class CrossFilteringFeature<
   constructor(private builder: QueryBuilder<Schema, State>) { }
 
   applyCrossFilters(crossFilter: CrossFilter<Schema, Extract<keyof Schema, string>>) {
-    const filterGroup = crossFilter.getConditions();
+    const root = crossFilter.getConditions();
 
-    if (filterGroup.conditions.length === 0) {
-      return this.builder.getConfig();
+    if (root.conditions.length === 0) {
+      return this.builder;
     }
 
-    if (filterGroup.operator === 'AND') {
-      this.applyAndConditions(filterGroup.conditions);
-    } else {
-      this.builder.whereGroup(builder => {
-        this.applyOrConditions(filterGroup.conditions, builder);
-      });
-    }
-
-    return this.builder.getConfig();
+    return root.operator === 'AND'
+      ? this.applyAndConditions(this.builder, root.conditions)
+      : this.builder.whereGroup(groupBuilder => this.applyOrConditions(groupBuilder, root.conditions));
   }
 
-  private applyAndConditions(conditions: Array<FilterConditionInput<any, Schema, any> | FilterGroup<Schema, any>>): void {
-    conditions.forEach(condition => {
+  private applyAndConditions(
+    builder: QueryBuilder<Schema, State>,
+    conditions: CrossFilterNode<Schema>[]
+  ): QueryBuilder<Schema, State> {
+    return conditions.reduce((currentBuilder, condition) => {
       if (isFilterCondition(condition)) {
-        this.builder.where(
-          condition.column,
-          condition.operator,
-          condition.value
-        );
-      } else if (isFilterGroup(condition)) {
-        if (condition.operator === 'AND') {
-          this.builder.whereGroup(builder => {
-            const feature = new CrossFilteringFeature(builder);
-            feature.applyAndConditions(condition.conditions);
-          });
-        } else {
-          this.builder.whereGroup(builder => {
-            const feature = new CrossFilteringFeature(builder);
-            feature.applyOrConditions(condition.conditions, builder);
-          });
-        }
+        return currentBuilder.where(condition.column, condition.operator, condition.value);
       }
-    });
+
+      return condition.operator === 'AND'
+        ? currentBuilder.whereGroup(groupBuilder => this.applyAndConditions(groupBuilder, condition.conditions))
+        : currentBuilder.whereGroup(groupBuilder => this.applyOrConditions(groupBuilder, condition.conditions));
+    }, builder);
   }
 
   private applyOrConditions(
-    conditions: Array<FilterConditionInput<any, Schema, any> | FilterGroup<Schema, any>>,
-    builder: QueryBuilder<Schema, State> = this.builder
-  ): void {
-    if (conditions.length === 0) return;
-
-    const firstCondition = conditions[0];
-    if (isFilterCondition(firstCondition)) {
-      builder.where(
-        firstCondition.column,
-        firstCondition.operator,
-        firstCondition.value
-      );
-    } else if (isFilterGroup(firstCondition)) {
-      if (firstCondition.operator === 'AND') {
-        builder.whereGroup(innerBuilder => {
-          const feature = new CrossFilteringFeature(innerBuilder);
-          feature.applyAndConditions(firstCondition.conditions);
-        });
-      } else {
-        builder.whereGroup(innerBuilder => {
-          const feature = new CrossFilteringFeature(innerBuilder);
-          feature.applyOrConditions(firstCondition.conditions, innerBuilder);
-        });
-      }
-    }
-
-    for (let i = 1; i < conditions.length; i++) {
-      const condition = conditions[i];
+    builder: QueryBuilder<Schema, State>,
+    conditions: CrossFilterNode<Schema>[]
+  ): QueryBuilder<Schema, State> {
+    return conditions.reduce((currentBuilder, condition, index) => {
       if (isFilterCondition(condition)) {
-        builder.orWhere(
-          condition.column,
-          condition.operator,
-          condition.value
-        );
-      } else if (isFilterGroup(condition)) {
-        if (condition.operator === 'AND') {
-          builder.orWhereGroup(innerBuilder => {
-            const feature = new CrossFilteringFeature(innerBuilder);
-            feature.applyAndConditions(condition.conditions);
-          });
-        } else {
-          builder.orWhereGroup(innerBuilder => {
-            const feature = new CrossFilteringFeature(innerBuilder);
-            feature.applyOrConditions(condition.conditions, innerBuilder);
-          });
-        }
+        return index === 0
+          ? currentBuilder.where(condition.column, condition.operator, condition.value)
+          : currentBuilder.orWhere(condition.column, condition.operator, condition.value);
       }
-    }
+
+      if (condition.operator === 'AND') {
+        return index === 0
+          ? currentBuilder.whereGroup(groupBuilder => this.applyAndConditions(groupBuilder, condition.conditions))
+          : currentBuilder.orWhereGroup(groupBuilder => this.applyAndConditions(groupBuilder, condition.conditions));
+      }
+
+      return index === 0
+        ? currentBuilder.whereGroup(groupBuilder => this.applyOrConditions(groupBuilder, condition.conditions))
+        : currentBuilder.orWhereGroup(groupBuilder => this.applyOrConditions(groupBuilder, condition.conditions));
+    }, builder);
   }
 }

--- a/packages/clickhouse/src/core/features/executor.ts
+++ b/packages/clickhouse/src/core/features/executor.ts
@@ -15,10 +15,8 @@ export class ExecutorFeature<
   constructor(private builder: QueryBuilder<Schema, State>) { }
 
   toSQLWithParams(): { sql: string, parameters: any[] } {
-    const sql = this.toSQLWithoutParameters();
-    const config = this.builder.getConfig();
-    const parameters = config.parameters || [];
-    return { sql, parameters };
+    const compiled = this.compileQuery();
+    return { sql: compiled.query, parameters: [...compiled.parameters] };
   }
 
   toSQL(): string {
@@ -129,9 +127,9 @@ export class ExecutorFeature<
     }
   }
 
-  private toSQLWithoutParameters(): string {
-    const config = this.builder.getConfig();
-    return this.builder.getDialect().compileQuery(config, {
+  private compileQuery() {
+    const queryNode = this.builder.toQueryNode();
+    return this.builder.getDialect().compileQuery(queryNode, {
       tableName: this.builder.getTableName(),
     });
   }

--- a/packages/clickhouse/src/core/features/executor.ts
+++ b/packages/clickhouse/src/core/features/executor.ts
@@ -27,8 +27,8 @@ export class ExecutorFeature<
 
   async execute(options?: ExecutorRunOptions): Promise<State['output'][]> {
     const adapter = this.builder.getAdapter();
+    const queryNode = this.builder.toQueryNode();
     const { sql, parameters } = this.toSQLWithParams();
-    const config = this.builder.getConfig();
     const renderSql = adapter.render ? adapter.render(sql, parameters) : substituteParameters(sql, parameters);
 
     const startTime = Date.now();
@@ -43,7 +43,7 @@ export class ExecutorFeature<
 
     try {
       const rows = await adapter.query<State['output']>(sql, parameters, {
-        clickhouseSettings: config.settings,
+        clickhouseSettings: queryNode.settings,
         queryId: options?.queryId,
       });
       const endTime = Date.now();
@@ -81,8 +81,8 @@ export class ExecutorFeature<
 
   async stream(): Promise<ReadableStream<State['output'][]>> {
     const adapter = this.builder.getAdapter();
+    const queryNode = this.builder.toQueryNode();
     const { sql, parameters } = this.toSQLWithParams();
-    const config = this.builder.getConfig();
     const renderSql = adapter.render ? adapter.render(sql, parameters) : substituteParameters(sql, parameters);
 
     const startTime = Date.now();
@@ -98,7 +98,7 @@ export class ExecutorFeature<
         throw new Error(`Streaming is not supported by adapter "${adapter.name}".`);
       }
       const webStream = await adapter.stream<State['output']>(sql, parameters, {
-        clickhouseSettings: config.settings,
+        clickhouseSettings: queryNode.settings,
       });
 
       const endTime = Date.now();

--- a/packages/clickhouse/src/core/features/filtering.ts
+++ b/packages/clickhouse/src/core/features/filtering.ts
@@ -1,7 +1,32 @@
 import type { BuilderState, SchemaDefinition } from '../types/builder-state.js';
 import { QueryBuilder } from '../query-builder.js';
-import { FilterOperator } from '../../types/index.js';
+import { FilterOperator, type ExprNode, type ValueNode } from '../../types/index.js';
 import { PredicateExpression } from '../utils/predicate-builder.js';
+
+function appendExpression(
+  existing: ExprNode | undefined,
+  next: ExprNode,
+  conjunction: 'AND' | 'OR'
+): ExprNode {
+  if (!existing) {
+    return next;
+  }
+
+  if (existing.kind === 'sequence') {
+    return {
+      ...existing,
+      items: [...existing.items, { conjunction, expression: next }],
+    };
+  }
+
+  return {
+    kind: 'sequence',
+    items: [
+      { expression: existing },
+      { conjunction, expression: next },
+    ],
+  };
+}
 
 export class FilteringFeature<
   Schema extends SchemaDefinition<Schema>,
@@ -9,41 +34,51 @@ export class FilteringFeature<
 > {
   constructor(private builder: QueryBuilder<Schema, State>) { }
 
+  private wrapValue(operator: FilterOperator, value: any) {
+    if (operator === 'inSubquery' || operator === 'globalInSubquery' || operator === 'inTable' || operator === 'globalInTable') {
+      return value;
+    }
+
+    if (operator === 'between') {
+      return [
+        { kind: 'value' as const, value: value[0] },
+        { kind: 'value' as const, value: value[1] },
+      ] as [ValueNode, ValueNode];
+    }
+
+    if (operator === 'inTuple' || operator === 'globalInTuple') {
+      return value.map((tuple: any[]) => tuple.map(tupleValue => ({ kind: 'value' as const, value: tupleValue })));
+    }
+
+    if (operator === 'in' || operator === 'notIn' || operator === 'globalIn' || operator === 'globalNotIn') {
+      return value.map((item: any) => ({ kind: 'value' as const, value: item }));
+    }
+
+    return { kind: 'value' as const, value };
+  }
+
   addCondition(
+    clause: 'where' | 'prewhere',
     conjunction: 'AND' | 'OR',
     column: string | string[],
     operator: FilterOperator,
     value: any
   ) {
     const config = this.builder.getConfig();
-    const where = config.where || [];
-    const parameters = config.parameters || [];
 
     const columnString = Array.isArray(column)
       ? `(${column.map(String).join(', ')})`
       : String(column);
 
-    where.push({
-      column: columnString,
-      operator,
-      value,
-      conjunction,
-      type: 'condition'
-    });
-
     if (operator === 'in' || operator === 'notIn' || operator === 'globalIn' || operator === 'globalNotIn') {
       if (!Array.isArray(value)) {
         throw new Error(`Expected an array for ${operator} operator, but got ${typeof value}`);
       }
-      parameters.push(...value);
     }
     else if (operator === 'inTuple' || operator === 'globalInTuple') {
       if (!Array.isArray(value)) {
         throw new Error(`Expected an array of tuples for ${operator} operator, but got ${typeof value}`);
       }
-      value.forEach((tuple: any[]) => {
-        parameters.push(...tuple);
-      });
     }
     else if (operator === 'inSubquery' || operator === 'globalInSubquery') {
       if (typeof value !== 'string') {
@@ -55,95 +90,57 @@ export class FilteringFeature<
         throw new Error(`Expected a string (table name) for ${operator} operator, but got ${typeof value}`);
       }
     }
-    else if (operator === 'between') {
-      parameters.push(value[0], value[1]);
-    }
-    else {
-      parameters.push(value);
-    }
+
+    const nextExpr: ExprNode = {
+      kind: 'condition',
+      column: columnString,
+      operator,
+      value: this.wrapValue(operator, value),
+    };
 
     return {
       ...config,
-      where,
-      parameters
+      [clause]: appendExpression(config[clause], nextExpr, conjunction)
     };
   }
 
   addExpressionCondition(
+    clause: 'where' | 'prewhere',
     conjunction: 'AND' | 'OR',
     expression: PredicateExpression
   ) {
     const config = this.builder.getConfig();
-    const where = config.where || [];
-    const parameters = config.parameters || [];
 
-    where.push({
-      type: 'expression',
+    const nextExpr: ExprNode = {
+      kind: 'raw',
       expression: expression.sql,
-      parameters: expression.parameters,
-      conjunction
-    });
-
-    parameters.push(...expression.parameters);
+      parameters: expression.parameters.map(value => ({ kind: 'value' as const, value })),
+    };
 
     return {
       ...config,
-      where,
-      parameters
+      [clause]: appendExpression(config[clause], nextExpr, conjunction)
     };
   }
 
-  startWhereGroup() {
+  addGroup(
+    clause: 'where' | 'prewhere',
+    conjunction: 'AND' | 'OR',
+    expression: ExprNode | undefined
+  ) {
     const config = this.builder.getConfig();
-    const where = config.where || [];
+    if (!expression) {
+      return config;
+    }
 
-    where.push({
-      column: '',
-      operator: 'eq',
-      value: null,
-      conjunction: 'AND',
-      type: 'group-start'
-    });
-
-    return {
-      ...config,
-      where
+    const grouped: ExprNode = {
+      kind: 'group',
+      expression,
     };
-  }
-
-  startOrWhereGroup() {
-    const config = this.builder.getConfig();
-    const where = config.where || [];
-
-    where.push({
-      column: '',
-      operator: 'eq',
-      value: null,
-      conjunction: 'OR',
-      type: 'group-start'
-    });
 
     return {
       ...config,
-      where
-    };
-  }
-
-  endWhereGroup() {
-    const config = this.builder.getConfig();
-    const where = config.where || [];
-
-    where.push({
-      column: '',
-      operator: 'eq',
-      value: null,
-      conjunction: 'AND',
-      type: 'group-end'
-    });
-
-    return {
-      ...config,
-      where
+      [clause]: appendExpression(config[clause], grouped, conjunction)
     };
   }
 }

--- a/packages/clickhouse/src/core/features/filtering.ts
+++ b/packages/clickhouse/src/core/features/filtering.ts
@@ -1,6 +1,6 @@
 import type { BuilderState, SchemaDefinition } from '../types/builder-state.js';
 import { QueryBuilder } from '../query-builder.js';
-import { FilterOperator, type ExprNode, type ValueNode } from '../../types/index.js';
+import { FilterOperator, type ExprNode, type SelectQueryNode, type ValueNode } from '../../types/index.js';
 import { PredicateExpression } from '../utils/predicate-builder.js';
 
 function appendExpression(
@@ -63,8 +63,8 @@ export class FilteringFeature<
     column: string | string[],
     operator: FilterOperator,
     value: any
-  ) {
-    const config = this.builder.getConfig();
+  ): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
 
     const columnString = Array.isArray(column)
       ? `(${column.map(String).join(', ')})`
@@ -99,8 +99,8 @@ export class FilteringFeature<
     };
 
     return {
-      ...config,
-      [clause]: appendExpression(config[clause], nextExpr, conjunction)
+      ...query,
+      [clause]: appendExpression(query[clause], nextExpr, conjunction)
     };
   }
 
@@ -108,8 +108,8 @@ export class FilteringFeature<
     clause: 'where' | 'prewhere',
     conjunction: 'AND' | 'OR',
     expression: PredicateExpression
-  ) {
-    const config = this.builder.getConfig();
+  ): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
 
     const nextExpr: ExprNode = {
       kind: 'raw',
@@ -118,8 +118,8 @@ export class FilteringFeature<
     };
 
     return {
-      ...config,
-      [clause]: appendExpression(config[clause], nextExpr, conjunction)
+      ...query,
+      [clause]: appendExpression(query[clause], nextExpr, conjunction)
     };
   }
 
@@ -127,10 +127,10 @@ export class FilteringFeature<
     clause: 'where' | 'prewhere',
     conjunction: 'AND' | 'OR',
     expression: ExprNode | undefined
-  ) {
-    const config = this.builder.getConfig();
+  ): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
     if (!expression) {
-      return config;
+      return query;
     }
 
     const grouped: ExprNode = {
@@ -139,8 +139,8 @@ export class FilteringFeature<
     };
 
     return {
-      ...config,
-      [clause]: appendExpression(config[clause], grouped, conjunction)
+      ...query,
+      [clause]: appendExpression(query[clause], grouped, conjunction)
     };
   }
 }

--- a/packages/clickhouse/src/core/features/joins.ts
+++ b/packages/clickhouse/src/core/features/joins.ts
@@ -1,6 +1,6 @@
 import type { BuilderState, SchemaDefinition } from '../types/builder-state.js';
 import { QueryBuilder } from '../query-builder.js';
-import { JoinType } from '../../types/index.js';
+import { JoinType, type QueryConfig } from '../../types/index.js';
 
 export class JoinFeature<
   Schema extends SchemaDefinition<Schema>,
@@ -14,13 +14,23 @@ export class JoinFeature<
     leftColumn: string,
     rightColumn: `${TableName & string}.${keyof Schema[TableName] & string}`,
     alias?: string
-  ) {
+  ): QueryConfig<State['output'], Schema> {
     const config = this.builder.getConfig();
+    const renderedRightColumn = alias
+      ? rightColumn.replace(`${String(table)}.`, `${alias}.`) as typeof rightColumn
+      : rightColumn;
     const newConfig = {
       ...config,
       joins: [
         ...(config.joins || []),
-        { type, table: String(table), leftColumn: String(leftColumn), rightColumn, alias }
+        {
+          kind: 'join' as const,
+          type,
+          table: String(table),
+          leftColumn: String(leftColumn),
+          rightColumn: renderedRightColumn,
+          alias,
+        }
       ]
     };
     return newConfig;

--- a/packages/clickhouse/src/core/features/joins.ts
+++ b/packages/clickhouse/src/core/features/joins.ts
@@ -1,6 +1,6 @@
 import type { BuilderState, SchemaDefinition } from '../types/builder-state.js';
 import { QueryBuilder } from '../query-builder.js';
-import { JoinType, type QueryConfig } from '../../types/index.js';
+import { JoinType, type SelectQueryNode } from '../../types/index.js';
 
 export class JoinFeature<
   Schema extends SchemaDefinition<Schema>,
@@ -14,15 +14,15 @@ export class JoinFeature<
     leftColumn: string,
     rightColumn: `${TableName & string}.${keyof Schema[TableName] & string}`,
     alias?: string
-  ): QueryConfig<State['output'], Schema> {
-    const config = this.builder.getConfig();
+  ): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
     const renderedRightColumn = alias
       ? rightColumn.replace(`${String(table)}.`, `${alias}.`) as typeof rightColumn
       : rightColumn;
     const newConfig = {
-      ...config,
+      ...query,
       joins: [
-        ...(config.joins || []),
+        ...(query.joins || []),
         {
           kind: 'join' as const,
           type,

--- a/packages/clickhouse/src/core/features/query-modifiers.ts
+++ b/packages/clickhouse/src/core/features/query-modifiers.ts
@@ -12,7 +12,8 @@ export class QueryModifiersFeature<
     const config = this.builder.getConfig();
     return {
       ...config,
-      groupBy: Array.isArray(columns) ? columns.map(String) : [String(columns)]
+      groupBy: (Array.isArray(columns) ? columns.map(String) : [String(columns)])
+        .map(expression => ({ kind: 'group-by-item' as const, expression }))
     };
   }
 
@@ -36,19 +37,24 @@ export class QueryModifiersFeature<
     const config = this.builder.getConfig();
     return {
       ...config,
-      orderBy: [...(config.orderBy || []), { column, direction }]
+      orderBy: [...(config.orderBy || []), { kind: 'order-by-item' as const, column, direction }]
     };
   }
 
   addHaving(condition: string, parameters?: any[]) {
     const config = this.builder.getConfig();
-    const having = [...(config.having || []), condition];
-    const newParams = parameters ? [...(config.parameters || []), ...parameters] : config.parameters;
+    const having = [
+      ...(config.having || []),
+      {
+        kind: 'having' as const,
+        expression: condition,
+        parameters: parameters?.map(value => ({ kind: 'value' as const, value })),
+      }
+    ];
 
     return {
       ...config,
-      having,
-      parameters: newParams
+      having
     };
   }
 

--- a/packages/clickhouse/src/core/features/query-modifiers.ts
+++ b/packages/clickhouse/src/core/features/query-modifiers.ts
@@ -1,6 +1,6 @@
 import type { BuilderState, SchemaDefinition } from '../types/builder-state.js';
 import { QueryBuilder } from '../query-builder.js';
-import { OrderDirection } from '../../types/index.js';
+import { OrderDirection, type SelectQueryNode } from '../../types/index.js';
 
 export class QueryModifiersFeature<
   Schema extends SchemaDefinition<Schema>,
@@ -8,43 +8,43 @@ export class QueryModifiersFeature<
 > {
   constructor(private builder: QueryBuilder<Schema, State>) { }
 
-  addGroupBy(columns: string | string[]) {
-    const config = this.builder.getConfig();
+  addGroupBy(columns: string | string[]): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
     return {
-      ...config,
+      ...query,
       groupBy: (Array.isArray(columns) ? columns.map(String) : [String(columns)])
         .map(expression => ({ kind: 'group-by-item' as const, expression }))
     };
   }
 
-  addLimit(count: number) {
-    const config = this.builder.getConfig();
+  addLimit(count: number): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
     return {
-      ...config,
+      ...query,
       limit: count
     };
   }
 
-  addOffset(count: number) {
-    const config = this.builder.getConfig();
+  addOffset(count: number): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
     return {
-      ...config,
+      ...query,
       offset: count
     };
   }
 
-  addOrderBy(column: string, direction: OrderDirection = 'ASC') {
-    const config = this.builder.getConfig();
+  addOrderBy(column: string, direction: OrderDirection = 'ASC'): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
     return {
-      ...config,
-      orderBy: [...(config.orderBy || []), { kind: 'order-by-item' as const, column, direction }]
+      ...query,
+      orderBy: [...(query.orderBy || []), { kind: 'order-by-item' as const, column, direction }]
     };
   }
 
-  addHaving(condition: string, parameters?: any[]) {
-    const config = this.builder.getConfig();
+  addHaving(condition: string, parameters?: any[]): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
     const having = [
-      ...(config.having || []),
+      ...(query.having || []),
       {
         kind: 'having' as const,
         expression: condition,
@@ -53,15 +53,15 @@ export class QueryModifiersFeature<
     ];
 
     return {
-      ...config,
+      ...query,
       having
     };
   }
 
-  setDistinct() {
-    const config = this.builder.getConfig();
+  setDistinct(): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
     return {
-      ...config,
+      ...query,
       distinct: true
     };
   }

--- a/packages/clickhouse/src/core/formatters/sql-formatter.ts
+++ b/packages/clickhouse/src/core/formatters/sql-formatter.ts
@@ -1,24 +1,24 @@
-import { QueryConfig, FilterOperator, type CompiledQuery, type ExprNode, type SourceNode, type ValueNode } from '../../types/index.js';
+import { FilterOperator, type CompiledQuery, type ExprNode, type SelectQueryNode, type SourceNode, type ValueNode } from '../../types/index.js';
 
 export class SQLFormatter {
-  formatSelect(config: QueryConfig<any, any>): string {
-    const distinctClause = config.distinct ? 'DISTINCT ' : '';
-    if (!config.select?.length) return distinctClause + '*';
-    return distinctClause + config.select.map(item => item.selection).join(', ');
+  formatSelect(query: SelectQueryNode<any, any>): string {
+    const distinctClause = query.distinct ? 'DISTINCT ' : '';
+    if (!query.select?.length) return distinctClause + '*';
+    return distinctClause + query.select.map(item => item.selection).join(', ');
   }
 
-  formatGroupBy(config: QueryConfig<any, any>): string {
-    const groupBy = config.groupBy;
+  formatGroupBy(query: SelectQueryNode<any, any>): string {
+    const groupBy = query.groupBy;
     if (!groupBy?.length) return '';
     return groupBy.map(item => item.expression).join(', ');
   }
 
-  formatPrewhere(config: QueryConfig<any, any>): string {
-    return this.compileExpr(config.prewhere).query;
+  formatPrewhere(query: SelectQueryNode<any, any>): string {
+    return this.compileExpr(query.prewhere).query;
   }
 
-  formatWhere(config: QueryConfig<any, any>): string {
-    return this.compileExpr(config.where).query;
+  formatWhere(query: SelectQueryNode<any, any>): string {
+    return this.compileExpr(query.where).query;
   }
 
   formatFrom(source?: SourceNode): string {
@@ -169,11 +169,11 @@ export class SQLFormatter {
     };
   }
 
-  compileHaving(config: QueryConfig<any, any>): CompiledQuery {
-    if (!config.having?.length) return { query: '', parameters: [] };
+  compileHaving(query: SelectQueryNode<any, any>): CompiledQuery {
+    if (!query.having?.length) return { query: '', parameters: [] };
 
     return this.combineCompiledWithSeparator(
-      config.having.map(item => ({
+      query.having.map(item => ({
         query: item.expression,
         parameters: item.parameters?.map(parameter => parameter.value) || [],
       })),
@@ -195,10 +195,10 @@ export class SQLFormatter {
     }
   }
 
-  formatJoins(config: QueryConfig<any, any>): string {
-    if (!config.joins?.length) return '';
+  formatJoins(query: SelectQueryNode<any, any>): string {
+    if (!query.joins?.length) return '';
 
-    return config.joins.map(join => {
+    return query.joins.map(join => {
       const tableClause = join.alias
         ? `${join.table} AS ${join.alias}`
         : join.table;
@@ -206,14 +206,14 @@ export class SQLFormatter {
     }).join(' ');
   }
 
-  formatCtes(config: QueryConfig<any, any>): string {
-    if (!config.ctes?.length) return '';
-    return config.ctes.map(item => item.expression).join(', ');
+  formatCtes(query: SelectQueryNode<any, any>): string {
+    if (!query.ctes?.length) return '';
+    return query.ctes.map(item => item.expression).join(', ');
   }
 
-  formatOrderBy(config: QueryConfig<any, any>): string {
-    if (!config.orderBy?.length) return '';
-    return config.orderBy
+  formatOrderBy(query: SelectQueryNode<any, any>): string {
+    if (!query.orderBy?.length) return '';
+    return query.orderBy
       .map(({ column, direction }) => `${String(column)} ${direction}`.trim())
       .join(', ');
   }

--- a/packages/clickhouse/src/core/formatters/sql-formatter.ts
+++ b/packages/clickhouse/src/core/formatters/sql-formatter.ts
@@ -1,119 +1,184 @@
-import { QueryConfig, FilterOperator } from '../../types/index.js';
+import { QueryConfig, FilterOperator, type CompiledQuery, type ExprNode, type SourceNode, type ValueNode } from '../../types/index.js';
 
 export class SQLFormatter {
   formatSelect(config: QueryConfig<any, any>): string {
     const distinctClause = config.distinct ? 'DISTINCT ' : '';
     if (!config.select?.length) return distinctClause + '*';
-    return distinctClause + config.select.join(', ');
+    return distinctClause + config.select.map(item => item.selection).join(', ');
   }
 
   formatGroupBy(config: QueryConfig<any, any>): string {
     const groupBy = config.groupBy;
     if (!groupBy?.length) return '';
-    if (Array.isArray(groupBy)) {
-      return groupBy.join(', ');
-    }
-    return String(groupBy);
+    return groupBy.map(item => item.expression).join(', ');
+  }
+
+  formatPrewhere(config: QueryConfig<any, any>): string {
+    return this.compileExpr(config.prewhere).query;
   }
 
   formatWhere(config: QueryConfig<any, any>): string {
-    if (!config.where?.length) return '';
+    return this.compileExpr(config.where).query;
+  }
 
-    let afterGroupStart = false; // Track whether we're immediately after a group-start
+  formatFrom(source?: SourceNode): string {
+    if (!source) return '';
+    switch (source.kind) {
+      case 'table':
+        return `${source.name}${source.final ? ' FINAL' : ''}`;
+      default:
+        throw new Error(`Unsupported source kind: ${String((source as { kind?: string }).kind)}`);
+    }
+  }
 
-    // First pass - generate the SQL fragments for each condition
-    const fragments = config.where.map((condition, index) => {
-      // Handle expression predicates
-      if (condition.type === 'expression') {
-        const prefix = index === 0 || afterGroupStart ? '' : ` ${condition.conjunction} `;
-        afterGroupStart = false;
-        return `${prefix}${condition.expression}`.trim();
-      }
+  compileExpr(expr?: ExprNode, nested = false): CompiledQuery {
+    if (!expr) return { query: '', parameters: [] };
 
-      // Handle special group markers
-      if (condition.type === 'group-start') {
-        const prefix = index === 0 ? '' : ` ${condition.conjunction} `;
-        afterGroupStart = true; // Mark that the next condition follows a group-start
-        return `${prefix}(`.trim();
-      }
-
-      if (condition.type === 'group-end') {
-        afterGroupStart = false; // Reset the flag after group-end
-        return ')';
-      }
-
-      // Normal conditions
-      const { column, operator, value, conjunction } = condition;
-
-      // Don't add conjunction if it's the first condition or right after a group-start
-      const prefix = index === 0 || afterGroupStart ? '' : ` ${conjunction} `;
-
-      // Reset the afterGroupStart flag
-      afterGroupStart = false;
-
-      // Handle IN operators
-      if (operator === 'in' || operator === 'notIn') {
-        if (!Array.isArray(value)) {
-          throw new Error(`Expected an array for ${operator} operator, but got ${typeof value}`);
+    switch (expr.kind) {
+      case 'raw':
+        return {
+          query: expr.expression,
+          parameters: expr.parameters.map(parameter => parameter.value),
+        };
+      case 'group':
+        if (!expr.expression) {
+          return { query: '', parameters: [] };
         }
-        if (value.length === 0) {
-          return `${prefix}1 = 0`;
+        const compiledGroup = this.compileExpr(expr.expression);
+        if (!compiledGroup.query) {
+          return { query: '', parameters: [] };
         }
-        const placeholders = value.map(() => '?').join(', ');
-        return `${prefix}${column} ${operator === 'in' ? 'IN' : 'NOT IN'} (${placeholders})`.trim();
+        return {
+          query: `(${compiledGroup.query})`,
+          parameters: compiledGroup.parameters,
+        };
+      case 'sequence':
+        return this.combineCompiled(
+          expr.items
+            .map((item, index) => {
+              const rendered = this.compileExpr(item.expression, true);
+              return {
+                query: index === 0 ? rendered.query : ` ${item.conjunction} ${rendered.query}`,
+                parameters: rendered.parameters,
+              };
+            })
+            .filter(part => part.query.length > 0)
+        );
+      case 'logical': {
+        const rendered = expr.conditions
+          .map(condition => this.compileExpr(condition, true))
+          .filter(part => part.query.length > 0);
+        if (rendered.length === 0) return { query: '', parameters: [] };
+        const combined = this.combineCompiledWithSeparator(rendered, ` ${expr.operator} `);
+        return {
+          query: nested ? `(${combined.query})` : combined.query,
+          parameters: combined.parameters,
+        };
       }
-      // Handle GLOBAL IN operators
-      else if (operator === 'globalIn' || operator === 'globalNotIn') {
-        if (!Array.isArray(value)) {
-          throw new Error(`Expected an array for ${operator} operator, but got ${typeof value}`);
-        }
-        if (value.length === 0) {
-          return `${prefix}1 = 0`;
-        }
-        const placeholders = value.map(() => '?').join(', ');
-        return `${prefix}${column} ${operator === 'globalIn' ? 'GLOBAL IN' : 'GLOBAL NOT IN'} (${placeholders})`.trim();
-      }
-      // Handle subquery IN operators
-      else if (operator === 'inSubquery' || operator === 'globalInSubquery') {
-        if (typeof value !== 'string') {
-          throw new Error(`Expected a string (subquery) for ${operator} operator, but got ${typeof value}`);
-        }
-        return `${prefix}${column} ${operator === 'inSubquery' ? 'IN' : 'GLOBAL IN'} (${value})`.trim();
-      }
-      // Handle table reference IN operators
-      else if (operator === 'inTable' || operator === 'globalInTable') {
-        if (typeof value !== 'string') {
-          throw new Error(`Expected a string (table name) for ${operator} operator, but got ${typeof value}`);
-        }
-        return `${prefix}${column} ${operator === 'inTable' ? 'IN' : 'GLOBAL IN'} ${value}`.trim();
-      }
-      // Handle tuple IN operators
-      else if (operator === 'inTuple' || operator === 'globalInTuple') {
-        if (!Array.isArray(value)) {
-          throw new Error(`Expected an array of tuples for ${operator} operator, but got ${typeof value}`);
-        }
-        if (value.length === 0) {
-          return `${prefix}1 = 0`;
-        }
-        const placeholders = value.map(() => '(?, ?)').join(', ');
-        return `${prefix}${column} ${operator === 'inTuple' ? 'IN' : 'GLOBAL IN'} (${placeholders})`.trim();
-      }
-      else if (operator === 'between') {
-        return `${prefix}${column} BETWEEN ? AND ?`.trim();
-      } else if (operator === 'like') {
-        return `${prefix}${column} LIKE ?`.trim();
-      } else {
-        return `${prefix}${column} ${this.getSqlOperator(operator)} ?`.trim();
-      }
-    });
+      case 'condition':
+        return this.compileCondition(expr);
+      default:
+        throw new Error(`Unsupported expression kind: ${String((expr as { kind?: string }).kind)}`);
+    }
+  }
 
-    // Join fragments and then remove extra spaces around parentheses
-    let result = fragments.join(' ');
+  private compileCondition({ column, operator, value }: Extract<ExprNode, { kind: 'condition' }>): CompiledQuery {
+    if (operator === 'isNull' || operator === 'isNotNull') {
+      return {
+        query: `${column} IS ${operator === 'isNull' ? '' : 'NOT '}NULL`.trim(),
+        parameters: [],
+      };
+    }
+    if (operator === 'in' || operator === 'notIn') {
+      if (!Array.isArray(value)) {
+        throw new Error(`Expected an array for ${operator} operator, but got ${typeof value}`);
+      }
+      if (value.length === 0) {
+        return { query: '1 = 0', parameters: [] };
+      }
+      return {
+        query: `${column} ${operator === 'in' ? 'IN' : 'NOT IN'} (${value.map(() => '?').join(', ')})`,
+        parameters: (value as ValueNode[]).map(item => item.value),
+      };
+    }
+    if (operator === 'globalIn' || operator === 'globalNotIn') {
+      if (!Array.isArray(value)) {
+        throw new Error(`Expected an array for ${operator} operator, but got ${typeof value}`);
+      }
+      if (value.length === 0) {
+        return { query: '1 = 0', parameters: [] };
+      }
+      return {
+        query: `${column} ${operator === 'globalIn' ? 'GLOBAL IN' : 'GLOBAL NOT IN'} (${value.map(() => '?').join(', ')})`,
+        parameters: (value as ValueNode[]).map(item => item.value),
+      };
+    }
+    if (operator === 'inSubquery' || operator === 'globalInSubquery') {
+      if (typeof value !== 'string') {
+        throw new Error(`Expected a string (subquery) for ${operator} operator, but got ${typeof value}`);
+      }
+      return {
+        query: `${column} ${operator === 'inSubquery' ? 'IN' : 'GLOBAL IN'} (${value})`,
+        parameters: [],
+      };
+    }
+    if (operator === 'inTable' || operator === 'globalInTable') {
+      if (typeof value !== 'string') {
+        throw new Error(`Expected a string (table name) for ${operator} operator, but got ${typeof value}`);
+      }
+      return {
+        query: `${column} ${operator === 'inTable' ? 'IN' : 'GLOBAL IN'} ${value}`,
+        parameters: [],
+      };
+    }
+    if (operator === 'inTuple' || operator === 'globalInTuple') {
+      if (!Array.isArray(value)) {
+        throw new Error(`Expected an array of tuples for ${operator} operator, but got ${typeof value}`);
+      }
+      if (value.length === 0) {
+        return { query: '1 = 0', parameters: [] };
+      }
+      const tupleWidth = (value[0] as ValueNode[]).length;
+      if (tupleWidth === 0) {
+        throw new Error(`Expected non-empty tuples for ${operator} operator`);
+      }
+      const tuplePlaceholder = `(${Array.from({ length: tupleWidth }, () => '?').join(', ')})`;
+      return {
+        query: `${column} ${operator === 'inTuple' ? 'IN' : 'GLOBAL IN'} (${value.map(() => tuplePlaceholder).join(', ')})`,
+        parameters: (value as ValueNode[][]).flatMap(tuple => tuple.map(item => item.value)),
+      };
+    }
+    if (operator === 'between') {
+      const range = value as [ValueNode, ValueNode];
+      return {
+        query: `${column} BETWEEN ? AND ?`,
+        parameters: [range[0].value, range[1].value],
+      };
+    }
+    if (operator === 'like') {
+      const parameter = value as ValueNode;
+      return {
+        query: `${column} LIKE ?`,
+        parameters: [parameter.value],
+      };
+    }
+    const parameter = value as ValueNode;
+    return {
+      query: `${column} ${this.getSqlOperator(operator)} ?`,
+      parameters: [parameter.value],
+    };
+  }
 
-    // Replace "( " with "(" and " )" with ")"
-    result = result.replace(/\(\s+/g, '(').replace(/\s+\)/g, ')');
+  compileHaving(config: QueryConfig<any, any>): CompiledQuery {
+    if (!config.having?.length) return { query: '', parameters: [] };
 
-    return result;
+    return this.combineCompiledWithSeparator(
+      config.having.map(item => ({
+        query: item.expression,
+        parameters: item.parameters?.map(parameter => parameter.value) || [],
+      })),
+      ' AND '
+    );
   }
 
   private getSqlOperator(operator: FilterOperator): string {
@@ -139,5 +204,31 @@ export class SQLFormatter {
         : join.table;
       return `${join.type} JOIN ${tableClause} ON ${join.leftColumn} = ${join.rightColumn}`;
     }).join(' ');
+  }
+
+  formatCtes(config: QueryConfig<any, any>): string {
+    if (!config.ctes?.length) return '';
+    return config.ctes.map(item => item.expression).join(', ');
+  }
+
+  formatOrderBy(config: QueryConfig<any, any>): string {
+    if (!config.orderBy?.length) return '';
+    return config.orderBy
+      .map(({ column, direction }) => `${String(column)} ${direction}`.trim())
+      .join(', ');
+  }
+
+  private combineCompiled(parts: CompiledQuery[]): CompiledQuery {
+    return {
+      query: parts.map(part => part.query).join(''),
+      parameters: parts.flatMap(part => part.parameters),
+    };
+  }
+
+  private combineCompiledWithSeparator(parts: CompiledQuery[], separator: string): CompiledQuery {
+    return {
+      query: parts.map(part => part.query).join(separator),
+      parameters: parts.flatMap(part => part.parameters),
+    };
   }
 } 

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -7,7 +7,6 @@ import {
   FilterOperator,
   OperatorValueMap,
   OrderDirection,
-  QueryConfig,
   JoinType,
   type SelectQueryNode,
 } from '../types/index.js';
@@ -41,6 +40,7 @@ import type { QueryRuntimeContext } from './cache/runtime-context.js';
 import { executeWithCache } from './cache/cache-manager.js';
 import { mergeCacheOptionsPartial, initializeCacheRuntime } from './cache/utils.js';
 import { normalizeFilterApplication } from './utils/filter-application.js';
+import { toLegacyQueryConfig } from './utils/query-config-compat.js';
 import { applyRelationPath, resolveRelationPath } from './utils/relation-application.js';
 import type {
   BuilderState,
@@ -79,10 +79,10 @@ type JoinPathTableName<
 > = Extract<Path['to'], keyof Schema>;
 type JoinPathAlias<Path extends JoinPath<any>, OverrideAlias extends string | undefined> =
   OverrideAlias extends string
-    ? OverrideAlias
-    : Path['alias'] extends string
-      ? Path['alias']
-      : undefined;
+  ? OverrideAlias
+  : Path['alias'] extends string
+  ? Path['alias']
+  : undefined;
 type ApplyJoinPathState<
   Schema extends SchemaDefinition<Schema>,
   State extends AnyBuilderState,
@@ -90,10 +90,10 @@ type ApplyJoinPathState<
   OverrideAlias extends string | undefined = undefined
 > = JoinPathAlias<Path, OverrideAlias> extends string
   ? AddAlias<
-      WidenTables<State, JoinPathTableName<Schema, Path>>,
-      JoinPathAlias<Path, OverrideAlias>,
-      JoinPathTableName<Schema, Path>
-    >
+    WidenTables<State, JoinPathTableName<Schema, Path>>,
+    JoinPathAlias<Path, OverrideAlias>,
+    JoinPathTableName<Schema, Path>
+  >
   : WidenTables<State, JoinPathTableName<Schema, Path>>;
 type ApplyJoinPathChainState<
   Schema extends SchemaDefinition<Schema>,
@@ -101,10 +101,10 @@ type ApplyJoinPathChainState<
   Paths extends readonly JoinPath<Schema>[]
 > = Paths extends readonly [infer First, ...infer Rest]
   ? First extends JoinPath<Schema>
-    ? Rest extends readonly JoinPath<Schema>[]
-      ? ApplyJoinPathChainState<Schema, ApplyJoinPathState<Schema, State, First>, Rest>
-      : ApplyJoinPathState<Schema, State, First>
-    : State
+  ? Rest extends readonly JoinPath<Schema>[]
+  ? ApplyJoinPathChainState<Schema, ApplyJoinPathState<Schema, State, First>, Rest>
+  : ApplyJoinPathState<Schema, State, First>
+  : State
   : State;
 const ADVANCED_IN_OPERATORS = new Set<FilterOperator>([
   'globalIn',
@@ -992,7 +992,7 @@ export class QueryBuilder<
    * transformed query tree used during compilation.
    */
   getConfig() {
-    return cloneSelectQueryNode(this.query);
+    return toLegacyQueryConfig(this.getQueryNode());
   }
 
   toQueryNode(): SelectQueryNode<State['output'], Schema> {
@@ -1041,10 +1041,10 @@ export class QueryBuilder<
       options,
       (currentQuery, joinPath, relationOptions) => {
         next.query = currentQuery;
-      const type = options?.type || joinPath.type || 'INNER';
-      const alias = relationOptions?.alias || joinPath.alias;
-      const table = String(joinPath.to) as Extract<keyof Schema, string>;
-      const rightColumn = `${table}.${joinPath.rightColumn}` as `${typeof table}.${keyof Schema[typeof table] & string}`;
+        const type = options?.type || joinPath.type || 'INNER';
+        const alias = relationOptions?.alias || joinPath.alias;
+        const table = String(joinPath.to) as Extract<keyof Schema, string>;
+        const rightColumn = `${table}.${joinPath.rightColumn}` as `${typeof table}.${keyof Schema[typeof table] & string}`;
         return next.joins.addJoin(type, table, String(joinPath.leftColumn), rightColumn, alias);
       },
       label

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -8,7 +8,8 @@ import {
   OperatorValueMap,
   OrderDirection,
   QueryConfig,
-  JoinType
+  JoinType,
+  type SelectQueryNode,
 } from '../types/index.js';
 import { AnySchema, ColumnType } from '../types/schema.js';
 import { AggregationFeature } from './features/aggregations.js';
@@ -26,6 +27,12 @@ import {
   createPredicateBuilder,
 } from './utils/predicate-builder.js';
 import { CrossFilteringFeature } from './features/cross-filtering.js';
+import {
+  cloneSelectQueryNode,
+  createSelectQueryNode,
+  type QueryNodeTransform,
+  transformSelectQueryNode,
+} from './query-node.js';
 import type { ClickHouseSettings, BaseClickHouseClientConfigOptions } from '@clickhouse/client-common';
 import type { ClickHouseClient as NodeClickHouseClient } from '@clickhouse/client';
 import type { ClickHouseClient as WebClickHouseClient } from '@clickhouse/client-web';
@@ -64,6 +71,16 @@ type ColumnOperatorValue<
 // Union type that accepts either client type
 type ClickHouseClient = NodeClickHouseClient | WebClickHouseClient;
 type ScalarAlias<Alias extends string> = Alias extends `${string} ${string}` ? never : Alias;
+const ADVANCED_IN_OPERATORS = new Set<FilterOperator>([
+  'globalIn',
+  'globalNotIn',
+  'inSubquery',
+  'globalInSubquery',
+  'inTable',
+  'globalInTable',
+  'inTuple',
+  'globalInTuple',
+]);
 
 export interface ExecuteOptions {
   queryId?: string;
@@ -101,7 +118,7 @@ export class QueryBuilder<
 > {
   private static relationships: JoinRelationships<any>;
 
-  private config: QueryConfig<State['output'], Schema> = {};
+  private query: SelectQueryNode<State['output'], Schema>;
   private tableName: string;
   private state: State;
   private aggregations: AggregationFeature<Schema, State>;
@@ -115,6 +132,7 @@ export class QueryBuilder<
   private adapter: DatabaseAdapter;
   private dialect: SqlDialect;
   private cacheOptions?: CacheOptions;
+  private queryTransforms: Array<QueryNodeTransform<State['output'], Schema>> = [];
 
   constructor(
     tableName: string,
@@ -124,6 +142,12 @@ export class QueryBuilder<
     dialect: SqlDialect
   ) {
     this.tableName = tableName;
+    this.query = createSelectQueryNode({
+      from: {
+        kind: 'table',
+        name: tableName,
+      },
+    });
     this.state = state;
     this.runtime = runtime;
     this.adapter = adapter;
@@ -149,27 +173,139 @@ export class QueryBuilder<
     state: NextState,
     config: QueryConfig<NextState['output'], Schema>
   ): QueryBuilder<Schema, NextState> {
+    return this.transition(state, config);
+  }
+
+  private transition<
+    NextState extends BuilderState<
+      Schema,
+      string,
+      any,
+      State['baseTable'],
+      Partial<Record<string, keyof Schema>>
+    >
+  >(
+    state: NextState,
+    query: QueryConfig<NextState['output'], Schema> | SelectQueryNode<NextState['output'], Schema>
+  ): QueryBuilder<Schema, NextState> {
     const builder = new QueryBuilder<Schema, NextState>(this.tableName, state, this.runtime, this.adapter, this.dialect);
-    builder.config = { ...config };
-    builder.cacheOptions = this.cacheOptions;
+    builder.query = createSelectQueryNode(query);
+    builder.cacheOptions = this.cacheOptions ? { ...this.cacheOptions } : undefined;
+    builder.queryTransforms = [...this.queryTransforms] as Array<QueryNodeTransform<NextState['output'], Schema>>;
     return builder;
+  }
+
+  private cloneMutable(): this {
+    return this.fork(this.state, this.query) as this;
+  }
+
+  private assignQuery(
+    builder: this,
+    query: QueryConfig<State['output'], Schema> | SelectQueryNode<State['output'], Schema>
+  ): this {
+    builder.query = createSelectQueryNode(query);
+    return builder;
+  }
+
+  private updateQuery(
+    updater: (
+      query: SelectQueryNode<State['output'], Schema>
+    ) => QueryConfig<State['output'], Schema> | SelectQueryNode<State['output'], Schema>
+  ): this {
+    return this.assignQuery(this.cloneMutable(), updater(this.query));
+  }
+
+  private withAliasesState<
+    NextState extends BuilderState<
+      Schema,
+      string,
+      any,
+      State['baseTable'],
+      Partial<Record<string, keyof Schema>>
+    >
+  >(aliases: NextState['aliases']): NextState {
+    return {
+      ...this.state,
+      aliases,
+    } as unknown as NextState;
+  }
+
+  private buildSelectState<NextOutput>(output: NextOutput): UpdateOutput<State, NextOutput> {
+    return {
+      ...this.state,
+      output,
+    } as UpdateOutput<State, NextOutput>;
+  }
+
+  private buildSelectQuery<NextOutput>(selections: string[]): QueryConfig<NextOutput, Schema> {
+    return {
+      ...this.query,
+      select: selections.map(selection => ({ kind: 'selection' as const, selection })),
+      orderBy: this.query.orderBy?.map(({ column, direction }) => ({
+        kind: 'order-by-item' as const,
+        column: String(column),
+        direction,
+      })),
+    };
+  }
+
+  private createDetachedBuilder(): this {
+    const builder = new QueryBuilder<Schema, State>(
+      this.tableName,
+      this.state,
+      this.runtime,
+      this.adapter,
+      this.dialect
+    ) as this;
+    builder.query = createSelectQueryNode();
+    builder.cacheOptions = this.cacheOptions ? { ...this.cacheOptions } : undefined;
+    builder.queryTransforms = [...this.queryTransforms];
+    return builder;
+  }
+
+  private runDraftCallback(seed: this, callback: (builder: this) => void): this {
+    let current: QueryBuilder<Schema, State> = seed;
+
+    // Group callbacks expect fluent chaining, so the draft keeps rebinding
+    // method calls to the latest immutable builder instance produced so far.
+    const draft = new Proxy(seed as object, {
+      get: (_target, prop, receiver) => {
+        const value = Reflect.get(current as object, prop, receiver);
+        if (typeof value !== 'function') {
+          return value;
+        }
+
+        return (...args: unknown[]) => {
+          const result = value.apply(current, args);
+          if (result instanceof QueryBuilder) {
+            current = result;
+            return draft;
+          }
+          return result;
+        };
+      },
+    });
+
+    callback(draft as this);
+    return current as this;
   }
 
   debug() {
     console.log('Current Type:', {
       state: this.state,
-      config: this.config
+      query: this.query
     });
     return this;
   }
 
   cache(options: CacheOptions | false): this {
+    const next = this.cloneMutable();
     if (options === false) {
-      this.cacheOptions = { mode: 'no-store', ttlMs: 0, staleTtlMs: 0, cacheTimeMs: 0 };
-      return this;
+      next.cacheOptions = { mode: 'no-store', ttlMs: 0, staleTtlMs: 0, cacheTimeMs: 0 };
+      return next;
     }
-    this.cacheOptions = mergeCacheOptionsPartial(this.cacheOptions, options);
-    return this;
+    next.cacheOptions = mergeCacheOptionsPartial(next.cacheOptions, options);
+    return next;
   }
 
   // --- Analytics Helper: Add a CTE.
@@ -177,8 +313,7 @@ export class QueryBuilder<
     alias: string,
     subquery: QueryBuilder<any, AnyBuilderState> | string
   ): this {
-    this.config = this.analytics.addCTE(alias, subquery);
-    return this;
+    return this.updateQuery(() => this.analytics.addCTE(alias, subquery));
   }
 
   // --- Analytics Helper: Add a scalar WITH alias.
@@ -192,28 +327,17 @@ export class QueryBuilder<
       );
     }
     const expression = expressionBuilder(createPredicateBuilder<State>());
-    const nextConfig = this.analytics.addScalar(alias, expression) as QueryConfig<
-      AddScalar<State, Alias, TValue>['output'],
-      Schema
-    >;
-    const nextState = {
+    const nextConfig = this.analytics.addScalar(alias, expression);
+    const nextScalars = {
+      ...this.state.scalars,
+      [alias]: undefined as TValue,
+    } as AddScalar<State, Alias, TValue>['scalars'];
+    const nextState: AddScalar<State, Alias, TValue> = {
       ...this.state,
-      scalars: {
-        ...this.state.scalars,
-        [alias]: undefined as TValue,
-      },
-    } as unknown as AddScalar<State, Alias, TValue>;
+      scalars: nextScalars,
+    };
 
-    const builder = new QueryBuilder<Schema, AddScalar<State, Alias, TValue>>(
-      this.tableName,
-      nextState,
-      this.runtime,
-      this.adapter,
-      this.dialect
-    );
-    builder.config = { ...nextConfig };
-    builder.cacheOptions = this.cacheOptions;
-    return builder;
+    return this.transition<AddScalar<State, Alias, TValue>>(nextState, nextConfig);
   }
 
   /**
@@ -233,28 +357,36 @@ export class QueryBuilder<
     interval: string,
     method: 'toStartOfInterval' | 'toStartOfMinute' | 'toStartOfHour' | 'toStartOfDay' | 'toStartOfWeek' | 'toStartOfMonth' | 'toStartOfQuarter' | 'toStartOfYear' = 'toStartOfInterval'
   ): this {
-    this.config = this.analytics.addTimeInterval(
+    return this.updateQuery(() => this.analytics.addTimeInterval(
       String(column),
       interval,
       method,
       this.dialect,
-    );
-    return this;
+    ));
   }
 
   // --- Analytics Helper: Add a raw SQL fragment.
   raw(sql: string): this {
-    // Use raw() to inject SQL that isn't supported by the builder.
-    // Use with caution.
-    this.config.having = this.config.having || [];
-    this.config.having.push(sql);
-    return this;
+    return this.updateQuery(query => ({
+      ...query,
+      having: [...(query.having || []), { kind: 'having' as const, expression: sql }],
+    }));
   }
 
   // --- Analytics Helper: Add query settings.
   settings(opts: ClickHouseSettings): this {
-    this.config = this.analytics.addSettings(opts);
-    return this;
+    return this.updateQuery(() => this.analytics.addSettings(opts));
+  }
+
+  final(): this {
+    return this.updateQuery(query => ({
+      ...query,
+      from: {
+        kind: 'table',
+        name: this.tableName,
+        final: true,
+      },
+    }));
   }
 
   /**
@@ -268,9 +400,9 @@ export class QueryBuilder<
   applyCrossFilters(
     crossFilter: CrossFilter<Schema, Extract<keyof Schema, string>> | CrossFilter<AnySchema, string>
   ): this {
-    const normalized = crossFilter as unknown as CrossFilter<Schema, Extract<keyof Schema, string>>;
-    this.config = this.crossFiltering.applyCrossFilters(normalized);
-    return this;
+    return this.crossFiltering.applyCrossFilters(
+      crossFilter as unknown as CrossFilter<Schema, Extract<keyof Schema, string>>
+    ) as this;
   }
 
 
@@ -291,22 +423,11 @@ export class QueryBuilder<
   ): QueryBuilder<Schema, UpdateOutput<State, SelectionResult<State, Selections[number]>>>;
   select<Selections extends ReadonlyArray<SelectableItem<State>>>(columnsOrAsterisk: '*' | Selections) {
     if (columnsOrAsterisk === '*') {
-      type NextState = UpdateOutput<State, BaseRow<State>>;
-      const nextState = {
-        ...this.state,
-        output: {}
-      } as NextState;
-
-      const nextConfig = {
-        ...this.config,
-        select: ['*'],
-        orderBy: this.config.orderBy?.map(({ column, direction }) => ({
-          column: String(column),
-          direction
-        }))
-      } as QueryConfig<NextState['output'], Schema>;
-
-      return this.fork(nextState, nextConfig);
+      type NextOutput = BaseRow<State>;
+      return this.fork(
+        this.buildSelectState<NextOutput>({} as NextOutput),
+        this.buildSelectQuery<NextOutput>(['*']),
+      );
     }
 
     const columns = columnsOrAsterisk as Selections;
@@ -318,22 +439,11 @@ export class QueryBuilder<
       return String(col);
     });
 
-    type NextState = UpdateOutput<State, SelectionResult<State, Selections[number]>>;
-    const nextState = {
-      ...this.state,
-      output: {} as SelectionResult<State, Selections[number]>
-    } as NextState;
-
-    const nextConfig = {
-      ...this.config,
-      select: processedColumns,
-      orderBy: this.config.orderBy?.map(({ column, direction }) => ({
-        column: String(column),
-        direction
-      }))
-    } as QueryConfig<NextState['output'], Schema>;
-
-    return this.fork(nextState, nextConfig);
+    type NextOutput = SelectionResult<State, Selections[number]>;
+    return this.fork(
+      this.buildSelectState<NextOutput>({} as NextOutput),
+      this.buildSelectQuery<NextOutput>(processedColumns),
+    );
   }
 
   selectConst<Selections extends ReadonlyArray<SelectableItem<State>>>(
@@ -391,18 +501,15 @@ export class QueryBuilder<
     column: Column,
     alias: Alias | undefined,
     suffix: string,
-    updater: (column: string, alias: Alias) => QueryConfig<any, Schema>
+    updater: (column: string, alias: Alias) => QueryConfig<AppendToOutput<State, Record<Alias, string>>['output'], Schema>
   ): QueryBuilder<Schema, AppendToOutput<State, Record<Alias, string>>> {
     const columnName = String(column);
     const finalAlias = (alias || `${columnName}_${suffix}`) as Alias;
 
     type NextState = AppendToOutput<State, Record<Alias, string>>;
-    const nextState = {
-      ...this.state,
-      output: {} as NextState['output']
-    } as NextState;
+    const nextState = this.buildSelectState<NextState['output']>({} as NextState['output']) as NextState;
 
-    const nextConfig = updater(columnName, finalAlias) as QueryConfig<NextState['output'], Schema>;
+    const nextConfig = updater(columnName, finalAlias);
     return this.fork(nextState, nextConfig);
   }
 
@@ -483,11 +590,7 @@ export class QueryBuilder<
     }
 
     // Skip validation for advanced IN operators - they handle their own validation
-    const advancedInOperators = [
-      'globalIn', 'globalNotIn', 'inSubquery', 'globalInSubquery',
-      'inTable', 'globalInTable', 'inTuple', 'globalInTuple'
-    ];
-    if (advancedInOperators.includes(operator)) {
+    if (ADVANCED_IN_OPERATORS.has(operator) || operator === 'isNull' || operator === 'isNotNull') {
       return;
     }
 
@@ -500,6 +603,46 @@ export class QueryBuilder<
       { column: columnName, operator, value },
       columnType
     );
+  }
+
+  private applyFilter(
+    clause: 'where' | 'prewhere',
+    conjunction: 'AND' | 'OR',
+    columnOrColumns: WhereColumn<State> | WhereColumn<State>[] | ((expr: PredicateBuilder<State>) => PredicateExpression),
+    operator?: FilterOperator,
+    value?: any
+  ): this {
+    if (typeof columnOrColumns === 'function') {
+      const expression = columnOrColumns(createPredicateBuilder<State>());
+      return this.updateQuery(() => this.filtering.addExpressionCondition(clause, conjunction, expression));
+    }
+
+    if (operator === undefined) {
+      throw new Error(`Operator is required when specifying a column for ${conjunction === 'AND' ? clause : `or${clause[0]!.toUpperCase()}${clause.slice(1)}`}()`);
+    }
+
+    if (Array.isArray(columnOrColumns) && (operator === 'inTuple' || operator === 'globalInTuple')) {
+      const columns = columnOrColumns.map(String);
+      if (!Array.isArray(value)) {
+        throw new Error(`Expected an array of tuples for ${operator} operator, but got ${typeof value}`);
+      }
+      value.forEach((tuple: unknown, index: number) => {
+        if (!Array.isArray(tuple)) {
+          throw new Error(`Expected tuple ${index + 1} for ${operator} operator to be an array`);
+        }
+        if (tuple.length !== columns.length) {
+          throw new Error(
+            `Expected tuple ${index + 1} for ${operator} operator to have ${columns.length} values, but got ${tuple.length}`
+          );
+        }
+      });
+      this.validateFilterValue(columnOrColumns, operator, value);
+      return this.updateQuery(() => this.filtering.addCondition(clause, conjunction, columns, operator, value));
+    }
+
+    const column = Array.isArray(columnOrColumns) ? String(columnOrColumns[0]) : String(columnOrColumns);
+    this.validateFilterValue(columnOrColumns as WhereColumn<State>, operator, value);
+    return this.updateQuery(() => this.filtering.addCondition(clause, conjunction, column, operator, value));
   }
 
   /**
@@ -544,28 +687,7 @@ export class QueryBuilder<
     operator?: Op,
     value?: any
   ): this {
-    if (typeof columnOrColumns === 'function') {
-      const expression = columnOrColumns(createPredicateBuilder<State>());
-      this.config = this.filtering.addExpressionCondition('AND', expression);
-      return this;
-    }
-
-    if (operator === undefined) {
-      throw new Error('Operator is required when specifying a column for where()');
-    }
-
-    // Handle tuple operations
-    if (Array.isArray(columnOrColumns) && (operator === 'inTuple' || operator === 'globalInTuple')) {
-      const columns = columnOrColumns as Column[];
-      this.validateFilterValue(columns, operator, value);
-      this.config = this.filtering.addCondition('AND', columns.map(String), operator, value);
-      return this;
-    }
-
-    const column = columnOrColumns as Column;
-    this.validateFilterValue(column, operator, value);
-    this.config = this.filtering.addCondition('AND', String(column), operator, value);
-    return this;
+    return this.applyFilter('where', 'AND', columnOrColumns, operator as FilterOperator | undefined, value);
   }
 
   orWhere(
@@ -586,27 +708,49 @@ export class QueryBuilder<
     operator?: FilterOperator,
     value?: any
   ): this {
-    if (typeof columnOrColumns === 'function') {
-      const expression = columnOrColumns(createPredicateBuilder<State>());
-      this.config = this.filtering.addExpressionCondition('OR', expression);
-      return this;
-    }
+    return this.applyFilter('where', 'OR', columnOrColumns, operator, value);
+  }
 
-    if (operator === undefined) {
-      throw new Error('Operator is required when specifying a column for orWhere()');
-    }
+  prewhere(
+    expressionBuilder: (expr: PredicateBuilder<State>) => PredicateExpression
+  ): this;
+  prewhere<Column extends WhereColumn<State>, Op extends keyof OperatorValueMap<any, Schema>>(
+    columnOrColumns: Column | Column[],
+    operator: Op,
+    value: ColumnOperatorValue<Schema, State, Column, Op>
+  ): this;
+  prewhere<Column extends WhereColumn<State>>(
+    columns: Column[],
+    operator: 'inTuple' | 'globalInTuple',
+    value: any
+  ): this;
+  prewhere<Column extends WhereColumn<State>, Op extends keyof OperatorValueMap<any, Schema>>(
+    columnOrColumns: Column | Column[] | ((expr: PredicateBuilder<State>) => PredicateExpression),
+    operator?: Op,
+    value?: any
+  ): this {
+    return this.applyFilter('prewhere', 'AND', columnOrColumns, operator as FilterOperator | undefined, value);
+  }
 
-    if (Array.isArray(columnOrColumns) && (operator === 'inTuple' || operator === 'globalInTuple')) {
-      const columns = columnOrColumns as Column[];
-      this.validateFilterValue(columns, operator, value);
-      this.config = this.filtering.addCondition('OR', columns.map(String), operator, value);
-      return this;
-    }
-
-    const column = columnOrColumns as Column;
-    this.validateFilterValue(column, operator, value);
-    this.config = this.filtering.addCondition('OR', String(column), operator, value);
-    return this;
+  orPrewhere(
+    expressionBuilder: (expr: PredicateBuilder<State>) => PredicateExpression
+  ): this;
+  orPrewhere<Column extends WhereColumn<State>>(
+    column: Column,
+    operator: FilterOperator,
+    value: any
+  ): this;
+  orPrewhere<Column extends WhereColumn<State>>(
+    columns: Column[],
+    operator: 'inTuple' | 'globalInTuple',
+    value: any
+  ): this;
+  orPrewhere<Column extends WhereColumn<State>>(
+    columnOrColumns: Column | Column[] | ((expr: PredicateBuilder<State>) => PredicateExpression),
+    operator?: FilterOperator,
+    value?: any
+  ): this {
+    return this.applyFilter('prewhere', 'OR', columnOrColumns, operator, value);
   }
 
   /**
@@ -621,10 +765,8 @@ export class QueryBuilder<
    * ```
    */
   whereGroup(callback: (builder: this) => void): this {
-    this.config = this.filtering.startWhereGroup();
-    callback(this);
-    this.config = this.filtering.endWhereGroup();
-    return this;
+    const groupBuilder = this.runDraftCallback(this.createDetachedBuilder(), callback);
+    return this.updateQuery(() => this.filtering.addGroup('where', 'AND', groupBuilder.getConfig().where));
   }
 
   /**
@@ -639,10 +781,8 @@ export class QueryBuilder<
    * ```
    */
   orWhereGroup(callback: (builder: this) => void): this {
-    this.config = this.filtering.startOrWhereGroup();
-    callback(this);
-    this.config = this.filtering.endWhereGroup();
-    return this;
+    const groupBuilder = this.runDraftCallback(this.createDetachedBuilder(), callback);
+    return this.updateQuery(() => this.filtering.addGroup('where', 'OR', groupBuilder.getConfig().where));
   }
 
   /**
@@ -656,18 +796,15 @@ export class QueryBuilder<
    */
   groupBy(columns: SelectableColumn<State> | Array<SelectableColumn<State>>): this {
     const normalized = Array.isArray(columns) ? columns.map(String) : String(columns);
-    this.config = this.modifiers.addGroupBy(normalized);
-    return this;
+    return this.updateQuery(() => this.modifiers.addGroupBy(normalized));
   }
 
   limit(count: number): this {
-    this.config = this.modifiers.addLimit(count);
-    return this;
+    return this.updateQuery(() => this.modifiers.addLimit(count));
   }
 
   offset(count: number): this {
-    this.config = this.modifiers.addOffset(count);
-    return this;
+    return this.updateQuery(() => this.modifiers.addOffset(count));
   }
 
   /**
@@ -684,8 +821,7 @@ export class QueryBuilder<
     column: SelectableColumn<State>,
     direction: OrderDirection = 'ASC'
   ): this {
-    this.config = this.modifiers.addOrderBy(String(column), direction);
-    return this;
+    return this.updateQuery(() => this.modifiers.addOrderBy(String(column), direction));
   }
 
   /**
@@ -698,13 +834,35 @@ export class QueryBuilder<
    * ```
    */
   having(condition: string, parameters?: any[]): this {
-    this.config = this.modifiers.addHaving(condition, parameters);
-    return this;
+    return this.updateQuery(() => this.modifiers.addHaving(condition, parameters));
   }
 
   distinct(): this {
-    this.config = this.modifiers.setDistinct();
-    return this;
+    return this.updateQuery(() => this.modifiers.setDistinct());
+  }
+
+  whereNull<Column extends WhereColumn<State>>(column: Column): this {
+    return this.updateQuery(() => this.filtering.addCondition('where', 'AND', String(column), 'isNull', null));
+  }
+
+  whereNotNull<Column extends WhereColumn<State>>(column: Column): this {
+    return this.updateQuery(() => this.filtering.addCondition('where', 'AND', String(column), 'isNotNull', null));
+  }
+
+  orWhereNull<Column extends WhereColumn<State>>(column: Column): this {
+    return this.updateQuery(() => this.filtering.addCondition('where', 'OR', String(column), 'isNull', null));
+  }
+
+  orWhereNotNull<Column extends WhereColumn<State>>(column: Column): this {
+    return this.updateQuery(() => this.filtering.addCondition('where', 'OR', String(column), 'isNotNull', null));
+  }
+
+  prewhereNull<Column extends WhereColumn<State>>(column: Column): this {
+    return this.updateQuery(() => this.filtering.addCondition('prewhere', 'AND', String(column), 'isNull', null));
+  }
+
+  prewhereNotNull<Column extends WhereColumn<State>>(column: Column): this {
+    return this.updateQuery(() => this.filtering.addCondition('prewhere', 'AND', String(column), 'isNotNull', null));
   }
 
   whereBetween<Column extends keyof BaseRow<State>>(
@@ -714,7 +872,11 @@ export class QueryBuilder<
     if (min === null || max === null) {
       throw new Error('BETWEEN values cannot be null');
     }
-    return this.where(column, 'between', [min, max] as any);
+    return this.where(
+      column,
+      'between',
+      [min, max] as ColumnOperatorValue<Schema, State, Column, 'between'>
+    );
   }
 
   innerJoin<TableName extends Extract<keyof Schema, string>, Alias extends string | undefined = undefined>(
@@ -788,18 +950,35 @@ export class QueryBuilder<
     type JoinedState = WidenTables<State, TableName>;
     type NextState = Alias extends string ? AddAlias<JoinedState, Alias, TableName> : JoinedState;
 
-    const nextState = {
-      ...this.state,
-      aliases: alias ? { ...this.state.aliases, [alias]: table } : this.state.aliases
-    } as unknown as NextState;
+    const nextAliases = (
+      alias
+        ? { ...this.state.aliases, [alias]: table }
+        : this.state.aliases
+    ) as NextState['aliases'];
 
-    const nextConfig = this.joins.addJoin(type, table, String(leftColumn), rightColumn, alias) as QueryConfig<NextState['output'], Schema>;
-    return this.fork<NextState>(nextState, nextConfig);
+    const nextState = this.withAliasesState<NextState>(nextAliases);
+
+    const nextConfig = this.joins.addJoin(type, table, String(leftColumn), rightColumn, alias);
+    return this.transition<NextState>(nextState, nextConfig);
   }
 
-  // Make config accessible to features
+  /**
+   * @deprecated Prefer `getQueryNode()` for inspection or `toQueryNode()` for the
+   * transformed query tree used during compilation.
+   */
   getConfig() {
-    return this.config;
+    return cloneSelectQueryNode(this.query);
+  }
+
+  toQueryNode(): SelectQueryNode<State['output'], Schema> {
+    return transformSelectQueryNode(
+      this.query,
+      this.queryTransforms as ReadonlyArray<QueryNodeTransform<State['output'], Schema>>,
+    );
+  }
+
+  getQueryNode(): SelectQueryNode<State['output'], Schema> {
+    return cloneSelectQueryNode(this.query);
   }
 
   static setJoinRelationships<S extends SchemaDefinition<S>>(
@@ -812,6 +991,7 @@ export class QueryBuilder<
    * Apply a predefined join relationship
    */
   withRelation(name: string, options?: JoinPathOptions): this {
+    let next = this.cloneMutable();
     const relationships = QueryBuilder.relationships;
     if (!relationships) {
       throw new Error('Join relationships have not been initialized. Call QueryBuilder.setJoinRelationships first.');
@@ -827,7 +1007,7 @@ export class QueryBuilder<
       const alias = options?.alias || joinPath.alias;
       const table = String(joinPath.to) as Extract<keyof Schema, string>;
       const rightColumn = `${table}.${joinPath.rightColumn}` as `${typeof table}.${keyof Schema[typeof table] & string}`;
-      this.config = this.joins.addJoin(type, table, joinPath.leftColumn as any, rightColumn, alias);
+      next.query = createSelectQueryNode(next.joins.addJoin(type, table, String(joinPath.leftColumn), rightColumn, alias));
     };
 
     if (Array.isArray(path)) {
@@ -836,7 +1016,7 @@ export class QueryBuilder<
       applyJoin(path);
     }
 
-    return this;
+    return next;
   }
 }
 

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -71,6 +71,39 @@ type ColumnOperatorValue<
 // Union type that accepts either client type
 type ClickHouseClient = NodeClickHouseClient | WebClickHouseClient;
 type ScalarAlias<Alias extends string> = Alias extends `${string} ${string}` ? never : Alias;
+type JoinPathTableName<
+  Schema extends SchemaDefinition<Schema>,
+  Path extends JoinPath<Schema>
+> = Extract<Path['to'], keyof Schema>;
+type JoinPathAlias<Path extends JoinPath<any>, OverrideAlias extends string | undefined> =
+  OverrideAlias extends string
+    ? OverrideAlias
+    : Path['alias'] extends string
+      ? Path['alias']
+      : undefined;
+type ApplyJoinPathState<
+  Schema extends SchemaDefinition<Schema>,
+  State extends AnyBuilderState,
+  Path extends JoinPath<Schema>,
+  OverrideAlias extends string | undefined = undefined
+> = JoinPathAlias<Path, OverrideAlias> extends string
+  ? AddAlias<
+      WidenTables<State, JoinPathTableName<Schema, Path>>,
+      JoinPathAlias<Path, OverrideAlias>,
+      JoinPathTableName<Schema, Path>
+    >
+  : WidenTables<State, JoinPathTableName<Schema, Path>>;
+type ApplyJoinPathChainState<
+  Schema extends SchemaDefinition<Schema>,
+  State extends AnyBuilderState,
+  Paths extends readonly JoinPath<Schema>[]
+> = Paths extends readonly [infer First, ...infer Rest]
+  ? First extends JoinPath<Schema>
+    ? Rest extends readonly JoinPath<Schema>[]
+      ? ApplyJoinPathChainState<Schema, ApplyJoinPathState<Schema, State, First>, Rest>
+      : ApplyJoinPathState<Schema, State, First>
+    : State
+  : State;
 const ADVANCED_IN_OPERATORS = new Set<FilterOperator>([
   'globalIn',
   'globalNotIn',
@@ -640,6 +673,22 @@ export class QueryBuilder<
       return this.updateQuery(() => this.filtering.addCondition(clause, conjunction, columns, operator, value));
     }
 
+    if (operator === 'inTuple' || operator === 'globalInTuple') {
+      if (!Array.isArray(value)) {
+        throw new Error(`Expected an array of tuples for ${operator} operator, but got ${typeof value}`);
+      }
+      value.forEach((tuple: unknown, index: number) => {
+        if (!Array.isArray(tuple)) {
+          throw new Error(`Expected tuple ${index + 1} for ${operator} operator to be an array`);
+        }
+        if (tuple.length !== 1) {
+          throw new Error(
+            `Expected tuple ${index + 1} for ${operator} operator to have 1 value, but got ${tuple.length}`
+          );
+        }
+      });
+    }
+
     const column = Array.isArray(columnOrColumns) ? String(columnOrColumns[0]) : String(columnOrColumns);
     this.validateFilterValue(columnOrColumns as WhereColumn<State>, operator, value);
     return this.updateQuery(() => this.filtering.addCondition(clause, conjunction, column, operator, value));
@@ -990,16 +1039,47 @@ export class QueryBuilder<
   /**
    * Apply a predefined join relationship
    */
-  withRelation(name: string, options?: JoinPathOptions): this {
+  withRelation<
+    Path extends JoinPath<Schema>,
+    Alias extends string | undefined = undefined
+  >(
+    path: Path,
+    options?: Omit<JoinPathOptions, 'alias'> & { alias?: Alias }
+  ): QueryBuilder<Schema, ApplyJoinPathState<Schema, State, Path, Alias>>;
+  withRelation<
+    Paths extends readonly [JoinPath<Schema>, ...JoinPath<Schema>[]]
+  >(
+    paths: Paths,
+    options?: Omit<JoinPathOptions, 'alias'>
+  ): QueryBuilder<Schema, ApplyJoinPathChainState<Schema, State, Paths>>;
+  withRelation(name: string, options?: JoinPathOptions): this;
+  withRelation(
+    nameOrPath: string | JoinPath<Schema> | readonly JoinPath<Schema>[],
+    options?: JoinPathOptions
+  ): QueryBuilder<Schema, any> {
     let next = this.cloneMutable();
-    const relationships = QueryBuilder.relationships;
-    if (!relationships) {
-      throw new Error('Join relationships have not been initialized. Call QueryBuilder.setJoinRelationships first.');
+    let path: JoinPath<Schema> | readonly JoinPath<Schema>[];
+
+    if (typeof nameOrPath === 'string') {
+      const relationships = QueryBuilder.relationships;
+      if (!relationships) {
+        throw new Error('Join relationships have not been initialized. Call QueryBuilder.setJoinRelationships first.');
+      }
+
+      const resolved = relationships.get(nameOrPath);
+      if (!resolved) {
+        throw new Error(`Join relationship '${nameOrPath}' not found`);
+      }
+      path = resolved;
+    } else {
+      path = nameOrPath;
     }
 
-    const path = relationships.get(name);
-    if (!path) {
-      throw new Error(`Join relationship '${name}' not found`);
+    if (Array.isArray(path) && options?.alias) {
+      const nameLabel = typeof nameOrPath === 'string' ? `'${nameOrPath}' ` : '';
+      throw new Error(
+        `Join relationship ${nameLabel}is a chain; alias override is only supported for single-join relationships`
+      );
     }
 
     const applyJoin = (joinPath: JoinPath<Schema>) => {
@@ -1013,7 +1093,7 @@ export class QueryBuilder<
     if (Array.isArray(path)) {
       path.forEach(applyJoin);
     } else {
-      applyJoin(path);
+      applyJoin(path as JoinPath<Schema>);
     }
 
     return next;

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -40,6 +40,8 @@ import type { CacheOptions, CacheConfig } from './cache/types.js';
 import type { QueryRuntimeContext } from './cache/runtime-context.js';
 import { executeWithCache } from './cache/cache-manager.js';
 import { mergeCacheOptionsPartial, initializeCacheRuntime } from './cache/utils.js';
+import { normalizeFilterApplication } from './utils/filter-application.js';
+import { applyRelationPath, resolveRelationPath } from './utils/relation-application.js';
 import type {
   BuilderState,
   AnyBuilderState,
@@ -204,9 +206,9 @@ export class QueryBuilder<
     >
   >(
     state: NextState,
-    config: QueryConfig<NextState['output'], Schema>
+    query: SelectQueryNode<NextState['output'], Schema>
   ): QueryBuilder<Schema, NextState> {
-    return this.transition(state, config);
+    return this.transition(state, query);
   }
 
   private transition<
@@ -219,10 +221,10 @@ export class QueryBuilder<
     >
   >(
     state: NextState,
-    query: QueryConfig<NextState['output'], Schema> | SelectQueryNode<NextState['output'], Schema>
+    query: SelectQueryNode<NextState['output'], Schema>
   ): QueryBuilder<Schema, NextState> {
     const builder = new QueryBuilder<Schema, NextState>(this.tableName, state, this.runtime, this.adapter, this.dialect);
-    builder.query = createSelectQueryNode(query);
+    builder.query = cloneSelectQueryNode(query);
     builder.cacheOptions = this.cacheOptions ? { ...this.cacheOptions } : undefined;
     builder.queryTransforms = [...this.queryTransforms] as Array<QueryNodeTransform<NextState['output'], Schema>>;
     return builder;
@@ -234,16 +236,16 @@ export class QueryBuilder<
 
   private assignQuery(
     builder: this,
-    query: QueryConfig<State['output'], Schema> | SelectQueryNode<State['output'], Schema>
+    query: SelectQueryNode<State['output'], Schema>
   ): this {
-    builder.query = createSelectQueryNode(query);
+    builder.query = cloneSelectQueryNode(query);
     return builder;
   }
 
   private updateQuery(
     updater: (
       query: SelectQueryNode<State['output'], Schema>
-    ) => QueryConfig<State['output'], Schema> | SelectQueryNode<State['output'], Schema>
+    ) => SelectQueryNode<State['output'], Schema>
   ): this {
     return this.assignQuery(this.cloneMutable(), updater(this.query));
   }
@@ -270,7 +272,7 @@ export class QueryBuilder<
     } as UpdateOutput<State, NextOutput>;
   }
 
-  private buildSelectQuery<NextOutput>(selections: string[]): QueryConfig<NextOutput, Schema> {
+  private buildSelectQuery<NextOutput>(selections: string[]): SelectQueryNode<NextOutput, Schema> {
     return {
       ...this.query,
       select: selections.map(selection => ({ kind: 'selection' as const, selection })),
@@ -534,7 +536,7 @@ export class QueryBuilder<
     column: Column,
     alias: Alias | undefined,
     suffix: string,
-    updater: (column: string, alias: Alias) => QueryConfig<AppendToOutput<State, Record<Alias, string>>['output'], Schema>
+    updater: (column: string, alias: Alias) => SelectQueryNode<AppendToOutput<State, Record<Alias, string>>['output'], Schema>
   ): QueryBuilder<Schema, AppendToOutput<State, Record<Alias, string>>> {
     const columnName = String(column);
     const finalAlias = (alias || `${columnName}_${suffix}`) as Alias;
@@ -645,53 +647,27 @@ export class QueryBuilder<
     operator?: FilterOperator,
     value?: any
   ): this {
-    if (typeof columnOrColumns === 'function') {
-      const expression = columnOrColumns(createPredicateBuilder<State>());
-      return this.updateQuery(() => this.filtering.addExpressionCondition(clause, conjunction, expression));
+    const normalized = normalizeFilterApplication(
+      clause,
+      conjunction,
+      columnOrColumns as string | string[] | ((expr: PredicateBuilder<any>) => PredicateExpression),
+      operator,
+      value,
+      builder => builder(createPredicateBuilder<State>())
+    );
+
+    if (normalized.kind === 'expression') {
+      return this.updateQuery(() => this.filtering.addExpressionCondition(clause, conjunction, normalized.expression));
     }
 
-    if (operator === undefined) {
-      throw new Error(`Operator is required when specifying a column for ${conjunction === 'AND' ? clause : `or${clause[0]!.toUpperCase()}${clause.slice(1)}`}()`);
-    }
-
-    if (Array.isArray(columnOrColumns) && (operator === 'inTuple' || operator === 'globalInTuple')) {
-      const columns = columnOrColumns.map(String);
-      if (!Array.isArray(value)) {
-        throw new Error(`Expected an array of tuples for ${operator} operator, but got ${typeof value}`);
-      }
-      value.forEach((tuple: unknown, index: number) => {
-        if (!Array.isArray(tuple)) {
-          throw new Error(`Expected tuple ${index + 1} for ${operator} operator to be an array`);
-        }
-        if (tuple.length !== columns.length) {
-          throw new Error(
-            `Expected tuple ${index + 1} for ${operator} operator to have ${columns.length} values, but got ${tuple.length}`
-          );
-        }
-      });
-      this.validateFilterValue(columnOrColumns, operator, value);
-      return this.updateQuery(() => this.filtering.addCondition(clause, conjunction, columns, operator, value));
-    }
-
-    if (operator === 'inTuple' || operator === 'globalInTuple') {
-      if (!Array.isArray(value)) {
-        throw new Error(`Expected an array of tuples for ${operator} operator, but got ${typeof value}`);
-      }
-      value.forEach((tuple: unknown, index: number) => {
-        if (!Array.isArray(tuple)) {
-          throw new Error(`Expected tuple ${index + 1} for ${operator} operator to be an array`);
-        }
-        if (tuple.length !== 1) {
-          throw new Error(
-            `Expected tuple ${index + 1} for ${operator} operator to have 1 value, but got ${tuple.length}`
-          );
-        }
-      });
-    }
-
-    const column = Array.isArray(columnOrColumns) ? String(columnOrColumns[0]) : String(columnOrColumns);
-    this.validateFilterValue(columnOrColumns as WhereColumn<State>, operator, value);
-    return this.updateQuery(() => this.filtering.addCondition(clause, conjunction, column, operator, value));
+    this.validateFilterValue(normalized.validationTarget as WhereColumn<State> | WhereColumn<State>[], normalized.operator, normalized.value);
+    return this.updateQuery(() => this.filtering.addCondition(
+      clause,
+      conjunction,
+      normalized.column,
+      normalized.operator,
+      normalized.value
+    ));
   }
 
   /**
@@ -815,7 +791,7 @@ export class QueryBuilder<
    */
   whereGroup(callback: (builder: this) => void): this {
     const groupBuilder = this.runDraftCallback(this.createDetachedBuilder(), callback);
-    return this.updateQuery(() => this.filtering.addGroup('where', 'AND', groupBuilder.getConfig().where));
+    return this.updateQuery(() => this.filtering.addGroup('where', 'AND', groupBuilder.getQueryNode().where));
   }
 
   /**
@@ -831,7 +807,7 @@ export class QueryBuilder<
    */
   orWhereGroup(callback: (builder: this) => void): this {
     const groupBuilder = this.runDraftCallback(this.createDetachedBuilder(), callback);
-    return this.updateQuery(() => this.filtering.addGroup('where', 'OR', groupBuilder.getConfig().where));
+    return this.updateQuery(() => this.filtering.addGroup('where', 'OR', groupBuilder.getQueryNode().where));
   }
 
   /**
@@ -1057,45 +1033,22 @@ export class QueryBuilder<
     nameOrPath: string | JoinPath<Schema> | readonly JoinPath<Schema>[],
     options?: JoinPathOptions
   ): QueryBuilder<Schema, any> {
-    let next = this.cloneMutable();
-    let path: JoinPath<Schema> | readonly JoinPath<Schema>[];
-
-    if (typeof nameOrPath === 'string') {
-      const relationships = QueryBuilder.relationships;
-      if (!relationships) {
-        throw new Error('Join relationships have not been initialized. Call QueryBuilder.setJoinRelationships first.');
-      }
-
-      const resolved = relationships.get(nameOrPath);
-      if (!resolved) {
-        throw new Error(`Join relationship '${nameOrPath}' not found`);
-      }
-      path = resolved;
-    } else {
-      path = nameOrPath;
-    }
-
-    if (Array.isArray(path) && options?.alias) {
-      const nameLabel = typeof nameOrPath === 'string' ? `'${nameOrPath}' ` : '';
-      throw new Error(
-        `Join relationship ${nameLabel}is a chain; alias override is only supported for single-join relationships`
-      );
-    }
-
-    const applyJoin = (joinPath: JoinPath<Schema>) => {
+    const next = this.cloneMutable();
+    const { path, label } = resolveRelationPath(nameOrPath, QueryBuilder.relationships as JoinRelationships<Schema> | undefined);
+    next.query = applyRelationPath(
+      next.query,
+      path,
+      options,
+      (currentQuery, joinPath, relationOptions) => {
+        next.query = currentQuery;
       const type = options?.type || joinPath.type || 'INNER';
-      const alias = options?.alias || joinPath.alias;
+      const alias = relationOptions?.alias || joinPath.alias;
       const table = String(joinPath.to) as Extract<keyof Schema, string>;
       const rightColumn = `${table}.${joinPath.rightColumn}` as `${typeof table}.${keyof Schema[typeof table] & string}`;
-      next.query = createSelectQueryNode(next.joins.addJoin(type, table, String(joinPath.leftColumn), rightColumn, alias));
-    };
-
-    if (Array.isArray(path)) {
-      path.forEach(applyJoin);
-    } else {
-      applyJoin(path as JoinPath<Schema>);
-    }
-
+        return next.joins.addJoin(type, table, String(joinPath.leftColumn), rightColumn, alias);
+      },
+      label
+    );
     return next;
   }
 }

--- a/packages/clickhouse/src/core/query-node.ts
+++ b/packages/clickhouse/src/core/query-node.ts
@@ -1,0 +1,97 @@
+import type {
+  ConditionValueNode,
+  ExprNode,
+  QueryConfig,
+  SelectQueryNode,
+} from '../types/index.js';
+
+function cloneConditionValue(value: ConditionValueNode): ConditionValueNode {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => Array.isArray(item) ? item.map(inner => ({ ...inner })) : { ...item }) as ConditionValueNode;
+  }
+  return { ...value };
+}
+
+export function cloneExprNode(expr?: ExprNode): ExprNode | undefined {
+  if (!expr) return undefined;
+
+  switch (expr.kind) {
+    case 'condition':
+      return { ...expr, value: cloneConditionValue(expr.value) };
+    case 'raw':
+      return {
+        ...expr,
+        parameters: expr.parameters.map(parameter => ({ ...parameter })),
+      };
+    case 'group':
+      return {
+        ...expr,
+        expression: cloneExprNode(expr.expression),
+      };
+    case 'logical':
+      return {
+        ...expr,
+        conditions: expr.conditions.map(condition => cloneExprNode(condition)!),
+      };
+    case 'sequence':
+      return {
+        ...expr,
+        items: expr.items.map(item => ({
+          ...item,
+          expression: cloneExprNode(item.expression)!,
+        })),
+      };
+    default:
+      throw new Error(`Unsupported expression kind: ${String((expr as { kind?: string }).kind)}`);
+  }
+}
+
+export function createSelectQueryNode<TOutput, TSchema>(
+  config: QueryConfig<TOutput, TSchema> = {}
+): SelectQueryNode<TOutput, TSchema> {
+  return {
+    kind: 'select-query',
+    from: config.from ? { ...config.from } : undefined,
+    select: config.select ? config.select.map(item => ({ ...item })) : undefined,
+    prewhere: cloneExprNode(config.prewhere),
+    where: cloneExprNode(config.where),
+    groupBy: config.groupBy ? config.groupBy.map(item => ({ ...item })) : undefined,
+    having: config.having
+      ? config.having.map(item => ({
+        ...item,
+        parameters: item.parameters?.map(parameter => ({ ...parameter })),
+      }))
+      : undefined,
+    limit: config.limit,
+    offset: config.offset,
+    distinct: config.distinct,
+    orderBy: config.orderBy ? config.orderBy.map(item => ({ ...item })) : undefined,
+    joins: config.joins ? config.joins.map(item => ({ ...item })) : undefined,
+    ctes: config.ctes ? config.ctes.map(item => ({ ...item })) : undefined,
+    unionQueries: config.unionQueries ? [...config.unionQueries] : undefined,
+    settings: config.settings ? { ...config.settings } : undefined,
+  };
+}
+
+export function cloneSelectQueryNode<TOutput, TSchema>(
+  query: SelectQueryNode<TOutput, TSchema>
+): SelectQueryNode<TOutput, TSchema> {
+  return createSelectQueryNode(query);
+}
+
+export type QueryNodeTransform<TOutput, TSchema> = (
+  query: SelectQueryNode<TOutput, TSchema>
+) => SelectQueryNode<TOutput, TSchema>;
+
+export function transformSelectQueryNode<TOutput, TSchema>(
+  query: SelectQueryNode<TOutput, TSchema>,
+  transforms: ReadonlyArray<QueryNodeTransform<TOutput, TSchema>>
+): SelectQueryNode<TOutput, TSchema> {
+  return transforms.reduce(
+    (current, transform) => transform(current),
+    cloneSelectQueryNode(query),
+  );
+}

--- a/packages/clickhouse/src/core/tests/advanced-in-operators.test.ts
+++ b/packages/clickhouse/src/core/tests/advanced-in-operators.test.ts
@@ -116,6 +116,16 @@ describe('Advanced IN Operators', () => {
   });
 
   describe('Tuple IN Operators', () => {
+    it('should generate IN tuple SQL for a single column', () => {
+      const query = builder
+        .where('id', 'inTuple', [[1], [2]]);
+
+      const { sql, parameters } = query.toSQLWithParams();
+
+      expect(sql).toContain('WHERE id IN ((?), (?))');
+      expect(parameters).toEqual([1, 2]);
+    });
+
     it('should generate IN tuple SQL for multiple columns', () => {
       const query = builder
         .where(['id', 'created_by'], 'inTuple', [[1, 123], [2, 456]]);
@@ -216,6 +226,12 @@ describe('Advanced IN Operators', () => {
   });
 
   describe('Error Handling', () => {
+    it('should throw error for malformed single-column tuple values', () => {
+      expect(() => {
+        builder.where('id', 'inTuple', [[1, 2], [3]] as any).toSQLWithParams();
+      }).toThrow('Expected tuple 1 for inTuple operator to have 1 value, but got 2');
+    });
+
     it('should throw error for non-array value in globalIn', () => {
       expect(() => {
         builder.where('id', 'globalIn', 'not-an-array' as any);

--- a/packages/clickhouse/src/core/tests/advanced-in-operators.test.ts
+++ b/packages/clickhouse/src/core/tests/advanced-in-operators.test.ts
@@ -155,6 +155,16 @@ describe('Advanced IN Operators', () => {
       expect(sql).toContain('WHERE (id, created_by) IN ((?, ?))');
       expect(parameters).toEqual([1, 123]);
     });
+
+    it('should support wider tuples when the column list is wider', () => {
+      const query = builder
+        .where(['id', 'created_by', 'updated_by'] as any, 'inTuple', [[1, 123, 456], [2, 234, 567]]);
+
+      const { sql, parameters } = query.toSQLWithParams();
+
+      expect(sql).toContain('WHERE (id, created_by, updated_by) IN ((?, ?, ?), (?, ?, ?))');
+      expect(parameters).toEqual([1, 123, 456, 2, 234, 567]);
+    });
   });
 
   describe('Combined Usage', () => {
@@ -228,6 +238,12 @@ describe('Advanced IN Operators', () => {
       expect(() => {
         builder.where(['id', 'created_by'], 'inTuple', 'not-an-array' as any);
       }).toThrow('Expected an array of tuples for inTuple operator, but got string');
+    });
+
+    it('should throw error when tuple width does not match the column width', () => {
+      expect(() => {
+        builder.where(['id', 'created_by'], 'inTuple', [[1, 2, 3]] as any);
+      }).toThrow('Expected tuple 1 for inTuple operator to have 2 values, but got 3');
     });
   });
 

--- a/packages/clickhouse/src/core/tests/cache-manager.test.ts
+++ b/packages/clickhouse/src/core/tests/cache-manager.test.ts
@@ -327,6 +327,40 @@ describe('Cache manager integration', () => {
     expect(queryMock).toHaveBeenCalledTimes(2);
   });
 
+  it('uses transformed query settings when computing cache keys', async () => {
+    const provider = new TestCacheProvider();
+    let callCount = 0;
+    queryMock.mockImplementation(() => Promise.resolve([{ id: ++callCount, email: `user-${callCount}`, active: 1 }]));
+
+    const db = createQueryBuilder<TestSchema>({
+      adapter: testAdapter,
+      cache: {
+        mode: 'cache-first',
+        ttlMs: 10_000,
+        provider
+      }
+    });
+
+    const base = db.table('users').select(['id']);
+    const fastQuery = base.cache({ ttlMs: 10_000 });
+    (fastQuery as any).queryTransforms.push((query: any) => ({
+      ...query,
+      settings: { max_execution_time: 10 },
+    }));
+
+    const slowQuery = base.cache({ ttlMs: 10_000 });
+    (slowQuery as any).queryTransforms.push((query: any) => ({
+      ...query,
+      settings: { max_execution_time: 20 },
+    }));
+
+    await fastQuery.execute();
+    await slowQuery.execute();
+
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    expect(provider.store.size).toBe(2);
+  });
+
   it('reports hit rate including stale serves', async () => {
     let callCount = 0;
     queryMock.mockImplementation(() => Promise.resolve([{ id: ++callCount, email: `user-${callCount}`, active: 1 }]));

--- a/packages/clickhouse/src/core/tests/dialect-seam.test.ts
+++ b/packages/clickhouse/src/core/tests/dialect-seam.test.ts
@@ -38,9 +38,10 @@ describe('dialect seam', () => {
     formatTimeIntervalMock.mockReset();
 
     formatTimeIntervalMock.mockReturnValue('bucket(created_at, 1 day)');
-    compileQueryMock.mockImplementation((config, context) => (
-      `compiled:${context.tableName}:${config.groupBy?.join('|') ?? 'none'}:${JSON.stringify(config.settings ?? null)}`
-    ));
+    compileQueryMock.mockImplementation((config, context) => ({
+      query: `compiled:${context.tableName}:${config.groupBy?.map((item: any) => typeof item === 'string' ? item : item.expression).join('|') ?? 'none'}:${JSON.stringify(config.settings ?? null)}`,
+      parameters: [42],
+    }));
     renderMock.mockImplementation((sql, params = []) => `rendered:${sql}:${params.join(',')}`);
     queryMock.mockResolvedValue([{ id: 1 }]);
   });
@@ -95,6 +96,36 @@ describe('dialect seam', () => {
     expect(renderMock).toHaveBeenCalledWith(
       'compiled:users:bucket(created_at, 1 day):{"max_execution_time":10}',
       [42],
+    );
+  });
+
+  it('passes a root select-query node into injected dialects', () => {
+    const db = createQueryBuilder<TestSchema>({
+      adapter,
+      dialect,
+      cache: {
+        mode: 'cache-first',
+        ttlMs: 10_000,
+        provider: new MemoryCacheProvider({ maxEntries: 10 }),
+      },
+    });
+
+    const query = db
+      .table('users')
+      .select(['id'])
+      .where('id', 'eq', 42)
+      .orderBy('id', 'DESC');
+
+    query.toSQL();
+
+    expect(compileQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'select-query',
+        from: { kind: 'table', name: 'users' },
+        select: [{ kind: 'selection', selection: 'id' }],
+        orderBy: [{ kind: 'order-by-item', column: 'id', direction: 'DESC' }],
+      }),
+      expect.anything(),
     );
   });
 });

--- a/packages/clickhouse/src/core/tests/join-relationships.test.ts
+++ b/packages/clickhouse/src/core/tests/join-relationships.test.ts
@@ -1,5 +1,7 @@
+import type { Equal, Expect } from '@type-challenges/utils';
 import { JoinRelationships } from '../join-relationships.js';
 import { QueryBuilder } from '../query-builder.js';
+import type { JoinPath } from '../join-relationships.js';
 import { TestSchema, setupTestBuilder } from './test-utils.js';
 
 describe('JoinRelationships', () => {
@@ -111,7 +113,7 @@ describe('JoinRelationships', () => {
         .withRelation('complexChain')
         .toSQL();
 
-      expect(sql).toBe('SELECT * FROM test_table INNER JOIN users ON created_by = users.id LEFT JOIN test_table AS updated_by_user ON id = test_table.updated_by');
+      expect(sql).toBe('SELECT * FROM test_table INNER JOIN users ON created_by = users.id LEFT JOIN test_table AS updated_by_user ON id = updated_by_user.updated_by');
     });
 
     it('should override join type', () => {
@@ -128,6 +130,74 @@ describe('JoinRelationships', () => {
         .toSQL();
 
       expect(sql).toBe('SELECT * FROM test_table LEFT JOIN users ON created_by = users.id');
+    });
+
+    it('should support typed direct join paths with alias-aware selection', () => {
+      const orderCustomerPath = {
+        from: 'test_table',
+        to: 'users',
+        leftColumn: 'created_by',
+        rightColumn: 'id',
+        alias: 'author'
+      } as const satisfies JoinPath<TestSchema>;
+
+      const query = builder
+        .withRelation(orderCustomerPath)
+        .select(['author.user_name']);
+
+      type Result = Awaited<ReturnType<typeof query.execute>>;
+      type Expected = { user_name: string }[];
+      type _Assert = Expect<Equal<Result, Expected>>;
+
+      expect(query.toSQL()).toBe(
+        'SELECT author.user_name FROM test_table INNER JOIN users AS author ON created_by = author.id'
+      );
+    });
+
+    it('should support alias override for a direct single-join path', () => {
+      const orderCustomerPath = {
+        from: 'test_table',
+        to: 'users',
+        leftColumn: 'created_by',
+        rightColumn: 'id',
+      } as const satisfies JoinPath<TestSchema>;
+
+      const query = builder
+        .withRelation(orderCustomerPath, { type: 'LEFT', alias: 'customer' })
+        .select(['customer.email']);
+
+      type Result = Awaited<ReturnType<typeof query.execute>>;
+      type Expected = { email: string }[];
+      type _Assert = Expect<Equal<Result, Expected>>;
+
+      expect(query.toSQL()).toBe(
+        'SELECT customer.email FROM test_table LEFT JOIN users AS customer ON created_by = customer.id'
+      );
+    });
+
+    it('should throw when alias override is used for a join chain', () => {
+      relationships.defineChain('complexChain', [
+        {
+          from: 'test_table',
+          to: 'users',
+          leftColumn: 'created_by',
+          rightColumn: 'id',
+          type: 'INNER'
+        },
+        {
+          from: 'users',
+          to: 'test_table',
+          leftColumn: 'id',
+          rightColumn: 'updated_by',
+          type: 'LEFT'
+        }
+      ]);
+
+      expect(() => {
+        builder.withRelation('complexChain', { alias: 'customer' });
+      }).toThrow(
+        "Join relationship 'complexChain' is a chain; alias override is only supported for single-join relationships"
+      );
     });
 
     it('should throw error for undefined relationship', () => {

--- a/packages/clickhouse/src/core/tests/join-relationships.test.ts
+++ b/packages/clickhouse/src/core/tests/join-relationships.test.ts
@@ -200,6 +200,48 @@ describe('JoinRelationships', () => {
       );
     });
 
+    it('should throw when a single relationship starts from an unavailable source', () => {
+      relationships.define('usersToTestTable', {
+        from: 'users',
+        to: 'test_table',
+        leftColumn: 'id',
+        rightColumn: 'updated_by',
+        type: 'LEFT'
+      });
+
+      expect(() => {
+        builder.withRelation('usersToTestTable');
+      }).toThrow(
+        "Join relationship 'usersToTestTable' step 1 expects source 'users', but available sources are: test_table"
+      );
+    });
+
+    it('should throw when a join chain references an unavailable intermediate source', () => {
+      relationships.defineChain('brokenChain', [
+        {
+          from: 'test_table',
+          to: 'users',
+          leftColumn: 'created_by',
+          rightColumn: 'id',
+          type: 'INNER',
+          alias: 'creator'
+        },
+        {
+          from: 'users',
+          to: 'test_table',
+          leftColumn: 'id',
+          rightColumn: 'updated_by',
+          type: 'LEFT'
+        }
+      ]);
+
+      expect(() => {
+        builder.withRelation('brokenChain');
+      }).toThrow(
+        "Join relationship 'brokenChain' step 2 expects source 'users', but available sources are: test_table, creator"
+      );
+    });
+
     it('should throw error for undefined relationship', () => {
       expect(() => {
         builder.withRelation('nonexistent');

--- a/packages/clickhouse/src/core/tests/query-builder-analytics.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder-analytics.test.ts
@@ -114,6 +114,17 @@ describe('QueryBuilder Analytics Features', () => {
     });
   });
 
+  describe('final', () => {
+    it('renders FINAL on the table source', () => {
+      const sql = queryBuilder
+        .final()
+        .select(['id'])
+        .toSQL();
+
+      expect(sql).toBe('SELECT id FROM test_table FINAL');
+    });
+  });
+
   describe('withCTE', () => {
     it('should add CTE using a subquery', () => {
       const subquery = builderUsers

--- a/packages/clickhouse/src/core/tests/query-builder.basic.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.basic.test.ts
@@ -128,10 +128,141 @@ describe('QueryBuilder - Basic Operations', () => {
       const query = builder.select(['id']).where('id', 'eq', 1);
       const config = query.getConfig();
 
-      config.select?.push({ kind: 'selection', selection: 'name' });
+      config.select?.push('name');
 
       expect(query.toSQL()).toBe('SELECT id FROM test_table WHERE id = 1');
-      expect(query.getConfig().select?.map(item => item.selection)).toEqual(['id']);
+      expect(query.getConfig().select).toEqual(['id']);
+    });
+
+    it('preserves legacy getConfig() shapes for select, joins, ordering, and parameters', () => {
+      const query = builder
+        .innerJoin('users', 'created_by', 'users.id', 'author')
+        .select(['id', 'author.user_name'])
+        .where('active', 'eq', 1)
+        .where('category', 'in', ['premium', 'vip'])
+        .orderBy('id', 'DESC')
+        .limit(10)
+        .offset(20);
+
+      const config = query.getConfig();
+
+      expect(config.select).toEqual(['id', 'author.user_name']);
+      expect(config.joins).toEqual([
+        {
+          type: 'INNER',
+          table: 'users',
+          leftColumn: 'created_by',
+          rightColumn: 'author.id',
+          alias: 'author',
+        },
+      ]);
+      expect(config.orderBy).toEqual([
+        {
+          column: 'id',
+          direction: 'DESC',
+        },
+      ]);
+      expect(config.limit).toBe(10);
+      expect(config.offset).toBe(20);
+      expect(config.parameters).toEqual([1, 'premium', 'vip']);
+      expect(config.where).toEqual([
+        {
+          column: 'active',
+          operator: 'eq',
+          value: 1,
+          conjunction: 'AND',
+        },
+        {
+          column: 'category',
+          operator: 'in',
+          value: ['premium', 'vip'],
+          conjunction: 'AND',
+        },
+      ]);
+    });
+
+    it('preserves legacy grouped where serialization in getConfig()', () => {
+      const query = builder
+        .where('active', 'eq', 1)
+        .whereGroup((qb) => {
+          qb.where('price', 'gte', 100)
+            .orWhere('category', 'eq', 'premium');
+        })
+        .orWhere('created_by', 'eq', 42);
+
+      const config = query.getConfig();
+
+      expect(config.parameters).toEqual([1, 100, 'premium', 42]);
+      expect(config.where).toEqual([
+        {
+          column: 'active',
+          operator: 'eq',
+          value: 1,
+          conjunction: 'AND',
+        },
+        {
+          column: '',
+          operator: 'eq',
+          value: null,
+          conjunction: 'AND',
+          type: 'group-start',
+        },
+        {
+          column: 'price',
+          operator: 'gte',
+          value: 100,
+          conjunction: 'AND',
+        },
+        {
+          column: 'category',
+          operator: 'eq',
+          value: 'premium',
+          conjunction: 'OR',
+        },
+        {
+          column: '',
+          operator: 'eq',
+          value: null,
+          conjunction: 'AND',
+          type: 'group-end',
+        },
+        {
+          column: 'created_by',
+          operator: 'eq',
+          value: 42,
+          conjunction: 'OR',
+        },
+      ]);
+    });
+
+    it('preserves legacy prewhere and having serialization in getConfig()', () => {
+      const query = builder
+        .select(['category'])
+        .prewhere('active', 'eq', 1)
+        .orPrewhere('optional_name', 'isNull' as any, null)
+        .groupBy('category')
+        .having('COUNT(*) > ?', [5])
+        .having('SUM(price) < ?', [1000]);
+
+      const config = query.getConfig();
+
+      expect(config.prewhere).toEqual([
+        {
+          column: 'active',
+          operator: 'eq',
+          value: 1,
+          conjunction: 'AND',
+        },
+        {
+          column: 'optional_name',
+          operator: 'isNull',
+          value: null,
+          conjunction: 'OR',
+        },
+      ]);
+      expect(config.groupBy).toEqual(['category']);
+      expect(config.having).toEqual(['COUNT(*) > ?', 'SUM(price) < ?']);
+      expect(config.parameters).toEqual([1, 5, 1000]);
     });
   });
 });

--- a/packages/clickhouse/src/core/tests/query-builder.basic.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.basic.test.ts
@@ -87,4 +87,51 @@ describe('QueryBuilder - Basic Operations', () => {
       expect(sql).toContain('SELECT id FROM test_table WHERE id IN (SELECT id FROM recent_ids)');
     });
   });
-}); 
+
+  describe('immutability', () => {
+    it('does not mutate the base builder when branching', () => {
+      const base = builder.select(['id', 'name']);
+      const recent = base.orderBy('id', 'DESC').limit(10);
+      const filtered = base.where('category', 'eq', 'premium');
+
+      expect(base.toSQL()).toBe('SELECT id, name FROM test_table');
+      expect(recent.toSQL()).toBe('SELECT id, name FROM test_table ORDER BY id DESC LIMIT 10');
+      expect(filtered.toSQL()).toBe("SELECT id, name FROM test_table WHERE category = 'premium'");
+    });
+
+    it('does not leak nested array state across branches', () => {
+      const base = builder.where('active', 'eq', 1);
+      const a = base.where('category', 'eq', 'premium');
+      const b = base.where('brand', 'eq', 'luxury');
+
+      expect(base.toSQL()).toBe('SELECT * FROM test_table WHERE active = 1');
+      expect(a.toSQL()).toBe("SELECT * FROM test_table WHERE active = 1 AND category = 'premium'");
+      expect(b.toSQL()).toBe("SELECT * FROM test_table WHERE active = 1 AND brand = 'luxury'");
+    });
+
+    it('exposes a root select-query node as the builder source of truth', () => {
+      const query = builder
+        .select(['id'])
+        .where('id', 'eq', 1)
+        .groupBy('id')
+        .orderBy('id', 'DESC')
+        .toQueryNode();
+
+      expect(query.kind).toBe('select-query');
+      expect(query.select?.map(item => item.selection)).toEqual(['id']);
+      expect(query.where?.kind).toBe('condition');
+      expect(query.groupBy?.map(item => item.expression)).toEqual(['id']);
+      expect(query.orderBy?.map(item => [item.column, item.direction])).toEqual([['id', 'DESC']]);
+    });
+
+    it('returns a snapshot from getConfig instead of leaking internal mutability', () => {
+      const query = builder.select(['id']).where('id', 'eq', 1);
+      const config = query.getConfig();
+
+      config.select?.push({ kind: 'selection', selection: 'name' });
+
+      expect(query.toSQL()).toBe('SELECT id FROM test_table WHERE id = 1');
+      expect(query.getConfig().select?.map(item => item.selection)).toEqual(['id']);
+    });
+  });
+});

--- a/packages/clickhouse/src/core/tests/query-builder.conditional-joins.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.conditional-joins.test.ts
@@ -42,14 +42,14 @@ describe('Conditional Joins', () => {
     // Test with updater only
     const updaterOnlyQuery = buildUserQuery(false, true);
     const updaterOnlySQL = updaterOnlyQuery.toSQL();
-    expect(updaterOnlySQL).toContain('LEFT JOIN users AS updater ON updated_by = users.id');
+    expect(updaterOnlySQL).toContain('LEFT JOIN users AS updater ON updated_by = updater.id');
     expect(updaterOnlySQL).not.toContain('users ON created_by');
 
     // Test with both
     const bothQuery = buildUserQuery(true, true);
     const bothSQL = bothQuery.toSQL();
     expect(bothSQL).toContain('LEFT JOIN users ON created_by = users.id');
-    expect(bothSQL).toContain('LEFT JOIN users AS updater ON updated_by = users.id');
+    expect(bothSQL).toContain('LEFT JOIN users AS updater ON updated_by = updater.id');
 
     // Test with neither
     const neitherQuery = buildUserQuery(false, false);
@@ -82,7 +82,7 @@ describe('Conditional Joins', () => {
       joinType: 'INNER'
     });
     const innerJoinSQL = innerJoinQuery.toSQL();
-    expect(innerJoinSQL).toContain('INNER JOIN users AS creator ON created_by = users.id');
+    expect(innerJoinSQL).toContain('INNER JOIN users AS creator ON created_by = creator.id');
     expect(innerJoinSQL).not.toContain('LEFT JOIN');
 
     // Test with LEFT join for creator
@@ -92,7 +92,7 @@ describe('Conditional Joins', () => {
       joinType: 'LEFT'
     });
     const leftJoinSQL = leftJoinQuery.toSQL();
-    expect(leftJoinSQL).toContain('LEFT JOIN users AS creator ON created_by = users.id');
+    expect(leftJoinSQL).toContain('LEFT JOIN users AS creator ON created_by = creator.id');
   });
 
   it('should maintain type safety in conditional joins', () => {

--- a/packages/clickhouse/src/core/tests/query-builder.helpers.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.helpers.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JoinRelationships, type JoinPath } from '../join-relationships.js';
+import { normalizeFilterApplication } from '../utils/filter-application.js';
+import { applyRelationPath, resolveRelationPath } from '../utils/relation-application.js';
+import { validateRelationAliasOverride, validateRelationPathOrigin } from '../utils/relation-validation.js';
+import { validateTupleFilterValue } from '../utils/tuple-filter-validation.js';
+import { createSelectQueryNode } from '../query-node.js';
+
+type TestSchema = {
+  test_table: {
+    id: 'Int32';
+    created_by: 'Int32';
+    updated_by: 'Int32';
+  };
+  users: {
+    id: 'Int32';
+    user_name: 'String';
+  };
+};
+
+describe('Query Builder Helper Utilities', () => {
+  describe('normalizeFilterApplication', () => {
+    it('normalizes expression callbacks', () => {
+      const expression = { sql: 'id = ?', parameters: [1] };
+      const buildExpression = vi.fn(() => expression);
+
+      const result = normalizeFilterApplication(
+        'where',
+        'AND',
+        () => expression as any,
+        undefined,
+        undefined,
+        buildExpression,
+      );
+
+      expect(result).toEqual({
+        kind: 'expression',
+        expression,
+      });
+      expect(buildExpression).toHaveBeenCalledOnce();
+    });
+
+    it('normalizes tuple conditions for multiple columns', () => {
+      const result = normalizeFilterApplication(
+        'where',
+        'AND',
+        ['id', 'created_by'],
+        'inTuple',
+        [[1, 2]],
+        () => {
+          throw new Error('should not build expression');
+        },
+      );
+
+      expect(result).toEqual({
+        kind: 'condition',
+        column: ['id', 'created_by'],
+        validationTarget: ['id', 'created_by'],
+        operator: 'inTuple',
+        value: [[1, 2]],
+      });
+    });
+
+    it('throws when an operator is omitted for a column condition', () => {
+      expect(() => {
+        normalizeFilterApplication(
+          'prewhere',
+          'OR',
+          'id',
+          undefined,
+          1,
+          () => {
+            throw new Error('should not build expression');
+          },
+        );
+      }).toThrow('Operator is required when specifying a column for orPrewhere()');
+    });
+  });
+
+  describe('validateTupleFilterValue', () => {
+    it('allows non-tuple operators without tuple validation', () => {
+      expect(() => {
+        validateTupleFilterValue('eq', 'not-an-array', 1);
+      }).not.toThrow();
+    });
+
+    it('throws for tuple width mismatches', () => {
+      expect(() => {
+        validateTupleFilterValue('inTuple', [[1, 2], [3]], 1);
+      }).toThrow('Expected tuple 1 for inTuple operator to have 1 value, but got 2');
+    });
+  });
+
+  describe('resolveRelationPath', () => {
+    it('resolves named relationships from the registry', () => {
+      const relationships = new JoinRelationships<TestSchema>();
+      relationships.define('testToUsers', {
+        from: 'test_table',
+        to: 'users',
+        leftColumn: 'created_by',
+        rightColumn: 'id',
+      });
+
+      const result = resolveRelationPath('testToUsers', relationships);
+
+      expect(result.label).toBe('testToUsers');
+      expect(result.path).toEqual({
+        from: 'test_table',
+        to: 'users',
+        leftColumn: 'created_by',
+        rightColumn: 'id',
+      });
+    });
+
+    it('passes direct paths through unchanged', () => {
+      const directPath = {
+        from: 'test_table',
+        to: 'users',
+        leftColumn: 'created_by',
+        rightColumn: 'id',
+      } as const satisfies JoinPath<TestSchema>;
+
+      const result = resolveRelationPath(directPath, undefined);
+      expect(result).toEqual({ path: directPath });
+    });
+  });
+
+  describe('relation validation and application', () => {
+    const baseQuery = createSelectQueryNode<any, TestSchema>({
+      from: { kind: 'table', name: 'test_table' },
+    });
+
+    it('rejects alias override on chains', () => {
+      const chain: readonly JoinPath<TestSchema>[] = [
+        {
+          from: 'test_table',
+          to: 'users',
+          leftColumn: 'created_by',
+          rightColumn: 'id',
+        },
+        {
+          from: 'users',
+          to: 'test_table',
+          leftColumn: 'id',
+          rightColumn: 'updated_by',
+        },
+      ];
+
+      expect(() => {
+        validateRelationAliasOverride(chain, 'customer', 'chain');
+      }).toThrow(
+        "Join relationship 'chain' is a chain; alias override is only supported for single-join relationships"
+      );
+    });
+
+    it('validates that chained relations start from available sources', () => {
+      const chain: readonly JoinPath<TestSchema>[] = [
+        {
+          from: 'test_table',
+          to: 'users',
+          leftColumn: 'created_by',
+          rightColumn: 'id',
+          alias: 'creator',
+        },
+        {
+          from: 'users',
+          to: 'test_table',
+          leftColumn: 'id',
+          rightColumn: 'updated_by',
+        },
+      ];
+
+      expect(() => {
+        validateRelationPathOrigin(baseQuery, chain, 'brokenChain');
+      }).toThrow(
+        "Join relationship 'brokenChain' step 2 expects source 'users', but available sources are: test_table, creator"
+      );
+    });
+
+    it('applies validated relation paths in sequence', () => {
+      const chain: readonly JoinPath<TestSchema>[] = [
+        {
+          from: 'test_table',
+          to: 'users',
+          leftColumn: 'created_by',
+          rightColumn: 'id',
+          alias: 'creator',
+        },
+        {
+          from: 'creator',
+          to: 'test_table',
+          leftColumn: 'id',
+          rightColumn: 'updated_by',
+          alias: 'updated_by_user',
+        },
+      ];
+
+      const result = applyRelationPath(
+        baseQuery,
+        chain,
+        undefined,
+        (currentQuery, joinPath) => ({
+          ...currentQuery,
+          joins: [
+            ...(currentQuery.joins || []),
+            {
+              kind: 'join' as const,
+              type: joinPath.type || 'INNER',
+              table: String(joinPath.to),
+              leftColumn: String(joinPath.leftColumn),
+              rightColumn: `${joinPath.alias || String(joinPath.to)}.${joinPath.rightColumn}`,
+              alias: joinPath.alias,
+            },
+          ],
+        }),
+      );
+
+      expect(result.joins?.map(join => [join.table, join.alias, join.rightColumn])).toEqual([
+        ['users', 'creator', 'creator.id'],
+        ['test_table', 'updated_by_user', 'updated_by_user.updated_by'],
+      ]);
+    });
+  });
+});

--- a/packages/clickhouse/src/core/tests/query-builder.joins.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.joins.test.ts
@@ -26,7 +26,7 @@ describe('QueryBuilder - Joins', () => {
         .innerJoin('users', 'created_by', 'users.id', 'u1')
         .innerJoin('users', 'updated_by', 'users.id', 'u2')
         .toSQL();
-      expect(sql).toBe('SELECT * FROM test_table INNER JOIN users AS u1 ON created_by = users.id INNER JOIN users AS u2 ON updated_by = users.id');
+      expect(sql).toBe('SELECT * FROM test_table INNER JOIN users AS u1 ON created_by = u1.id INNER JOIN users AS u2 ON updated_by = u2.id');
     });
 
     it('should maintain types when joining on same column name', () => {
@@ -37,6 +37,27 @@ describe('QueryBuilder - Joins', () => {
           'id',
           'users.id'
         );
+
+      type Result = Awaited<ReturnType<typeof query.execute>>;
+      type Expected = { id: number }[];
+      type _Assert = Expect<Equal<Result, Expected>>;
+    });
+
+    it('should use the join alias in the ON clause when an alias is provided', () => {
+      const sql = builder
+        .innerJoin('users', 'created_by', 'users.id', 'author')
+        .select(['author.user_name'])
+        .toSQL();
+
+      expect(sql).toBe(
+        'SELECT author.user_name FROM test_table INNER JOIN users AS author ON created_by = author.id'
+      );
+    });
+
+    it('requires aliases when selecting duplicate leaf column names from joined tables', () => {
+      const query = builder
+        .innerJoin('users', 'created_by', 'users.id')
+        .select(['test_table.id', 'users.id']);
 
       type Result = Awaited<ReturnType<typeof query.execute>>;
       type Expected = { id: number }[];
@@ -146,8 +167,8 @@ describe('QueryBuilder - Joins', () => {
       expect(sql).toBe(
         'SELECT test_table.name, u1.user_name as creator, u2.user_name as updater ' +
         'FROM test_table ' +
-        'INNER JOIN users AS u1 ON created_by = users.id ' +
-        'LEFT JOIN users AS u2 ON updated_by = users.id'
+        'INNER JOIN users AS u1 ON created_by = u1.id ' +
+        'LEFT JOIN users AS u2 ON updated_by = u2.id'
       );
     });
 
@@ -204,6 +225,42 @@ describe('QueryBuilder - Joins', () => {
         'HAVING COUNT(*) > 1 ' +
         'ORDER BY users.user_name DESC'
       );
+    });
+
+    it('should preserve join, aggregation, and having nodes in the query tree', () => {
+      const query = builder
+        .innerJoin('users', 'created_by', 'users.id', 'author')
+        .select(['author.user_name'])
+        .sum('price', 'revenue')
+        .count('id', 'order_count')
+        .where('active', 'eq', 1)
+        .groupBy('author.user_name')
+        .having('revenue > ?', [1000])
+        .having('order_count > ?', [5])
+        .orderBy('author.user_name', 'DESC');
+
+      expect(query.toSQL()).toBe(
+        "SELECT author.user_name, SUM(price) AS revenue, COUNT(id) AS order_count FROM test_table " +
+        "INNER JOIN users AS author ON created_by = author.id " +
+        "WHERE active = 1 " +
+        "GROUP BY author.user_name " +
+        "HAVING revenue > 1000 AND order_count > 5 " +
+        "ORDER BY author.user_name DESC"
+      );
+
+      const queryNode = query.toQueryNode();
+      expect(queryNode.joins?.map(join => [join.type, join.table, join.alias])).toEqual([
+        ['INNER', 'users', 'author'],
+      ]);
+      expect(queryNode.select?.map(item => item.selection)).toEqual([
+        'author.user_name',
+        'SUM(price) AS revenue',
+        'COUNT(id) AS order_count',
+      ]);
+      expect(queryNode.having?.map(item => item.expression)).toEqual([
+        'revenue > ?',
+        'order_count > ?',
+      ]);
     });
 
   });

--- a/packages/clickhouse/src/core/tests/query-builder.where.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.where.test.ts
@@ -32,6 +32,34 @@ describe('QueryBuilder - Where Conditions', () => {
         .toSQL();
       expect(sql).toBe("SELECT * FROM test_table WHERE name LIKE '%O''Brien%'");
     });
+
+    it('should support explicit null helpers', () => {
+      const sql = builder
+        .whereNull('optional_name')
+        .orWhereNotNull('name')
+        .toSQL();
+
+      expect(sql).toBe('SELECT * FROM test_table WHERE optional_name IS NULL OR name IS NOT NULL');
+    });
+
+    it('should support prewhere clauses', () => {
+      const sql = builder
+        .prewhere('active', 'eq', 1)
+        .orPrewhere('category', 'eq', 'premium')
+        .where('price', 'gt', 100)
+        .toSQL();
+
+      expect(sql).toBe("SELECT * FROM test_table PREWHERE active = 1 OR category = 'premium' WHERE price > 100");
+    });
+
+    it('should support prewhere null helpers', () => {
+      const sql = builder
+        .prewhereNull('optional_name')
+        .prewhereNotNull('name')
+        .toSQL();
+
+      expect(sql).toBe('SELECT * FROM test_table PREWHERE optional_name IS NULL AND name IS NOT NULL');
+    });
   });
 
   describe('orWhere conditions', () => {
@@ -63,6 +91,15 @@ describe('QueryBuilder - Where Conditions', () => {
   });
 
   describe('whereGroup conditions', () => {
+    it('treats an empty whereGroup as a no-op', () => {
+      const sql = builder
+        .where('active', 'eq', 1)
+        .whereGroup(() => {})
+        .toSQL();
+
+      expect(sql).toBe('SELECT * FROM test_table WHERE active = 1');
+    });
+
     it('should handle simple whereGroup', () => {
       const sql = builder
         .whereGroup((qb) => {
@@ -101,6 +138,15 @@ describe('QueryBuilder - Where Conditions', () => {
   });
 
   describe('orWhereGroup conditions', () => {
+    it('treats an empty orWhereGroup as a no-op', () => {
+      const sql = builder
+        .where('active', 'eq', 1)
+        .orWhereGroup(() => {})
+        .toSQL();
+
+      expect(sql).toBe('SELECT * FROM test_table WHERE active = 1');
+    });
+
     it('should handle simple orWhereGroup', () => {
       const sql = builder
         .where('active', 'eq', 1)
@@ -184,6 +230,32 @@ describe('QueryBuilder - Where Conditions', () => {
         .toSQL();
       expect(sql).toBe("SELECT * FROM test_table WHERE (active = 1 AND (price >= 100 OR (category = 'premium' OR brand = 'luxury')))");
     });
+
+    it('should preserve nested where/orWhere groups alongside prewhere clauses', () => {
+      const query = builder
+        .prewhere('active', 'eq', 1)
+        .orPrewhere('category', 'eq', 'premium')
+        .whereGroup((qb) => {
+          qb.where('status', 'eq', 'completed')
+            .orWhereGroup((innerQb) => {
+              innerQb.where('total', 'gte', 100)
+                .whereGroup((deepQb) => {
+                  deepQb.where('priority', 'eq', 'high')
+                    .orWhere('brand', 'eq', 'luxury');
+                });
+            });
+        })
+        .whereNotNull('optional_name');
+
+      expect(query.toSQL()).toBe(
+        "SELECT * FROM test_table PREWHERE active = 1 OR category = 'premium' WHERE (status = 'completed' OR (total >= 100 AND (priority = 'high' OR brand = 'luxury'))) AND optional_name IS NOT NULL"
+      );
+
+      const queryNode = query.toQueryNode();
+      expect(queryNode.kind).toBe('select-query');
+      expect(queryNode.prewhere?.kind).toBe('sequence');
+      expect(queryNode.where?.kind).toBe('sequence');
+    });
   });
 
   describe('complex mixed conditions', () => {
@@ -248,7 +320,7 @@ describe('QueryBuilder - Where Conditions', () => {
           // Empty group
         })
         .toSQL();
-      expect(sql).toBe('SELECT * FROM test_table WHERE ()');
+      expect(sql).toBe('SELECT * FROM test_table');
     });
 
     it('should handle single condition in whereGroup', () => {

--- a/packages/clickhouse/src/core/utils/filter-application.ts
+++ b/packages/clickhouse/src/core/utils/filter-application.ts
@@ -1,0 +1,59 @@
+import type { FilterOperator } from '../../types/index.js';
+import type { PredicateBuilder, PredicateExpression } from './predicate-builder.js';
+import { validateTupleFilterValue } from './tuple-filter-validation.js';
+
+export interface FilterExpressionApplication<TExpression> {
+  kind: 'expression';
+  expression: TExpression;
+}
+
+export interface FilterConditionApplication {
+  kind: 'condition';
+  column: string | string[];
+  validationTarget: string | string[];
+  operator: FilterOperator;
+  value: unknown;
+}
+
+export function normalizeFilterApplication<TExpression>(
+  clause: 'where' | 'prewhere',
+  conjunction: 'AND' | 'OR',
+  columnOrColumns: string | string[] | ((expr: PredicateBuilder<any>) => PredicateExpression),
+  operator: FilterOperator | undefined,
+  value: unknown,
+  buildExpression: (builder: (expr: PredicateBuilder<any>) => PredicateExpression) => TExpression
+): FilterExpressionApplication<TExpression> | FilterConditionApplication {
+  if (typeof columnOrColumns === 'function') {
+    return {
+      kind: 'expression',
+      expression: buildExpression(columnOrColumns),
+    };
+  }
+
+  if (operator === undefined) {
+    throw new Error(`Operator is required when specifying a column for ${conjunction === 'AND' ? clause : `or${clause[0]!.toUpperCase()}${clause.slice(1)}`}()`);
+  }
+
+  if (Array.isArray(columnOrColumns) && (operator === 'inTuple' || operator === 'globalInTuple')) {
+    const columns = columnOrColumns.map(String);
+    validateTupleFilterValue(operator, value, columns.length);
+    return {
+      kind: 'condition',
+      column: columns,
+      validationTarget: columns,
+      operator,
+      value,
+    };
+  }
+
+  validateTupleFilterValue(operator, value, 1);
+
+  const column = Array.isArray(columnOrColumns) ? String(columnOrColumns[0]) : String(columnOrColumns);
+  return {
+    kind: 'condition',
+    column,
+    validationTarget: Array.isArray(columnOrColumns) ? columnOrColumns.map(String) : column,
+    operator,
+    value,
+  };
+}

--- a/packages/clickhouse/src/core/utils/query-config-compat.ts
+++ b/packages/clickhouse/src/core/utils/query-config-compat.ts
@@ -1,0 +1,214 @@
+import type { ClickHouseSettings } from '@clickhouse/client-common';
+import type {
+  ConditionValueNode,
+  ExprNode,
+  FilterOperator,
+  JoinType,
+  OrderDirection,
+  SelectQueryNode,
+  ValueNode,
+} from '../../types/index.js';
+
+export type LegacyStandardWhereCondition = {
+  column: string;
+  operator: FilterOperator;
+  value: any;
+  conjunction: 'AND' | 'OR';
+  type?: 'condition' | 'group-start' | 'group-end';
+};
+
+export type LegacyExpressionWhereCondition = {
+  type: 'expression';
+  expression: string;
+  parameters: any[];
+  conjunction: 'AND' | 'OR';
+};
+
+export type LegacyWhereCondition = LegacyStandardWhereCondition | LegacyExpressionWhereCondition;
+
+export type LegacyQueryConfig<T> = {
+  select?: Array<keyof T | string>;
+  from?: { kind: 'table'; name: string; final?: boolean };
+  where?: LegacyWhereCondition[];
+  prewhere?: LegacyWhereCondition[];
+  groupBy?: string[];
+  having?: string[];
+  limit?: number;
+  offset?: number;
+  distinct?: boolean;
+  orderBy?: Array<{
+    column: keyof T | string;
+    direction: OrderDirection;
+  }>;
+  joins?: Array<{
+    type: JoinType;
+    table: string;
+    leftColumn: string;
+    rightColumn: string;
+    alias?: string;
+  }>;
+  parameters?: any[];
+  ctes?: string[];
+  unionQueries?: string[];
+  settings?: ClickHouseSettings;
+};
+
+function unwrapValueNode(value: ValueNode): any {
+  return value.value;
+}
+
+function unwrapConditionValue(value: ConditionValueNode): any {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => Array.isArray(item) ? item.map(unwrapValueNode) : unwrapValueNode(item));
+  }
+
+  return unwrapValueNode(value);
+}
+
+function collectExprParameters(expr?: ExprNode): any[] {
+  if (!expr) return [];
+
+  switch (expr.kind) {
+    case 'condition': {
+      const value = unwrapConditionValue(expr.value);
+      if (expr.operator === 'between') {
+        return Array.isArray(value) ? value : [];
+      }
+      if (
+        expr.operator === 'in' ||
+        expr.operator === 'notIn' ||
+        expr.operator === 'globalIn' ||
+        expr.operator === 'globalNotIn'
+      ) {
+        return Array.isArray(value) ? value : [];
+      }
+      if (expr.operator === 'inTuple' || expr.operator === 'globalInTuple') {
+        return Array.isArray(value) ? value.flat() : [];
+      }
+      if (
+        expr.operator === 'inSubquery' ||
+        expr.operator === 'globalInSubquery' ||
+        expr.operator === 'inTable' ||
+        expr.operator === 'globalInTable' ||
+        expr.operator === 'isNull' ||
+        expr.operator === 'isNotNull'
+      ) {
+        return [];
+      }
+      return [value];
+    }
+    case 'raw':
+      return expr.parameters.map(unwrapValueNode);
+    case 'group':
+      return collectExprParameters(expr.expression);
+    case 'logical':
+      return expr.conditions.flatMap(condition => collectExprParameters(condition));
+    case 'sequence':
+      return expr.items.flatMap(item => collectExprParameters(item.expression));
+    default:
+      return [];
+  }
+}
+
+function flattenExprToLegacyConditions(
+  expr: ExprNode | undefined,
+  firstConjunction: 'AND' | 'OR' = 'AND'
+): LegacyWhereCondition[] {
+  if (!expr) return [];
+
+  switch (expr.kind) {
+    case 'condition':
+      return [{
+        column: expr.column,
+        operator: expr.operator,
+        value: unwrapConditionValue(expr.value),
+        conjunction: firstConjunction,
+      }];
+    case 'raw':
+      return [{
+        type: 'expression',
+        expression: expr.expression,
+        parameters: expr.parameters.map(unwrapValueNode),
+        conjunction: firstConjunction,
+      }];
+    case 'group': {
+      if (!expr.expression) return [];
+      return [
+        {
+          column: '',
+          operator: 'eq',
+          value: null,
+          conjunction: firstConjunction,
+          type: 'group-start',
+        },
+        ...flattenExprToLegacyConditions(expr.expression, 'AND'),
+        {
+          column: '',
+          operator: 'eq',
+          value: null,
+          conjunction: 'AND',
+          type: 'group-end',
+        },
+      ];
+    }
+    case 'sequence':
+      return expr.items.flatMap((item, index) =>
+        flattenExprToLegacyConditions(
+          item.expression,
+          index === 0 ? firstConjunction : (item.conjunction || 'AND')
+        )
+      );
+    case 'logical':
+      return flattenExprToLegacyConditions(
+        {
+          kind: 'sequence',
+          items: expr.conditions.map((condition, index) => ({
+            conjunction: index === 0 ? undefined : expr.operator,
+            expression: condition,
+          })),
+        },
+        firstConjunction
+      );
+    default:
+      return [];
+  }
+}
+
+export function toLegacyQueryConfig<T, Schema>(
+  queryNode: SelectQueryNode<T, Schema>
+): LegacyQueryConfig<T> {
+  return {
+    select: queryNode.select?.map(item => item.selection) as Array<keyof T | string> | undefined,
+    from: queryNode.from ? { ...queryNode.from } : undefined,
+    where: flattenExprToLegacyConditions(queryNode.where),
+    prewhere: flattenExprToLegacyConditions(queryNode.prewhere),
+    groupBy: queryNode.groupBy?.map(item => item.expression),
+    having: queryNode.having?.map(item => item.expression),
+    limit: queryNode.limit,
+    offset: queryNode.offset,
+    distinct: queryNode.distinct,
+    orderBy: queryNode.orderBy?.map(item => ({
+      column: item.column as keyof T | string,
+      direction: item.direction,
+    })),
+    joins: queryNode.joins?.map(join => ({
+      type: join.type,
+      table: join.table,
+      leftColumn: join.leftColumn,
+      rightColumn: join.rightColumn,
+      alias: join.alias,
+    })),
+    parameters: [
+      ...collectExprParameters(queryNode.prewhere),
+      ...collectExprParameters(queryNode.where),
+      ...(queryNode.having?.flatMap(item => item.parameters?.map(unwrapValueNode) || []) || []),
+    ],
+    ctes: queryNode.ctes?.map(item => item.expression),
+    unionQueries: queryNode.unionQueries ? [...queryNode.unionQueries] : undefined,
+    settings: queryNode.settings ? { ...queryNode.settings } : undefined,
+  };
+}

--- a/packages/clickhouse/src/core/utils/relation-application.ts
+++ b/packages/clickhouse/src/core/utils/relation-application.ts
@@ -1,0 +1,44 @@
+import type { SelectQueryNode } from '../../types/index.js';
+import type { SchemaDefinition } from '../types/builder-state.js';
+import type { JoinPath, JoinPathOptions, JoinRelationships } from '../join-relationships.js';
+import { validateRelationAliasOverride, validateRelationPathOrigin } from './relation-validation.js';
+
+export function resolveRelationPath<Schema extends SchemaDefinition<Schema>>(
+  nameOrPath: string | JoinPath<Schema> | readonly JoinPath<Schema>[],
+  relationships: JoinRelationships<Schema> | undefined
+): { path: JoinPath<Schema> | readonly JoinPath<Schema>[]; label?: string } {
+  if (typeof nameOrPath !== 'string') {
+    return { path: nameOrPath };
+  }
+
+  if (!relationships) {
+    throw new Error('Join relationships have not been initialized. Call QueryBuilder.setJoinRelationships first.');
+  }
+
+  const path = relationships.get(nameOrPath);
+  if (!path) {
+    throw new Error(`Join relationship '${nameOrPath}' not found`);
+  }
+
+  return { path, label: nameOrPath };
+}
+
+export function applyRelationPath<Schema extends SchemaDefinition<Schema>>(
+  query: SelectQueryNode<any, Schema>,
+  path: JoinPath<Schema> | readonly JoinPath<Schema>[],
+  options: JoinPathOptions | undefined,
+  appendJoin: (
+    currentQuery: SelectQueryNode<any, Schema>,
+    joinPath: JoinPath<Schema>,
+    options: JoinPathOptions | undefined
+  ) => SelectQueryNode<any, Schema>,
+  label?: string
+): SelectQueryNode<any, Schema> {
+  validateRelationAliasOverride(path, options?.alias, label);
+  validateRelationPathOrigin(query, path, label);
+
+  return (Array.isArray(path) ? path : [path]).reduce(
+    (currentQuery, joinPath) => appendJoin(currentQuery, joinPath, options),
+    query
+  );
+}

--- a/packages/clickhouse/src/core/utils/relation-validation.ts
+++ b/packages/clickhouse/src/core/utils/relation-validation.ts
@@ -1,0 +1,52 @@
+import type { SelectQueryNode } from '../../types/index.js';
+import type { SchemaDefinition } from '../types/builder-state.js';
+import type { JoinPath } from '../join-relationships.js';
+
+function getAvailableRelationSources<Schema extends SchemaDefinition<Schema>>(
+  query: SelectQueryNode<any, Schema>
+): Set<string> {
+  const sources = new Set<string>();
+  if (query.from?.kind === 'table') {
+    sources.add(query.from.name);
+  }
+  for (const join of query.joins || []) {
+    sources.add(join.alias || join.table);
+  }
+  return sources;
+}
+
+export function validateRelationPathOrigin<Schema extends SchemaDefinition<Schema>>(
+  query: SelectQueryNode<any, Schema>,
+  path: JoinPath<Schema> | readonly JoinPath<Schema>[],
+  label?: string
+): void {
+  const availableSources = getAvailableRelationSources(query);
+  const paths = Array.isArray(path) ? path : [path];
+
+  paths.forEach((joinPath, index) => {
+    const from = String(joinPath.from);
+    if (!availableSources.has(from)) {
+      const relationshipLabel = label ? ` '${label}'` : '';
+      throw new Error(
+        `Join relationship${relationshipLabel} step ${index + 1} expects source '${from}', but available sources are: ${Array.from(availableSources).join(', ')}`
+      );
+    }
+
+    availableSources.add(joinPath.alias || String(joinPath.to));
+  });
+}
+
+export function validateRelationAliasOverride(
+  path: JoinPath<any> | readonly JoinPath<any>[],
+  alias: string | undefined,
+  label?: string
+): void {
+  if (!Array.isArray(path) || !alias) {
+    return;
+  }
+
+  const nameLabel = label ? `'${label}' ` : '';
+  throw new Error(
+    `Join relationship ${nameLabel}is a chain; alias override is only supported for single-join relationships`
+  );
+}

--- a/packages/clickhouse/src/core/utils/tuple-filter-validation.ts
+++ b/packages/clickhouse/src/core/utils/tuple-filter-validation.ts
@@ -1,0 +1,26 @@
+import type { FilterOperator } from '../../types/index.js';
+
+export function validateTupleFilterValue(
+  operator: FilterOperator,
+  value: unknown,
+  expectedWidth: number
+): void {
+  if (operator !== 'inTuple' && operator !== 'globalInTuple') {
+    return;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error(`Expected an array of tuples for ${operator} operator, but got ${typeof value}`);
+  }
+
+  value.forEach((tuple: unknown, index: number) => {
+    if (!Array.isArray(tuple)) {
+      throw new Error(`Expected tuple ${index + 1} for ${operator} operator to be an array`);
+    }
+    if (tuple.length !== expectedWidth) {
+      throw new Error(
+        `Expected tuple ${index + 1} for ${operator} operator to have ${expectedWidth} value${expectedWidth === 1 ? '' : 's'}, but got ${tuple.length}`
+      );
+    }
+  });
+}

--- a/packages/clickhouse/src/types/base.ts
+++ b/packages/clickhouse/src/types/base.ts
@@ -3,20 +3,18 @@ import { FilterOperator } from "./filters.js";
 import type { TableColumn } from './schema.js';
 
 export interface QueryConfig<T, Schema> {
-  select?: Array<keyof T | string>;
-  where?: WhereCondition[];
-  groupBy?: string[];
-  having?: string[];
+  select?: SelectionNode[];
+  from?: SourceNode;
+  prewhere?: ExprNode;
+  where?: ExprNode;
+  groupBy?: GroupByItemNode[];
+  having?: HavingNode[];
   limit?: number;
   offset?: number;
   distinct?: boolean;
-  orderBy?: Array<{
-    column: keyof T | TableColumn<Schema>;
-    direction: OrderDirection;
-  }>;
-  joins?: JoinClause[];
-  parameters?: any[];
-  ctes?: string[];
+  orderBy?: OrderByItemNode[];
+  joins?: JoinNode[];
+  ctes?: CteNode[];
   unionQueries?: string[];
   settings?: ClickHouseSettings;
 }
@@ -28,31 +26,105 @@ export type GroupByExpression<T> = keyof T | Array<keyof T>;
 
 export type OrderDirection = 'ASC' | 'DESC';
 
-export interface StandardWhereCondition {
+export interface CompiledQuery {
+  query: string;
+  parameters: unknown[];
+}
+
+export interface SelectionNode {
+  kind: 'selection';
+  selection: string;
+}
+
+export interface ValueNode {
+  kind: 'value';
+  value: unknown;
+}
+
+export type ConditionValueNode =
+  | ValueNode
+  | ValueNode[]
+  | ValueNode[][]
+  | [ValueNode, ValueNode]
+  | string;
+
+export interface ConditionExprNode {
+  kind: 'condition';
   column: string;
   operator: FilterOperator;
-  value: any;
-  conjunction: 'AND' | 'OR';
-  type?: 'condition' | 'group-start' | 'group-end';
+  value: ConditionValueNode;
 }
 
-export interface ExpressionWhereCondition {
-  type: 'expression';
+export interface RawExprNode {
+  kind: 'raw';
   expression: string;
-  parameters: any[];
-  conjunction: 'AND' | 'OR';
+  parameters: ValueNode[];
 }
 
-export type WhereCondition = StandardWhereCondition | ExpressionWhereCondition;
+export interface LogicalExprNode {
+  kind: 'logical';
+  operator: 'AND' | 'OR';
+  conditions: ExprNode[];
+}
+
+export interface SequenceExprNode {
+  kind: 'sequence';
+  items: Array<{
+    conjunction?: 'AND' | 'OR';
+    expression: ExprNode;
+  }>;
+}
+
+export interface GroupExprNode {
+  kind: 'group';
+  expression?: ExprNode;
+}
+
+export type ExprNode = ConditionExprNode | RawExprNode | LogicalExprNode | SequenceExprNode | GroupExprNode;
+
+export interface TableSourceNode {
+  kind: 'table';
+  name: string;
+  final?: boolean;
+}
+
+export type SourceNode = TableSourceNode;
+
+export interface GroupByItemNode {
+  kind: 'group-by-item';
+  expression: string;
+}
+
+export interface HavingNode {
+  kind: 'having';
+  expression: string;
+  parameters?: ValueNode[];
+}
 
 export type JoinType = 'INNER' | 'LEFT' | 'RIGHT' | 'FULL';
 
-export interface JoinClause {
+export interface JoinNode {
+  kind: 'join';
   type: JoinType;
   table: string;
   leftColumn: string;
   rightColumn: string;
   alias?: string;
+}
+
+export interface OrderByItemNode {
+  kind: 'order-by-item';
+  column: string;
+  direction: OrderDirection;
+}
+
+export interface CteNode {
+  kind: 'cte';
+  expression: string;
+}
+
+export interface SelectQueryNode<T, Schema> extends QueryConfig<T, Schema> {
+  kind: 'select-query';
 }
 
 export type AggregationType<T, Aggregations, Column, A extends string, Suffix extends string, HasSelect extends boolean> =

--- a/packages/clickhouse/src/types/filters.ts
+++ b/packages/clickhouse/src/types/filters.ts
@@ -25,8 +25,8 @@ export type FilterCondition<T> = {
   globalInSubquery: string;
   inTable: string;
   globalInTable: string;
-  inTuple: FilterValue<T>[][];
-  globalInTuple: FilterValue<T>[][];
+  inTuple: [FilterValue<T>][];
+  globalInTuple: [FilterValue<T>][];
   isNull: never;
   isNotNull: never;
 };
@@ -42,7 +42,7 @@ export type FilterValueType<T, Op extends FilterOperator, Schema = any> =
   : Op extends 'inTable' | 'globalInTable'
   ? keyof Schema
   : Op extends 'inTuple' | 'globalInTuple'
-  ? T[][]
+  ? [T][]
   : Op extends 'isNull' | 'isNotNull'
   ? never
   : T;
@@ -66,8 +66,8 @@ export type OperatorValueMap<T, Schema = any> = {
   'globalInSubquery': string;
   'inTable': keyof Schema;
   'globalInTable': keyof Schema;
-  'inTuple': (T | string)[][];
-  'globalInTuple': (T | string)[][];
+  'inTuple': [T | string][];
+  'globalInTuple': [T | string][];
   'isNull': never;
   'isNotNull': never;
 };

--- a/packages/clickhouse/src/types/filters.ts
+++ b/packages/clickhouse/src/types/filters.ts
@@ -25,8 +25,10 @@ export type FilterCondition<T> = {
   globalInSubquery: string;
   inTable: string;
   globalInTable: string;
-  inTuple: [FilterValue<T>, FilterValue<T>][];
-  globalInTuple: [FilterValue<T>, FilterValue<T>][];
+  inTuple: FilterValue<T>[][];
+  globalInTuple: FilterValue<T>[][];
+  isNull: never;
+  isNotNull: never;
 };
 
 // Define type-safe filter operators and their expected value types
@@ -40,7 +42,9 @@ export type FilterValueType<T, Op extends FilterOperator, Schema = any> =
   : Op extends 'inTable' | 'globalInTable'
   ? keyof Schema
   : Op extends 'inTuple' | 'globalInTuple'
-  ? [T, T][]
+  ? T[][]
+  : Op extends 'isNull' | 'isNotNull'
+  ? never
   : T;
 
 // Type-safe operator mapping
@@ -62,8 +66,10 @@ export type OperatorValueMap<T, Schema = any> = {
   'globalInSubquery': string;
   'inTable': keyof Schema;
   'globalInTable': keyof Schema;
-  'inTuple': [T | string, T | string][];
-  'globalInTuple': [T | string, T | string][];
+  'inTuple': (T | string)[][];
+  'globalInTuple': (T | string)[][];
+  'isNull': never;
+  'isNotNull': never;
 };
 
 export type FilterOperator = keyof OperatorValueMap<any>;

--- a/website-next/docs/query-building/join-relationships.mdx
+++ b/website-next/docs/query-building/join-relationships.mdx
@@ -10,6 +10,11 @@ import { CodeBlock, Pre } from 'fumadocs-ui/components/codeblock';
 
 Inline joins are often enough for one-off queries. When the same join path appears across multiple queries, `JoinRelationships` gives you a reusable, named relationship that you can apply with `withRelation()`.
 
+There are two `withRelation()` modes:
+
+- pass a relationship name from `JoinRelationships` for reusable runtime lookup
+- pass a `JoinPath` object (or chain) directly when you want compile-time table/alias widening
+
 ## When to use this
 
 Use join relationships when you want to:
@@ -17,7 +22,7 @@ Use join relationships when you want to:
 - define common join paths once
 - keep multi-query join logic consistent
 - reuse multi-step joins without rewriting them
-- override join type or alias per query while keeping a shared base definition
+- override join type per query while keeping a shared base definition
 
 <Callout type="info" title="Query builder syntax">
   These examples use a typed standalone `db` client so the query builder stays the focus.
@@ -133,14 +138,49 @@ const rows = await db
 
 ## Override join options per query
 
-You can override the join type or alias without redefining the relationship:
+You can override the join type without redefining the relationship:
 
 <CodeBlock>
 <Pre>
 ```typescript
 const rows = await db
   .table('orders')
-  .withRelation('orderCustomer', { type: 'INNER', alias: 'customer' })
+  .withRelation('orderCustomer', { type: 'INNER' })
+  .select([
+    'orders.id',
+    'users.name',
+  ])
+  .execute();
+```
+</Pre>
+</CodeBlock>
+
+This is useful when the shared relationship is usually `LEFT`, but one query needs stricter matching.
+
+`alias` can be defined on the relationship itself for SQL generation, but `withRelation()` does not widen the builder's alias typing the way inline `join(..., alias)` methods do. For typed alias-based column selection, prefer inline joins.
+
+Alias override is only supported for single-join relationships. For `defineChain()` relationships, each step should define its own alias explicitly if needed.
+
+## Typed direct-path usage
+
+If you want `withRelation()` to widen the builder type for joined-table or aliased column selection, pass a `JoinPath` directly instead of looking it up by string name:
+
+<CodeBlock>
+<Pre>
+```typescript
+import type { JoinPath } from '@hypequery/clickhouse';
+
+const orderCustomerPath = {
+  from: 'orders',
+  to: 'users',
+  leftColumn: 'orders.user_id',
+  rightColumn: 'id',
+  alias: 'customer',
+} as const satisfies JoinPath<Schema>;
+
+const rows = await db
+  .table('orders')
+  .withRelation(orderCustomerPath)
   .select([
     'orders.id',
     'customer.name',
@@ -150,7 +190,7 @@ const rows = await db
 </Pre>
 </CodeBlock>
 
-This is useful when the shared relationship is usually `LEFT`, but one query needs stricter matching.
+String-based registry lookups remain convenient for reuse, but their widening is runtime-only because the relationship name is not available to TypeScript.
 
 ## Initialization requirements
 


### PR DESCRIPTION
## Summary
This PR splits core query-builder responsibilities into smaller internal modules and moves query state toward an
explicit query-node model. It preserves the public query-builder workflow while making filtering, relation
application, SQL compilation, and validation easier to reason about and test.

The branch also tightens `withRelation()` semantics, improves advanced `IN` operator coverage, and updates the
join-relationships docs to reflect the actual typed/runtime behavior.

## Why
The query builder had accumulated a large amount of logic inside `query-builder.ts`, including:
- mutation/cloning of query state
- filter normalization
- relation lookup and application
- validation around relation origin and tuple filters
- SQL compilation assumptions spread across multiple features
- 
That made behavior harder to verify and slowed down follow-on work. This refactor creates clearer internal seams
without changing the overall product shape.

## What changed

### 1. Introduce explicit query-node infrastructure
- Added `packages/clickhouse/src/core/query-node.ts`
- Added cloning and transform helpers for `SelectQueryNode`
- Moved the builder toward a node-based internal representation instead of ad hoc config mutation

### 2. Split reusable internal logic into focused helpers
- Added `filter-application.ts`
- Added `relation-application.ts`
- Added `relation-validation.ts`
- Added `tuple-filter-validation.ts`
This separates normalization/validation from the builder orchestration logic.

### 3. Refactor `query-builder.ts` around internal transitions
- Builder now carries a `SelectQueryNode`
- Added structured transform/fork/transition flow
- Reduced inlined condition/relation plumbing in favor of shared helpers

### 4. Expand core query AST types
- `QueryConfig` now uses structured nodes for select/from/where/prewhere/group/order/joins/having/ctes
- Added `ExprNode`, `SelectionNode`, `JoinNode`, `OrderByItemNode`, `CteNode`, `SelectQueryNode`, etc.
- Added `CompiledQuery` type

### 5. Tighten filter typing and validation
- Added `isNull` / `isNotNull` operators
- Improved advanced `IN` handling
- Tuple filters are validated explicitly by expected width
- Single-column tuple `IN` cases are now covered

### 6. Tighten `withRelation()` behavior
- Shared relation lookup/application now validates that each step starts from an available source
- Alias override is rejected for chained relationships
- Runtime string lookups remain supported
- Direct `JoinPath` usage is documented as the typed path for compile-time widening

### 7. Update docs and tests
- Added helper-focused tests in `query-builder.helpers.test.ts`
- Expanded tests for:
  - advanced `IN` operators
  - join relationships
  - where behavior
  - analytics/basic/join edge cases
- Updated docs for join relationships to describe the two `withRelation()` modes and the alias limitations clearly

## Behavioral notes
- `withRelation('name')` still works for reusable registered relationships.
- For typed alias/table widening, callers should pass a direct `JoinPath` rather than a string registry key.
- Alias override is only supported for single-step relationships, not chains.
- Tuple `IN` validation is stricter and now fails earlier with clearer errors when tuple width does not match the
selected columns.

##  Follow-up:
  - remove `context.tableName` fallback from dialect compilation once `SelectQueryNode.from` is guaranteed on all
  builder paths
  - simplify `CompileQueryContext` accordingly