### PR TITLE
  feat(clickhouse): add array join, limit by, with totals

### DIFF
--- a/packages/clickhouse/scripts/run-integration-tests.js
+++ b/packages/clickhouse/scripts/run-integration-tests.js
@@ -280,7 +280,7 @@ async function seedDatabase() {
     `DROP TABLE IF EXISTS ${CLICKHOUSE_DB}.test_table`,
     `DROP TABLE IF EXISTS ${CLICKHOUSE_DB}.users`,
     `DROP TABLE IF EXISTS ${CLICKHOUSE_DB}.orders`,
-    `CREATE TABLE ${CLICKHOUSE_DB}.test_table (\n      id UInt32,\n      name String,\n      category String,\n      price Float64,\n      created_at Date,\n      is_active Boolean\n    ) ENGINE = MergeTree()\n    ORDER BY id`,
+    `CREATE TABLE ${CLICKHOUSE_DB}.test_table (\n      id UInt32,\n      name String,\n      category String,\n      price Float64,\n      created_at Date,\n      is_active Boolean,\n      tags Array(String)\n    ) ENGINE = MergeTree()\n    ORDER BY id`,
     `CREATE TABLE ${CLICKHOUSE_DB}.users (\n      id UInt32,\n      user_name String,\n      email String,\n      status String,\n      created_at Date\n    ) ENGINE = MergeTree()\n    ORDER BY id`,
     `CREATE TABLE ${CLICKHOUSE_DB}.orders (\n      id UInt32,\n      user_id UInt32,\n      product_id UInt32,\n      quantity UInt32,\n      total Float64,\n      status String,\n      created_at Date\n    ) ENGINE = MergeTree()\n    ORDER BY id`
   ];
@@ -292,7 +292,7 @@ async function seedDatabase() {
   const testTableRows = (data.test_table ?? []).map(row =>
     pickColumns(
       row,
-      ['id', 'name', 'category', 'price', 'created_at', 'is_active'],
+      ['id', 'name', 'category', 'price', 'created_at', 'is_active', 'tags'],
       { created_at: normalizeDateValue }
     )
   );

--- a/packages/clickhouse/src/core/dialects/clickhouse-dialect.ts
+++ b/packages/clickhouse/src/core/dialects/clickhouse-dialect.ts
@@ -17,6 +17,10 @@ export class ClickHouseDialect implements SqlDialect {
     parts.push(`SELECT ${this.formatter.formatSelect(query)}`);
     parts.push(`FROM ${this.formatter.formatFrom(query.from ?? { kind: 'table', name: context.tableName })}`);
 
+    if (query.arrayJoins?.length) {
+      parts.push(this.formatter.formatArrayJoins(query));
+    }
+
     if (query.joins?.length) {
       parts.push(this.formatter.formatJoins(query));
     }
@@ -34,7 +38,8 @@ export class ClickHouseDialect implements SqlDialect {
     }
 
     if (query.groupBy?.length) {
-      parts.push(`GROUP BY ${this.formatter.formatGroupBy(query)}`);
+      const groupByClause = `GROUP BY ${this.formatter.formatGroupBy(query)}`;
+      parts.push(query.withTotals ? `${groupByClause} WITH TOTALS` : groupByClause);
     }
 
     if (query.having?.length) {
@@ -45,6 +50,10 @@ export class ClickHouseDialect implements SqlDialect {
 
     if (query.orderBy?.length) {
       parts.push(`ORDER BY ${this.formatter.formatOrderBy(query)}`);
+    }
+
+    if (query.limitBy) {
+      parts.push(`LIMIT ${this.formatter.formatLimitBy(query)}`);
     }
 
     if (query.limit) {

--- a/packages/clickhouse/src/core/features/joins.ts
+++ b/packages/clickhouse/src/core/features/joins.ts
@@ -13,7 +13,8 @@ export class JoinFeature<
     table: TableName,
     leftColumn: string,
     rightColumn: `${TableName & string}.${keyof Schema[TableName] & string}`,
-    alias?: string
+    alias?: string,
+    leftSource?: string
   ): SelectQueryNode<State['output'], Schema> {
     const query = this.builder.getQueryNode();
     const renderedRightColumn = alias
@@ -28,6 +29,7 @@ export class JoinFeature<
           type,
           table: String(table),
           leftColumn: String(leftColumn),
+          leftSource,
           rightColumn: renderedRightColumn,
           alias,
         }

--- a/packages/clickhouse/src/core/features/query-modifiers.ts
+++ b/packages/clickhouse/src/core/features/query-modifiers.ts
@@ -24,11 +24,38 @@ export class QueryModifiersFeature<
     };
   }
 
+  addArrayJoin(type: 'ARRAY' | 'LEFT ARRAY', expression: string): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
+    return {
+      ...query,
+      arrayJoins: [
+        ...(query.arrayJoins || []),
+        {
+          kind: 'array-join' as const,
+          type,
+          expression,
+        },
+      ],
+    };
+  }
+
   addLimit(count: number): SelectQueryNode<State['output'], Schema> {
     const query = this.builder.getQueryNode();
     return {
       ...query,
       limit: count
+    };
+  }
+
+  addLimitBy(limit: number, by: string | string[]): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
+    return {
+      ...query,
+      limitBy: {
+        kind: 'limit-by' as const,
+        limit,
+        by: Array.isArray(by) ? by.map(String) : [String(by)],
+      },
     };
   }
 
@@ -70,6 +97,14 @@ export class QueryModifiersFeature<
     return {
       ...query,
       distinct: true
+    };
+  }
+
+  setWithTotals(): SelectQueryNode<State['output'], Schema> {
+    const query = this.builder.getQueryNode();
+    return {
+      ...query,
+      withTotals: true,
     };
   }
 }

--- a/packages/clickhouse/src/core/formatters/sql-formatter.ts
+++ b/packages/clickhouse/src/core/formatters/sql-formatter.ts
@@ -209,7 +209,10 @@ export class SQLFormatter {
       const tableClause = join.alias
         ? `${join.table} AS ${join.alias}`
         : join.table;
-      return `${join.type} JOIN ${tableClause} ON ${join.leftColumn} = ${join.rightColumn}`;
+      const leftColumn = join.leftSource && !join.leftColumn.includes('.')
+        ? `${join.leftSource}.${join.leftColumn}`
+        : join.leftColumn;
+      return `${join.type} JOIN ${tableClause} ON ${leftColumn} = ${join.rightColumn}`;
     }).join(' ');
   }
 

--- a/packages/clickhouse/src/core/formatters/sql-formatter.ts
+++ b/packages/clickhouse/src/core/formatters/sql-formatter.ts
@@ -13,6 +13,13 @@ export class SQLFormatter {
     return groupBy.map(item => item.expression).join(', ');
   }
 
+  formatArrayJoins(query: SelectQueryNode<any, any>): string {
+    if (!query.arrayJoins?.length) return '';
+    return query.arrayJoins
+      .map(item => `${item.type} JOIN ${item.expression}`)
+      .join(' ');
+  }
+
   formatPrewhere(query: SelectQueryNode<any, any>): string {
     return this.compileExpr(query.prewhere).query;
   }
@@ -216,6 +223,11 @@ export class SQLFormatter {
     return query.orderBy
       .map(({ column, direction }) => `${String(column)} ${direction}`.trim())
       .join(', ');
+  }
+
+  formatLimitBy(query: SelectQueryNode<any, any>): string {
+    if (!query.limitBy) return '';
+    return `${query.limitBy.limit} BY ${query.limitBy.by.join(', ')}`;
   }
 
   private combineCompiled(parts: CompiledQuery[]): CompiledQuery {

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -1073,12 +1073,11 @@ export class QueryBuilder<
         next.query = currentQuery;
         const type = options?.type || joinPath.type || 'INNER';
         const alias = relationOptions?.alias || joinPath.alias;
+        const leftColumn = String(joinPath.leftColumn);
+        const leftSource = String(joinPath.from);
         const table = String(joinPath.to) as Extract<keyof Schema, string>;
-        const leftColumn = String(joinPath.leftColumn).includes('.')
-          ? String(joinPath.leftColumn)
-          : `${String(joinPath.from)}.${String(joinPath.leftColumn)}`;
         const rightColumn = `${table}.${joinPath.rightColumn}` as `${typeof table}.${keyof Schema[typeof table] & string}`;
-        return next.joins.addJoin(type, table, leftColumn, rightColumn, alias);
+        return next.joins.addJoin(type, table, leftColumn, rightColumn, alias, leftSource);
       },
       label
     );

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -831,8 +831,24 @@ export class QueryBuilder<
     return this.updateQuery(() => this.modifiers.addGroupBy(normalized));
   }
 
+  arrayJoin(column: SelectableColumn<State>): this {
+    return this.updateQuery(() => this.modifiers.addArrayJoin('ARRAY', String(column)));
+  }
+
+  leftArrayJoin(column: SelectableColumn<State>): this {
+    return this.updateQuery(() => this.modifiers.addArrayJoin('LEFT ARRAY', String(column)));
+  }
+
   limit(count: number): this {
     return this.updateQuery(() => this.modifiers.addLimit(count));
+  }
+
+  limitBy(
+    count: number,
+    by: SelectableColumn<State> | Array<SelectableColumn<State>>
+  ): this {
+    const normalized = Array.isArray(by) ? by.map(String) : String(by);
+    return this.updateQuery(() => this.modifiers.addLimitBy(count, normalized));
   }
 
   offset(count: number): this {
@@ -871,6 +887,10 @@ export class QueryBuilder<
 
   distinct(): this {
     return this.updateQuery(() => this.modifiers.setDistinct());
+  }
+
+  withTotals(): this {
+    return this.updateQuery(() => this.modifiers.setWithTotals());
   }
 
   whereNull<Column extends WhereColumn<State>>(column: Column): this {

--- a/packages/clickhouse/src/core/query-node.ts
+++ b/packages/clickhouse/src/core/query-node.ts
@@ -56,14 +56,22 @@ export function createSelectQueryNode<TOutput, TSchema>(
     kind: 'select-query',
     from: config.from ? { ...config.from } : undefined,
     select: config.select ? config.select.map(item => ({ ...item })) : undefined,
+    arrayJoins: config.arrayJoins ? config.arrayJoins.map(item => ({ ...item })) : undefined,
     prewhere: cloneExprNode(config.prewhere),
     where: cloneExprNode(config.where),
     groupBy: config.groupBy ? config.groupBy.map(item => ({ ...item })) : undefined,
+    withTotals: config.withTotals,
     having: config.having
       ? config.having.map(item => ({
         ...item,
         parameters: item.parameters?.map(parameter => ({ ...parameter })),
       }))
+      : undefined,
+    limitBy: config.limitBy
+      ? {
+        ...config.limitBy,
+        by: [...config.limitBy.by],
+      }
       : undefined,
     limit: config.limit,
     offset: config.offset,

--- a/packages/clickhouse/src/core/tests/integration/analytical-queries.test.ts
+++ b/packages/clickhouse/src/core/tests/integration/analytical-queries.test.ts
@@ -5,9 +5,7 @@ import {
   TEST_DATA
 } from './setup';
 import { raw } from '../../utils/sql-expressions.js';
-
-// Skip integration tests if running in CI or if explicitly disabled
-const SKIP_INTEGRATION_TESTS = process.env.SKIP_INTEGRATION_TESTS === 'true' || process.env.CI === 'true';
+import { SKIP_INTEGRATION_TESTS, SETUP_TIMEOUT } from './test-config.js';
 
 describe('Integration Tests - Analytical Queries', () => {
   // Only run these tests if not skipped
@@ -25,7 +23,7 @@ describe('Integration Tests - Analytical Queries', () => {
           throw error;
         }
       }
-    }, 30000);
+    }, SETUP_TIMEOUT);
 
     test('should analyze sales by product category', async () => {
       const result = await db

--- a/packages/clickhouse/src/core/tests/integration/basic-queries.test.ts
+++ b/packages/clickhouse/src/core/tests/integration/basic-queries.test.ts
@@ -4,14 +4,12 @@ import {
   setupTestDatabase,
   TEST_DATA
 } from './setup';
-
-// Skip integration tests if running in CI or if explicitly disabled
-const SKIP_INTEGRATION_TESTS = process.env.SKIP_INTEGRATION_TESTS === 'true' || process.env.CI === 'true';
+import { SKIP_INTEGRATION_TESTS, SETUP_TIMEOUT } from './test-config.js';
 
 describe('Integration Tests - Basic Queries', () => {
   // Only run these tests if not skipped
   (SKIP_INTEGRATION_TESTS ? describe.skip : describe)('ClickHouse Integration', () => {
-    let db: Awaited<ReturnType<any>>;
+    let db: Awaited<ReturnType<typeof initializeTestConnection>>;
 
     beforeAll(async () => {
       if (!SKIP_INTEGRATION_TESTS) {
@@ -24,7 +22,7 @@ describe('Integration Tests - Basic Queries', () => {
           throw error;
         }
       }
-    }, 30000);
+    }, SETUP_TIMEOUT);
 
     test('should execute a simple SELECT query', async () => {
       const result = await db.table('test_table')
@@ -181,6 +179,29 @@ describe('Integration Tests - Basic Queries', () => {
       expect(result.map(row => ({ id: Number(row.id), tags: String(row.tags) }))).toEqual(expected);
     });
 
+    test('should execute LEFT ARRAY JOIN queries', async () => {
+      const result = await db.table('test_table')
+        .select(['id', 'tags'])
+        .leftArrayJoin('tags')
+        .orderBy('id', 'ASC')
+        .execute();
+
+      const expected = TEST_DATA.test_table.flatMap(item =>
+        item.tags.length > 0
+          ? item.tags.map(tag => ({
+              id: item.id,
+              tags: tag,
+            }))
+          : [{
+              id: item.id,
+              tags: '',
+            }]
+      );
+
+      expect(result).toHaveLength(expected.length);
+      expect(result.map(row => ({ id: Number(row.id), tags: String(row.tags) }))).toEqual(expected);
+    });
+
     test('should execute LIMIT BY queries', async () => {
       const result = await db.table('orders')
         .select(['user_id', 'id', 'created_at'])
@@ -189,24 +210,62 @@ describe('Integration Tests - Basic Queries', () => {
         .execute();
 
       const expected = Object.values(
-        TEST_DATA.orders
-          .slice()
-          .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)))
-          .reduce((acc, order) => {
-            if (!acc[order.user_id]) {
-              acc[order.user_id] = {
-                user_id: order.user_id,
-                id: order.id,
-                created_at: order.created_at,
-              };
-            }
-            return acc;
-          }, {} as Record<number, { user_id: number; id: number; created_at: string }>)
+        Array.from(
+          TEST_DATA.orders
+            .slice()
+            .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)))
+            .reduce((acc, order) => {
+              if (!acc.has(order.user_id)) {
+                acc.set(order.user_id, {
+                  user_id: order.user_id,
+                  id: order.id,
+                  created_at: order.created_at,
+                });
+              }
+              return acc;
+            }, new Map<number, { user_id: number; id: number; created_at: string }>())
+            .values()
+        )
       );
 
       expect(result).toHaveLength(expected.length);
       expect(result.map(row => ({
         user_id: Number(row.user_id),
+        id: Number(row.id),
+        created_at: String(row.created_at),
+      }))).toEqual(expected);
+    });
+
+    test('should execute multi-column LIMIT BY queries', async () => {
+      const result = await db.table('test_table')
+        .select(['category', 'is_active', 'id', 'created_at'])
+        .orderBy('created_at', 'DESC')
+        .limitBy(1, ['category', 'is_active'])
+        .execute();
+
+      const expected = Array.from(
+        TEST_DATA.test_table
+          .slice()
+          .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)))
+          .reduce((acc, row) => {
+            const key = `${row.category}|${row.is_active ? 1 : 0}`;
+            if (!acc.has(key)) {
+              acc.set(key, {
+                category: row.category,
+                is_active: row.is_active ? 1 : 0,
+                id: row.id,
+                created_at: row.created_at,
+              });
+            }
+            return acc;
+          }, new Map<string, { category: string; is_active: number; id: number; created_at: string }>())
+          .values()
+      );
+
+      expect(result).toHaveLength(expected.length);
+      expect(result.map(row => ({
+        category: String(row.category),
+        is_active: Number(row.is_active),
         id: Number(row.id),
         created_at: String(row.created_at),
       }))).toEqual(expected);

--- a/packages/clickhouse/src/core/tests/integration/basic-queries.test.ts
+++ b/packages/clickhouse/src/core/tests/integration/basic-queries.test.ts
@@ -163,6 +163,78 @@ describe('Integration Tests - Basic Queries', () => {
       }
     });
 
+    test('should execute ARRAY JOIN queries', async () => {
+      const result = await db.table('test_table')
+        .select(['id', 'tags'])
+        .arrayJoin('tags')
+        .orderBy('id', 'ASC')
+        .execute();
+
+      const expected = TEST_DATA.test_table.flatMap(item =>
+        item.tags.map(tag => ({
+          id: item.id,
+          tags: tag,
+        }))
+      );
+
+      expect(result).toHaveLength(expected.length);
+      expect(result.map(row => ({ id: Number(row.id), tags: String(row.tags) }))).toEqual(expected);
+    });
+
+    test('should execute LIMIT BY queries', async () => {
+      const result = await db.table('orders')
+        .select(['user_id', 'id', 'created_at'])
+        .orderBy('created_at', 'DESC')
+        .limitBy(1, 'user_id')
+        .execute();
+
+      const expected = Object.values(
+        TEST_DATA.orders
+          .slice()
+          .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)))
+          .reduce((acc, order) => {
+            if (!acc[order.user_id]) {
+              acc[order.user_id] = {
+                user_id: order.user_id,
+                id: order.id,
+                created_at: order.created_at,
+              };
+            }
+            return acc;
+          }, {} as Record<number, { user_id: number; id: number; created_at: string }>)
+      );
+
+      expect(result).toHaveLength(expected.length);
+      expect(result.map(row => ({
+        user_id: Number(row.user_id),
+        id: Number(row.id),
+        created_at: String(row.created_at),
+      }))).toEqual(expected);
+    });
+
+    test('should execute GROUP BY queries with WITH TOTALS enabled', async () => {
+      const result = await db.table('test_table')
+        .select(['category'])
+        .count('id', 'count')
+        .groupBy('category')
+        .withTotals()
+        .orderBy('category', 'ASC')
+        .execute();
+
+      const expected = [...new Set(TEST_DATA.test_table.map(item => item.category))]
+        .sort((a, b) => a.localeCompare(b))
+        .map(category => ({
+          category,
+          count: TEST_DATA.test_table.filter(item => item.category === category).length,
+        }));
+
+      expect(result).toHaveLength(expected.length);
+      expect(result.map(row => ({
+        category: String(row.category),
+        count: Number(row.count),
+      }))).toEqual(expected);
+    });
+
     test('should handle complex queries', async () => {
       const result = await db.table('test_table')
         .select(['category'])

--- a/packages/clickhouse/src/core/tests/integration/complex-joins.test.ts
+++ b/packages/clickhouse/src/core/tests/integration/complex-joins.test.ts
@@ -272,6 +272,58 @@ describe('Integration Tests - Complex Joins', () => {
       }
     });
 
+    test('should execute alias-origin withRelation chains with unqualified leftColumn values', async () => {
+      const result = await db
+        .table('orders')
+        .withRelation([
+          {
+            from: 'orders',
+            to: 'users',
+            leftColumn: 'user_id',
+            rightColumn: 'id',
+            alias: 'customer',
+          },
+          {
+            from: 'customer',
+            to: 'orders',
+            leftColumn: 'id',
+            rightColumn: 'user_id',
+            alias: 'customer_order',
+          },
+        ])
+        .select([
+          'orders.id as order_id',
+          'customer.user_name',
+          'customer_order.id as related_order_id',
+        ])
+        .orderBy('orders.id', 'ASC')
+        .orderBy('customer_order.id', 'ASC')
+        .execute();
+
+      const expected = TEST_DATA.orders
+        .slice()
+        .sort((a, b) => a.id - b.id)
+        .flatMap(order => {
+          const customer = TEST_DATA.users.find(user => user.id === order.user_id);
+          const relatedOrders = TEST_DATA.orders
+            .filter(candidate => candidate.user_id === order.user_id)
+            .slice()
+            .sort((a, b) => a.id - b.id);
+
+          return relatedOrders.map(relatedOrder => ({
+            order_id: order.id,
+            user_name: customer?.user_name ?? null,
+            related_order_id: relatedOrder.id,
+          }));
+        });
+
+      expect(result.map(row => ({
+        order_id: Number(row.order_id),
+        user_name: row.user_name,
+        related_order_id: Number(row.related_order_id),
+      }))).toEqual(expected);
+    });
+
     test('should handle complex filtering and aggregation in joined queries', async () => {
       const result = await db
         .table('users')

--- a/packages/clickhouse/src/core/tests/integration/setup.ts
+++ b/packages/clickhouse/src/core/tests/integration/setup.ts
@@ -241,6 +241,7 @@ export interface TestSchemaType {
     price: number;
     created_at: string;
     is_active: boolean;
+    tags: string[];
   }>;
   users: Array<{
     id: number;
@@ -283,7 +284,8 @@ function normalizeTestData() {
     category: row.category,
     price: row.price,
     created_at: normalizeDateValue(row.created_at),
-    is_active: row.is_active
+    is_active: row.is_active,
+    tags: row.tags ?? [],
   }));
 
   const users = (rawTestData.users ?? []).map(row => ({
@@ -345,7 +347,8 @@ export const setupTestDatabase = async (): Promise<void> => {
           category String,
           price Float64,
           created_at Date,
-          is_active Boolean
+          is_active Boolean,
+          tags Array(String)
         ) ENGINE = MergeTree()
         ORDER BY id
       `

--- a/packages/clickhouse/src/core/tests/query-builder.grouping.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.grouping.test.ts
@@ -34,6 +34,16 @@ describe('QueryBuilder - Grouping and Ordering', () => {
         .toSQL();
       expect(sql).toBe('SELECT name, category FROM test_table GROUP BY name, category');
     });
+
+    it('should render WITH TOTALS after GROUP BY', () => {
+      const sql = builder
+        .select(['category'])
+        .sum('price')
+        .groupBy('category')
+        .withTotals()
+        .toSQL();
+      expect(sql).toBe('SELECT category, SUM(price) AS price_sum FROM test_table GROUP BY category WITH TOTALS');
+    });
   });
 
   describe('ORDER BY', () => {
@@ -53,5 +63,34 @@ describe('QueryBuilder - Grouping and Ordering', () => {
         .toSQL();
       expect(sql).toBe('SELECT name, price FROM test_table ORDER BY price DESC, name ASC');
     });
+
+    it('should render LIMIT BY after ORDER BY and before LIMIT', () => {
+      const sql = builder
+        .select(['name', 'category'])
+        .orderBy('price', 'DESC')
+        .limitBy(3, ['category'])
+        .limit(10)
+        .toSQL();
+      expect(sql).toBe('SELECT name, category FROM test_table ORDER BY price DESC LIMIT 3 BY category LIMIT 10');
+    });
   });
-}); 
+
+  describe('ARRAY JOIN', () => {
+    it('should render ARRAY JOIN after FROM and before WHERE', () => {
+      const sql = builder
+        .select(['id', 'tags'])
+        .arrayJoin('tags')
+        .where('id', 'gt', 1)
+        .toSQL();
+      expect(sql).toBe('SELECT id, tags FROM test_table ARRAY JOIN tags WHERE id > 1');
+    });
+
+    it('should render LEFT ARRAY JOIN', () => {
+      const sql = builder
+        .select(['id', 'categories'])
+        .leftArrayJoin('categories')
+        .toSQL();
+      expect(sql).toBe('SELECT id, categories FROM test_table LEFT ARRAY JOIN categories');
+    });
+  });
+});

--- a/packages/clickhouse/src/types/base.ts
+++ b/packages/clickhouse/src/types/base.ts
@@ -5,10 +5,13 @@ import type { TableColumn } from './schema.js';
 export interface QueryConfig<T, Schema> {
   select?: SelectionNode[];
   from?: SourceNode;
+  arrayJoins?: ArrayJoinNode[];
   prewhere?: ExprNode;
   where?: ExprNode;
   groupBy?: GroupByItemNode[];
+  withTotals?: boolean;
   having?: HavingNode[];
+  limitBy?: LimitByNode;
   limit?: number;
   offset?: number;
   distinct?: boolean;
@@ -95,6 +98,12 @@ export interface GroupByItemNode {
   expression: string;
 }
 
+export interface ArrayJoinNode {
+  kind: 'array-join';
+  type: 'ARRAY' | 'LEFT ARRAY';
+  expression: string;
+}
+
 export interface HavingNode {
   kind: 'having';
   expression: string;
@@ -116,6 +125,12 @@ export interface OrderByItemNode {
   kind: 'order-by-item';
   column: string;
   direction: OrderDirection;
+}
+
+export interface LimitByNode {
+  kind: 'limit-by';
+  limit: number;
+  by: string[];
 }
 
 export interface CteNode {

--- a/packages/clickhouse/src/types/base.ts
+++ b/packages/clickhouse/src/types/base.ts
@@ -117,6 +117,7 @@ export interface JoinNode {
   type: JoinType;
   table: string;
   leftColumn: string;
+  leftSource?: string;
   rightColumn: string;
   alias?: string;
 }

--- a/packages/clickhouse/type-tests/query-builder-types.test.ts
+++ b/packages/clickhouse/type-tests/query-builder-types.test.ts
@@ -91,6 +91,12 @@ type ArrayResult = Awaited<ReturnType<typeof arrayQuery.execute>>;
 type ArrayExpected = { tags: string[]; categories: string[] }[];
 type AssertArraySelect = Expect<Equal<ArrayResult, ArrayExpected>>;
 
+builder.arrayJoin('tags');
+builder.leftArrayJoin('categories');
+builder.limitBy(3, 'category');
+builder.limitBy(5, ['category', 'brand']);
+builder.groupBy('category').withTotals();
+
 const nullableQuery = builder.select(['optional_name', 'optional_tags']);
 type NullableResult = Awaited<ReturnType<typeof nullableQuery.execute>>;
 type NullableExpected = { optional_name: string | null; optional_tags: string[] | null }[];


### PR DESCRIPTION
## Summary

  Adds three ClickHouse-specific query-builder features to `@hypequery/clickhouse`:

  - `arrayJoin()`
  - `leftArrayJoin()`
  - `limitBy()`
  - `withTotals()`

  ## What changed

  - extended the query AST and ClickHouse SQL renderer to support:
    - `ARRAY JOIN`
    - `LEFT ARRAY JOIN`
    - `LIMIT ... BY ...`
    - `GROUP BY ... WITH TOTALS`
  - added fluent builder methods for each feature
  - added unit coverage for SQL rendering and method behaviour
  - added type coverage for the new builder surface
  - added integration tests for all three features