### PR TITLE
fix with relation join type chaining

### DIFF
--- a/packages/clickhouse/src/core/join-relationships.ts
+++ b/packages/clickhouse/src/core/join-relationships.ts
@@ -1,14 +1,57 @@
 import { JoinType } from '../types/index.js';
 import { ColumnType } from '../types/schema.js';
 
-export interface JoinPath<Schema> {
-  from: keyof Schema;
-  to: keyof Schema;
+type SchemaTableName<Schema> = Extract<keyof Schema, string>;
+
+export interface JoinPath<
+  Schema,
+  From extends string = SchemaTableName<Schema>,
+  To extends SchemaTableName<Schema> = SchemaTableName<Schema>
+> {
+  from: From;
+  to: To;
   leftColumn: string;
   rightColumn: string;
   type?: JoinType;
   alias?: string;
 }
+
+type AppendJoinPathSource<
+  Schema,
+  AvailableSources extends string,
+  Path extends JoinPath<Schema, string, SchemaTableName<Schema>>
+> = AvailableSources | (Path['alias'] extends string ? Path['alias'] : Path['to']);
+
+type ValidateJoinPathChainInternal<
+  Schema,
+  AvailableSources extends string,
+  Paths extends readonly JoinPath<Schema, string, SchemaTableName<Schema>>[]
+> = Paths extends readonly [
+  infer First,
+  ...infer Rest,
+]
+  ? First extends JoinPath<Schema, AvailableSources, SchemaTableName<Schema>>
+    ? Rest extends readonly JoinPath<Schema, string, SchemaTableName<Schema>>[]
+      ? readonly [
+        First,
+        ...ValidateJoinPathChainInternal<
+          Schema,
+          AppendJoinPathSource<Schema, AvailableSources, First>,
+          Rest
+        >,
+      ]
+      : readonly [First]
+    : never
+  : readonly [];
+
+export type ValidJoinPathChain<
+  Schema,
+  AvailableSources extends string,
+  Paths extends readonly [
+    JoinPath<Schema, AvailableSources, SchemaTableName<Schema>>,
+    ...JoinPath<Schema, string, SchemaTableName<Schema>>[],
+  ],
+> = ValidateJoinPathChainInternal<Schema, AvailableSources, Paths>;
 
 export interface JoinPathOptions {
   type?: JoinType;
@@ -17,7 +60,7 @@ export interface JoinPathOptions {
 }
 
 export class JoinRelationships<Schema extends { [K in keyof Schema]: { [columnName: string]: ColumnType } }> {
-  private paths = new Map<string, JoinPath<Schema> | JoinPath<Schema>[]>();
+  private paths = new Map<string, JoinPath<Schema, string> | JoinPath<Schema, string>[]>();
 
   /**
    * Define a single join relationship
@@ -32,20 +75,25 @@ export class JoinRelationships<Schema extends { [K in keyof Schema]: { [columnNa
   /**
    * Define a chain of join relationships
    */
-  defineChain(name: string, paths: JoinPath<Schema>[]): void {
+  defineChain<
+    Paths extends readonly [
+      JoinPath<Schema>,
+      ...JoinPath<Schema, string>[],
+    ],
+  >(name: string, paths: Paths & ValidJoinPathChain<Schema, SchemaTableName<Schema>, Paths>): void {
     if (this.paths.has(name)) {
       throw new Error(`Join chain '${name}' is already defined`);
     }
-    if (paths.length === 0) {
+    if ((paths as readonly JoinPath<Schema, string>[]).length === 0) {
       throw new Error('Join chain must contain at least one path');
     }
-    this.paths.set(name, paths);
+    this.paths.set(name, [...paths]);
   }
 
   /**
    * Get a join relationship by name
    */
-  get(name: string): JoinPath<Schema> | JoinPath<Schema>[] | undefined {
+  get(name: string): JoinPath<Schema, string> | JoinPath<Schema, string>[] | undefined {
     return this.paths.get(name);
   }
 

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -18,7 +18,7 @@ import { AnalyticsFeature } from './features/analytics.js';
 import { ExecutorFeature } from './features/executor.js';
 import { QueryModifiersFeature } from './features/query-modifiers.js';
 import { FilterValidator } from './validators/filter-validator.js';
-import { JoinRelationships, JoinPathOptions, type JoinPath } from './join-relationships.js';
+import { JoinRelationships, JoinPathOptions, type JoinPath, type ValidJoinPathChain } from './join-relationships.js';
 import { SqlExpression } from './utils/sql-expressions.js';
 import {
   PredicateBuilder,
@@ -75,9 +75,9 @@ type ClickHouseClient = NodeClickHouseClient | WebClickHouseClient;
 type ScalarAlias<Alias extends string> = Alias extends `${string} ${string}` ? never : Alias;
 type JoinPathTableName<
   Schema extends SchemaDefinition<Schema>,
-  Path extends JoinPath<Schema>
+  Path extends JoinPath<Schema, string>
 > = Extract<Path['to'], keyof Schema>;
-type JoinPathAlias<Path extends JoinPath<any>, OverrideAlias extends string | undefined> =
+type JoinPathAlias<Path extends JoinPath<any, string>, OverrideAlias extends string | undefined> =
   OverrideAlias extends string
   ? OverrideAlias
   : Path['alias'] extends string
@@ -86,7 +86,7 @@ type JoinPathAlias<Path extends JoinPath<any>, OverrideAlias extends string | un
 type ApplyJoinPathState<
   Schema extends SchemaDefinition<Schema>,
   State extends AnyBuilderState,
-  Path extends JoinPath<Schema>,
+  Path extends JoinPath<Schema, string>,
   OverrideAlias extends string | undefined = undefined
 > = JoinPathAlias<Path, OverrideAlias> extends string
   ? AddAlias<
@@ -98,10 +98,10 @@ type ApplyJoinPathState<
 type ApplyJoinPathChainState<
   Schema extends SchemaDefinition<Schema>,
   State extends AnyBuilderState,
-  Paths extends readonly JoinPath<Schema>[]
+  Paths extends readonly JoinPath<Schema, string>[]
 > = Paths extends readonly [infer First, ...infer Rest]
-  ? First extends JoinPath<Schema>
-  ? Rest extends readonly JoinPath<Schema>[]
+  ? First extends JoinPath<Schema, string>
+  ? Rest extends readonly JoinPath<Schema, string>[]
   ? ApplyJoinPathChainState<Schema, ApplyJoinPathState<Schema, State, First>, Rest>
   : ApplyJoinPathState<Schema, State, First>
   : State
@@ -1023,16 +1023,19 @@ export class QueryBuilder<
    * Apply a predefined join relationship
    */
   withRelation<
-    Path extends JoinPath<Schema>,
+    Path extends JoinPath<Schema, State['tables']>,
     Alias extends string | undefined = undefined
   >(
     path: Path,
     options?: Omit<JoinPathOptions, 'alias'> & { alias?: Alias }
   ): QueryBuilder<Schema, ApplyJoinPathState<Schema, State, Path, Alias>>;
   withRelation<
-    Paths extends readonly [JoinPath<Schema>, ...JoinPath<Schema>[]]
+    Paths extends readonly [
+      JoinPath<Schema, State['tables']>,
+      ...JoinPath<Schema, string>[],
+    ]
   >(
-    paths: Paths,
+    paths: Paths & ValidJoinPathChain<Schema, State['tables'], Paths>,
     options?: Omit<JoinPathOptions, 'alias'>
   ): QueryBuilder<Schema, ApplyJoinPathChainState<Schema, State, Paths>>;
   withRelation(name: string, options?: JoinPathOptions): this;

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -1054,8 +1054,11 @@ export class QueryBuilder<
         const type = options?.type || joinPath.type || 'INNER';
         const alias = relationOptions?.alias || joinPath.alias;
         const table = String(joinPath.to) as Extract<keyof Schema, string>;
+        const leftColumn = String(joinPath.leftColumn).includes('.')
+          ? String(joinPath.leftColumn)
+          : `${String(joinPath.from)}.${String(joinPath.leftColumn)}`;
         const rightColumn = `${table}.${joinPath.rightColumn}` as `${typeof table}.${keyof Schema[typeof table] & string}`;
-        return next.joins.addJoin(type, table, String(joinPath.leftColumn), rightColumn, alias);
+        return next.joins.addJoin(type, table, leftColumn, rightColumn, alias);
       },
       label
     );

--- a/packages/clickhouse/src/core/tests/integration/complex-joins.test.ts
+++ b/packages/clickhouse/src/core/tests/integration/complex-joins.test.ts
@@ -4,6 +4,8 @@ import {
   setupTestDatabase,
   TEST_DATA
 } from './setup';
+import { JoinRelationships } from '../../join-relationships.js';
+import { QueryBuilder } from '../../query-builder.js';
 import { SKIP_INTEGRATION_TESTS, SETUP_TIMEOUT } from './test-config.js';
 
 describe('Integration Tests - Complex Joins', () => {
@@ -17,6 +19,27 @@ describe('Integration Tests - Complex Joins', () => {
           // Setup only - don't start/stop container (handled by shell script)
           db = await initializeTestConnection();
           await setupTestDatabase();
+
+          const relationships = new JoinRelationships();
+          relationships.defineChain('orderCustomerEcho', [
+            {
+              from: 'orders',
+              to: 'users',
+              leftColumn: 'user_id',
+              rightColumn: 'id',
+              type: 'INNER',
+              alias: 'customer',
+            },
+            {
+              from: 'customer',
+              to: 'users',
+              leftColumn: 'id',
+              rightColumn: 'id',
+              type: 'INNER',
+              alias: 'customer_echo',
+            },
+          ]);
+          QueryBuilder.setJoinRelationships(relationships);
         } catch (error) {
           console.error('Failed to set up integration tests:', error);
           throw error;
@@ -49,6 +72,29 @@ describe('Integration Tests - Complex Joins', () => {
         expect(row.order_status).toBe(order?.status);
         expect(row.user_name).toBe(user?.user_name);
         expect(row.email).toBe(user?.email);
+      }
+    });
+
+    test('should execute alias-origin relation chains with unqualified left columns', async () => {
+      const result = await db
+        .table('orders')
+        .withRelation('orderCustomerEcho')
+        .select([
+          'orders.id as order_id',
+          'customer.user_name as customer_name',
+          'customer_echo.user_name as echoed_customer_name',
+        ])
+        .orderBy('orders.id', 'ASC')
+        .execute();
+
+      expect(result).toHaveLength(TEST_DATA.orders.length);
+
+      for (const row of result) {
+        const order = TEST_DATA.orders.find(o => o.id === Number(row.order_id));
+        const user = TEST_DATA.users.find(u => u.id === order?.user_id);
+
+        expect(row.customer_name).toBe(user?.user_name);
+        expect(row.echoed_customer_name).toBe(user?.user_name);
       }
     });
 

--- a/packages/clickhouse/src/core/tests/join-relationships.test.ts
+++ b/packages/clickhouse/src/core/tests/join-relationships.test.ts
@@ -87,7 +87,7 @@ describe('JoinRelationships', () => {
         .withRelation('testToUsers')
         .toSQL();
 
-      expect(sql).toBe('SELECT * FROM test_table INNER JOIN users ON created_by = users.id');
+      expect(sql).toBe('SELECT * FROM test_table INNER JOIN users ON test_table.created_by = users.id');
     });
 
     it('should apply join chain', () => {
@@ -113,7 +113,7 @@ describe('JoinRelationships', () => {
         .withRelation('complexChain')
         .toSQL();
 
-      expect(sql).toBe('SELECT * FROM test_table INNER JOIN users ON created_by = users.id LEFT JOIN test_table AS updated_by_user ON id = updated_by_user.updated_by');
+      expect(sql).toBe('SELECT * FROM test_table INNER JOIN users ON test_table.created_by = users.id LEFT JOIN test_table AS updated_by_user ON users.id = updated_by_user.updated_by');
     });
 
     it('should apply join chains that continue from a prior alias', () => {
@@ -140,7 +140,7 @@ describe('JoinRelationships', () => {
         .withRelation('aliasChain')
         .toSQL();
 
-      expect(sql).toBe('SELECT * FROM test_table INNER JOIN users AS creator ON created_by = creator.id LEFT JOIN test_table AS updated_by_user ON id = updated_by_user.updated_by');
+      expect(sql).toBe('SELECT * FROM test_table INNER JOIN users AS creator ON test_table.created_by = creator.id LEFT JOIN test_table AS updated_by_user ON creator.id = updated_by_user.updated_by');
     });
 
     it('should override join type', () => {
@@ -156,7 +156,7 @@ describe('JoinRelationships', () => {
         .withRelation('testToUsers', { type: 'LEFT' })
         .toSQL();
 
-      expect(sql).toBe('SELECT * FROM test_table LEFT JOIN users ON created_by = users.id');
+      expect(sql).toBe('SELECT * FROM test_table LEFT JOIN users ON test_table.created_by = users.id');
     });
 
     it('should support typed direct join paths with alias-aware selection', () => {
@@ -177,7 +177,7 @@ describe('JoinRelationships', () => {
       type _Assert = Expect<Equal<Result, Expected>>;
 
       expect(query.toSQL()).toBe(
-        'SELECT author.user_name FROM test_table INNER JOIN users AS author ON created_by = author.id'
+        'SELECT author.user_name FROM test_table INNER JOIN users AS author ON test_table.created_by = author.id'
       );
     });
 
@@ -198,7 +198,7 @@ describe('JoinRelationships', () => {
       type _Assert = Expect<Equal<Result, Expected>>;
 
       expect(query.toSQL()).toBe(
-        'SELECT customer.email FROM test_table LEFT JOIN users AS customer ON created_by = customer.id'
+        'SELECT customer.email FROM test_table LEFT JOIN users AS customer ON test_table.created_by = customer.id'
       );
     });
 

--- a/packages/clickhouse/src/core/tests/join-relationships.test.ts
+++ b/packages/clickhouse/src/core/tests/join-relationships.test.ts
@@ -116,6 +116,33 @@ describe('JoinRelationships', () => {
       expect(sql).toBe('SELECT * FROM test_table INNER JOIN users ON created_by = users.id LEFT JOIN test_table AS updated_by_user ON id = updated_by_user.updated_by');
     });
 
+    it('should apply join chains that continue from a prior alias', () => {
+      relationships.defineChain('aliasChain', [
+        {
+          from: 'test_table',
+          to: 'users',
+          leftColumn: 'created_by',
+          rightColumn: 'id',
+          type: 'INNER',
+          alias: 'creator'
+        },
+        {
+          from: 'creator',
+          to: 'test_table',
+          leftColumn: 'id',
+          rightColumn: 'updated_by',
+          type: 'LEFT',
+          alias: 'updated_by_user'
+        }
+      ]);
+
+      const sql = builder
+        .withRelation('aliasChain')
+        .toSQL();
+
+      expect(sql).toBe('SELECT * FROM test_table INNER JOIN users AS creator ON created_by = creator.id LEFT JOIN test_table AS updated_by_user ON id = updated_by_user.updated_by');
+    });
+
     it('should override join type', () => {
       relationships.define('testToUsers', {
         from: 'test_table',

--- a/packages/clickhouse/src/core/tests/query-builder.helpers.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.helpers.test.ts
@@ -131,7 +131,7 @@ describe('Query Builder Helper Utilities', () => {
     });
 
     it('rejects alias override on chains', () => {
-      const chain: readonly JoinPath<TestSchema>[] = [
+      const chain: readonly JoinPath<TestSchema, string>[] = [
         {
           from: 'test_table',
           to: 'users',
@@ -154,7 +154,7 @@ describe('Query Builder Helper Utilities', () => {
     });
 
     it('validates that chained relations start from available sources', () => {
-      const chain: readonly JoinPath<TestSchema>[] = [
+      const chain: readonly JoinPath<TestSchema, string>[] = [
         {
           from: 'test_table',
           to: 'users',
@@ -178,7 +178,7 @@ describe('Query Builder Helper Utilities', () => {
     });
 
     it('applies validated relation paths in sequence', () => {
-      const chain: readonly JoinPath<TestSchema>[] = [
+      const chain: readonly JoinPath<TestSchema, string>[] = [
         {
           from: 'test_table',
           to: 'users',

--- a/packages/clickhouse/src/core/tests/query-builder.helpers.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.helpers.test.ts
@@ -207,7 +207,9 @@ describe('Query Builder Helper Utilities', () => {
               kind: 'join' as const,
               type: joinPath.type || 'INNER',
               table: String(joinPath.to),
-              leftColumn: String(joinPath.leftColumn),
+              leftColumn: String(joinPath.leftColumn).includes('.')
+                ? String(joinPath.leftColumn)
+                : `${String(joinPath.from)}.${String(joinPath.leftColumn)}`,
               rightColumn: `${joinPath.alias || String(joinPath.to)}.${joinPath.rightColumn}`,
               alias: joinPath.alias,
             },
@@ -218,6 +220,10 @@ describe('Query Builder Helper Utilities', () => {
       expect(result.joins?.map(join => [join.table, join.alias, join.rightColumn])).toEqual([
         ['users', 'creator', 'creator.id'],
         ['test_table', 'updated_by_user', 'updated_by_user.updated_by'],
+      ]);
+      expect(result.joins?.map(join => join.leftColumn)).toEqual([
+        'test_table.created_by',
+        'creator.id',
       ]);
     });
   });

--- a/packages/clickhouse/src/core/utils/relation-application.ts
+++ b/packages/clickhouse/src/core/utils/relation-application.ts
@@ -4,9 +4,9 @@ import type { JoinPath, JoinPathOptions, JoinRelationships } from '../join-relat
 import { validateRelationAliasOverride, validateRelationPathOrigin } from './relation-validation.js';
 
 export function resolveRelationPath<Schema extends SchemaDefinition<Schema>>(
-  nameOrPath: string | JoinPath<Schema> | readonly JoinPath<Schema>[],
+  nameOrPath: string | JoinPath<Schema, string> | readonly JoinPath<Schema, string>[],
   relationships: JoinRelationships<Schema> | undefined
-): { path: JoinPath<Schema> | readonly JoinPath<Schema>[]; label?: string } {
+): { path: JoinPath<Schema, string> | readonly JoinPath<Schema, string>[]; label?: string } {
   if (typeof nameOrPath !== 'string') {
     return { path: nameOrPath };
   }
@@ -25,11 +25,11 @@ export function resolveRelationPath<Schema extends SchemaDefinition<Schema>>(
 
 export function applyRelationPath<Schema extends SchemaDefinition<Schema>>(
   query: SelectQueryNode<any, Schema>,
-  path: JoinPath<Schema> | readonly JoinPath<Schema>[],
+  path: JoinPath<Schema, string> | readonly JoinPath<Schema, string>[],
   options: JoinPathOptions | undefined,
   appendJoin: (
     currentQuery: SelectQueryNode<any, Schema>,
-    joinPath: JoinPath<Schema>,
+    joinPath: JoinPath<Schema, string>,
     options: JoinPathOptions | undefined
   ) => SelectQueryNode<any, Schema>,
   label?: string

--- a/packages/clickhouse/src/core/utils/relation-validation.ts
+++ b/packages/clickhouse/src/core/utils/relation-validation.ts
@@ -17,7 +17,7 @@ function getAvailableRelationSources<Schema extends SchemaDefinition<Schema>>(
 
 export function validateRelationPathOrigin<Schema extends SchemaDefinition<Schema>>(
   query: SelectQueryNode<any, Schema>,
-  path: JoinPath<Schema> | readonly JoinPath<Schema>[],
+  path: JoinPath<Schema, string> | readonly JoinPath<Schema, string>[],
   label?: string
 ): void {
   const availableSources = getAvailableRelationSources(query);
@@ -37,7 +37,7 @@ export function validateRelationPathOrigin<Schema extends SchemaDefinition<Schem
 }
 
 export function validateRelationAliasOverride(
-  path: JoinPath<any> | readonly JoinPath<any>[],
+  path: JoinPath<any, string> | readonly JoinPath<any, string>[],
   alias: string | undefined,
   label?: string
 ): void {

--- a/packages/clickhouse/type-tests/query-builder-types.test.ts
+++ b/packages/clickhouse/type-tests/query-builder-types.test.ts
@@ -1,5 +1,6 @@
 import { QueryBuilder } from '../src/core/query-builder.js';
 import { CrossFilter } from '../src/core/cross-filter.js';
+import { JoinRelationships } from '../src/core/join-relationships.js';
 import { setupTestBuilder, setupUsersBuilder, TestSchema, TEST_SCHEMAS } from '../src/core/tests/test-utils.js';
 import { createPredicateBuilder } from '../src/core/utils/predicate-builder.js';
 import { rawAs } from '../src/core/utils/sql-expressions.js';
@@ -206,3 +207,75 @@ type AssertAliasJoin = Expect<Equal<AliasJoinResult, AliasJoinExpected>>;
 builder
   .innerJoin('users', 'created_by', 'users.id', 'creator')
   .where('creator.user_name', 'eq', 'team@example.com');
+
+const aliasedRelationQuery = builder.withRelation([
+  {
+    from: 'test_table',
+    to: 'users',
+    leftColumn: 'created_by',
+    rightColumn: 'id',
+    alias: 'creator',
+  },
+  {
+    from: 'creator',
+    to: 'test_table',
+    leftColumn: 'id',
+    rightColumn: 'updated_by',
+    alias: 'updated_by_user',
+  },
+] as const).select(['creator.user_name', 'updated_by_user.name']);
+type AliasedRelationResult = Awaited<ReturnType<typeof aliasedRelationQuery.execute>>;
+type AliasedRelationExpected = { user_name: string; name: string }[];
+type AssertAliasedRelation = Expect<Equal<AliasedRelationResult, AliasedRelationExpected>>;
+
+// @ts-expect-error second relation step cannot start from an unknown source
+builder.withRelation([
+  {
+    from: 'test_table',
+    to: 'users',
+    leftColumn: 'created_by',
+    rightColumn: 'id',
+    alias: 'creator',
+  },
+  {
+    from: 'unknown_alias',
+    to: 'test_table',
+    leftColumn: 'id',
+    rightColumn: 'updated_by',
+  },
+] as const);
+
+const relationships = new JoinRelationships<TestSchema>();
+relationships.defineChain('creatorChain', [
+  {
+    from: 'test_table',
+    to: 'users',
+    leftColumn: 'created_by',
+    rightColumn: 'id',
+    alias: 'creator',
+  },
+  {
+    from: 'creator',
+    to: 'test_table',
+    leftColumn: 'id',
+    rightColumn: 'updated_by',
+    alias: 'updated_by_user',
+  },
+] as const);
+
+// @ts-expect-error registry chains must also reference a source introduced earlier in the chain
+relationships.defineChain('invalidCreatorChain', [
+  {
+    from: 'test_table',
+    to: 'users',
+    leftColumn: 'created_by',
+    rightColumn: 'id',
+    alias: 'creator',
+  },
+  {
+    from: 'missing_alias',
+    to: 'test_table',
+    leftColumn: 'id',
+    rightColumn: 'updated_by',
+  },
+] as const);

--- a/website-next/docs/query-building/join-relationships.mdx
+++ b/website-next/docs/query-building/join-relationships.mdx
@@ -177,7 +177,7 @@ import type { JoinPath } from '@hypequery/clickhouse';
 const orderCustomerPath = {
   from: 'orders',
   to: 'users',
-  leftColumn: 'orders.user_id',
+  leftColumn: 'user_id',
   rightColumn: 'id',
   alias: 'customer',
 } as const satisfies JoinPath<Schema>;

--- a/website-next/docs/query-building/join-relationships.mdx
+++ b/website-next/docs/query-building/join-relationships.mdx
@@ -43,7 +43,7 @@ const relationships = new JoinRelationships<Schema>();
 relationships.define('orderCustomer', {
   from: 'orders',
   to: 'users',
-  leftColumn: 'orders.user_id',
+  leftColumn: 'user_id',
   rightColumn: 'id',
   type: 'LEFT',
 });
@@ -102,14 +102,14 @@ relationships.defineChain('orderCustomerRegion', [
   {
     from: 'orders',
     to: 'users',
-    leftColumn: 'orders.user_id',
+    leftColumn: 'user_id',
     rightColumn: 'id',
     type: 'INNER',
   },
   {
     from: 'users',
     to: 'regions',
-    leftColumn: 'users.region_id',
+    leftColumn: 'region_id',
     rightColumn: 'id',
     type: 'LEFT',
   },
@@ -157,7 +157,11 @@ const rows = await db
 
 This is useful when the shared relationship is usually `LEFT`, but one query needs stricter matching.
 
-`alias` can be defined on the relationship itself for SQL generation, but `withRelation()` does not widen the builder's alias typing the way inline `join(..., alias)` methods do. For typed alias-based column selection, prefer inline joins.
+`alias` can be defined on the relationship itself for SQL generation.
+
+- For string-based registry lookups such as `withRelation('orderCustomer')`, TypeScript cannot inspect the stored relationship shape, so alias/table widening is runtime-only.
+- For direct `JoinPath` usage, `withRelation()` does widen the builder type for joined tables and aliases.
+- Inline joins are still a good choice for one-off joins, but direct `JoinPath` usage is fully typed when you want reusable path objects with compile-time widening.
 
 Alias override is only supported for single-join relationships. For `defineChain()` relationships, each step should define its own alias explicitly if needed.
 


### PR DESCRIPTION
  
## Description

withRelation() direct-chain typing did not match runtime behavior.

Specifically:

  - Runtime already allowed a join chain where a later step starts from an alias introduced by an earlier step.
  - TypeScript rejected that shape because JoinPath<Schema> required from to be a schema table key only.

  Example of the broken case:

  builder.withRelation([
    {
      from: 'orders',
      to: 'users',
      leftColumn: 'user_id',
      rightColumn: 'id',
      alias: 'customer',
    },
    {
      from: 'customer',
      to: 'regions',
      leftColumn: 'region_id',
      rightColumn: 'id',
    },

We also fixed the same mismatch for named chains defined via JoinRelationships.defineChain(...), so registry-defined alias-origin chains can now be represented in the type system too.