### PR TITLE
fix: Some query builder correctness issues

### DIFF
--- a/packages/clickhouse/src/core/features/aggregations.ts
+++ b/packages/clickhouse/src/core/features/aggregations.ts
@@ -8,6 +8,19 @@ export class AggregationFeature<
 > {
   constructor(private builder: QueryBuilder<Schema, State>) { }
 
+  private inferGroupBySelections(select: Array<{ selection: string }>) {
+    return select
+      .map(item => item.selection)
+      .filter(selection => selection !== '*')
+      .map(selection => {
+        const aliasMatch = selection.match(/\s+AS\s+([A-Za-z_][A-Za-z0-9_]*)$/i);
+        return {
+          kind: 'group-by-item' as const,
+          expression: aliasMatch ? aliasMatch[1] : selection,
+        };
+      });
+  }
+
   private createAggregation(
     column: string,
     fn: 'COUNT' | 'SUM' | 'AVG' | 'MIN' | 'MAX',
@@ -17,13 +30,10 @@ export class AggregationFeature<
     const query = this.builder.getQueryNode();
 
     if (query.select) {
-      const selections = query.select.map(item => item.selection);
       return {
         ...query,
         select: [...query.select, { kind: 'selection' as const, selection: aggregationSQL }],
-        groupBy: selections
-          .filter(col => !col.includes(' AS '))
-          .map(expression => ({ kind: 'group-by-item' as const, expression }))
+        groupBy: query.groupBy || this.inferGroupBySelections(query.select)
       };
     }
 

--- a/packages/clickhouse/src/core/features/query-modifiers.ts
+++ b/packages/clickhouse/src/core/features/query-modifiers.ts
@@ -10,10 +10,17 @@ export class QueryModifiersFeature<
 
   addGroupBy(columns: string | string[]): SelectQueryNode<State['output'], Schema> {
     const query = this.builder.getQueryNode();
+    const existingExpressions = new Set((query.groupBy || []).map(item => item.expression));
+    const groupByItems = (Array.isArray(columns) ? columns.map(String) : [String(columns)])
+      .filter(expression => {
+        if (existingExpressions.has(expression)) return false;
+        existingExpressions.add(expression);
+        return true;
+      })
+      .map(expression => ({ kind: 'group-by-item' as const, expression }));
     return {
       ...query,
-      groupBy: (Array.isArray(columns) ? columns.map(String) : [String(columns)])
-        .map(expression => ({ kind: 'group-by-item' as const, expression }))
+      groupBy: [...(query.groupBy || []), ...groupByItems]
     };
   }
 

--- a/packages/clickhouse/src/core/formatters/sql-formatter.ts
+++ b/packages/clickhouse/src/core/formatters/sql-formatter.ts
@@ -94,7 +94,7 @@ export class SQLFormatter {
         throw new Error(`Expected an array for ${operator} operator, but got ${typeof value}`);
       }
       if (value.length === 0) {
-        return { query: '1 = 0', parameters: [] };
+        return { query: operator === 'in' ? '1 = 0' : '1 = 1', parameters: [] };
       }
       return {
         query: `${column} ${operator === 'in' ? 'IN' : 'NOT IN'} (${value.map(() => '?').join(', ')})`,
@@ -106,7 +106,7 @@ export class SQLFormatter {
         throw new Error(`Expected an array for ${operator} operator, but got ${typeof value}`);
       }
       if (value.length === 0) {
-        return { query: '1 = 0', parameters: [] };
+        return { query: operator === 'globalIn' ? '1 = 0' : '1 = 1', parameters: [] };
       }
       return {
         query: `${column} ${operator === 'globalIn' ? 'GLOBAL IN' : 'GLOBAL NOT IN'} (${value.map(() => '?').join(', ')})`,

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -494,7 +494,7 @@ export class QueryBuilder<
     return this.select(columns);
   }
 
-  sum<Column extends keyof BaseRow<State>, Alias extends string = `${Column & string}_sum`>(
+  sum<Column extends SelectableColumn<State>, Alias extends string = `${Column & string}_sum`>(
     column: Column,
     alias?: Alias
   ): QueryBuilder<Schema, AppendToOutput<State, Record<Alias, string>>> {
@@ -503,7 +503,7 @@ export class QueryBuilder<
     );
   }
 
-  count<Column extends keyof BaseRow<State>, Alias extends string = `${Column & string}_count`>(
+  count<Column extends SelectableColumn<State>, Alias extends string = `${Column & string}_count`>(
     column: Column,
     alias?: Alias
   ): QueryBuilder<Schema, AppendToOutput<State, Record<Alias, string>>> {
@@ -512,7 +512,7 @@ export class QueryBuilder<
     );
   }
 
-  avg<Column extends keyof BaseRow<State>, Alias extends string = `${Column & string}_avg`>(
+  avg<Column extends SelectableColumn<State>, Alias extends string = `${Column & string}_avg`>(
     column: Column,
     alias?: Alias
   ): QueryBuilder<Schema, AppendToOutput<State, Record<Alias, string>>> {
@@ -521,7 +521,7 @@ export class QueryBuilder<
     );
   }
 
-  min<Column extends keyof BaseRow<State>, Alias extends string = `${Column & string}_min`>(
+  min<Column extends SelectableColumn<State>, Alias extends string = `${Column & string}_min`>(
     column: Column,
     alias?: Alias
   ): QueryBuilder<Schema, AppendToOutput<State, Record<Alias, string>>> {
@@ -530,7 +530,7 @@ export class QueryBuilder<
     );
   }
 
-  max<Column extends keyof BaseRow<State>, Alias extends string = `${Column & string}_max`>(
+  max<Column extends SelectableColumn<State>, Alias extends string = `${Column & string}_max`>(
     column: Column,
     alias?: Alias
   ): QueryBuilder<Schema, AppendToOutput<State, Record<Alias, string>>> {
@@ -539,7 +539,7 @@ export class QueryBuilder<
     );
   }
 
-  private applyAggregation<Column extends keyof BaseRow<State>, Alias extends string>(
+  private applyAggregation<Column extends SelectableColumn<State>, Alias extends string>(
     column: Column,
     alias: Alias | undefined,
     suffix: string,

--- a/packages/clickhouse/src/core/tests/advanced-in-operators.test.ts
+++ b/packages/clickhouse/src/core/tests/advanced-in-operators.test.ts
@@ -44,7 +44,7 @@ describe('Advanced IN Operators', () => {
 
       const { sql, parameters } = query.toSQLWithParams();
 
-      expect(sql).toContain('WHERE 1 = 0');
+      expect(sql).toContain('WHERE 1 = 1');
       expect(parameters).toEqual([]);
     });
   });

--- a/packages/clickhouse/src/core/tests/query-builder.aggregations.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.aggregations.test.ts
@@ -1,3 +1,4 @@
+import { rawAs } from '../utils/sql-expressions.js';
 import { setupTestBuilder } from './test-utils.js';
 
 describe('QueryBuilder - Aggregations', () => {
@@ -28,6 +29,25 @@ describe('QueryBuilder - Aggregations', () => {
       .count('id')
       .toSQL();
     expect(sql).toBe('SELECT name, SUM(price) AS price_sum, COUNT(id) AS id_count FROM test_table GROUP BY name');
+  });
+
+  it('should infer GROUP BY from aliased expressions when adding aggregations', () => {
+    const sql = builder
+      .select([rawAs('toDate(created_at)', 'day')])
+      .sum('price')
+      .toSQL();
+
+    expect(sql).toBe('SELECT toDate(created_at) AS day, SUM(price) AS price_sum FROM test_table GROUP BY day');
+  });
+
+  it('should preserve an explicit GROUP BY when adding aggregations later', () => {
+    const sql = builder
+      .select(['name'])
+      .groupBy('name')
+      .sum('price')
+      .toSQL();
+
+    expect(sql).toBe('SELECT name, SUM(price) AS price_sum FROM test_table GROUP BY name');
   });
 
   describe('HAVING', () => {

--- a/packages/clickhouse/src/core/tests/query-builder.grouping.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.grouping.test.ts
@@ -25,6 +25,15 @@ describe('QueryBuilder - Grouping and Ordering', () => {
         .toSQL();
       expect(sql).toBe('SELECT name, created_at, SUM(price) AS price_sum FROM test_table GROUP BY name, created_at');
     });
+
+    it('should append when GROUP BY is called multiple times', () => {
+      const sql = builder
+        .select(['name', 'category'])
+        .groupBy('name')
+        .groupBy('category')
+        .toSQL();
+      expect(sql).toBe('SELECT name, category FROM test_table GROUP BY name, category');
+    });
   });
 
   describe('ORDER BY', () => {

--- a/packages/clickhouse/src/core/tests/query-builder.joins.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.joins.test.ts
@@ -173,11 +173,11 @@ describe('QueryBuilder - Joins', () => {
     });
 
     describe('type safety for column selection', () => {
-      it('should maintain correct types for joined table columns', () => {
-        const query = builder
-          .innerJoin(
-            'users',
-            'created_by',
+    it('should maintain correct types for joined table columns', () => {
+      const query = builder
+        .innerJoin(
+          'users',
+          'created_by',
             'users.id'
           )
           .select(['test_table.price', 'users.user_name'] as const);
@@ -189,6 +189,26 @@ describe('QueryBuilder - Joins', () => {
         }[];
 
         type _Assert = Expect<Equal<Result, Expected>>;
+      });
+
+      it('should allow aggregating qualified columns from joined tables', () => {
+        const query = builder
+          .innerJoin('users', 'created_by', 'users.id')
+          .select(['users.user_name'])
+          .count('users.id', 'user_count')
+          .groupBy('users.user_name');
+
+        type Result = Awaited<ReturnType<typeof query.execute>>;
+        type Expected = {
+          user_name: string;
+          user_count: string;
+        }[];
+
+        type _Assert = Expect<Equal<Result, Expected>>;
+
+        expect(query.toSQL()).toBe(
+          'SELECT users.user_name, COUNT(users.id) AS user_count FROM test_table INNER JOIN users ON created_by = users.id GROUP BY users.user_name'
+        );
       });
     });
 

--- a/packages/clickhouse/src/core/tests/query-builder.where.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.where.test.ts
@@ -314,6 +314,13 @@ describe('QueryBuilder - Where Conditions', () => {
       expect(sql).toBe('SELECT * FROM test_table WHERE 1 = 0');
     });
 
+    it('should handle empty arrays in NOT IN as a match-all condition', () => {
+      const sql = builder
+        .where('id', 'notIn', [])
+        .toSQL();
+      expect(sql).toBe('SELECT * FROM test_table WHERE 1 = 1');
+    });
+
     it('should handle empty whereGroup', () => {
       const sql = builder
         .whereGroup((_qb) => {


### PR DESCRIPTION
## Summary

This PR fixes several query-builder correctness issues around grouping, aggregation inference, and empty-set filter semantics, and tightens aggregation typing for joined columns.

## What changed

### 1. Fix empty `NOT IN` / `GLOBAL NOT IN` semantics

Empty exclusion lists were previously compiled to `1 = 0`, which incorrectly returned no rows.
This PR changes the behavior to:

- `IN []` / `GLOBAL IN []` → `1 = 0`
- `NOT IN []` / `GLOBAL NOT IN []` → `1 = 1`

That matches the expected semantics of "exclude nothing".

### 2. Make `.groupBy()` additive

Repeated `.groupBy()` calls previously overwrote earlier grouping state.
This PR changes `.groupBy()` to:

- append additional grouping expressions
- de-duplicate repeated grouping expressions

This makes it consistent with the rest of the fluent builder API such as `.orderBy()` and `.having()`.

### 3. Fix aggregation grouping inference for aliased expressions

When an aggregation was added after selecting an aliased expression, the builder could generate invalid SQL by omitting the required `GROUP BY` entry.

Example of the old broken behavior:

```ts
builder
  .select([rawAs('toDate(created_at)', 'day')])
  .sum('price')
```

Previously generated:

```sql
SELECT toDate(created_at) AS day, SUM(price) AS price_sum FROM test_table
```

This PR updates aggregation inference so aliased selected expressions are grouped correctly, e.g. `GROUP BY day`.

### 4. Preserve explicit GROUP BY when aggregations are added

If a query already had an explicit `groupBy`, adding an aggregation could rebuild grouping and introduce duplicate entries such as:

```sql
GROUP BY name, name
```

This PR preserves explicit grouping and avoids duplicate inferred entries.

### 5. Widen aggregation typing to support qualified joined columns

Aggregation helpers like `.sum()`, `.count()`, `.avg()`, `.min()`, and `.max()` were typed only against base-table columns.
This PR widens them to accept the same selectable column surface already supported elsewhere, including qualified joined columns such as:

```ts
.count('users.id', 'user_count')
.sum('orders.total', 'total_sales')
```

This brings the type surface in line with actual runtime SQL support.

## Why

The query builder already had decent coverage for simple grouping and aggregation cases, but it was missing tests for:

- repeated `.groupBy()` calls
- explicit grouping combined with inferred grouping
- aliased expressions combined with aggregations
- empty negative set operators
- aggregation on qualified joined columns

Those gaps allowed a few pre-existing correctness issues to survive in the fluent API.