### PR TITLE
feat: update connection url path

### DIFF
--- a/examples/next-dashboard/package.json
+++ b/examples/next-dashboard/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@clickhouse/client": "^1.11.2",
+    "@clickhouse/client": "^1.18.3",
     "@hypequery/clickhouse": "*",
     "@hypequery/react": "*",
     "@hypequery/serve": "*",

--- a/examples/next-dashboard/src/analytics/client.ts
+++ b/examples/next-dashboard/src/analytics/client.ts
@@ -11,11 +11,16 @@ const resolveEnv = (...keys: (keyof NodeJS.ProcessEnv)[]): string | undefined =>
   return undefined;
 };
 
-const host = resolveEnv('CLICKHOUSE_HOST', 'NEXT_PUBLIC_CLICKHOUSE_HOST');
+const url = resolveEnv(
+  'CLICKHOUSE_URL',
+  'NEXT_PUBLIC_CLICKHOUSE_URL',
+  'CLICKHOUSE_HOST',
+  'NEXT_PUBLIC_CLICKHOUSE_HOST',
+);
 
-if (!host) {
+if (!url) {
   throw new Error(
-    'Missing CLICKHOUSE_HOST (or NEXT_PUBLIC_CLICKHOUSE_HOST) environment variable. Copy examples/next-dashboard/.env.example to .env and fill it in.',
+    'Missing CLICKHOUSE_URL (or NEXT_PUBLIC_CLICKHOUSE_URL). Legacy CLICKHOUSE_HOST variables are still supported. Copy examples/next-dashboard/.env.example to .env and fill it in.',
   );
 }
 
@@ -27,7 +32,7 @@ const database =
   process.env.CLICKHOUSE_DATABASE ?? process.env.NEXT_PUBLIC_CLICKHOUSE_DATABASE ?? 'default';
 
 const client = createClient({
-  host,
+  url,
   username,
   password,
   database,

--- a/examples/node-embedded/package.json
+++ b/examples/node-embedded/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@clickhouse/client": "^1.11.2",
+    "@clickhouse/client": "^1.18.3",
     "@hypequery/clickhouse": "*",
     "@hypequery/serve": "*",
     "dotenv": "^16.6.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@clickhouse/client": "^1.16.0",
+    "@clickhouse/client": "^1.18.3",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "dotenv": "^16.4.7",

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -84,7 +84,7 @@ export async function generateCommand(options: GenerateOptions = {}) {
         logger.indent('• Firewall blocking connection');
         logger.newline();
         logger.info('Check your configuration:');
-        logger.indent('CLICKHOUSE_HOST=' + (process.env.CLICKHOUSE_HOST || 'not set'));
+        logger.indent('CLICKHOUSE_URL=' + (process.env.CLICKHOUSE_URL || process.env.CLICKHOUSE_HOST || 'not set'));
         logger.newline();
         logger.info('Docs: https://hypequery.com/docs/troubleshooting#connection-errors');
       } else if (error.message.includes('ETIMEDOUT') || error.message.includes('timeout')) {

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -88,7 +88,7 @@ describe('init command - graceful failure handling', () => {
       // Should create placeholder files
       expect(writeFile).toHaveBeenCalledWith(
         expect.stringContaining('.env'),
-        expect.stringContaining('YOUR_CLICKHOUSE_HOST')
+        expect.stringContaining('YOUR_CLICKHOUSE_URL')
       );
       expect(writeFile).toHaveBeenCalledWith(
         expect.stringContaining('schema.ts'),
@@ -136,7 +136,7 @@ describe('init command - graceful failure handling', () => {
       expect(logger.info).toHaveBeenCalledWith('Continuing without database connection.');
       expect(writeFile).toHaveBeenCalledWith(
         expect.stringContaining('.env'),
-        expect.stringContaining('YOUR_CLICKHOUSE_HOST')
+        expect.stringContaining('YOUR_CLICKHOUSE_URL')
       );
     });
 
@@ -200,7 +200,7 @@ describe('init command - graceful failure handling', () => {
       expect(mockGenerateTypes).toHaveBeenCalled();
       expect(writeFile).toHaveBeenCalledWith(
         expect.stringContaining('.env'),
-        expect.not.stringContaining('YOUR_CLICKHOUSE_HOST')
+        expect.not.stringContaining('YOUR_CLICKHOUSE_URL')
       );
     });
 
@@ -298,7 +298,8 @@ describe('init command - graceful failure handling', () => {
 
   describe('Non-interactive mode', () => {
     it('should use environment variables in non-interactive mode', async () => {
-      process.env.CLICKHOUSE_HOST = 'http://test:8123';
+      process.env.CLICKHOUSE_URL = 'http://test:8123';
+      delete process.env.CLICKHOUSE_HOST;
       process.env.CLICKHOUSE_DATABASE = 'test_db';
       process.env.CLICKHOUSE_USERNAME = 'test_user';
       process.env.CLICKHOUSE_PASSWORD = 'test_pass';

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -60,20 +60,21 @@ async function determineDatabase(options: InitOptions): Promise<DatabaseType> {
 
 async function resolveConnectionConfig(options: InitOptions): Promise<ConnectionConfig | null> {
   if (options.noInteractive) {
-    const required = (key: string): string => {
-      const value = process.env[key];
+    const required = (keys: string | string[]): string => {
+      const values = Array.isArray(keys) ? keys : [keys];
+      const value = values.map((key) => process.env[key]).find(Boolean);
       if (!value) {
         throw new Error(
-          `Missing ${key}. Provide ClickHouse connection info via environment variables when using --no-interactive.`,
+          `Missing ${values.join(' or ')}. Provide ClickHouse connection info via environment variables when using --no-interactive.`,
         );
       }
       return value;
     };
 
     return {
-      host: required('CLICKHOUSE_HOST'),
+      host: required(['CLICKHOUSE_URL', 'CLICKHOUSE_HOST']),
       database: required('CLICKHOUSE_DATABASE'),
-      username: required('CLICKHOUSE_USERNAME'),
+      username: required(['CLICKHOUSE_USERNAME', 'CLICKHOUSE_USER']),
       password: process.env.CLICKHOUSE_PASSWORD ?? '',
     };
   }
@@ -86,6 +87,7 @@ async function testConnection(
   dbType: DatabaseType,
 ): Promise<{ hasValidConnection: boolean; tableCount: number }> {
   const spinner = ora('Testing connection...').start();
+  process.env.CLICKHOUSE_URL = connectionConfig.host;
   process.env.CLICKHOUSE_HOST = connectionConfig.host;
   process.env.CLICKHOUSE_DATABASE = connectionConfig.database;
   process.env.CLICKHOUSE_USERNAME = connectionConfig.username;
@@ -235,7 +237,7 @@ export async function initCommand(options: InitOptions = {}) {
     const envExists = await hasEnvFile();
 
     const placeholderConfig = {
-      host: 'YOUR_CLICKHOUSE_HOST',
+      url: 'YOUR_CLICKHOUSE_URL',
       database: 'YOUR_DATABASE',
       username: 'YOUR_USERNAME',
       password: 'YOUR_PASSWORD',

--- a/packages/cli/src/templates/client.ts
+++ b/packages/cli/src/templates/client.ts
@@ -6,7 +6,7 @@ export function generateClientTemplate(): string {
 import type { IntrospectedSchema } from './schema';
 
 export const db = createQueryBuilder<IntrospectedSchema>({
-  host: process.env.CLICKHOUSE_HOST!,
+  url: process.env.CLICKHOUSE_URL ?? process.env.CLICKHOUSE_HOST!,
   database: process.env.CLICKHOUSE_DATABASE!,
   username: process.env.CLICKHOUSE_USERNAME!,
   password: process.env.CLICKHOUSE_PASSWORD,

--- a/packages/cli/src/templates/env.test.ts
+++ b/packages/cli/src/templates/env.test.ts
@@ -11,7 +11,7 @@ describe('env template', () => {
         password: 'secret123',
       });
 
-      expect(result).toContain('CLICKHOUSE_HOST=http://localhost:8123');
+      expect(result).toContain('CLICKHOUSE_URL=http://localhost:8123');
       expect(result).toContain('CLICKHOUSE_DATABASE=default');
       expect(result).toContain('CLICKHOUSE_USERNAME=admin');
       expect(result).toContain('CLICKHOUSE_PASSWORD=secret123');
@@ -26,7 +26,7 @@ describe('env template', () => {
         password: 'YOUR_PASSWORD',
       });
 
-      expect(result).toContain('CLICKHOUSE_HOST=YOUR_CLICKHOUSE_HOST');
+      expect(result).toContain('CLICKHOUSE_URL=YOUR_CLICKHOUSE_HOST');
       expect(result).toContain('Replace these placeholder values');
     });
 
@@ -52,7 +52,7 @@ describe('env template', () => {
         password: 'secret',
       }));
 
-      expect(result).toContain('CLICKHOUSE_HOST=http://localhost:8123');
+      expect(result).toContain('CLICKHOUSE_URL=http://localhost:8123');
     });
 
     it('should append to existing env file', () => {
@@ -65,14 +65,14 @@ describe('env template', () => {
       }));
 
       expect(result).toContain('EXISTING_VAR=value');
-      expect(result).toContain('CLICKHOUSE_HOST=http://localhost:8123');
+      expect(result).toContain('CLICKHOUSE_URL=http://localhost:8123');
     });
 
     it('should replace existing hypequery section', () => {
       const existing = `EXISTING_VAR=value
 
 # Hypequery Configuration
-CLICKHOUSE_HOST=http://old:8123
+CLICKHOUSE_URL=http://old:8123
 CLICKHOUSE_DATABASE=old_db
 CLICKHOUSE_USERNAME=old_user
 CLICKHOUSE_PASSWORD=old_pass
@@ -87,7 +87,7 @@ OTHER_VAR=value
         password: 'new_pass',
       }));
 
-      expect(result).toContain('CLICKHOUSE_HOST=http://new:8123');
+      expect(result).toContain('CLICKHOUSE_URL=http://new:8123');
       expect(result).toContain('CLICKHOUSE_DATABASE=new_db');
       expect(result).not.toContain('old_db');
       expect(result).toContain('EXISTING_VAR=value');
@@ -104,7 +104,7 @@ OTHER_VAR=value
       }));
 
       expect(result).toContain('EXISTING_VAR=value\n');
-      expect(result).toContain('CLICKHOUSE_HOST=http://localhost:8123');
+      expect(result).toContain('CLICKHOUSE_URL=http://localhost:8123');
     });
   });
 });

--- a/packages/cli/src/templates/env.ts
+++ b/packages/cli/src/templates/env.ts
@@ -2,18 +2,20 @@
  * Generate .env file content for ClickHouse
  */
 export function generateEnvTemplate(config: {
-  host: string;
+  host?: string;
+  url?: string;
   database: string;
   username: string;
   password: string;
 }): string {
-  const isPlaceholder = config.host.includes('YOUR_');
+  const connectionUrl = config.url ?? config.host ?? '';
+  const isPlaceholder = connectionUrl.includes('YOUR_');
 
   if (isPlaceholder) {
     return `# Hypequery Configuration
 # Replace these placeholder values with your actual ClickHouse credentials
 
-CLICKHOUSE_HOST=${config.host}
+CLICKHOUSE_URL=${connectionUrl}
 CLICKHOUSE_DATABASE=${config.database}
 CLICKHOUSE_USERNAME=${config.username}
 CLICKHOUSE_PASSWORD=${config.password}
@@ -21,7 +23,7 @@ CLICKHOUSE_PASSWORD=${config.password}
   }
 
   return `# Hypequery Configuration
-CLICKHOUSE_HOST=${config.host}
+CLICKHOUSE_URL=${connectionUrl}
 CLICKHOUSE_DATABASE=${config.database}
 CLICKHOUSE_USERNAME=${config.username}
 CLICKHOUSE_PASSWORD=${config.password}

--- a/packages/cli/src/utils/clickhouse-client.ts
+++ b/packages/cli/src/utils/clickhouse-client.ts
@@ -35,7 +35,7 @@ export function getClickHouseClient(): ClickHouseClient {
 
     if (!config) {
       throw new Error(
-        'ClickHouse connection details are missing. Set CLICKHOUSE_HOST (or CLICKHOUSE_URL), CLICKHOUSE_DATABASE, CLICKHOUSE_USERNAME, and CLICKHOUSE_PASSWORD.'
+        'ClickHouse connection details are missing. Set CLICKHOUSE_URL (or CLICKHOUSE_HOST), CLICKHOUSE_DATABASE, CLICKHOUSE_USERNAME, and CLICKHOUSE_PASSWORD.'
       );
     }
 

--- a/packages/cli/src/utils/prompts.test.ts
+++ b/packages/cli/src/utils/prompts.test.ts
@@ -87,7 +87,7 @@ describe('prompts', () => {
       const originalEnv = process.env;
       process.env = {
         ...originalEnv,
-        CLICKHOUSE_HOST: 'http://test:8123',
+        CLICKHOUSE_URL: 'http://test:8123',
         CLICKHOUSE_DATABASE: 'test_db',
         CLICKHOUSE_USERNAME: 'test_user',
         CLICKHOUSE_PASSWORD: 'test_pass',
@@ -129,6 +129,7 @@ describe('prompts', () => {
     it('should leave initial prompts empty when env vars not set', async () => {
       const originalEnv = process.env;
       process.env = { ...originalEnv };
+      delete process.env.CLICKHOUSE_URL;
       delete process.env.CLICKHOUSE_HOST;
       delete process.env.CLICKHOUSE_DATABASE;
       delete process.env.CLICKHOUSE_USERNAME;

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -38,8 +38,8 @@ export async function promptClickHouseConnection(): Promise<{
     {
       type: 'text',
       name: 'host',
-      message: 'ClickHouse host (or skip to configure later):',
-      initial: process.env.CLICKHOUSE_HOST ?? '',
+      message: 'ClickHouse URL (or skip to configure later):',
+      initial: process.env.CLICKHOUSE_URL ?? process.env.CLICKHOUSE_HOST ?? '',
     },
     {
       type: 'text',

--- a/packages/clickhouse/package.json
+++ b/packages/clickhouse/package.json
@@ -48,11 +48,11 @@
     "README-CLI.md"
   ],
   "dependencies": {
-    "@clickhouse/client": "^1.11.2",
+    "@clickhouse/client": "^1.18.3",
     "dotenv": "^16.0.0"
   },
   "peerDependencies": {
-    "@clickhouse/client-web": "^0.2.0 || ^1.0.0"
+    "@clickhouse/client-web": "^1.18.3"
   },
   "peerDependenciesMeta": {
     "@clickhouse/client-web": {
@@ -60,9 +60,9 @@
     }
   },
   "devDependencies": {
-    "@clickhouse/client": "^1.11.2",
-    "@clickhouse/client-common": "^1.11.2",
-    "@clickhouse/client-web": "^1.11.2",
+    "@clickhouse/client": "^1.18.3",
+    "@clickhouse/client-common": "^1.18.3",
+    "@clickhouse/client-web": "^1.18.3",
     "@types/node": "^18.19.80",
     "glob": "^11.0.3",
     "ts-node": "^10.9.0",

--- a/packages/clickhouse/package.json
+++ b/packages/clickhouse/package.json
@@ -52,7 +52,7 @@
     "dotenv": "^16.0.0"
   },
   "peerDependencies": {
-    "@clickhouse/client-web": "^1.18.3"
+    "@clickhouse/client-web": "^0.2.0 || ^1.0.0"
   },
   "peerDependenciesMeta": {
     "@clickhouse/client-web": {

--- a/packages/clickhouse/src/cli/bin.js
+++ b/packages/clickhouse/src/cli/bin.js
@@ -41,7 +41,8 @@ ${colors.bright}Usage:${colors.reset}
 
 ${colors.bright}Options:${colors.reset}
   --output=<path>            Path where TypeScript definitions will be saved (default: "./generated-schema.ts")
-  --host=<url>               ClickHouse server URL (default: http://localhost:8123)
+  --url=<url>                ClickHouse server URL (default: http://localhost:8123)
+  --host=<url>               Deprecated alias for --url
   --username=<user>          ClickHouse username (default: default)
   --password=<password>      ClickHouse password
   --database=<db>            ClickHouse database name (default: default)
@@ -53,9 +54,12 @@ ${colors.bright}Options:${colors.reset}
 ${colors.dim}Note: All options support both formats: --option=value or --option value${colors.reset}
 
 ${colors.bright}Environment variables:${colors.reset}
-  CLICKHOUSE_HOST            ClickHouse server URL
-  VITE_CLICKHOUSE_HOST       Alternative variable for Vite projects
-  NEXT_PUBLIC_CLICKHOUSE_HOST Alternative variable for Next.js projects
+  CLICKHOUSE_URL             ClickHouse server URL
+  VITE_CLICKHOUSE_URL        Alternative variable for Vite projects
+  NEXT_PUBLIC_CLICKHOUSE_URL Alternative variable for Next.js projects
+  CLICKHOUSE_HOST            Deprecated alternative
+  VITE_CLICKHOUSE_HOST       Deprecated alternative for Vite projects
+  NEXT_PUBLIC_CLICKHOUSE_HOST Deprecated alternative for Next.js projects
   
   CLICKHOUSE_USER            ClickHouse username
   VITE_CLICKHOUSE_USER       Alternative variable for Vite projects
@@ -73,8 +77,8 @@ ${colors.bright}Examples:${colors.reset}
   npx hypequery-generate-types
   npx hypequery-generate-types --output=./src/types/db-schema.ts
   npx hypequery-generate-types --output ./src/types/db-schema.ts
-  npx hypequery-generate-types --host=https://your-instance.clickhouse.cloud:8443 --secure
-  npx hypequery-generate-types --host http://localhost:8123 --username default --password password --database my_db
+  npx hypequery-generate-types --url=https://your-instance.clickhouse.cloud:8443 --secure
+  npx hypequery-generate-types --url http://localhost:8123 --username default --password password --database my_db
   npx hypequery-generate-types --include-tables=users,orders,products
   npx hypequery-generate-types --include-tables users,orders,products
   `);
@@ -107,6 +111,7 @@ function parseArguments(args) {
   // Parameter handlers map
   const paramHandlers = {
     '--output': (value) => config.output = value,
+    '--url': (value) => config.host = value,
     '--host': (value) => config.host = value,
     '--username': (value) => config.username = value,
     '--password': (value) => config.password = value,
@@ -176,6 +181,9 @@ async function main() {
   try {
     // Get connection parameters from args and environment variables
     const host = config.host ||
+      process.env.CLICKHOUSE_URL ||
+      process.env.VITE_CLICKHOUSE_URL ||
+      process.env.NEXT_PUBLIC_CLICKHOUSE_URL ||
       process.env.CLICKHOUSE_HOST ||
       process.env.VITE_CLICKHOUSE_HOST ||
       process.env.NEXT_PUBLIC_CLICKHOUSE_HOST ||
@@ -237,7 +245,7 @@ import { createQueryBuilder } from '@hypequery/clickhouse';
 import { IntrospectedSchema } from '${config.output.replace(/\.ts$/, '')}';
 
 const db = createQueryBuilder<IntrospectedSchema>({
-  host: '${host}',
+  url: '${host}',
   username: '${username}',
   password: '********',
   database: '${database}'

--- a/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
+++ b/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
@@ -18,14 +18,24 @@ function createClickHouseClient(config: ClickHouseConfig): ClickHouseClient {
   return clientModule.createClient(config);
 }
 
+function getConnectionEndpoint(config: ClickHouseConfig): string | undefined {
+  if ('url' in config && typeof config.url === 'string') {
+    return config.url;
+  }
+  if ('host' in config && typeof config.host === 'string') {
+    return config.host;
+  }
+  return undefined;
+}
+
 function deriveNamespace(config: ClickHouseConfig): string {
   if ('client' in config && config.client) {
     return 'client';
   }
-  const host = 'host' in config ? config.host : 'unknown-host';
+  const endpoint = getConnectionEndpoint(config);
   const database = 'database' in config ? config.database : 'default';
   const username = 'username' in config ? config.username : 'default';
-  return `${host || 'unknown-host'}|${database || 'default'}|${username || 'default'}`;
+  return `${endpoint || 'unknown-host'}|${database || 'default'}|${username || 'default'}`;
 }
 
 export class ClickHouseAdapter implements DatabaseAdapter {

--- a/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
+++ b/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
@@ -4,6 +4,7 @@ import type { ClickHouseClient as WebClickHouseClient } from '@clickhouse/client
 import type { ClickHouseConfig } from '../query-builder.js';
 import { isClientConfig } from '../query-builder.js';
 import { substituteParameters } from '../utils.js';
+import { getConnectionEndpoint } from '../utils/connection-endpoint.js';
 import { createJsonEachRowStream } from '../utils/streaming-helpers.js';
 import { getAutoClientModule } from '../env/auto-client.js';
 import type { AutoClientModule } from '../env/auto-client.js';
@@ -16,16 +17,6 @@ function createClickHouseClient(config: ClickHouseConfig): ClickHouseClient {
   }
   const clientModule: AutoClientModule = getAutoClientModule();
   return clientModule.createClient(config);
-}
-
-function getConnectionEndpoint(config: ClickHouseConfig): string | undefined {
-  if ('url' in config && typeof config.url === 'string') {
-    return config.url;
-  }
-  if ('host' in config && typeof config.host === 'string') {
-    return config.host;
-  }
-  return undefined;
 }
 
 function deriveNamespace(config: ClickHouseConfig): string {

--- a/packages/clickhouse/src/core/connection.ts
+++ b/packages/clickhouse/src/core/connection.ts
@@ -38,8 +38,8 @@ function getClickHouseClientSync(): ClickHouseClientModule {
     'Please use manual injection by providing a client instance:\n\n' +
     '```typescript\n' +
     'import { createClient } from \'@clickhouse/client-web\';\n' +
-    'const client = createClient({ host: \'http://localhost:8123\' });\n' +
-    'ClickHouseConnection.initialize({ host: \'http://localhost:8123\', client });\n' +
+    'const client = createClient({ url: \'http://localhost:8123\' });\n' +
+    'ClickHouseConnection.initialize({ url: \'http://localhost:8123\', client });\n' +
     '```\n\n' +
     'This is required because browser environments cannot use require() to load modules.'
   );
@@ -59,20 +59,20 @@ function getClickHouseClientSync(): ClickHouseClientModule {
  * // Method 1: Manual injection (required for browser environments)
  * import { createClient } from '@clickhouse/client-web';
  * const client = createClient({
- *   host: 'http://localhost:8123',
+ *   url: 'http://localhost:8123',
  *   username: 'default',
  *   password: 'password'
  * });
  * 
  * ClickHouseConnection.initialize({
- *   host: 'http://localhost:8123',
+ *   url: 'http://localhost:8123',
  *   database: 'my_database',
  *   client // Explicitly provide the client
  * });
  * 
  * // Method 2: Auto-detection (Node.js environments only)
  * ClickHouseConnection.initialize({
- *   host: 'http://localhost:8123',
+ *   url: 'http://localhost:8123',
  *   username: 'default',
  *   password: 'password',
  *   database: 'my_database'
@@ -114,12 +114,12 @@ export class ClickHouseConnection {
    * ```typescript
    * // Manual injection (required for browser environments)
    * import { createClient } from '@clickhouse/client-web';
-   * const client = createClient({ host: 'http://localhost:8123' });
-   * ClickHouseConnection.initialize({ host: 'http://localhost:8123', client });
+   * const client = createClient({ url: 'http://localhost:8123' });
+   * ClickHouseConnection.initialize({ url: 'http://localhost:8123', client });
    * 
    * // Auto-detection (Node.js environments only)
    * ClickHouseConnection.initialize({
-   *   host: 'http://localhost:8123',
+   *   url: 'http://localhost:8123',
    *   username: 'default',
    *   password: 'password',
    *   database: 'my_database'
@@ -133,7 +133,7 @@ export class ClickHouseConnection {
       return ClickHouseConnection;
     }
 
-    // Otherwise, auto-detect the client (we know we have a host-based config)
+    // Otherwise, auto-detect the client using the provided ClickHouse connection config.
     this.clientModule = getClickHouseClientSync();
     this.instance = this.clientModule.createClient(config);
     return ClickHouseConnection;

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -70,10 +70,17 @@ export interface ExecuteOptions {
   cache?: CacheOptions | false;
 }
 
+export interface ClickHouseConnectionOptions extends Omit<BaseClickHouseClientConfigOptions, 'host'> {
+  /**
+   * @deprecated Use `url` instead. `host` is kept for backward compatibility.
+   */
+  host?: BaseClickHouseClientConfigOptions['host'];
+}
+
 /**
  * Configuration for client-based connections.
  */
-export interface ClickHouseClientConfig extends BaseClickHouseClientConfigOptions {
+export interface ClickHouseClientConfig extends ClickHouseConnectionOptions {
   /** Pre-configured ClickHouse client instance. */
   client: ClickHouseClient;
 }
@@ -82,7 +89,7 @@ export interface ClickHouseClientConfig extends BaseClickHouseClientConfigOption
  * Configuration options for ClickHouse connections.
  * Either provide a client instance OR connection details, but not both.
  */
-export type ClickHouseConfig = BaseClickHouseClientConfigOptions | ClickHouseClientConfig;
+export type ClickHouseConfig = ClickHouseConnectionOptions | ClickHouseClientConfig;
 
 /**
  * Type guard to check if a config is a client-based configuration.

--- a/packages/clickhouse/src/core/tests/clickhouse-adapter.test.ts
+++ b/packages/clickhouse/src/core/tests/clickhouse-adapter.test.ts
@@ -3,6 +3,16 @@ import { ClickHouseAdapter } from '../adapters/clickhouse-adapter.js';
 import { createQueryBuilder } from '../query-builder.js';
 
 describe('ClickHouseAdapter', () => {
+  it('uses url when deriving the adapter namespace', () => {
+    const adapter = new ClickHouseAdapter({
+      url: 'https://example.clickhouse.cloud:8443',
+      username: 'default',
+      database: 'analytics',
+    });
+
+    expect(adapter.namespace).toBe('https://example.clickhouse.cloud:8443|analytics|default');
+  });
+
   it('forwards per-query settings and query ids to the ClickHouse client', async () => {
     const jsonMock = vi.fn().mockResolvedValue([{ id: 1 }]);
     const clientQueryMock = vi.fn().mockResolvedValue({

--- a/packages/clickhouse/src/core/tests/connection-config.test.ts
+++ b/packages/clickhouse/src/core/tests/connection-config.test.ts
@@ -21,4 +21,12 @@ describe('isClientConfig', () => {
 
     expect(isClientConfig(config)).toBe(false);
   });
+
+  it('returns false for url-only configs without a client', () => {
+    const config: ClickHouseConfig = {
+      url: 'http://localhost:8123'
+    };
+
+    expect(isClientConfig(config)).toBe(false);
+  });
 });

--- a/packages/clickhouse/src/core/tests/connection-config.test.ts
+++ b/packages/clickhouse/src/core/tests/connection-config.test.ts
@@ -1,7 +1,13 @@
+import { expect, describe, it, vi, afterEach } from 'vitest';
 import type { ClickHouseClientConfig, ClickHouseConfig } from '../query-builder.js';
 import { isClientConfig } from '../query-builder.js';
 
 const fakeClient = {} as ClickHouseClientConfig['client'];
+
+afterEach(() => {
+  vi.resetModules();
+  vi.unmock('../env/auto-client.js');
+});
 
 describe('isClientConfig', () => {
   it('treats configs with a client as client configs even if host information is present', () => {
@@ -28,5 +34,30 @@ describe('isClientConfig', () => {
     };
 
     expect(isClientConfig(config)).toBe(false);
+  });
+
+  it('passes host-only configs through to the ClickHouse client for deprecated compatibility', async () => {
+    const createClient = vi.fn().mockReturnValue(fakeClient);
+
+    vi.doMock('../env/auto-client.js', () => ({
+      getAutoClientModule: () => ({
+        createClient,
+        ClickHouseSettings: {},
+      }),
+    }));
+
+    const { ClickHouseConnection } = await import('../connection.js');
+
+    const config: ClickHouseConfig = {
+      host: 'http://localhost:8123',
+      username: 'default',
+      password: 'secret',
+      database: 'analytics',
+    };
+
+    ClickHouseConnection.initialize(config);
+
+    expect(createClient).toHaveBeenCalledWith(config);
+    expect(ClickHouseConnection.getClient()).toBe(fakeClient);
   });
 });

--- a/packages/clickhouse/src/core/utils/connection-endpoint.ts
+++ b/packages/clickhouse/src/core/utils/connection-endpoint.ts
@@ -1,0 +1,11 @@
+import type { ClickHouseConfig } from '../query-builder.js';
+
+export function getConnectionEndpoint(config: ClickHouseConfig): string | undefined {
+  if ('url' in config && typeof config.url === 'string') {
+    return config.url;
+  }
+  if ('host' in config && typeof config.host === 'string') {
+    return config.host;
+  }
+  return undefined;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,11 +63,11 @@ importers:
   examples/next-dashboard:
     dependencies:
       '@clickhouse/client':
-        specifier: ^1.11.2
-        version: 1.16.0
+        specifier: ^1.18.3
+        version: 1.18.3
       '@hypequery/clickhouse':
         specifier: '*'
-        version: link:../../packages/clickhouse
+        version: 1.6.1(@clickhouse/client-web@1.18.3)
       '@hypequery/react':
         specifier: '*'
         version: link:../../packages/react
@@ -167,7 +167,7 @@ importers:
     dependencies:
       '@hypequery/clickhouse':
         specifier: '*'
-        version: link:../../packages/clickhouse
+        version: 1.6.1(@clickhouse/client-web@1.18.3)
       '@hypequery/react':
         specifier: '*'
         version: link:../../packages/react
@@ -209,11 +209,11 @@ importers:
   examples/node-embedded:
     dependencies:
       '@clickhouse/client':
-        specifier: ^1.11.2
-        version: 1.16.0
+        specifier: ^1.18.3
+        version: 1.18.3
       '@hypequery/clickhouse':
         specifier: '*'
-        version: link:../../packages/clickhouse
+        version: 1.6.1(@clickhouse/client-web@1.18.3)
       '@hypequery/serve':
         specifier: '*'
         version: link:../../packages/serve
@@ -277,8 +277,8 @@ importers:
   packages/cli:
     dependencies:
       '@clickhouse/client':
-        specifier: ^1.16.0
-        version: 1.16.0
+        specifier: ^1.18.3
+        version: 1.18.3
       chalk:
         specifier: ^5.3.0
         version: 5.6.2
@@ -326,18 +326,18 @@ importers:
   packages/clickhouse:
     dependencies:
       '@clickhouse/client':
-        specifier: ^1.11.2
-        version: 1.16.0
+        specifier: ^1.18.3
+        version: 1.18.3
       dotenv:
         specifier: ^16.0.0
         version: 16.6.1
     devDependencies:
       '@clickhouse/client-common':
-        specifier: ^1.11.2
-        version: 1.16.0
+        specifier: ^1.18.3
+        version: 1.18.3
       '@clickhouse/client-web':
-        specifier: ^1.11.2
-        version: 1.16.0
+        specifier: ^1.18.3
+        version: 1.18.3
       '@types/node':
         specifier: ^18.19.80
         version: 18.19.130
@@ -591,14 +591,14 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@clickhouse/client-common@1.16.0':
-    resolution: {integrity: sha512-qMzkI1NmV29ZjFkNpVSvGNfA0c7sCExlufAQMv+V+5xtNeYXnRfdqzmBLIQoq6Pf1ij0kw/wGLD3HQrl7pTFLA==}
+  '@clickhouse/client-common@1.18.3':
+    resolution: {integrity: sha512-3axzO3zvrsGT5PzDenxgWscltYCNRDbhaHWUgdsmcM9OnW/VnZn9EarOcZogr9P82Z0mQh+Jd2x+p2K4TFD2fA==}
 
-  '@clickhouse/client-web@1.16.0':
-    resolution: {integrity: sha512-47+H8GsXXlultL3HFkTu94M7BGXJF8FOwiOUafPpvgCFoqra3o82I0YbWs3vTRqHIOuFjCvuOzrBNFvcT732eg==}
+  '@clickhouse/client-web@1.18.3':
+    resolution: {integrity: sha512-onqr4PJMGC3m+NiNRLqc1XxJFtKz0U2N0hHEj3SShlI++OqzE3DvyWPhRamQriKN1drSk/DAyhPeisK2FIbMzg==}
 
-  '@clickhouse/client@1.16.0':
-    resolution: {integrity: sha512-ThPhoRMsKsf/hmBEgWlUsGxFecsr3i+k3JI8JV0Od7UpH2BSmk9VKMGJoyPCrTL0vPUs5rJH+7o4iCqBF09Xvg==}
+  '@clickhouse/client@1.18.3':
+    resolution: {integrity: sha512-340ngdYktL8PLUBK2QKSwe0o02tYfZSz1mSn1uXCEU8TxHvwh9pnQxElf9YHumDGj5gX/IdgxPsJTGMs82Hgug==}
     engines: {node: '>=16'}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -895,6 +895,15 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@hypequery/clickhouse@1.6.1':
+    resolution: {integrity: sha512-MFFHCLBZCoixCiiagOUwWVnK7mF8i/SJ3fwY2o6ml+iVATHL7oJEhEWmT8f/a6wNfcIwH1lNfs3qW3D/fnjxYA==}
+    hasBin: true
+    peerDependencies:
+      '@clickhouse/client-web': ^0.2.0 || ^1.0.0
+    peerDependenciesMeta:
+      '@clickhouse/client-web':
+        optional: true
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -4767,15 +4776,15 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@clickhouse/client-common@1.16.0': {}
+  '@clickhouse/client-common@1.18.3': {}
 
-  '@clickhouse/client-web@1.16.0':
+  '@clickhouse/client-web@1.18.3':
     dependencies:
-      '@clickhouse/client-common': 1.16.0
+      '@clickhouse/client-common': 1.18.3
 
-  '@clickhouse/client@1.16.0':
+  '@clickhouse/client@1.18.3':
     dependencies:
-      '@clickhouse/client-common': 1.16.0
+      '@clickhouse/client-common': 1.18.3
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -5011,6 +5020,13 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@hypequery/clickhouse@1.6.1(@clickhouse/client-web@1.18.3)':
+    dependencies:
+      '@clickhouse/client': 1.18.3
+      dotenv: 16.6.1
+    optionalDependencies:
+      '@clickhouse/client-web': 1.18.3
 
   '@img/colour@1.1.0':
     optional: true


### PR DESCRIPTION
 ## Summary
  This PR updates the ClickHouse integration to standardize on `url` in docs and examples while preserving deprecated
  `host` support for existing users.

  It keeps the runtime compatibility path intact with `clickhouse-js`, updates namespace derivation to work with
  either `url` or `host`.

  ## What changed
  - Updated examples and connection docs to prefer `url` over `host`
  - Kept `host` in the public config types as a deprecated but supported option
  - Updated adapter namespace derivation to read either `url` or `host`
  - Added regression coverage proving `host`-only configs still initialize correctly through our connection path
  - Kept the broader `@clickhouse/client-web` peer dependency range to avoid unnecessary install-time breakage for
  existing `1.x` users
  - Bumped internal ClickHouse client packages to `^1.18.3`

  ## Why
  `clickhouse-js` has deprecated `host` in favor of `url`, so the library and examples should move in that direction.
  But since upstream still supports `host`, this PR preserves backward compatibility rather than turning the
  deprecation into a silent breaking change.

  ## Compatibility
  - `url` is now the preferred config field
  - `host` remains supported and is explicitly treated as deprecated
  - Existing consumers using `host` should continue to work
  - No peer dependency narrowing is introduced for `@clickhouse/client-web`