### PR TITLE
fix: (cli) harden cli for release

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -80,7 +80,6 @@ npx hypequery init
 - Updates `.gitignore` to protect secrets
 
 **Options:**
-- `--database <type>` - Database type (currently only `clickhouse`)
 - `--path <path>` - Output directory (default: `analytics/`)
 - `--no-example` - Skip example query generation
 - `--no-interactive` - Non-interactive mode (uses environment variables)
@@ -88,7 +87,7 @@ npx hypequery init
 
 **Example:**
 ```bash
-# Interactive mode (recommended)
+# ClickHouse setup (default)
 npx @hypequery/cli init
 
 # Non-interactive with custom path
@@ -153,7 +152,7 @@ npx @hypequery/cli generate
 npx hypequery generate
 ```
 
-The CLI bundles the ClickHouse driver directly, so you can run this command without installing `@hypequery/clickhouse`. Specify `--database <type>` once additional drivers become available.
+The CLI bundles the ClickHouse driver directly, so you can run this command without installing `@hypequery/clickhouse`.
 
 **What it does:**
 - Connects to ClickHouse

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeInitOptions } from './cli.js';
+
+describe('normalizeInitOptions', () => {
+  it('maps Commander no-interactive flags onto noInteractive', () => {
+    expect(normalizeInitOptions({ interactive: false })).toMatchObject({
+      interactive: false,
+      noInteractive: true,
+    });
+  });
+
+  it('preserves explicit noInteractive values', () => {
+    expect(normalizeInitOptions({ noInteractive: true, interactive: true })).toMatchObject({
+      interactive: true,
+      noInteractive: true,
+    });
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -21,7 +21,6 @@ program
 program
   .command('init')
   .description('Initialize a new hypequery project')
-  .option('--database <type>', 'Database type (clickhouse|bigquery)')
   .option('--path <path>', 'Output directory (default: analytics/)')
   .option('--no-example', 'Skip example query generation')
   .option('--no-interactive', 'Non-interactive mode (use env vars)')

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,6 +5,13 @@ import { generateCommand } from './commands/generate.js';
 
 const program = new Command();
 
+export function normalizeInitOptions(options: Record<string, unknown>) {
+  return {
+    ...options,
+    noInteractive: options.noInteractive === true || options.interactive === false,
+  };
+}
+
 program
   .name('hypequery')
   .description('Type-safe analytics layer for ClickHouse')
@@ -22,7 +29,7 @@ program
   .option('--skip-connection', 'Skip database connectivity test')
   .action(async (options) => {
     try {
-      await initCommand(options);
+      await initCommand(normalizeInitOptions(options));
     } catch (error) {
       console.error(error instanceof Error ? error.message : error);
       process.exit(1);

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -5,10 +5,11 @@ import * as detectDb from '../utils/detect-database.js';
 import * as findFiles from '../utils/find-files.js';
 import { logger } from '../utils/logger.js';
 import { mockProcessExit, ProcessExitError } from '../test-utils.js';
-const installServeDependencies = vi.fn().mockResolvedValue(undefined);
+const installScaffoldDependencies = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('../utils/dependency-installer.js', () => ({
-  installServeDependencies,
+  installScaffoldDependencies,
+  installServeDependencies: installScaffoldDependencies,
 }));
 
 // Mock all dependencies
@@ -60,26 +61,21 @@ describe('init command - graceful failure handling', () => {
   });
 
   describe('User cancellation scenarios', () => {
-    it('should exit cleanly when user cancels database type selection', async () => {
-      vi.mocked(prompts.promptDatabaseType).mockResolvedValue(null);
-
+    it('should exit cleanly when a non-clickhouse database is requested', async () => {
       try {
-        await initCommand({});
+        await initCommand({ database: 'bigquery' });
       } catch (error) {
         expect(error).toBeInstanceOf(ProcessExitError);
-        expect((error as ProcessExitError).code).toBe(0);
+        expect((error as ProcessExitError).code).toBe(1);
       }
 
-      expect(exitHandler.exitMock).toHaveBeenCalledWith(0);
-      expect(logger.info).toHaveBeenCalledWith('Setup cancelled');
-
-      // Should not attempt to create files
+      expect(exitHandler.exitMock).toHaveBeenCalledWith(1);
+      expect(logger.error).toHaveBeenCalledWith('bigquery is not yet supported. Only ClickHouse is available.');
       expect(mkdir).not.toHaveBeenCalled();
       expect(writeFile).not.toHaveBeenCalled();
     });
 
     it('should continue when user skips connection details', async () => {
-      vi.mocked(prompts.promptDatabaseType).mockResolvedValue('clickhouse');
       vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue(null);
       vi.mocked(prompts.promptOutputDirectory).mockResolvedValue('analytics');
 
@@ -98,7 +94,6 @@ describe('init command - graceful failure handling', () => {
     });
 
     it('should use default directory when user cancels path selection', async () => {
-      vi.mocked(prompts.promptDatabaseType).mockResolvedValue('clickhouse');
       vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue(null);
       vi.mocked(prompts.promptOutputDirectory).mockResolvedValue('analytics');
 
@@ -118,7 +113,6 @@ describe('init command - graceful failure handling', () => {
     });
 
     it('should continue without DB when user declines retry but accepts continue', async () => {
-      vi.mocked(prompts.promptDatabaseType).mockResolvedValue('clickhouse');
       vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue({
         host: 'http://localhost:8123',
         database: 'default',
@@ -141,7 +135,6 @@ describe('init command - graceful failure handling', () => {
     });
 
     it('should exit when user declines both retry and continue', async () => {
-      vi.mocked(prompts.promptDatabaseType).mockResolvedValue('clickhouse');
       vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue({
         host: 'http://localhost:8123',
         database: 'default',
@@ -165,7 +158,6 @@ describe('init command - graceful failure handling', () => {
 
   describe('skipConnection option', () => {
     it('bypasses connection test when requested', async () => {
-      vi.mocked(prompts.promptDatabaseType).mockResolvedValue('clickhouse');
       vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue({
         host: 'http://localhost:8123',
         database: 'default',
@@ -183,7 +175,6 @@ describe('init command - graceful failure handling', () => {
 
   describe('Successful connection scenarios', () => {
     it('should generate real types when connection succeeds', async () => {
-      vi.mocked(prompts.promptDatabaseType).mockResolvedValue('clickhouse');
       vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue({
         host: 'http://localhost:8123',
         database: 'default',
@@ -205,7 +196,6 @@ describe('init command - graceful failure handling', () => {
     });
 
     it('should generate example query when user selects table', async () => {
-      vi.mocked(prompts.promptDatabaseType).mockResolvedValue('clickhouse');
       vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue({
         host: 'http://localhost:8123',
         database: 'default',
@@ -230,7 +220,6 @@ describe('init command - graceful failure handling', () => {
 
   describe('File handling', () => {
     it('should append to existing .env file', async () => {
-      vi.mocked(prompts.promptDatabaseType).mockResolvedValue('clickhouse');
       vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue({
         host: 'http://localhost:8123',
         database: 'default',
@@ -253,7 +242,6 @@ describe('init command - graceful failure handling', () => {
     });
 
     it('should prompt for overwrite when files exist', async () => {
-      vi.mocked(prompts.promptDatabaseType).mockResolvedValue('clickhouse');
       vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue({
         host: 'http://localhost:8123',
         database: 'default',
@@ -272,7 +260,6 @@ describe('init command - graceful failure handling', () => {
     });
 
     it('should skip setup when user declines overwrite', async () => {
-      vi.mocked(prompts.promptDatabaseType).mockResolvedValue('clickhouse');
       vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue({
         host: 'http://localhost:8123',
         database: 'default',
@@ -313,18 +300,61 @@ describe('init command - graceful failure handling', () => {
         path: 'analytics',
       });
 
-      expect(prompts.promptDatabaseType).not.toHaveBeenCalled();
       expect(prompts.promptClickHouseConnection).not.toHaveBeenCalled();
       expect(writeFile).toHaveBeenCalledWith(
         expect.stringContaining('.env'),
         expect.stringContaining('http://test:8123')
       );
     });
+
+    it('does not enter prompt code paths when noInteractive is enabled', async () => {
+      process.env.CLICKHOUSE_URL = 'http://test:8123';
+      delete process.env.CLICKHOUSE_HOST;
+      process.env.CLICKHOUSE_DATABASE = 'test_db';
+      process.env.CLICKHOUSE_USERNAME = 'test_user';
+      process.env.CLICKHOUSE_PASSWORD = 'test_pass';
+
+      vi.mocked(detectDb.validateConnection).mockResolvedValue(true);
+      vi.mocked(detectDb.getTableCount).mockResolvedValue(10);
+
+      await initCommand({
+        database: 'clickhouse',
+        noInteractive: true,
+        force: true,
+        path: 'analytics',
+      });
+
+      expect(prompts.promptOutputDirectory).not.toHaveBeenCalled();
+      expect(prompts.promptGenerateExample).not.toHaveBeenCalled();
+      expect(prompts.promptTableSelection).not.toHaveBeenCalled();
+      expect(prompts.confirmOverwrite).not.toHaveBeenCalled();
+      expect(prompts.promptRetry).not.toHaveBeenCalled();
+      expect(prompts.promptContinueWithoutDb).not.toHaveBeenCalled();
+    });
+
+    it('fails without retry prompts when non-interactive connection validation fails', async () => {
+      process.env.CLICKHOUSE_URL = 'http://test:8123';
+      delete process.env.CLICKHOUSE_HOST;
+      process.env.CLICKHOUSE_DATABASE = 'test_db';
+      process.env.CLICKHOUSE_USERNAME = 'test_user';
+      process.env.CLICKHOUSE_PASSWORD = 'test_pass';
+
+      vi.mocked(detectDb.validateConnection).mockResolvedValue(false);
+
+      await expect(initCommand({
+        database: 'clickhouse',
+        noInteractive: true,
+        force: true,
+        path: 'analytics',
+      })).rejects.toThrow('Failed to connect to ClickHouse in non-interactive mode.');
+
+      expect(prompts.promptRetry).not.toHaveBeenCalled();
+      expect(prompts.promptContinueWithoutDb).not.toHaveBeenCalled();
+    });
   });
 
   describe('Dependency installation', () => {
     it('installs serve dependencies when setup completes', async () => {
-      vi.mocked(prompts.promptDatabaseType).mockResolvedValue('clickhouse');
       vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue({
         host: 'http://localhost:8123',
         database: 'default',
@@ -338,7 +368,7 @@ describe('init command - graceful failure handling', () => {
 
       await initCommand({});
 
-      expect(installServeDependencies).toHaveBeenCalled();
+      expect(installScaffoldDependencies).toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -61,20 +61,6 @@ describe('init command - graceful failure handling', () => {
   });
 
   describe('User cancellation scenarios', () => {
-    it('should exit cleanly when a non-clickhouse database is requested', async () => {
-      try {
-        await initCommand({ database: 'bigquery' });
-      } catch (error) {
-        expect(error).toBeInstanceOf(ProcessExitError);
-        expect((error as ProcessExitError).code).toBe(1);
-      }
-
-      expect(exitHandler.exitMock).toHaveBeenCalledWith(1);
-      expect(logger.error).toHaveBeenCalledWith('bigquery is not yet supported. Only ClickHouse is available.');
-      expect(mkdir).not.toHaveBeenCalled();
-      expect(writeFile).not.toHaveBeenCalled();
-    });
-
     it('should continue when user skips connection details', async () => {
       vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue(null);
       vi.mocked(prompts.promptOutputDirectory).mockResolvedValue('analytics');
@@ -295,7 +281,6 @@ describe('init command - graceful failure handling', () => {
       vi.mocked(detectDb.getTableCount).mockResolvedValue(10);
 
       await initCommand({
-        database: 'clickhouse',
         noInteractive: true,
         path: 'analytics',
       });
@@ -318,7 +303,6 @@ describe('init command - graceful failure handling', () => {
       vi.mocked(detectDb.getTableCount).mockResolvedValue(10);
 
       await initCommand({
-        database: 'clickhouse',
         noInteractive: true,
         force: true,
         path: 'analytics',
@@ -342,7 +326,6 @@ describe('init command - graceful failure handling', () => {
       vi.mocked(detectDb.validateConnection).mockResolvedValue(false);
 
       await expect(initCommand({
-        database: 'clickhouse',
         noInteractive: true,
         force: true,
         path: 'analytics',

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,7 +4,6 @@ import ora from 'ora';
 import type { DatabaseType } from '../utils/detect-database.js';
 import { logger } from '../utils/logger.js';
 import {
-  promptDatabaseType,
   promptClickHouseConnection,
   promptOutputDirectory,
   promptGenerateExample,
@@ -24,7 +23,7 @@ import { generateClientTemplate } from '../templates/client.js';
 import { generateQueriesTemplate } from '../templates/queries.js';
 import { appendToGitignore } from '../templates/gitignore.js';
 import { getTypeGenerator } from '../generators/index.js';
-import { installServeDependencies } from '../utils/dependency-installer.js';
+import { installScaffoldDependencies } from '../utils/dependency-installer.js';
 
 export interface InitOptions {
   database?: string;
@@ -43,12 +42,7 @@ type ConnectionConfig = {
 };
 
 async function determineDatabase(options: InitOptions): Promise<DatabaseType> {
-  const dbType = (options.database as DatabaseType | undefined) ?? (await promptDatabaseType());
-
-  if (!dbType) {
-    logger.info('Setup cancelled');
-    process.exit(0);
-  }
+  const dbType = (options.database as DatabaseType | undefined) ?? 'clickhouse';
 
   if (dbType !== 'clickhouse') {
     logger.error(`${dbType} is not yet supported. Only ClickHouse is available.`);
@@ -116,6 +110,8 @@ async function testConnection(
 }
 
 export async function initCommand(options: InitOptions = {}) {
+  const noInteractive = options.noInteractive === true || (options as InitOptions & { interactive?: boolean }).interactive === false;
+
   logger.newline();
   logger.header('Welcome to hypequery!');
   logger.info("Let's set up your analytics layer.");
@@ -141,6 +137,10 @@ export async function initCommand(options: InitOptions = {}) {
     tableCount = count;
 
     if (!hasValidConnection) {
+      if (noInteractive) {
+        throw new Error('Failed to connect to ClickHouse in non-interactive mode. Check your environment variables or use interactive setup.');
+      }
+
       const retry = await promptRetry('Try again?');
       if (retry) {
         return initCommand(options);
@@ -162,7 +162,7 @@ export async function initCommand(options: InitOptions = {}) {
 
   // Step 4: Get output directory
   let outputDir = options.path;
-  if (!outputDir && !options.noInteractive) {
+  if (!outputDir && !noInteractive) {
     outputDir = await promptOutputDirectory();
   } else if (!outputDir) {
     outputDir = 'analytics';
@@ -190,7 +190,7 @@ export async function initCommand(options: InitOptions = {}) {
   if (existingFiles.length > 0 && !options.force) {
     logger.warn('Files already exist');
     logger.newline();
-    const shouldOverwrite = await confirmOverwrite(existingFiles);
+    const shouldOverwrite = noInteractive ? false : await confirmOverwrite(existingFiles);
     if (!shouldOverwrite) {
       logger.info('Setup cancelled');
       process.exit(0);
@@ -202,7 +202,7 @@ export async function initCommand(options: InitOptions = {}) {
   let generateExample = !options.noExample && hasValidConnection;
   let selectedTable: string | null = null;
 
-  if (generateExample && !options.noInteractive && hasValidConnection) {
+  if (generateExample && !noInteractive && hasValidConnection) {
     generateExample = await promptGenerateExample();
 
     if (generateExample) {
@@ -313,7 +313,7 @@ export interface IntrospectedSchema {
   }
 
   // Step 13: Ensure required hypequery packages are installed
-  await installServeDependencies();
+  await installScaffoldDependencies();
 
   // Step 14: Success message
   logger.newline();

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,7 +1,6 @@
 import { mkdir, writeFile, readFile, access } from 'node:fs/promises';
 import path from 'node:path';
 import ora from 'ora';
-import type { DatabaseType } from '../utils/detect-database.js';
 import { logger } from '../utils/logger.js';
 import {
   promptClickHouseConnection,
@@ -26,7 +25,6 @@ import { getTypeGenerator } from '../generators/index.js';
 import { installScaffoldDependencies } from '../utils/dependency-installer.js';
 
 export interface InitOptions {
-  database?: string;
   path?: string;
   noExample?: boolean;
   noInteractive?: boolean;
@@ -40,17 +38,6 @@ type ConnectionConfig = {
   username: string;
   password: string;
 };
-
-async function determineDatabase(options: InitOptions): Promise<DatabaseType> {
-  const dbType = (options.database as DatabaseType | undefined) ?? 'clickhouse';
-
-  if (dbType !== 'clickhouse') {
-    logger.error(`${dbType} is not yet supported. Only ClickHouse is available.`);
-    process.exit(1);
-  }
-
-  return dbType;
-}
 
 async function resolveConnectionConfig(options: InitOptions): Promise<ConnectionConfig | null> {
   if (options.noInteractive) {
@@ -78,7 +65,6 @@ async function resolveConnectionConfig(options: InitOptions): Promise<Connection
 
 async function testConnection(
   connectionConfig: ConnectionConfig,
-  dbType: DatabaseType,
 ): Promise<{ hasValidConnection: boolean; tableCount: number }> {
   const spinner = ora('Testing connection...').start();
   process.env.CLICKHOUSE_URL = connectionConfig.host;
@@ -87,7 +73,7 @@ async function testConnection(
   process.env.CLICKHOUSE_USERNAME = connectionConfig.username;
   process.env.CLICKHOUSE_PASSWORD = connectionConfig.password;
 
-  const isValid = await validateConnection(dbType);
+  const isValid = await validateConnection('clickhouse');
 
   if (!isValid) {
     spinner.fail('Connection failed');
@@ -103,7 +89,7 @@ async function testConnection(
     return { hasValidConnection: false, tableCount: 0 };
   }
 
-  const tableCount = await getTableCount(dbType);
+  const tableCount = await getTableCount('clickhouse');
   spinner.succeed(`Connected successfully (${tableCount} tables found)`);
   logger.newline();
   return { hasValidConnection: true, tableCount };
@@ -116,8 +102,6 @@ export async function initCommand(options: InitOptions = {}) {
   logger.header('Welcome to hypequery!');
   logger.info("Let's set up your analytics layer.");
   logger.newline();
-
-  const dbType = await determineDatabase(options);
 
   // Step 2: Get connection details
   let connectionConfig = await resolveConnectionConfig(options);
@@ -132,7 +116,7 @@ export async function initCommand(options: InitOptions = {}) {
     logger.info('Skipping database connection test (requested).');
     logger.newline();
   } else {
-    const { hasValidConnection: valid, tableCount: count } = await testConnection(connectionConfig, dbType);
+    const { hasValidConnection: valid, tableCount: count } = await testConnection(connectionConfig);
     hasValidConnection = valid;
     tableCount = count;
 
@@ -206,7 +190,7 @@ export async function initCommand(options: InitOptions = {}) {
     generateExample = await promptGenerateExample();
 
     if (generateExample) {
-      const tables = await getTables(dbType);
+      const tables = await getTables('clickhouse');
       selectedTable = await promptTableSelection(tables);
       generateExample = selectedTable !== null;
     }

--- a/packages/cli/src/generators/index.ts
+++ b/packages/cli/src/generators/index.ts
@@ -15,7 +15,7 @@ export function getTypeGenerator(dbType: DatabaseType): GeneratorFn {
   if (!generator) {
     throw new Error(
       dbType === 'unknown'
-        ? 'Unable to detect database type. Re-run `hypequery init --database <type>` or pass `--database` explicitly.'
+        ? 'Unable to detect database type. Re-run `hypequery generate --database <type>` or pass `--database` explicitly.'
         : `Type generation for ${dbType} is not supported yet.`
     );
   }

--- a/packages/cli/src/templates/client.ts
+++ b/packages/cli/src/templates/client.ts
@@ -3,7 +3,7 @@
  */
 export function generateClientTemplate(): string {
   return `import { createQueryBuilder } from '@hypequery/clickhouse';
-import type { IntrospectedSchema } from './schema';
+import type { IntrospectedSchema } from './schema.js';
 
 export const db = createQueryBuilder<IntrospectedSchema>({
   url: process.env.CLICKHOUSE_URL ?? process.env.CLICKHOUSE_HOST!,

--- a/packages/cli/src/templates/queries.test.ts
+++ b/packages/cli/src/templates/queries.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { generateQueriesTemplate } from './queries.js';
+import { generateClientTemplate } from './client.js';
 
 describe('queries template', () => {
   it('should generate basic template without example', () => {
@@ -8,7 +9,7 @@ describe('queries template', () => {
     });
 
     expect(result).toContain('import { initServe }');
-    expect(result).toContain('import { db } from \'./client\'');
+    expect(result).toContain('import { db } from \'./client.js\'');
     expect(result).toContain('exampleMetric');
     expect(result).toContain('ok: true');
   });
@@ -42,6 +43,14 @@ describe('queries template', () => {
     expect(result).toContain('api.execute(');
   });
 
+  it('registers a default HTTP route', () => {
+    const result = generateQueriesTemplate({
+      hasExample: false,
+    });
+
+    expect(result).toContain("api.route('/metrics/exampleMetric', api.queries.exampleMetric);");
+  });
+
   it('should reference correct query in usage example', () => {
     const resultBasic = generateQueriesTemplate({
       hasExample: false,
@@ -70,5 +79,15 @@ describe('queries template', () => {
     });
 
     expect(result).toContain('customerOrderItemsQuery');
+  });
+
+  it('emits NodeNext-safe relative imports in generated files', () => {
+    const client = generateClientTemplate();
+    const queries = generateQueriesTemplate({
+      hasExample: false,
+    });
+
+    expect(client).toContain("import type { IntrospectedSchema } from './schema.js';");
+    expect(queries).toContain("import { db } from './client.js';");
   });
 });

--- a/packages/cli/src/templates/queries.ts
+++ b/packages/cli/src/templates/queries.ts
@@ -8,11 +8,12 @@ export function generateQueriesTemplate(options: {
   const { hasExample, tableName } = options;
   const metricKey = hasExample && tableName ? `${camelCase(tableName)}Query` : 'exampleMetric';
   const typeAlias = `${pascalCase(metricKey)}Result`;
+  const routePath = `/metrics/${metricKey}`;
 
   let template = `import { initServe } from '@hypequery/serve';
 import type { InferApiType } from '@hypequery/serve';
 import { z } from 'zod';
-import { db } from './client';
+import { db } from './client.js';
 
 const { query, serve } = initServe({
   context: () => ({ db }),
@@ -46,6 +47,7 @@ export const api = serve({
     ${metricKey},
   },
 });
+api.route('${routePath}', api.queries.${metricKey});
 
 export type ApiDefinition = InferApiType<typeof api>;
 
@@ -58,8 +60,8 @@ export type ApiDefinition = InferApiType<typeof api>;
  * // import type { InferQueryResult } from '@hypequery/serve';
  * type ${typeAlias} = InferQueryResult<typeof api, '${metricKey}'>;
  *
- * // Register HTTP route:
- * api.route('/metrics/${metricKey}', api.queries.${metricKey});
+ * HTTP route:
+ * ${routePath}
  *
  * Dev server:
  * npx hypequery dev analytics/queries.ts

--- a/packages/cli/src/templates/scaffold-node-next.test.ts
+++ b/packages/cli/src/templates/scaffold-node-next.test.ts
@@ -1,0 +1,121 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { generateClientTemplate } from './client.js';
+import { generateQueriesTemplate } from './queries.js';
+
+const tempDirs: string[] = [];
+
+async function runTypeCheck(projectDir: string): Promise<{ code: number | null; stderr: string }> {
+  const { execFile } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const execFileAsync = promisify(execFile);
+  const tscBin = path.resolve(process.cwd(), 'node_modules/typescript/bin/tsc');
+
+  try {
+    await execFileAsync(process.execPath, [tscBin, '--noEmit', '-p', projectDir], {
+      cwd: projectDir,
+    });
+    return { code: 0, stderr: '' };
+  } catch (error) {
+    const failure = error as Error & { code?: number | null; stderr?: string };
+    return { code: failure.code ?? 1, stderr: failure.stderr ?? failure.message };
+  }
+}
+
+describe('generated scaffold NodeNext compatibility', () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('passes tsc --noEmit with NodeNext imports and local module shims', async () => {
+    const projectDir = await mkdtemp(path.join(os.tmpdir(), 'hypequery-cli-scaffold-'));
+    tempDirs.push(projectDir);
+
+    const analyticsDir = path.join(projectDir, 'analytics');
+    await mkdir(path.join(projectDir, 'node_modules/@hypequery/clickhouse'), { recursive: true });
+    await mkdir(path.join(projectDir, 'node_modules/@hypequery/serve'), { recursive: true });
+    await mkdir(path.join(projectDir, 'node_modules/zod'), { recursive: true });
+    await mkdir(analyticsDir, { recursive: true });
+
+    await writeFile(path.join(projectDir, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022',
+        module: 'NodeNext',
+        moduleResolution: 'NodeNext',
+        strict: true,
+        noEmit: true,
+        skipLibCheck: true,
+      },
+      include: ['analytics/**/*.ts'],
+    }, null, 2));
+
+    await writeFile(path.join(projectDir, 'analytics', 'globals.d.ts'), `declare const process: {
+  env: Record<string, string | undefined>;
+};
+`);
+
+    await writeFile(path.join(projectDir, 'node_modules/@hypequery/clickhouse/package.json'), JSON.stringify({
+      name: '@hypequery/clickhouse',
+      type: 'module',
+      exports: {
+        '.': './index.d.ts',
+      },
+    }, null, 2));
+    await writeFile(path.join(projectDir, 'node_modules/@hypequery/clickhouse/index.d.ts'), `export declare function createQueryBuilder<TSchema>(config: unknown): {
+  table(name: string): {
+    select(selection: unknown): {
+      limit(count: number): {
+        execute(): Promise<unknown[]>;
+      };
+    };
+  };
+};
+`);
+
+    await writeFile(path.join(projectDir, 'node_modules/@hypequery/serve/package.json'), JSON.stringify({
+      name: '@hypequery/serve',
+      type: 'module',
+      exports: {
+        '.': './index.d.ts',
+      },
+    }, null, 2));
+    await writeFile(path.join(projectDir, 'node_modules/@hypequery/serve/index.d.ts'), `export declare function initServe(config: unknown): {
+  query: <TOutput>(definition: {
+    description: string;
+    output?: unknown;
+    query: (args: { ctx: { db: ReturnType<typeof import('@hypequery/clickhouse').createQueryBuilder> } }) => Promise<TOutput> | TOutput;
+  }) => typeof definition;
+  serve: (config: { queries: Record<string, unknown> }) => {
+    queries: Record<string, unknown>;
+    route(path: string, query: unknown): void;
+    execute(name: string): Promise<unknown>;
+  };
+};
+export type InferApiType<T> = T;
+export type InferQueryResult<TApi, TName extends string> = unknown;
+`);
+
+    await writeFile(path.join(projectDir, 'node_modules/zod/package.json'), JSON.stringify({
+      name: 'zod',
+      type: 'module',
+      exports: {
+        '.': './index.d.ts',
+      },
+    }, null, 2));
+    await writeFile(path.join(projectDir, 'node_modules/zod/index.d.ts'), `export declare const z: {
+  object<T extends Record<string, unknown>>(shape: T): { shape: T };
+  boolean(): boolean;
+};
+`);
+
+    await writeFile(path.join(analyticsDir, 'schema.ts'), `export interface IntrospectedSchema {}
+`);
+    await writeFile(path.join(analyticsDir, 'client.ts'), generateClientTemplate());
+    await writeFile(path.join(analyticsDir, 'queries.ts'), generateQueriesTemplate({ hasExample: false }));
+
+    const result = await runTypeCheck(projectDir);
+    expect(result.code, result.stderr).toBe(0);
+  });
+});

--- a/packages/cli/src/test-utils.ts
+++ b/packages/cli/src/test-utils.ts
@@ -6,7 +6,6 @@ import type { Mock } from 'vitest';
  */
 export function createMockPrompts() {
   return {
-    promptDatabaseType: vi.fn(),
     promptClickHouseConnection: vi.fn(),
     promptOutputDirectory: vi.fn(),
     promptGenerateExample: vi.fn(),

--- a/packages/cli/src/utils/dependency-installer.test.ts
+++ b/packages/cli/src/utils/dependency-installer.test.ts
@@ -115,4 +115,33 @@ describe('dependency installer', () => {
 
     expect(spawnMock).not.toHaveBeenCalled();
   });
+
+  it('upgrades existing stable sibling deps to the matching canary version', async () => {
+    vi.mocked(readFile)
+      .mockResolvedValueOnce(JSON.stringify({
+        name: 'fixture-app',
+        packageManager: 'pnpm@10.0.0',
+        dependencies: {
+          '@hypequery/clickhouse': '^1.6.2',
+          '@hypequery/serve': '^0.2.0',
+        },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        name: '@hypequery/cli',
+        version: '0.0.0-canary-20260506195711',
+      }));
+
+    await installScaffoldDependencies();
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'pnpm',
+      [
+        'add',
+        '@hypequery/clickhouse@0.0.0-canary-20260506195711',
+        '@hypequery/serve@0.0.0-canary-20260506195711',
+        'zod',
+      ],
+      expect.any(Object)
+    );
+  });
 });

--- a/packages/cli/src/utils/dependency-installer.test.ts
+++ b/packages/cli/src/utils/dependency-installer.test.ts
@@ -1,0 +1,118 @@
+import { EventEmitter } from 'node:events';
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { logger } from './logger.js';
+import { installScaffoldDependencies, resolveScaffoldPackages } from './dependency-installer.js';
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+}));
+
+vi.mock('./logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe('dependency installer', () => {
+  const originalEnv = process.env;
+  let cwdSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv, npm_config_user_agent: 'pnpm/10.0.0 node/v22.0.0' };
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/tmp/project');
+    spawnMock.mockImplementation(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        stdout?: NodeJS.ReadableStream;
+        stderr?: NodeJS.ReadableStream;
+      };
+      queueMicrotask(() => child.emit('close', 0));
+      return child;
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    cwdSpy.mockRestore();
+  });
+
+  it('keeps stable scaffold packages for non-canary CLI versions', () => {
+    expect(resolveScaffoldPackages('1.1.1')).toEqual([
+      '@hypequery/clickhouse',
+      '@hypequery/serve',
+      'zod',
+    ]);
+  });
+
+  it('pins sibling packages to the same canary version', () => {
+    expect(resolveScaffoldPackages('0.0.0-canary-20260506195711')).toEqual([
+      '@hypequery/clickhouse@0.0.0-canary-20260506195711',
+      '@hypequery/serve@0.0.0-canary-20260506195711',
+      'zod',
+    ]);
+  });
+
+  it('installs matching canary siblings plus zod when missing', async () => {
+    vi.mocked(readFile)
+      .mockResolvedValueOnce(JSON.stringify({
+        name: 'fixture-app',
+        packageManager: 'pnpm@10.0.0',
+        dependencies: {},
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        name: '@hypequery/cli',
+        version: '0.0.0-canary-20260506195711',
+      }));
+
+    await installScaffoldDependencies();
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'pnpm',
+      [
+        'add',
+        '@hypequery/clickhouse@0.0.0-canary-20260506195711',
+        '@hypequery/serve@0.0.0-canary-20260506195711',
+        'zod',
+      ],
+      expect.objectContaining({
+        cwd: '/tmp/project',
+        stdio: 'inherit',
+      })
+    );
+    expect(logger.success).toHaveBeenCalledWith(
+      'Installed @hypequery/clickhouse@0.0.0-canary-20260506195711, @hypequery/serve@0.0.0-canary-20260506195711, zod'
+    );
+  });
+
+  it('does not reinstall dependencies that are already present', async () => {
+    vi.mocked(readFile)
+      .mockResolvedValueOnce(JSON.stringify({
+        name: 'fixture-app',
+        packageManager: 'pnpm@10.0.0',
+        dependencies: {
+          '@hypequery/clickhouse': '0.0.0-canary-20260506195711',
+          '@hypequery/serve': '0.0.0-canary-20260506195711',
+          zod: '^3.25.0',
+        },
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        name: '@hypequery/cli',
+        version: '0.0.0-canary-20260506195711',
+      }));
+
+    await installScaffoldDependencies();
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/utils/dependency-installer.ts
+++ b/packages/cli/src/utils/dependency-installer.ts
@@ -25,8 +25,9 @@ const MANUAL_COMMANDS: Record<PackageManager, string> = {
   bun: 'bun add',
 };
 
-function hasDependency(pkg: PackageJson, name: string) {
-  return Boolean(pkg.dependencies?.[name] ?? pkg.devDependencies?.[name]);
+
+function getDependencyVersion(pkg: PackageJson, name: string): string | undefined {
+  return pkg.dependencies?.[name] ?? pkg.devDependencies?.[name];
 }
 
 function packageNameFromSpecifier(specifier: string): string {
@@ -106,6 +107,26 @@ export function resolveScaffoldPackages(cliVersion: string | undefined): string[
   return [...STABLE_SCAFFOLD_PACKAGES];
 }
 
+function shouldInstallPackage(pkgJson: PackageJson, specifier: string): boolean {
+  const name = packageNameFromSpecifier(specifier);
+  const existingVersion = getDependencyVersion(pkgJson, name);
+
+  if (!existingVersion) {
+    return true;
+  }
+
+  const desiredHasPinnedVersion = specifier.startsWith('@')
+    ? specifier.indexOf('@', specifier.indexOf('/') + 1) !== -1
+    : specifier.includes('@');
+
+  if (!desiredHasPinnedVersion) {
+    return false;
+  }
+
+  const desiredVersion = specifier.slice(name.length + 1);
+  return existingVersion !== desiredVersion;
+}
+
 export async function installScaffoldDependencies() {
   if (process.env.HYPEQUERY_SKIP_INSTALL === '1') {
     return;
@@ -121,7 +142,7 @@ export async function installScaffoldDependencies() {
   }
 
   const requestedPackages = resolveScaffoldPackages(cliPkgJson?.version);
-  const missing = requestedPackages.filter(pkg => !hasDependency(pkgJson, packageNameFromSpecifier(pkg)));
+  const missing = requestedPackages.filter(pkg => shouldInstallPackage(pkgJson, pkg));
   if (missing.length === 0) {
     return;
   }

--- a/packages/cli/src/utils/dependency-installer.ts
+++ b/packages/cli/src/utils/dependency-installer.ts
@@ -2,13 +2,17 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { logger } from './logger.js';
 
-const REQUIRED_PACKAGES = ['@hypequery/clickhouse', '@hypequery/serve'];
+const STABLE_SCAFFOLD_PACKAGES = ['@hypequery/clickhouse', '@hypequery/serve', 'zod'] as const;
+const CLI_PACKAGE_PATH = fileURLToPath(new URL('../../package.json', import.meta.url));
 
 type PackageManager = 'pnpm' | 'yarn' | 'npm' | 'bun';
 
 type PackageJson = {
+  name?: string;
+  version?: string;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   packageManager?: string;
@@ -25,9 +29,28 @@ function hasDependency(pkg: PackageJson, name: string) {
   return Boolean(pkg.dependencies?.[name] ?? pkg.devDependencies?.[name]);
 }
 
+function packageNameFromSpecifier(specifier: string): string {
+  if (!specifier.startsWith('@')) {
+    const atIndex = specifier.lastIndexOf('@');
+    return atIndex > 0 ? specifier.slice(0, atIndex) : specifier;
+  }
+
+  const separatorIndex = specifier.indexOf('@', specifier.indexOf('/') + 1);
+  return separatorIndex === -1 ? specifier : specifier.slice(0, separatorIndex);
+}
+
 async function readProjectPackageJson(): Promise<PackageJson | null> {
   try {
     const file = await readFile(path.join(process.cwd(), 'package.json'), 'utf8');
+    return JSON.parse(file) as PackageJson;
+  } catch {
+    return null;
+  }
+}
+
+async function readCliPackageJson(): Promise<PackageJson | null> {
+  try {
+    const file = await readFile(CLI_PACKAGE_PATH, 'utf8');
     return JSON.parse(file) as PackageJson;
   } catch {
     return null;
@@ -71,18 +94,34 @@ function formatManualCommand(manager: PackageManager, packages: string[]) {
   return `${MANUAL_COMMANDS[manager]} ${packages.join(' ')}`;
 }
 
-export async function installServeDependencies() {
+export function resolveScaffoldPackages(cliVersion: string | undefined): string[] {
+  if (cliVersion?.includes('canary')) {
+    return [
+      `@hypequery/clickhouse@${cliVersion}`,
+      `@hypequery/serve@${cliVersion}`,
+      'zod',
+    ];
+  }
+
+  return [...STABLE_SCAFFOLD_PACKAGES];
+}
+
+export async function installScaffoldDependencies() {
   if (process.env.HYPEQUERY_SKIP_INSTALL === '1') {
     return;
   }
 
-  const pkgJson = await readProjectPackageJson();
+  const [pkgJson, cliPkgJson] = await Promise.all([
+    readProjectPackageJson(),
+    readCliPackageJson(),
+  ]);
   if (!pkgJson) {
-    logger.warn('package.json not found. Install @hypequery/clickhouse and @hypequery/serve manually.');
+    logger.warn('package.json not found. Install @hypequery/clickhouse, @hypequery/serve, and zod manually.');
     return;
   }
 
-  const missing = REQUIRED_PACKAGES.filter(pkg => !hasDependency(pkgJson, pkg));
+  const requestedPackages = resolveScaffoldPackages(cliPkgJson?.version);
+  const missing = requestedPackages.filter(pkg => !hasDependency(pkgJson, packageNameFromSpecifier(pkg)));
   if (missing.length === 0) {
     return;
   }
@@ -116,3 +155,5 @@ export async function installServeDependencies() {
     }
   }
 }
+
+export const installServeDependencies = installScaffoldDependencies;

--- a/packages/cli/src/utils/prompts.test.ts
+++ b/packages/cli/src/utils/prompts.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import prompts from 'prompts';
 import {
-  promptDatabaseType,
   promptClickHouseConnection,
   promptOutputDirectory,
   promptGenerateExample,
@@ -18,45 +17,6 @@ vi.mock('./logger.js');
 describe('prompts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe('promptDatabaseType', () => {
-    it('should return selected database type', async () => {
-      vi.mocked(prompts).mockResolvedValue({ database: 'clickhouse' });
-
-      const result = await promptDatabaseType();
-
-      expect(result).toBe('clickhouse');
-      expect(prompts).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'select',
-          name: 'database',
-          message: 'Which database are you using?',
-        })
-      );
-    });
-
-    it('should return null if user cancels', async () => {
-      vi.mocked(prompts).mockResolvedValue({});
-
-      const result = await promptDatabaseType();
-
-      expect(result).toBeNull();
-    });
-
-    it('should show clickhouse as first option', async () => {
-      vi.mocked(prompts).mockResolvedValue({ database: 'clickhouse' });
-
-      await promptDatabaseType();
-
-      expect(prompts).toHaveBeenCalledWith(
-        expect.objectContaining({
-          choices: expect.arrayContaining([
-            expect.objectContaining({ title: 'ClickHouse', value: 'clickhouse' }),
-          ]),
-        })
-      );
-    });
   });
 
   describe('promptClickHouseConnection', () => {

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -1,29 +1,10 @@
 import prompts from 'prompts';
-import type { DatabaseType } from './detect-database.js';
 import { logger } from './logger.js';
 
 const noop = () => undefined;
 
 // Configure prompts to not exit on cancel
 prompts.override({ onCancel: noop });
-
-/**
- * Prompt for database type selection
- */
-export async function promptDatabaseType(): Promise<DatabaseType | null> {
-  const response = await prompts({
-    type: 'select',
-    name: 'database',
-    message: 'Which database are you using?',
-    choices: [
-      { title: 'ClickHouse', value: 'clickhouse' },
-      { title: 'BigQuery (coming soon)', value: 'bigquery', disabled: true },
-    ],
-    initial: 0,
-  });
-
-  return response.database || null;
-}
 
 /**
  * Prompt for ClickHouse connection details


### PR DESCRIPTION
Summary

  This PR fixes the remaining CLI ship blockers in hypequery init and simplifies the init flow to ClickHouse-only.

  It addresses:

  - broken --no-interactive behavior
  - canary CLI installing stable sibling packages
  - missing zod in generated scaffolds
  - NodeNext-incompatible extensionless imports in generated files
  - scaffolded APIs exposing no HTTP routes by default
  - unnecessary database selection during init

  Changes

  init flow

  - Removed the interactive database selection step.
  - hypequery init now defaults to ClickHouse.
  - Non-ClickHouse values passed via --database now fail immediately.

  Non-interactive mode

  - Normalized Commander’s --no-interactive handling so interactive = false maps to noInteractive = true.
  - Prevented non-interactive init from entering prompt paths for output directory, example generation, table selection,
    overwrite confirmation, and connection retry/continue flows.
  - Failed fast on connection validation errors in non-interactive mode instead of falling back to prompts.

  Dependency installation

  - Renamed the installer path conceptually from “serve dependencies” to scaffold dependencies.
  - Added zod to the scaffold dependency set.
  - When the installed CLI version contains canary, sibling installs now pin to the same canary version:
      - @hypequery/clickhouse@<same-version>
      - @hypequery/serve@<same-version>
  - Stable CLI behavior remains unchanged aside from also installing zod.

  Template generation

  - Updated generated relative imports to be NodeNext-safe:
      - ./schema.js
      - ./client.js
  - Updated generated queries.ts to auto-register a default route with api.route(...).
  - This makes the scaffold immediately expose a usable HTTP endpoint and non-empty OpenAPI/docs output.