### PR TITLE
fix: (ch) Aggregation GROUP BY inference so chained aggregate aliases are not treated as grouping dimensions.

### DIFF
--- a/.changeset/fair-rivers-lie.md
+++ b/.changeset/fair-rivers-lie.md
@@ -1,0 +1,5 @@
+---
+'@hypequery/clickhouse': patch
+---
+
+Fix aggregation `GROUP BY` inference when chaining aggregate helpers without an explicit grouping dimension. Aggregate aliases such as `revenue` from `SUM(price) AS revenue` are no longer reused as inferred `GROUP BY` keys, which avoids invalid SQL like `GROUP BY revenue` when additional aggregations are appended.

--- a/packages/clickhouse/src/core/features/aggregations.ts
+++ b/packages/clickhouse/src/core/features/aggregations.ts
@@ -1,6 +1,6 @@
 import type { BuilderState, SchemaDefinition } from '../types/builder-state.js';
 import { QueryBuilder } from '../query-builder.js';
-import type { SelectQueryNode } from '../../types/index.js';
+import type { SelectQueryNode, SelectionNode } from '../../types/index.js';
 
 export class AggregationFeature<
   Schema extends SchemaDefinition<Schema>,
@@ -20,11 +20,30 @@ export class AggregationFeature<
     return AggregationFeature.LEADING_AGGREGATE_CALL_PATTERN.test(expressionWithoutAlias);
   }
 
-  private inferGroupBySelections(select: Array<{ selection: string }>) {
+  private createAggregateSelection(selection: string): SelectionNode {
+    return {
+      kind: 'selection',
+      selection,
+      isAggregate: true,
+    };
+  }
+
+  private shouldInferGroupByFromSelection(item: SelectionNode) {
+    if (item.selection === '*') {
+      return false;
+    }
+
+    if (item.isAggregate === true) {
+      return false;
+    }
+
+    return !this.isAggregateSelection(item.selection);
+  }
+
+  private inferGroupBySelections(select: SelectionNode[]) {
     return select
+      .filter(item => this.shouldInferGroupByFromSelection(item))
       .map(item => item.selection)
-      .filter(selection => selection !== '*')
-      .filter(selection => !this.isAggregateSelection(selection))
       .map(selection => {
         const aliasMatch = selection.match(/\s+AS\s+([A-Za-z_][A-Za-z0-9_]*)$/i);
         return {
@@ -45,14 +64,14 @@ export class AggregationFeature<
     if (query.select) {
       return {
         ...query,
-        select: [...query.select, { kind: 'selection' as const, selection: aggregationSQL }],
+        select: [...query.select, this.createAggregateSelection(aggregationSQL)],
         groupBy: query.groupBy || this.inferGroupBySelections(query.select)
       };
     }
 
     return {
       ...query,
-      select: [{ kind: 'selection' as const, selection: aggregationSQL }]
+      select: [this.createAggregateSelection(aggregationSQL)]
     };
   }
 
@@ -83,14 +102,14 @@ export class AggregationFeature<
     if (query.select) {
       return {
         ...query,
-        select: [...query.select, { kind: 'selection' as const, selection: aggregationSQL }],
+        select: [...query.select, this.createAggregateSelection(aggregationSQL)],
         groupBy: query.groupBy || this.inferGroupBySelections(query.select),
       };
     }
 
     return {
       ...query,
-      select: [{ kind: 'selection' as const, selection: aggregationSQL }],
+      select: [this.createAggregateSelection(aggregationSQL)],
     };
   }
 }

--- a/packages/clickhouse/src/core/features/aggregations.ts
+++ b/packages/clickhouse/src/core/features/aggregations.ts
@@ -6,12 +6,25 @@ export class AggregationFeature<
   Schema extends SchemaDefinition<Schema>,
   State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>>
 > {
+  private static readonly TRAILING_ALIAS_PATTERN = /\s+AS\s+[A-Za-z_][A-Za-z0-9_]*$/i;
+  private static readonly LEADING_AGGREGATE_CALL_PATTERN = /^(COUNT|SUM|AVG|MIN|MAX)\s*\(/i;
+
   constructor(private builder: QueryBuilder<Schema, State>) { }
+
+  private stripTrailingAlias(selection: string) {
+    return selection.replace(AggregationFeature.TRAILING_ALIAS_PATTERN, '').trim();
+  }
+
+  private isAggregateSelection(selection: string) {
+    const expressionWithoutAlias = this.stripTrailingAlias(selection);
+    return AggregationFeature.LEADING_AGGREGATE_CALL_PATTERN.test(expressionWithoutAlias);
+  }
 
   private inferGroupBySelections(select: Array<{ selection: string }>) {
     return select
       .map(item => item.selection)
       .filter(selection => selection !== '*')
+      .filter(selection => !this.isAggregateSelection(selection))
       .map(selection => {
         const aliasMatch = selection.match(/\s+AS\s+([A-Za-z_][A-Za-z0-9_]*)$/i);
         return {

--- a/packages/clickhouse/src/core/tests/integration/basic-queries.test.ts
+++ b/packages/clickhouse/src/core/tests/integration/basic-queries.test.ts
@@ -58,6 +58,20 @@ describe('Integration Tests - Basic Queries', () => {
       expect(Number(result[0].average_price)).toBeCloseTo(expectedAvg, 2);
     });
 
+    test('should chain aggregations without inferring GROUP BY from aggregate aliases', async () => {
+      const result = await db.table('test_table')
+        .sum('price', 'revenue')
+        .count('id', 'order_count')
+        .execute();
+
+      expect(result).toHaveLength(1);
+      expect(Number(result[0].revenue)).toBeCloseTo(
+        TEST_DATA.test_table.reduce((sum, item) => sum + item.price, 0),
+        2
+      );
+      expect(Number(result[0].order_count)).toBe(TEST_DATA.test_table.length);
+    });
+
     test('should perform GROUP BY queries', async () => {
       const result = await db.table('test_table')
         .select(['category'])

--- a/packages/clickhouse/src/core/tests/query-builder.aggregations.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.aggregations.test.ts
@@ -49,6 +49,15 @@ describe('QueryBuilder - Aggregations', () => {
     expect(sql).toBe('SELECT SUM(price) AS revenue, COUNT(id) AS order_count FROM test_table');
   });
 
+  it('should not infer GROUP BY from raw aggregate selections when adding aggregations', () => {
+    const sql = builder
+      .select([rawAs('COUNT(*)', 'total_rows')])
+      .sum('price')
+      .toSQL();
+
+    expect(sql).toBe('SELECT COUNT(*) AS total_rows, SUM(price) AS price_sum FROM test_table');
+  });
+
   it('should preserve an explicit GROUP BY when adding aggregations later', () => {
     const sql = builder
       .select(['name'])

--- a/packages/clickhouse/src/core/tests/query-builder.aggregations.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.aggregations.test.ts
@@ -40,6 +40,15 @@ describe('QueryBuilder - Aggregations', () => {
     expect(sql).toBe('SELECT toDate(created_at) AS day, SUM(price) AS price_sum FROM test_table GROUP BY day');
   });
 
+  it('should not infer GROUP BY from aggregate aliases when chaining aggregations', () => {
+    const sql = builder
+      .sum('price', 'revenue')
+      .count('id', 'order_count')
+      .toSQL();
+
+    expect(sql).toBe('SELECT SUM(price) AS revenue, COUNT(id) AS order_count FROM test_table');
+  });
+
   it('should preserve an explicit GROUP BY when adding aggregations later', () => {
     const sql = builder
       .select(['name'])

--- a/packages/clickhouse/src/types/base.ts
+++ b/packages/clickhouse/src/types/base.ts
@@ -37,6 +37,7 @@ export interface CompiledQuery {
 export interface SelectionNode {
   kind: 'selection';
   selection: string;
+  isAggregate?: boolean;
 }
 
 export interface ValueNode {


### PR DESCRIPTION
## Summary

  Fix aggregation GROUP BY inference so chained aggregate aliases are not treated as grouping dimensions.

  Before this change, aggregation inference could reuse existing SELECT aliases when adding another aggregation, including
  aliases produced by aggregate expressions. That could generate invalid SQL such as:

  SELECT SUM(price) AS revenue, COUNT(id) AS order_count
  FROM test_table
  GROUP BY revenue

  This PR prevents aggregate selections from being inferred as GROUP BY keys.

  What changed

  - Updated aggregation inference in packages/clickhouse/src/core/features/aggregations.ts
  - Helper-generated aggregate selections now carry structured isAggregate metadata
  - GROUP BY inference uses that metadata first
  - Kept a string-based fallback for raw/manual selections that do not yet carry structured metadata
  - Added unit regression coverage for chained aggregate helpers without dimensions
  - Added unit regression coverage for raw aggregate selections followed by another aggregation
  - Added integration regression coverage to verify the query executes correctly against ClickHouse
  - Added a patch changeset

  Why this approach

  This keeps the release scoped to a patch-level correctness fix while making the main path more robust than pure SQL string
  matching. The remaining string fallback is only there for raw/manual selections that still enter the query model as plain SQL
  strings.

  Example

  Before:

  db.table('test_table')
    .sum('price', 'revenue')
    .count('id', 'order_count')

  could produce invalid SQL with GROUP BY revenue.

  After:

  SELECT SUM(price) AS revenue, COUNT(id) AS order_count FROM test_table

  with no inferred grouping dimension.