### PR TITLE
fix: (datasets) public api cleanup, filtered measures

### DIFF
--- a/packages/datasets/src/api.type-test.ts
+++ b/packages/datasets/src/api.type-test.ts
@@ -1,0 +1,59 @@
+import { dataset, dimension, measure, eq, MetricExecutor } from './index.js';
+import type { ExecutionContext, QueryBuilderFactoryLike } from './index.js';
+
+const Orders = dataset('orders', {
+  source: 'orders',
+  tenantKey: 'tenant_id',
+  timeKey: 'created_at',
+  dimensions: {
+    id: dimension.string(),
+    tenantId: dimension.string({ column: 'tenant_id' }),
+    status: dimension.string(),
+    amount: dimension.number(),
+    createdAt: dimension.timestamp({ column: 'created_at' }),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+    completedRevenue: measure.sum('amount', {
+      filters: [eq('status', 'completed')],
+    }),
+  },
+});
+
+const revenueMetric = Orders.metric('revenueMetric', { measure: 'revenue' });
+const completedRevenueMetric = Orders.metric('completedRevenueMetric', { measure: 'completedRevenue' });
+
+const runtimeContext: ExecutionContext = {
+  runtime: {
+    tenant: {
+      id: 'tenant-1',
+    },
+  },
+};
+
+const builderFactory: QueryBuilderFactoryLike = {
+  table: () => ({
+    select: () => builderFactory.table('orders'),
+    sum: () => builderFactory.table('orders'),
+    count: () => builderFactory.table('orders'),
+    countDistinct: () => builderFactory.table('orders'),
+    avg: () => builderFactory.table('orders'),
+    min: () => builderFactory.table('orders'),
+    max: () => builderFactory.table('orders'),
+    where: () => builderFactory.table('orders'),
+    groupBy: () => builderFactory.table('orders'),
+    orderBy: () => builderFactory.table('orders'),
+    limit: () => builderFactory.table('orders'),
+    offset: () => builderFactory.table('orders'),
+    toSQLWithParams: () => ({ sql: 'SELECT 1', parameters: [] }),
+    execute: async () => [],
+  }),
+  rawQuery: async () => [],
+};
+
+const executor = new MetricExecutor({ builderFactory });
+
+executor.validate(revenueMetric, { dimensions: ['status'] }, runtimeContext);
+executor.toSQL(completedRevenueMetric, { dimensions: ['status'] }, runtimeContext);
+
+void runtimeContext;

--- a/packages/datasets/src/api.type-test.ts
+++ b/packages/datasets/src/api.type-test.ts
@@ -1,5 +1,19 @@
-import { dataset, dimension, measure, eq, MetricExecutor } from './index.js';
-import type { ExecutionContext, QueryBuilderFactoryLike } from './index.js';
+import { dataset, dimension, measure, eq, desc, MetricExecutor } from './index.js';
+import type {
+  ExecutionContext,
+  MeasureOptions,
+  MetricFilter,
+  QueryBuilderFactoryLike,
+} from './index.js';
+
+type Assert<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type HasKey<T, K extends PropertyKey> = K extends keyof T ? true : false;
+type DatasetModule = typeof import('./index.js');
 
 const Orders = dataset('orders', {
   source: 'orders',
@@ -22,6 +36,25 @@ const Orders = dataset('orders', {
 
 const revenueMetric = Orders.metric('revenueMetric', { measure: 'revenue' });
 const completedRevenueMetric = Orders.metric('completedRevenueMetric', { measure: 'completedRevenue' });
+
+type _MeasureOptionsIncludeFilters = Assert<
+  Equal<HasKey<MeasureOptions, 'filters'>, true>
+>;
+type _MeasureFilterType = Assert<
+  Equal<MeasureOptions['filters'], MetricFilter[] | undefined>
+>;
+type _TenantRuntimeShape = Assert<
+  Equal<keyof NonNullable<NonNullable<ExecutionContext['runtime']>['tenant']>, 'id'>
+>;
+type _DatasetHasNoQueryMethod = Assert<
+  Equal<HasKey<typeof Orders, 'query'>, false>
+>;
+type _RootExportOmitsDatasetQueryRef = Assert<
+  Equal<HasKey<DatasetModule, 'DatasetQueryRef'>, false>
+>;
+type _RootExportOmitsPlannerHelper = Assert<
+  Equal<HasKey<DatasetModule, 'applyMeasureDefinition'>, false>
+>;
 
 const runtimeContext: ExecutionContext = {
   runtime: {
@@ -55,5 +88,6 @@ const executor = new MetricExecutor({ builderFactory });
 
 executor.validate(revenueMetric, { dimensions: ['status'] }, runtimeContext);
 executor.toSQL(completedRevenueMetric, { dimensions: ['status'] }, runtimeContext);
+executor.toSQL(revenueMetric, { orderBy: [desc('revenueMetric')] }, runtimeContext);
 
 void runtimeContext;

--- a/packages/datasets/src/dataset.ts
+++ b/packages/datasets/src/dataset.ts
@@ -32,6 +32,7 @@
 import type {
   DatasetConfig,
   DatasetInstance,
+  AnyDatasetInstance,
   DimensionDefinition,
   MeasureDefinition,
   RelationshipDefinition,
@@ -43,13 +44,16 @@ import type {
   BaseMetricConfig,
   DerivedMetricConfig,
   TimeGrain,
-  DatasetQueryConfig,
-  DatasetQueryRef,
   SemanticFiltersDefinition,
 } from './types.js';
+import { validateFilterValue } from './validation.js';
 
 const ALL_GRAINS: TimeGrain[] = ['day', 'week', 'month', 'quarter', 'year'];
 const NUMERIC_FIELD_TYPES = new Set(['number']);
+type AnyDimensions = Record<string, DimensionDefinition>;
+type AnyMeasures = Record<string, MeasureDefinition>;
+type AnyRelationships = Record<string, RelationshipDefinition>;
+type DatasetShape = AnyDatasetInstance;
 
 function isDerivedMetricConfig<
   TDimensions extends Record<string, DimensionDefinition>,
@@ -62,7 +66,7 @@ function isDerivedMetricConfig<
 
 function buildContract(
   metricName: string,
-  ds: DatasetInstance<any, any, any>,
+  ds: DatasetShape,
   spec: AggregationSpec | DerivedMetricSpec,
   label?: string,
   description?: string,
@@ -99,7 +103,7 @@ function buildContract(
 }
 
 function createMetricRef(
-  ds: DatasetInstance<any, any, any>,
+  ds: DatasetShape,
   name: string,
   spec: AggregationSpec | DerivedMetricSpec,
   label?: string,
@@ -140,7 +144,7 @@ function createMetricRef(
 }
 
 function validateBaseMetric(
-  ds: DatasetInstance<any, any, any>,
+  ds: DatasetShape,
   metricName: string,
   spec: AggregationSpec,
   options?: { allowHiddenField?: boolean },
@@ -161,10 +165,33 @@ function validateBaseMetric(
       `Invalid metric "${metricName}": ${spec.aggregation}() requires a numeric dimension, but "${spec.field}" is ${dimension.fieldType}.`,
     );
   }
+
+  for (const filter of spec.filters ?? []) {
+    const filterDefinition = ds.filters[filter.field];
+    const resolvedField = filterDefinition?.field ?? filter.field;
+    const fieldType = ds.dimensions[resolvedField]?.fieldType;
+
+    if (!fieldType) {
+      throw new Error(
+        `Invalid metric "${metricName}": measure filter field "${filter.field}" does not exist on dataset "${ds.name}".`,
+      );
+    }
+
+    if (filterDefinition?.operators && !filterDefinition.operators.includes(filter.operator)) {
+      throw new Error(
+        `Invalid metric "${metricName}": measure filter "${filter.field}" does not allow operator "${filter.operator}".`,
+      );
+    }
+
+    const filterError = validateFilterValue(filter, fieldType);
+    if (filterError) {
+      throw new Error(`Invalid metric "${metricName}": ${filterError}`);
+    }
+  }
 }
 
 function validateDerivedMetric(
-  ds: DatasetInstance<any, any, any>,
+  ds: DatasetShape,
   metricName: string,
   config: DerivedMetricConfig,
 ): void {
@@ -189,7 +216,7 @@ function validateDerivedMetric(
 }
 
 function normalizeDimensions<TDimensions extends Record<string, DimensionDefinition>>(
-  config: DatasetConfig<TDimensions, any, any>,
+  config: DatasetConfig<TDimensions, AnyMeasures, AnyRelationships>,
 ): TDimensions {
   return config.dimensions as TDimensions;
 }
@@ -226,20 +253,7 @@ function measureToAggregationSpec(
     __type: 'aggregation_spec',
     aggregation: definition.aggregation,
     field: definition.field,
-  };
-}
-
-function buildDatasetQueryContract(
-  ds: DatasetInstance<any, any, any>,
-  config: DatasetQueryConfig<any, any>,
-) {
-  return {
-    dataset: ds.name,
-    dimensions: config.dimensions ? [...config.dimensions] : Object.keys(ds.dimensions),
-    measures: config.measures ? [...config.measures] : Object.keys(ds.measures),
-    filters: Object.keys(ds.filters),
-    grains: ds.timeKey ? ALL_GRAINS : [],
-    tenantScoped: !!ds.tenantKey,
+    filters: definition.filters,
   };
 }
 
@@ -299,17 +313,6 @@ export function dataset<
         metricConfig.label ?? measure.label,
         metricConfig.description ?? measure.description,
       ) as MetricRef<string, TName>;
-    },
-
-    query(queryConfig: DatasetQueryConfig<TDimensions, TMeasures>): DatasetQueryRef<TDimensions, TMeasures> {
-      return {
-        __type: 'dataset_query_ref',
-        dataset: ds,
-        config: queryConfig,
-        contract() {
-          return buildDatasetQueryContract(ds, queryConfig);
-        },
-      };
     }
   };
 

--- a/packages/datasets/src/datasets.test.ts
+++ b/packages/datasets/src/datasets.test.ts
@@ -19,6 +19,7 @@ const Customers = dataset("customers", {
   tenantKey: "tenant_id",
   dimensions: {
     id: dimension.string(),
+    tenantId: dimension.string({ column: "tenant_id" }),
     name: dimension.string({ label: "Customer Name" }),
     country: dimension.string({ label: "Country" }),
     createdAt: dimension.timestamp(),
@@ -34,6 +35,7 @@ const Orders = dataset("orders", {
   timeKey: "created_at",
   dimensions: {
     id: dimension.string(),
+    tenantId: dimension.string({ column: "tenant_id" }),
     customerId: dimension.string({ column: "customer_id" }),
     country: dimension.string({ label: "Country" }),
     status: dimension.string({ label: "Order Status" }),
@@ -44,6 +46,9 @@ const Orders = dataset("orders", {
     revenue: measure.sum('amount'),
     orderCount: measure.count('id'),
     uniqueCustomers: measure.countDistinct('customerId'),
+    completedRevenue: measure.sum('amount', {
+      filters: [eq('status', 'completed')],
+    }),
   },
   relationships: {
     customer: belongsTo(() => Customers, { from: "customerId", to: "id" }),
@@ -238,41 +243,10 @@ describe("Dataset.metric()", () => {
   });
 });
 
-describe("Dataset.query()", () => {
-  it("creates a semantic dataset query from dimensions, measures, filters, and sort helpers", () => {
-    const queryRef = Orders.query({
-      dimensions: ['country'],
-      measures: ['revenue', 'orderCount'],
-      filters: [eq('status', 'completed'), between('createdAt', '2025-01-01', '2025-01-31')],
-      orderBy: [desc('revenue')],
-      by: 'month',
-      limit: 25,
-    });
-
-    expect(queryRef.__type).toBe('dataset_query_ref');
-    expect(queryRef.config.dimensions).toEqual(['country']);
-    expect(queryRef.config.filters).toEqual([
-      { field: 'status', operator: 'eq', value: 'completed' },
-      { field: 'createdAt', operator: 'between', value: ['2025-01-01', '2025-01-31'] },
-    ]);
-    expect(queryRef.config.orderBy).toEqual([{ field: 'revenue', direction: 'desc' }]);
-    expect(queryRef.contract()).toMatchObject({
-      dataset: 'orders',
-      tenantScoped: true,
-      grains: ['day', 'week', 'month', 'quarter', 'year'],
-    });
-  });
-
-  it("preserves relationship metadata without exposing related paths in current query contracts", () => {
-    const queryRef = Orders.query({
-      dimensions: ['country'],
-      measures: ['revenue'],
-    });
-
+describe("Dataset public surface", () => {
+  it("does not expose dataset.query()", () => {
+    expect('query' in (Orders as unknown as Record<string, unknown>)).toBe(false);
     expect(Orders.relationships.customer.target()).toBe(Customers);
-    expect(queryRef.contract().dimensions).toEqual(['country']);
-    expect(queryRef.contract().measures).toEqual(['revenue']);
-    expect(queryRef.contract().dimensions).not.toContain('customer.country');
   });
 });
 
@@ -395,6 +369,8 @@ describe("DatasetRegistry", () => {
 // =============================================================================
 
 describe("MetricExecutor", () => {
+  type BuilderColumnsInput = string[] | string;
+
   function createMockBuilderFactory(): QueryBuilderFactoryLike {
     const mockData = [
       { country: "US", totalRevenue: 5000 },
@@ -435,7 +411,7 @@ describe("MetricExecutor", () => {
       };
 
       const builder: QueryBuilderLike = {
-        select: (args: any) => {
+        select: (args: BuilderColumnsInput) => {
           state.select.push(...(Array.isArray(args) ? args : [args]));
           return builder;
         },
@@ -468,7 +444,7 @@ describe("MetricExecutor", () => {
           state.where.push(`${column} ${op} ?`);
           return builder;
         },
-        groupBy: (args: any) => {
+        groupBy: (args: BuilderColumnsInput) => {
           state.groupBy.push(...(Array.isArray(args) ? args : [args]));
           return builder;
         },
@@ -499,6 +475,89 @@ describe("MetricExecutor", () => {
     };
   }
 
+  function createBrokenDerivedGroupingBuilderFactory(): QueryBuilderFactoryLike {
+    function createBrokenBuilder(): QueryBuilderLike {
+      const state = {
+        select: [] as string[],
+        where: [] as string[],
+        groupBy: [] as string[],
+      };
+
+      const maybeInferBrokenGroupBy = () => {
+        if (state.select.length > 0 && state.groupBy.length === 0) {
+          const aliasMatch = state.select[0].match(/\s+AS\s+([A-Za-z_][A-Za-z0-9_]*)$/i);
+          if (aliasMatch) {
+            state.groupBy.push(aliasMatch[1]);
+          }
+        }
+      };
+
+      const builder: QueryBuilderLike = {
+        select: (args: BuilderColumnsInput) => {
+          state.select.push(...(Array.isArray(args) ? args : [args]));
+          return builder;
+        },
+        sum: (column: string, alias?: string) => {
+          state.select.push(`SUM(${column}) AS ${alias ?? `${column}_sum`}`);
+          return builder;
+        },
+        count: (column: string, alias?: string) => {
+          maybeInferBrokenGroupBy();
+          state.select.push(`COUNT(${column}) AS ${alias ?? `${column}_count`}`);
+          return builder;
+        },
+        countDistinct: (column: string, alias?: string) => {
+          maybeInferBrokenGroupBy();
+          state.select.push(`COUNT(DISTINCT ${column}) AS ${alias ?? `${column}_countDistinct`}`);
+          return builder;
+        },
+        avg: (column: string, alias?: string) => {
+          maybeInferBrokenGroupBy();
+          state.select.push(`AVG(${column}) AS ${alias ?? `${column}_avg`}`);
+          return builder;
+        },
+        min: (column: string, alias?: string) => {
+          maybeInferBrokenGroupBy();
+          state.select.push(`MIN(${column}) AS ${alias ?? `${column}_min`}`);
+          return builder;
+        },
+        max: (column: string, alias?: string) => {
+          maybeInferBrokenGroupBy();
+          state.select.push(`MAX(${column}) AS ${alias ?? `${column}_max`}`);
+          return builder;
+        },
+        where: (column: string, operator: string, _value: unknown) => {
+          const op = operator === 'eq' ? '=' : operator;
+          state.where.push(`${column} ${op} ?`);
+          return builder;
+        },
+        groupBy: (args: BuilderColumnsInput) => {
+          state.groupBy.push(...(Array.isArray(args) ? args : [args]));
+          return builder;
+        },
+        orderBy: () => builder,
+        limit: () => builder,
+        offset: () => builder,
+        toSQLWithParams: () => ({
+          sql: [
+            `SELECT ${state.select.join(', ')} FROM orders`,
+            state.where.length > 0 ? `WHERE ${state.where.join(' AND ')}` : '',
+            state.groupBy.length > 0 ? `GROUP BY ${state.groupBy.join(', ')}` : '',
+          ].filter(Boolean).join(' '),
+          parameters: [],
+        }),
+        execute: vi.fn().mockResolvedValue([]),
+      };
+
+      return builder;
+    }
+
+    return {
+      table: () => createBrokenBuilder(),
+      rawQuery: vi.fn().mockResolvedValue([]),
+    };
+  }
+
   const totalRevenue = Orders.metric("totalRevenue", {
     measure: "revenue",
     label: "Total Revenue",
@@ -506,6 +565,9 @@ describe("MetricExecutor", () => {
   const orderCount = Orders.metric("orderCount", { measure: "orderCount" });
   const uniqueCustomers = Orders.metric("uniqueCustomers", {
     measure: "uniqueCustomers",
+  });
+  const completedRevenue = Orders.metric("completedRevenue", {
+    measure: "completedRevenue",
   });
   const avgOrderValue = Orders.metric("avgOrderValue", {
     uses: { totalRevenue, orderCount },
@@ -530,7 +592,7 @@ describe("MetricExecutor", () => {
         dimensions: ["country"],
       }, {
         runtime: {
-          tenant: { id: "t1", column: "tenant_id", handledByBuilder: false },
+          tenant: { id: "t1" },
         },
       });
 
@@ -557,6 +619,16 @@ describe("MetricExecutor", () => {
 
       expect(sql).toContain("ORDER BY totalRevenue DESC");
       expect(sql).toContain("LIMIT 100");
+    });
+
+    it("compiles filtered measures into aggregation expressions", () => {
+      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
+      const sql = executor.toSQL(completedRevenue, {
+        dimensions: ["country"],
+      });
+
+      expect(sql).toContain("SUM(if((status = 'completed'), amount, 0)) AS completedRevenue");
+      expect(sql).toContain("GROUP BY country");
     });
 
     it("resolves column aliases for countDistinct metrics", () => {
@@ -612,6 +684,23 @@ describe("MetricExecutor", () => {
       expect(sql).toContain("(totalRevenue) / (NULLIF(orderCount, 0)) AS avgOrderValue");
       expect(sql).not.toContain("SELECT country, (totalRevenue) / (NULLIF(orderCount, 0)) AS avgOrderValue, totalRevenue, orderCount FROM base");
     });
+
+    it("does not emit GROUP BY for ungrouped derived metrics", () => {
+      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
+      const sql = executor.toSQL(avgOrderValue);
+
+      expect(sql).toContain("WITH base AS");
+      expect(sql).not.toContain("GROUP BY totalRevenue");
+      expect(sql).not.toContain("GROUP BY orderCount");
+    });
+
+    it("rejects derived plans that introduce aggregate aliases into GROUP BY", () => {
+      const executor = new MetricExecutor({ builderFactory: createBrokenDerivedGroupingBuilderFactory() });
+      const result = executor.validate(avgOrderValue, {});
+
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain("GROUP BY");
+    });
   });
 
   describe("run()", () => {
@@ -636,14 +725,14 @@ describe("MetricExecutor", () => {
 
       await executor.run(totalRevenue, {}, {
         runtime: {
-          tenant: { id: "t1", column: "tenant_id", handledByBuilder: false },
+          tenant: { id: "t1" },
         },
       });
 
       // Verify the SQL was generated (toSQL includes tenant filter)
       const sql = executor.toSQL(totalRevenue, {}, {
         runtime: {
-          tenant: { id: "t1", column: "tenant_id", handledByBuilder: false },
+          tenant: { id: "t1" },
         },
       });
       expect(sql).toContain("tenant_id");
@@ -729,6 +818,20 @@ describe("MetricExecutor", () => {
       });
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain("Too many dimensions");
+    });
+
+    it("rejects explicit tenant filters when runtime tenancy is active", () => {
+      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
+      const result = executor.validate(totalRevenue, {
+        filters: [{ field: "tenantId", operator: "eq", value: "t1" }],
+      }, {
+        runtime: {
+          tenant: { id: "t1" },
+        },
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('Cannot filter on tenant field "tenantId"');
     });
   });
 });

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -16,14 +16,11 @@ import type {
   MetricQuery,
   MetricResult,
   MetricFilter,
-  MetricContract,
   ExecutionContext,
   AggregationSpec,
   DerivedMetricSpec,
-  DatasetInstance,
+  AnyDatasetInstance,
   TimeGrain,
-  FormulaExpr,
-  FieldType,
 } from './types.js';
 
 import type {
@@ -32,7 +29,7 @@ import type {
 } from './query-builder-protocol.js';
 
 import { validateSQLIdentifier } from './sql-utils.js';
-import { validateFilterValue, matchesFieldType, type ValidationResult } from './validation.js';
+import { validateFilterValue, type ValidationResult } from './validation.js';
 import {
   applyAggregationSpec,
   appendOrderLimitOffset,
@@ -40,24 +37,28 @@ import {
   resolveFilterField,
   resolveTenantFilterColumn,
 } from './query-planner.js';
-
-// =============================================================================
-// VALIDATION
-// =============================================================================
-
+import {
+  assertMetricHandle,
+  getMetricGrain,
+  getMetricRef,
+  isTenantScopedFilter,
+  type MetricHandle,
+} from './utils/metric-handle.js';
+import { validateDerivedCteGrouping } from './utils/derived-cte-validation.js';
 
 function validateQuery(
-  metric: MetricRef | GrainedMetricRef,
+  metric: MetricHandle,
   query: MetricQuery,
+  context?: ExecutionContext,
 ): ValidationResult {
   const errors: string[] = [];
-  const ref = metric.__type === 'grained_metric_ref' ? metric.metric : metric;
+  const ref = getMetricRef(metric);
   const ds = ref.dataset;
   const dimensionNames = Object.keys(ds.dimensions);
   const filterNames = Object.keys(ds.filters).length > 0
     ? Object.keys(ds.filters)
     : dimensionNames;
-  const grain = metric.__type === 'grained_metric_ref' ? metric.grain : query.by;
+  const grain = getMetricGrain(metric, query);
   const orderableFields = new Set<string>([
     ...(query.dimensions ?? []),
     ref.name,
@@ -93,6 +94,13 @@ function validateQuery(
     }
 
     const resolvedField = ds.filters[filter.field]?.field ?? filter.field;
+    if (isTenantScopedFilter(ds, filter, context)) {
+      errors.push(
+        `Cannot filter on tenant field "${filter.field}" when runtime tenancy enforcement is active.`,
+      );
+      continue;
+    }
+
     const fieldType = ds.dimensions[resolvedField]?.fieldType;
     if (fieldType) {
       const filterError = validateFilterValue(filter, fieldType);
@@ -160,7 +168,8 @@ export class MetricExecutor {
     query: MetricQuery = {},
     context?: ExecutionContext,
   ): Promise<MetricResult<T>> {
-    const validation = this.validate(metric, query);
+    assertMetricHandle(metric);
+    const validation = this.validate(metric, query, context);
     if (!validation.valid) {
       throw new Error(`Invalid metric query: ${validation.errors.join('; ')}`);
     }
@@ -177,8 +186,14 @@ export class MetricExecutor {
     query: MetricQuery = {},
     context?: ExecutionContext,
   ): string {
-    const ref = metric.__type === 'grained_metric_ref' ? metric.metric : metric;
-    const grain = metric.__type === 'grained_metric_ref' ? metric.grain : query.by ?? undefined;
+    assertMetricHandle(metric);
+    const validation = this.validate(metric, query, context);
+    if (!validation.valid) {
+      throw new Error(`Invalid metric query: ${validation.errors.join('; ')}`);
+    }
+
+    const ref = getMetricRef(metric);
+    const grain = getMetricGrain(metric, query);
     const spec = ref.spec;
 
     if (spec.__type === 'derived_metric_spec') {
@@ -195,8 +210,32 @@ export class MetricExecutor {
   validate(
     metric: MetricRef | GrainedMetricRef,
     query: MetricQuery,
+    context?: ExecutionContext,
   ): ValidationResult {
-    return validateQuery(metric, query);
+    assertMetricHandle(metric);
+
+    const queryValidation = validateQuery(metric, query, context);
+    if (!queryValidation.valid) {
+      return queryValidation;
+    }
+
+    const ref = getMetricRef(metric);
+    const grain = getMetricGrain(metric, query);
+
+    try {
+      if (ref.spec.__type === 'derived_metric_spec') {
+        this.buildDerivedSQLViaBuilder(ref, ref.spec, query, grain, context);
+      } else {
+        this.buildBaseQuery(ref, ref.spec as AggregationSpec, ref.dataset, query, grain, context).toSQLWithParams();
+      }
+    } catch (error) {
+      return {
+        valid: false,
+        errors: [error instanceof Error ? error.message : String(error)],
+      };
+    }
+
+    return queryValidation;
   }
 
   // ---------------------------------------------------------------------------
@@ -209,8 +248,8 @@ export class MetricExecutor {
     context: ExecutionContext | undefined,
     start: number,
   ): Promise<MetricResult<T>> {
-    const ref = metric.__type === 'grained_metric_ref' ? metric.metric : metric;
-    const grain = metric.__type === 'grained_metric_ref' ? metric.grain : query.by ?? undefined;
+    const ref = getMetricRef(metric);
+    const grain = getMetricGrain(metric, query);
     const spec = ref.spec;
     const activeBuilderFactory = context?.runtime?.builderFactory ?? this.builderFactory;
 
@@ -233,7 +272,7 @@ export class MetricExecutor {
   private buildBaseQuery(
     ref: MetricRef,
     spec: AggregationSpec,
-    ds: DatasetInstance,
+    ds: AnyDatasetInstance,
     query: MetricQuery,
     grain: TimeGrain | undefined,
     context?: ExecutionContext,
@@ -261,13 +300,17 @@ export class MetricExecutor {
     // Tenant auto-injection
     const tenantColumn = resolveTenantFilterColumn(ds, context);
     const tenantId = context?.runtime?.tenant?.id;
-    const tenantHandledByBuilder = context?.runtime?.tenant?.handledByBuilder === true;
-    if (tenantId && tenantColumn && !tenantHandledByBuilder) {
+    if (tenantId && tenantColumn) {
       qb = qb.where(tenantColumn, 'eq', tenantId);
     }
 
     // User filters
     for (const filter of query.filters ?? []) {
+      if (isTenantScopedFilter(ds, filter, context)) {
+        throw new Error(
+          `Cannot filter on tenant field "${filter.field}" when runtime tenancy enforcement is active.`,
+        );
+      }
       const resolvedField = resolveFilterField(ds, filter.field);
       qb = qb.where(resolvedField, filter.operator, filter.value);
     }
@@ -302,6 +345,7 @@ export class MetricExecutor {
 
     // Base aggregations
     const refAliases: Record<string, string> = {};
+    const aggregateAliases: string[] = [];
     for (const [alias, baseMetric] of Object.entries(spec.uses)) {
       const baseSpec = baseMetric.spec;
       if (baseSpec.__type !== 'aggregation_spec') {
@@ -309,6 +353,7 @@ export class MetricExecutor {
       }
       cteBuilder = applyAggregationSpec(cteBuilder, ds, baseSpec, alias);
       refAliases[alias] = alias;
+      aggregateAliases.push(alias);
     }
 
     if (groupByParts.length > 0) {
@@ -318,16 +363,24 @@ export class MetricExecutor {
     // Filters on CTE
     const tenantColumn = resolveTenantFilterColumn(ds, context);
     const tenantId = context?.runtime?.tenant?.id;
-    const tenantHandledByBuilder = context?.runtime?.tenant?.handledByBuilder === true;
-    if (tenantId && tenantColumn && !tenantHandledByBuilder) {
+    if (tenantId && tenantColumn) {
       cteBuilder = cteBuilder.where(tenantColumn, 'eq', tenantId);
     }
     for (const filter of query.filters ?? []) {
+      if (isTenantScopedFilter(ds, filter, context)) {
+        throw new Error(
+          `Cannot filter on tenant field "${filter.field}" when runtime tenancy enforcement is active.`,
+        );
+      }
       const resolvedField = resolveFilterField(ds, filter.field);
       cteBuilder = cteBuilder.where(resolvedField, filter.operator, filter.value);
     }
 
     const { sql: cteSql, parameters: cteParams } = cteBuilder.toSQLWithParams();
+    const groupingErrors = validateDerivedCteGrouping(cteSql, aggregateAliases, groupByParts);
+    if (groupingErrors.length > 0) {
+      throw new Error(groupingErrors.join('; '));
+    }
 
     // Outer query: trivial SELECT from the CTE — stays as string concat
     // because table('base') would fail schema typing

--- a/packages/datasets/src/index.ts
+++ b/packages/datasets/src/index.ts
@@ -48,17 +48,6 @@ export { validateSQLIdentifier, isSafeSQLIdentifier, quoteSQLIdentifier } from '
 // Constants
 export { GRAIN_FUNCTIONS } from './constants.js';
 
-// Query planning helpers
-export {
-  resolveDimensionExpression,
-  resolveFilterField,
-  buildDimensionSelectionPlan,
-  applyAggregationSpec,
-  applyMeasureDefinition,
-  appendOrderLimitOffset,
-  resolveTenantFilterColumn,
-} from './query-planner.js';
-
 // Types
 export type {
   FieldType,
@@ -91,9 +80,6 @@ export type {
   SemanticFilterDefinition,
   SemanticFiltersDefinition,
   DatasetConfig,
-  DatasetQueryConfig,
-  DatasetQueryContract,
-  DatasetQueryRef,
   DatasetLimits,
   DatasetInstance,
   BaseMetricConfig,

--- a/packages/datasets/src/measure.ts
+++ b/packages/datasets/src/measure.ts
@@ -8,6 +8,7 @@ function createMeasureHelper(aggregation: MeasureAggregation) {
     sql: opts?.sql,
     label: opts?.label,
     description: opts?.description,
+    filters: opts?.filters,
   });
 }
 

--- a/packages/datasets/src/query-planner.ts
+++ b/packages/datasets/src/query-planner.ts
@@ -1,6 +1,6 @@
 import type {
   AggregationSpec,
-  DatasetInstance,
+  AnyDatasetInstance,
   ExecutionContext,
   MeasureDefinition,
   MetricOrderBy,
@@ -8,9 +8,12 @@ import type {
 } from "./types.js";
 import type { QueryBuilderLike } from "./query-builder-protocol.js";
 import { GRAIN_FUNCTIONS } from "./constants.js";
+import { applyFilteredAggregationExpression } from './utils/filtered-aggregation-sql.js';
+
+type DatasetShape = AnyDatasetInstance;
 
 export function resolveDimensionExpression(
-  ds: DatasetInstance,
+  ds: DatasetShape,
   dimensionName: string,
 ): string {
   const definition = ds.dimensions[dimensionName];
@@ -18,7 +21,7 @@ export function resolveDimensionExpression(
 }
 
 export function resolveFilterField(
-  ds: DatasetInstance,
+  ds: DatasetShape,
   filterField: string,
 ): string {
   const resolvedField = ds.filters[filterField]?.field ?? filterField;
@@ -26,17 +29,17 @@ export function resolveFilterField(
 }
 
 export function buildDimensionSelectionPlan(
-  ds: DatasetInstance,
+  ds: DatasetShape,
   dimensions: string[],
   grain: TimeGrain | undefined,
 ): { selectParts: string[]; groupByParts: string[] } {
   const selectParts: string[] = [];
-  const groupByParts: string[] = [];
+  const groupByParts = new Set<string>();
 
   if (grain) {
     const fn = GRAIN_FUNCTIONS[grain];
     selectParts.push(`${fn}(${ds.timeKey}) AS period`);
-    groupByParts.push("period");
+    groupByParts.add("period");
   }
 
   for (const dimensionName of dimensions) {
@@ -46,19 +49,23 @@ export function buildDimensionSelectionPlan(
     } else {
       selectParts.push(`${expression} AS ${dimensionName}`);
     }
-    groupByParts.push(dimensionName);
+    groupByParts.add(dimensionName);
   }
 
-  return { selectParts, groupByParts };
+  return { selectParts, groupByParts: Array.from(groupByParts) };
 }
 
 export function applyAggregationSpec(
   qb: QueryBuilderLike,
-  ds: DatasetInstance,
+  ds: DatasetShape,
   spec: AggregationSpec,
   alias: string,
 ): QueryBuilderLike {
-  const fieldOrExpr = resolveDimensionExpression(ds, spec.field);
+  const fieldOrExpr = applyFilteredAggregationExpression(
+    ds,
+    spec,
+    resolveDimensionExpression(ds, spec.field),
+  );
 
   switch (spec.aggregation) {
     case "sum":
@@ -80,7 +87,7 @@ export function applyAggregationSpec(
 
 export function applyMeasureDefinition(
   qb: QueryBuilderLike,
-  ds: DatasetInstance,
+  ds: DatasetShape,
   name: string,
   definition: MeasureDefinition,
 ): QueryBuilderLike {
@@ -130,8 +137,12 @@ export function appendOrderLimitOffset(
 }
 
 export function resolveTenantFilterColumn(
-  _ds: DatasetInstance,
+  ds: DatasetShape,
   context?: ExecutionContext,
 ): string | undefined {
-  return context?.runtime?.tenant?.column;
+  if (!context?.runtime?.tenant?.id) {
+    return undefined;
+  }
+
+  return ds.tenantKey;
 }

--- a/packages/datasets/src/types.ts
+++ b/packages/datasets/src/types.ts
@@ -47,12 +47,14 @@ export interface AggregationSpec {
   __type: 'aggregation_spec';
   aggregation: AggregationType;
   field: string;
+  filters?: MetricFilter[];
 }
 
 export interface MeasureOptions {
   sql?: string;
   label?: string;
   description?: string;
+  filters?: MetricFilter[];
 }
 
 export interface MeasureDefinition {
@@ -62,6 +64,7 @@ export interface MeasureDefinition {
   sql?: string;
   label?: string;
   description?: string;
+  filters?: MetricFilter[];
 }
 
 export type FormulaExpr = {
@@ -79,7 +82,7 @@ export interface MetricRef<
   spec: AggregationSpec | DerivedMetricSpec;
   label?: string;
   description?: string;
-  dataset: DatasetInstance<any, any, any>;
+  dataset: DatasetInstance<Record<string, DimensionDefinition>, Record<string, MeasureDefinition>, Record<string, RelationshipDefinition>>;
   by(grain: TimeGrain): GrainedMetricRef<TDatasetName, TMetricName>;
   contract(): MetricContract;
 }
@@ -156,8 +159,6 @@ export interface MetricResult<T = Record<string, unknown>> {
 
 export interface SemanticTenantRuntime {
   id: string;
-  column: string;
-  handledByBuilder: boolean;
 }
 
 export interface SemanticExecutionRuntime {
@@ -202,38 +203,6 @@ export interface DerivedMetricConfig {
   description?: string;
 }
 
-export interface DatasetQueryConfig<
-  TDimensions extends Record<string, DimensionDefinition> = Record<string, DimensionDefinition>,
-  TMeasures extends Record<string, MeasureDefinition> = Record<string, MeasureDefinition>,
-> {
-  dimensions?: Array<keyof TDimensions & string>;
-  measures?: Array<keyof TMeasures & string>;
-  filters?: MetricFilter[];
-  orderBy?: MetricOrderBy[];
-  limit?: number;
-  offset?: number;
-  by?: TimeGrain;
-}
-
-export interface DatasetQueryContract {
-  dataset: string;
-  dimensions: string[];
-  measures: string[];
-  filters: string[];
-  grains: TimeGrain[];
-  tenantScoped: boolean;
-}
-
-export interface DatasetQueryRef<
-  TDimensions extends Record<string, DimensionDefinition> = Record<string, DimensionDefinition>,
-  TMeasures extends Record<string, MeasureDefinition> = Record<string, MeasureDefinition>,
-> {
-  __type: 'dataset_query_ref';
-  dataset: DatasetInstance<TDimensions, TMeasures, any>;
-  config: DatasetQueryConfig<TDimensions, TMeasures>;
-  contract(): DatasetQueryContract;
-}
-
 export interface DatasetConfig<
   TDimensions extends Record<string, DimensionDefinition> = Record<string, DimensionDefinition>,
   TMeasures extends Record<string, MeasureDefinition> = Record<string, MeasureDefinition>,
@@ -268,7 +237,6 @@ export interface DatasetInstance<
     metricName: TName,
     metricConfig: BaseMetricConfig<TDimensions, TMeasures> | DerivedMetricConfig,
   ): MetricRef<string, TName>;
-  query(config: DatasetQueryConfig<TDimensions, TMeasures>): DatasetQueryRef<TDimensions, TMeasures>;
 }
 
 export interface DatasetRegistryInstance {
@@ -277,6 +245,12 @@ export interface DatasetRegistryInstance {
   getAll(): DatasetInstance[];
   has(name: string): boolean;
 }
+
+export type AnyDatasetInstance = DatasetInstance<
+  Record<string, DimensionDefinition>,
+  Record<string, MeasureDefinition>,
+  Record<string, RelationshipDefinition>
+>;
 
 export type DatasetFieldNames<TDataset extends DatasetInstance> =
   keyof TDataset['dimensions'] & string;

--- a/packages/datasets/src/utils/derived-cte-validation.ts
+++ b/packages/datasets/src/utils/derived-cte-validation.ts
@@ -1,0 +1,49 @@
+export function extractGroupByExpressions(sql: string): string[] {
+  const match = sql.match(/\bGROUP BY\b\s+(.+?)(?:\bHAVING\b|\bORDER BY\b|\bLIMIT\b|\bOFFSET\b|$)/is);
+  if (!match) {
+    return [];
+  }
+
+  return match[1]
+    .split(',')
+    .map(part => part.trim())
+    .filter(Boolean);
+}
+
+export function validateDerivedCteGrouping(
+  sql: string,
+  aggregateAliases: string[],
+  intendedGroupBy: string[],
+): string[] {
+  const errors: string[] = [];
+  const actualGroupBy = extractGroupByExpressions(sql);
+
+  if (intendedGroupBy.length === 0 && actualGroupBy.length > 0) {
+    errors.push('Derived metric planner emitted GROUP BY for an ungrouped query.');
+  }
+
+  const duplicates = actualGroupBy.filter((expression, index) => actualGroupBy.indexOf(expression) !== index);
+  if (duplicates.length > 0) {
+    errors.push(
+      `Derived metric planner emitted duplicate GROUP BY expressions: ${Array.from(new Set(duplicates)).join(', ')}`,
+    );
+  }
+
+  const aggregateAliasSet = new Set(aggregateAliases);
+  const aggregateAliasesInGroupBy = actualGroupBy.filter(expression => aggregateAliasSet.has(expression));
+  if (aggregateAliasesInGroupBy.length > 0) {
+    errors.push(
+      `Derived metric planner emitted aggregate aliases in GROUP BY: ${Array.from(new Set(aggregateAliasesInGroupBy)).join(', ')}`,
+    );
+  }
+
+  const intendedGroupBySet = new Set(intendedGroupBy);
+  const unexpectedGroupBy = actualGroupBy.filter(expression => !intendedGroupBySet.has(expression));
+  if (unexpectedGroupBy.length > 0) {
+    errors.push(
+      `Derived metric planner emitted unexpected GROUP BY expressions: ${Array.from(new Set(unexpectedGroupBy)).join(', ')}`,
+    );
+  }
+
+  return errors;
+}

--- a/packages/datasets/src/utils/filtered-aggregation-sql.ts
+++ b/packages/datasets/src/utils/filtered-aggregation-sql.ts
@@ -1,0 +1,95 @@
+import type { AggregationSpec, AnyDatasetInstance, MetricFilter } from '../types.js';
+import { resolveDimensionExpression, resolveFilterField } from '../query-planner.js';
+
+type DatasetShape = AnyDatasetInstance;
+
+function renderMeasureFilterLiteral(value: unknown): string {
+  if (value === null) {
+    return 'NULL';
+  }
+
+  if (typeof value === 'string') {
+    return `'${value.replace(/'/g, "''")}'`;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`Invalid non-finite numeric literal in measure filter: ${value}`);
+    }
+    return String(value);
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? '1' : '0';
+  }
+
+  throw new Error(`Unsupported literal type in measure filter: ${typeof value}`);
+}
+
+function renderMeasureFilterCondition(
+  ds: DatasetShape,
+  filter: MetricFilter,
+): string {
+  const field = resolveFilterField(ds, filter.field);
+
+  switch (filter.operator) {
+    case 'eq':
+      return `${field} = ${renderMeasureFilterLiteral(filter.value)}`;
+    case 'neq':
+      return `${field} != ${renderMeasureFilterLiteral(filter.value)}`;
+    case 'gt':
+      return `${field} > ${renderMeasureFilterLiteral(filter.value)}`;
+    case 'gte':
+      return `${field} >= ${renderMeasureFilterLiteral(filter.value)}`;
+    case 'lt':
+      return `${field} < ${renderMeasureFilterLiteral(filter.value)}`;
+    case 'lte':
+      return `${field} <= ${renderMeasureFilterLiteral(filter.value)}`;
+    case 'like':
+      return `${field} LIKE ${renderMeasureFilterLiteral(filter.value)}`;
+    case 'in':
+    case 'notIn': {
+      if (!Array.isArray(filter.value) || filter.value.length === 0) {
+        throw new Error(`"${filter.operator}" measure filters require a non-empty array.`);
+      }
+
+      const values = filter.value.map(renderMeasureFilterLiteral).join(', ');
+      return `${field} ${filter.operator === 'in' ? 'IN' : 'NOT IN'} (${values})`;
+    }
+    case 'between': {
+      if (!Array.isArray(filter.value) || filter.value.length !== 2) {
+        throw new Error('"between" measure filters require a two-item array.');
+      }
+
+      return `${field} BETWEEN ${renderMeasureFilterLiteral(filter.value[0])} AND ${renderMeasureFilterLiteral(filter.value[1])}`;
+    }
+  }
+}
+
+export function applyFilteredAggregationExpression(
+  ds: DatasetShape,
+  spec: AggregationSpec,
+  fieldOrExpr: string,
+): string {
+  if (!spec.filters?.length) {
+    return fieldOrExpr;
+  }
+
+  const combinedCondition = spec.filters
+    .map(filter => renderMeasureFilterCondition(ds, filter))
+    .map(condition => `(${condition})`)
+    .join(' AND ');
+
+  switch (spec.aggregation) {
+    case 'sum':
+      return `if(${combinedCondition}, ${fieldOrExpr}, 0)`;
+    case 'count':
+    case 'countDistinct':
+    case 'avg':
+    case 'min':
+    case 'max':
+      return `if(${combinedCondition}, ${fieldOrExpr}, NULL)`;
+    default:
+      return fieldOrExpr;
+  }
+}

--- a/packages/datasets/src/utils/metric-handle.ts
+++ b/packages/datasets/src/utils/metric-handle.ts
@@ -1,0 +1,64 @@
+import type {
+  AnyDatasetInstance,
+  ExecutionContext,
+  GrainedMetricRef,
+  MetricFilter,
+  MetricQuery,
+  MetricRef,
+  TimeGrain,
+} from '../types.js';
+import { resolveDimensionExpression, resolveFilterField, resolveTenantFilterColumn } from '../query-planner.js';
+type DatasetShape = AnyDatasetInstance;
+
+export type MetricHandle = MetricRef | GrainedMetricRef;
+
+export function isMetricHandle(value: unknown): value is MetricHandle {
+  return typeof value === 'object'
+    && value !== null
+    && '__type' in value
+    && (
+      (value as { __type?: string }).__type === 'metric_ref'
+      || (value as { __type?: string }).__type === 'grained_metric_ref'
+    );
+}
+
+export function assertMetricHandle(value: unknown): asserts value is MetricHandle {
+  if (!isMetricHandle(value)) {
+    throw new Error(
+      'MetricExecutor only supports MetricRef and GrainedMetricRef. ' +
+      'dataset.query(...) is not part of the public execution API.',
+    );
+  }
+}
+
+export function getMetricRef(metric: MetricHandle): MetricRef {
+  return metric.__type === 'grained_metric_ref' ? metric.metric : metric;
+}
+
+export function getMetricGrain(metric: MetricHandle, query: MetricQuery): TimeGrain | undefined {
+  return metric.__type === 'grained_metric_ref' ? metric.grain : query.by ?? undefined;
+}
+
+export function getTenantRuntimeColumn(
+  ds: DatasetShape,
+  context?: ExecutionContext,
+): string | undefined {
+  if (!context?.runtime?.tenant?.id) {
+    return undefined;
+  }
+
+  return resolveTenantFilterColumn(ds, context);
+}
+
+export function isTenantScopedFilter(
+  ds: DatasetShape,
+  filter: MetricFilter,
+  context?: ExecutionContext,
+): boolean {
+  const tenantColumn = getTenantRuntimeColumn(ds, context);
+  if (!tenantColumn) {
+    return false;
+  }
+
+  return resolveFilterField(ds, filter.field) === resolveDimensionExpression(ds, tenantColumn);
+}

--- a/packages/datasets/tsconfig.tsbuildinfo
+++ b/packages/datasets/tsconfig.tsbuildinfo
@@ -1,1 +1,2384 @@
-{"fileNames":["../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es5.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2016.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.dom.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.dom.iterable.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.dom.asynciterable.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.webworker.importscripts.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.scripthost.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.core.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.collection.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.generator.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.iterable.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.promise.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.proxy.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.reflect.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.symbol.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2016.array.include.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2016.intl.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.arraybuffer.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.date.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.object.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.sharedmemory.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.string.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.intl.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.typedarrays.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.asyncgenerator.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.asynciterable.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.intl.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.promise.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.regexp.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.array.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.object.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.string.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.symbol.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.intl.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.bigint.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.date.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.promise.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.sharedmemory.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.string.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.symbol.wellknown.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.intl.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.number.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.promise.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.string.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.weakref.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.intl.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.array.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.error.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.intl.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.object.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.string.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.regexp.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.decorators.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.decorators.legacy.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.full.d.ts","./src/query-builder-protocol.ts","./src/types.ts","./src/aggregations.ts","./src/constants.ts","./src/dataset.ts","./src/sql-utils.ts","./src/validation.ts","./src/query-planner.ts","./src/executor.ts","./src/field.ts","./src/formulas.ts","./src/measure.ts","./src/relationships.ts","./src/query-helpers.ts","./src/registry.ts","./src/index.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/compatibility/disposable.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/compatibility/indexable.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/compatibility/iterators.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/compatibility/index.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/globals.typedarray.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/buffer.buffer.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/globals.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/web-globals/abortcontroller.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/web-globals/domexception.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/web-globals/events.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/header.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/readable.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/file.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/fetch.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/formdata.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/connector.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/client.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/errors.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/dispatcher.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/global-dispatcher.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/global-origin.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/pool-stats.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/pool.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/handlers.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/balanced-pool.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/agent.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/mock-interceptor.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/mock-agent.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/mock-client.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/mock-pool.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/mock-errors.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/proxy-agent.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/api.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/cookies.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/patch.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/filereader.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/diagnostics-channel.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/websocket.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/content-type.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/cache.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/interceptors.d.ts","../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/index.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/web-globals/fetch.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/assert.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/assert/strict.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/async_hooks.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/buffer.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/child_process.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/cluster.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/console.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/constants.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/crypto.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/dgram.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/diagnostics_channel.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/dns.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/dns/promises.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/domain.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/events.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/fs.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/fs/promises.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/http.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/http2.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/https.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/inspector.generated.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/module.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/net.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/os.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/path.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/perf_hooks.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/process.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/punycode.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/querystring.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/readline.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/readline/promises.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/repl.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/stream.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/stream/promises.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/stream/consumers.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/stream/web.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/string_decoder.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/test.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/timers.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/timers/promises.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/tls.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/trace_events.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/tty.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/url.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/util.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/v8.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/vm.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/wasi.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/worker_threads.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/zlib.d.ts","../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/index.d.ts"],"fileIdsList":[[85,123,126],[85,125,126],[126],[85,126,131,158],[85,126,127,137,145,155,166],[85,126,127,128,137,145],[85,126],[80,81,82,85,126],[85,126,129,167],[85,126,130,131,138,146],[85,126,131,155,163],[85,126,132,134,137,145],[85,125,126,133],[85,126,134,135],[85,126,136,137],[85,125,126,137],[85,126,137,138,139,155,166],[85,126,137,138,139,152,155,158],[85,126,134,137,140,145,155,166],[85,126,137,138,140,141,145,155,163,166],[85,126,140,142,155,163,166],[83,84,85,86,87,88,89,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172],[85,126,137,143],[85,126,144,166,171],[85,126,134,137,145,155],[85,126,146],[85,126,147],[85,125,126,148],[85,126,149,165,171],[85,126,150],[85,126,151],[85,126,137,152,153],[85,126,152,154,167,169],[85,126,137,155,156,158],[85,126,157,158],[85,126,155,156],[85,126,158],[85,126,159],[85,126,155,160],[85,126,137,161,162],[85,126,161,162],[85,126,131,145,155,163],[85,126,164],[85,126,145,165],[85,126,140,151,166],[85,126,131,167],[85,126,155,168],[85,126,144,169],[85,126,170],[85,121,126],[85,121,126,137,139,148,155,158,166,169,171],[85,126,155,172],[85,98,102,126,166],[85,98,126,155,166],[85,93,126],[85,95,98,126,163,166],[85,126,145,163],[85,126,173],[85,93,126,173],[85,95,98,126,145,166],[85,90,91,94,97,126,137,155,166],[85,90,96,126],[85,94,98,126,158,166,173],[85,114,126,173],[85,92,93,126,173],[85,98,126],[85,92,93,94,95,96,97,98,99,100,102,103,104,105,106,107,108,109,110,111,112,113,115,116,117,118,119,120,126],[85,98,105,106,126],[85,96,98,106,107,126],[85,97,126],[85,90,93,98,126],[85,98,102,106,107,126],[85,102,126],[85,96,98,101,126,166],[85,90,95,96,98,102,105,126],[85,126,155],[85,93,98,114,126,171,173],[65,85,126],[64,65,69,70,71,85,126],[64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,85,126],[64,65,67,85,126],[64,85,126]],"fileInfos":[{"version":"c430d44666289dae81f30fa7b2edebf186ecc91a2d4c71266ea6ae76388792e1","affectsGlobalScope":true,"impliedFormat":1},{"version":"45b7ab580deca34ae9729e97c13cfd999df04416a79116c3bfb483804f85ded4","impliedFormat":1},{"version":"3facaf05f0c5fc569c5649dd359892c98a85557e3e0c847964caeb67076f4d75","impliedFormat":1},{"version":"e44bb8bbac7f10ecc786703fe0a6a4b952189f908707980ba8f3c8975a760962","impliedFormat":1},{"version":"5e1c4c362065a6b95ff952c0eab010f04dcd2c3494e813b493ecfd4fcb9fc0d8","impliedFormat":1},{"version":"68d73b4a11549f9c0b7d352d10e91e5dca8faa3322bfb77b661839c42b1ddec7","impliedFormat":1},{"version":"5efce4fc3c29ea84e8928f97adec086e3dc876365e0982cc8479a07954a3efd4","impliedFormat":1},{"version":"feecb1be483ed332fad555aff858affd90a48ab19ba7272ee084704eb7167569","impliedFormat":1},{"version":"ee7bad0c15b58988daa84371e0b89d313b762ab83cb5b31b8a2d1162e8eb41c2","impliedFormat":1},{"version":"080941d9f9ff9307f7e27a83bcd888b7c8270716c39af943532438932ec1d0b9","affectsGlobalScope":true,"impliedFormat":1},{"version":"2e80ee7a49e8ac312cc11b77f1475804bee36b3b2bc896bead8b6e1266befb43","affectsGlobalScope":true,"impliedFormat":1},{"version":"d7a3c8b952931daebdfc7a2897c53c0a1c73624593fa070e46bd537e64dcd20a","affectsGlobalScope":true,"impliedFormat":1},{"version":"80e18897e5884b6723488d4f5652167e7bb5024f946743134ecc4aa4ee731f89","affectsGlobalScope":true,"impliedFormat":1},{"version":"cd034f499c6cdca722b60c04b5b1b78e058487a7085a8e0d6fb50809947ee573","affectsGlobalScope":true,"impliedFormat":1},{"version":"c57796738e7f83dbc4b8e65132f11a377649c00dd3eee333f672b8f0a6bea671","affectsGlobalScope":true,"impliedFormat":1},{"version":"dc2df20b1bcdc8c2d34af4926e2c3ab15ffe1160a63e58b7e09833f616efff44","affectsGlobalScope":true,"impliedFormat":1},{"version":"515d0b7b9bea2e31ea4ec968e9edd2c39d3eebf4a2d5cbd04e88639819ae3b71","affectsGlobalScope":true,"impliedFormat":1},{"version":"0559b1f683ac7505ae451f9a96ce4c3c92bdc71411651ca6ddb0e88baaaad6a3","affectsGlobalScope":true,"impliedFormat":1},{"version":"0dc1e7ceda9b8b9b455c3a2d67b0412feab00bd2f66656cd8850e8831b08b537","affectsGlobalScope":true,"impliedFormat":1},{"version":"ce691fb9e5c64efb9547083e4a34091bcbe5bdb41027e310ebba8f7d96a98671","affectsGlobalScope":true,"impliedFormat":1},{"version":"8d697a2a929a5fcb38b7a65594020fcef05ec1630804a33748829c5ff53640d0","affectsGlobalScope":true,"impliedFormat":1},{"version":"4ff2a353abf8a80ee399af572debb8faab2d33ad38c4b4474cff7f26e7653b8d","affectsGlobalScope":true,"impliedFormat":1},{"version":"fb0f136d372979348d59b3f5020b4cdb81b5504192b1cacff5d1fbba29378aa1","affectsGlobalScope":true,"impliedFormat":1},{"version":"d15bea3d62cbbdb9797079416b8ac375ae99162a7fba5de2c6c505446486ac0a","affectsGlobalScope":true,"impliedFormat":1},{"version":"68d18b664c9d32a7336a70235958b8997ebc1c3b8505f4f1ae2b7e7753b87618","affectsGlobalScope":true,"impliedFormat":1},{"version":"eb3d66c8327153d8fa7dd03f9c58d351107fe824c79e9b56b462935176cdf12a","affectsGlobalScope":true,"impliedFormat":1},{"version":"38f0219c9e23c915ef9790ab1d680440d95419ad264816fa15009a8851e79119","affectsGlobalScope":true,"impliedFormat":1},{"version":"69ab18c3b76cd9b1be3d188eaf8bba06112ebbe2f47f6c322b5105a6fbc45a2e","affectsGlobalScope":true,"impliedFormat":1},{"version":"a680117f487a4d2f30ea46f1b4b7f58bef1480456e18ba53ee85c2746eeca012","affectsGlobalScope":true,"impliedFormat":1},{"version":"2f11ff796926e0832f9ae148008138ad583bd181899ab7dd768a2666700b1893","affectsGlobalScope":true,"impliedFormat":1},{"version":"4de680d5bb41c17f7f68e0419412ca23c98d5749dcaaea1896172f06435891fc","affectsGlobalScope":true,"impliedFormat":1},{"version":"954296b30da6d508a104a3a0b5d96b76495c709785c1d11610908e63481ee667","affectsGlobalScope":true,"impliedFormat":1},{"version":"ac9538681b19688c8eae65811b329d3744af679e0bdfa5d842d0e32524c73e1c","affectsGlobalScope":true,"impliedFormat":1},{"version":"0a969edff4bd52585473d24995c5ef223f6652d6ef46193309b3921d65dd4376","affectsGlobalScope":true,"impliedFormat":1},{"version":"9e9fbd7030c440b33d021da145d3232984c8bb7916f277e8ffd3dc2e3eae2bdb","affectsGlobalScope":true,"impliedFormat":1},{"version":"811ec78f7fefcabbda4bfa93b3eb67d9ae166ef95f9bff989d964061cbf81a0c","affectsGlobalScope":true,"impliedFormat":1},{"version":"717937616a17072082152a2ef351cb51f98802fb4b2fdabd32399843875974ca","affectsGlobalScope":true,"impliedFormat":1},{"version":"d7e7d9b7b50e5f22c915b525acc5a49a7a6584cf8f62d0569e557c5cfc4b2ac2","affectsGlobalScope":true,"impliedFormat":1},{"version":"71c37f4c9543f31dfced6c7840e068c5a5aacb7b89111a4364b1d5276b852557","affectsGlobalScope":true,"impliedFormat":1},{"version":"576711e016cf4f1804676043e6a0a5414252560eb57de9faceee34d79798c850","affectsGlobalScope":true,"impliedFormat":1},{"version":"89c1b1281ba7b8a96efc676b11b264de7a8374c5ea1e6617f11880a13fc56dc6","affectsGlobalScope":true,"impliedFormat":1},{"version":"74f7fa2d027d5b33eb0471c8e82a6c87216223181ec31247c357a3e8e2fddc5b","affectsGlobalScope":true,"impliedFormat":1},{"version":"d6d7ae4d1f1f3772e2a3cde568ed08991a8ae34a080ff1151af28b7f798e22ca","affectsGlobalScope":true,"impliedFormat":1},{"version":"063600664504610fe3e99b717a1223f8b1900087fab0b4cad1496a114744f8df","affectsGlobalScope":true,"impliedFormat":1},{"version":"934019d7e3c81950f9a8426d093458b65d5aff2c7c1511233c0fd5b941e608ab","affectsGlobalScope":true,"impliedFormat":1},{"version":"52ada8e0b6e0482b728070b7639ee42e83a9b1c22d205992756fe020fd9f4a47","affectsGlobalScope":true,"impliedFormat":1},{"version":"3bdefe1bfd4d6dee0e26f928f93ccc128f1b64d5d501ff4a8cf3c6371200e5e6","affectsGlobalScope":true,"impliedFormat":1},{"version":"59fb2c069260b4ba00b5643b907ef5d5341b167e7d1dbf58dfd895658bda2867","affectsGlobalScope":true,"impliedFormat":1},{"version":"639e512c0dfc3fad96a84caad71b8834d66329a1f28dc95e3946c9b58176c73a","affectsGlobalScope":true,"impliedFormat":1},{"version":"368af93f74c9c932edd84c58883e736c9e3d53cec1fe24c0b0ff451f529ceab1","affectsGlobalScope":true,"impliedFormat":1},{"version":"af3dd424cf267428f30ccfc376f47a2c0114546b55c44d8c0f1d57d841e28d74","affectsGlobalScope":true,"impliedFormat":1},{"version":"995c005ab91a498455ea8dfb63aa9f83fa2ea793c3d8aa344be4a1678d06d399","affectsGlobalScope":true,"impliedFormat":1},{"version":"959d36cddf5e7d572a65045b876f2956c973a586da58e5d26cde519184fd9b8a","affectsGlobalScope":true,"impliedFormat":1},{"version":"965f36eae237dd74e6cca203a43e9ca801ce38824ead814728a2807b1910117d","affectsGlobalScope":true,"impliedFormat":1},{"version":"3925a6c820dcb1a06506c90b1577db1fdbf7705d65b62b99dce4be75c637e26b","affectsGlobalScope":true,"impliedFormat":1},{"version":"0a3d63ef2b853447ec4f749d3f368ce642264246e02911fcb1590d8c161b8005","affectsGlobalScope":true,"impliedFormat":1},{"version":"8cdf8847677ac7d20486e54dd3fcf09eda95812ac8ace44b4418da1bbbab6eb8","affectsGlobalScope":true,"impliedFormat":1},{"version":"8444af78980e3b20b49324f4a16ba35024fef3ee069a0eb67616ea6ca821c47a","affectsGlobalScope":true,"impliedFormat":1},{"version":"3287d9d085fbd618c3971944b65b4be57859f5415f495b33a6adc994edd2f004","affectsGlobalScope":true,"impliedFormat":1},{"version":"b4b67b1a91182421f5df999988c690f14d813b9850b40acd06ed44691f6727ad","affectsGlobalScope":true,"impliedFormat":1},{"version":"8e7f8264d0fb4c5339605a15daadb037bf238c10b654bb3eee14208f860a32ea","affectsGlobalScope":true,"impliedFormat":1},{"version":"782dec38049b92d4e85c1585fbea5474a219c6984a35b004963b00beb1aab538","affectsGlobalScope":true,"impliedFormat":1},{"version":"3cbad9a1ba4453443026ed38e4b8be018abb26565fa7c944376463ad9df07c41","impliedFormat":1},{"version":"7da208e2711b2e64d423f73b4c46721ab1ac5435b5041d44e18d29825bac5b81","signature":"9229744ea25e18a192f5953aa3b3f455d70eef16856888369b4a6979d0d96bae","impliedFormat":99},{"version":"63819b6f0351f394e5399e8b38d76e6841316224cf626ba560f872d40eb3ca45","signature":"5aec75ee5fa189dc5c35748219c22244702ec0d0d966fcd3d42d490b1f48ee09","impliedFormat":99},{"version":"eddf149fd995882b2e5f40425f7f4e10372fad7643a430ddc5395a785678d7e3","signature":"6dbb943e2651b8adaff2f73dada2bc506876926ae1a8e4dfc97d217408c98c3c","impliedFormat":99},{"version":"da8b85075ee3ce12be8e3a36767c021a18c0582684ed4daba3615151b14a298e","signature":"155be70478040379afa4b43bcb26f95383a0014c76f5cde69db9ac40720d414e","impliedFormat":99},{"version":"98b8c161962e0f7d98e95fd62cb77b747e4f461492e90647c4a9c934e23bfc40","signature":"f17daf0c5d1f20be1f983d0447e8aece97fdc198c9fa81ebe601f9e42dd1b321","impliedFormat":99},{"version":"01edbf8abf3eee6139eef3af98e304eb38a79b440632cc50d41db5107bca1743","signature":"ca37646b3fe21707e0d7c3c3276971c58105fb7abe98230b73f1fa85628300c3","impliedFormat":99},{"version":"1898267e95a6abe9948dd879bd6c8e3640f1325f3a4fed45239ca68be0cc1b01","signature":"bc82f0deae147bb18c9e9a3b015f62994ed76122e09d06e3e2cce4f6b1b2c945","impliedFormat":99},{"version":"720a0f9b790389c249d8f4a02c09d29fa7c0ec9847d186844b58fc887cf8e0a0","signature":"62bf81731c59340fa709e78e0dc44ad3e15d69fc2dd093abdb9926613abd3ee5","impliedFormat":99},{"version":"0d0323f03c9a2d28bab834e94c4d3ee451056ecb104c34a418b9ad45a7708053","signature":"5546b8dc48d6a8b9b2487e57b7c3cbe0af7db5a8d9abb8993694fec581b07546","impliedFormat":99},{"version":"2d0b8b809746cb205667d4eb4bf879018bf19b17f74870184fa10932c22785f9","signature":"0e7de46779b62e113b2266811b6d5c5f20b693d50d844447d09c6f203929a348","impliedFormat":99},{"version":"5f054400971765f8d4172db3f820d57f9caef611143f7d16397a05de84633b3f","signature":"d1d300d88d14b034e0904ee5fffb82d348604e876b872a1fbb6ebcea0e00149a","impliedFormat":99},{"version":"04cd6f876da8ecd983b78207003f55d18d22c95a804f2a621d9382259e38c69e","signature":"08b97f852e158ac5d2eaa7f9e375cb74f95b044ca056b0229133b8bd80b1a5d2","impliedFormat":99},{"version":"7e2e1686fe75cb85541d6de4eee027c646796e2b26c2572fe6b7f525c2598139","signature":"f510cb6b6494801377cfe8acf3aeebfc94a552490a49da49f68656fc28a51ad6","impliedFormat":99},{"version":"fbb3c9bd5ff6c778897f7d012c5a0b9d5fef4dd7801df5e5b6f3497f483c9c0e","signature":"56ea81afc382c20b1146a4a0a31f99c430024e554e1e2192fa561b2b9a6bbd00","impliedFormat":99},{"version":"8d967fb174d97544dd5eaa171379461ef59b270fe46db3537fce41f9a1007c2c","signature":"62cf651f9b9b298228a5b0ffd02e9441615996f2a06e783faae3a455aa4165d9","impliedFormat":99},{"version":"35a657bdaffdb943fee2484eca838447e209796d56c46f9ddf061c23a712b2aa","signature":"c2743fddf0130b0e179367a8e5491fae3b1078dccdb9105aaa6c2d4bb882a0de","impliedFormat":99},{"version":"6c7176368037af28cb72f2392010fa1cef295d6d6744bca8cfb54985f3a18c3e","affectsGlobalScope":true,"impliedFormat":1},{"version":"ab41ef1f2cdafb8df48be20cd969d875602483859dc194e9c97c8a576892c052","affectsGlobalScope":true,"impliedFormat":1},{"version":"437e20f2ba32abaeb7985e0afe0002de1917bc74e949ba585e49feba65da6ca1","affectsGlobalScope":true,"impliedFormat":1},{"version":"21d819c173c0cf7cc3ce57c3276e77fd9a8a01d35a06ad87158781515c9a438a","impliedFormat":1},{"version":"a79e62f1e20467e11a904399b8b18b18c0c6eea6b50c1168bf215356d5bebfaf","affectsGlobalScope":true,"impliedFormat":1},{"version":"32cb3140d0e9cee0aea7264fd6a1d297394052a18eb05ca0220d133e6c043fb5","affectsGlobalScope":true,"impliedFormat":1},{"version":"362d474eb9feae178a83ead94d757c21e42d6d7090e4182f0c12e92830a3d25e","affectsGlobalScope":true,"impliedFormat":1},{"version":"1db0b7dca579049ca4193d034d835f6bfe73096c73663e5ef9a0b5779939f3d0","affectsGlobalScope":true,"impliedFormat":1},{"version":"9798340ffb0d067d69b1ae5b32faa17ab31b82466a3fc00d8f2f2df0c8554aaa","affectsGlobalScope":true,"impliedFormat":1},{"version":"dc27badd4bf4a2b0024a0cd32a9bbf0be7073902c5177a58be14242e7d8bf2c7","affectsGlobalScope":true,"impliedFormat":1},{"version":"5929864ce17fba74232584d90cb721a89b7ad277220627cc97054ba15a98ea8f","impliedFormat":1},{"version":"7180c03fd3cb6e22f911ce9ba0f8a7008b1a6ddbe88ccf16a9c8140ef9ac1686","impliedFormat":1},{"version":"25c8056edf4314820382a5fdb4bb7816999acdcb929c8f75e3f39473b87e85bc","impliedFormat":1},{"version":"54cb85a47d760da1c13c00add10d26b5118280d44d58e6908d8e89abbd9d7725","impliedFormat":1},{"version":"3e4825171442666d31c845aeb47fcd34b62e14041bb353ae2b874285d78482aa","impliedFormat":1},{"version":"c6fd2c5a395f2432786c9cb8deb870b9b0e8ff7e22c029954fabdd692bff6195","impliedFormat":1},{"version":"a967bfe3ad4e62243eb604bf956101e4c740f5921277c60debaf325c1320bf88","impliedFormat":1},{"version":"e9775e97ac4877aebf963a0289c81abe76d1ec9a2a7778dbe637e5151f25c5f3","impliedFormat":1},{"version":"471e1da5a78350bc55ef8cef24eb3aca6174143c281b8b214ca2beda51f5e04a","impliedFormat":1},{"version":"cadc8aced301244057c4e7e73fbcae534b0f5b12a37b150d80e5a45aa4bebcbd","impliedFormat":1},{"version":"385aab901643aa54e1c36f5ef3107913b10d1b5bb8cbcd933d4263b80a0d7f20","impliedFormat":1},{"version":"9670d44354bab9d9982eca21945686b5c24a3f893db73c0dae0fd74217a4c219","impliedFormat":1},{"version":"db3435f3525cd785bf21ec6769bf8da7e8a776be1a99e2e7efb5f244a2ef5fee","impliedFormat":1},{"version":"c3b170c45fc031db31f782e612adf7314b167e60439d304b49e704010e7bafe5","impliedFormat":1},{"version":"40383ebef22b943d503c6ce2cb2e060282936b952a01bea5f9f493d5fb487cc7","impliedFormat":1},{"version":"4893a895ea92c85345017a04ed427cbd6a1710453338df26881a6019432febdd","impliedFormat":1},{"version":"3a84b7cb891141824bd00ef8a50b6a44596aded4075da937f180c90e362fe5f6","impliedFormat":1},{"version":"13f6f39e12b1518c6650bbb220c8985999020fe0f21d818e28f512b7771d00f9","impliedFormat":1},{"version":"9b5369969f6e7175740bf51223112ff209f94ba43ecd3bb09eefff9fd675624a","impliedFormat":1},{"version":"4fe9e626e7164748e8769bbf74b538e09607f07ed17c2f20af8d680ee49fc1da","impliedFormat":1},{"version":"24515859bc0b836719105bb6cc3d68255042a9f02a6022b3187948b204946bd2","impliedFormat":1},{"version":"33203609eba548914dc83ddf6cadbc0bcb6e8ef89f6d648ca0908ae887f9fcc5","impliedFormat":1},{"version":"0db18c6e78ea846316c012478888f33c11ffadab9efd1cc8bcc12daded7a60b6","impliedFormat":1},{"version":"89167d696a849fce5ca508032aabfe901c0868f833a8625d5a9c6e861ef935d2","impliedFormat":1},{"version":"e53a3c2a9f624d90f24bf4588aacd223e7bec1b9d0d479b68d2f4a9e6011147f","impliedFormat":1},{"version":"339dc5265ee5ed92e536a93a04c4ebbc2128f45eeec6ed29f379e0085283542c","impliedFormat":1},{"version":"9f0a92164925aa37d4a5d9dd3e0134cff8177208dba55fd2310cd74beea40ee2","impliedFormat":1},{"version":"8bfdb79bf1a9d435ec48d9372dc93291161f152c0865b81fc0b2694aedb4578d","impliedFormat":1},{"version":"2e85db9e6fd73cfa3d7f28e0ab6b55417ea18931423bd47b409a96e4a169e8e6","impliedFormat":1},{"version":"c46e079fe54c76f95c67fb89081b3e399da2c7d109e7dca8e4b58d83e332e605","impliedFormat":1},{"version":"d32275be3546f252e3ad33976caf8c5e842c09cb87d468cb40d5f4cf092d1acc","impliedFormat":1},{"version":"4a0c3504813a3289f7fb1115db13967c8e004aa8e4f8a9021b95285502221bd1","impliedFormat":1},{"version":"b972357e61ef2e072f8a88b9f4f5a70984c417237e6106f6b2390414a09ce523","affectsGlobalScope":true,"impliedFormat":1},{"version":"076cac5898bd833255def0f7c5717b83534212873505c9c958f1926d49f9bec6","impliedFormat":1},{"version":"7394959e5a741b185456e1ef5d64599c36c60a323207450991e7a42e08911419","impliedFormat":1},{"version":"75eb536b960b85f75e21490beeab53ea616646a995ad203e1af532d67a774fb6","impliedFormat":1},{"version":"36d0976d3dad74078f707af107b5082dbe42ffcadb3442ff140c36c8a33b4887","affectsGlobalScope":true,"impliedFormat":1},{"version":"86e0d632e9ef88593e8724ffb6af05104e13a08f9d8df733a30f9991ac387fff","impliedFormat":1},{"version":"7646ad748a9ca15bf43d4c88f83cc851c67f8ec9c1186295605b59ba6bb36dcb","impliedFormat":1},{"version":"cef8931bc129687165253f0642427c2a72705a4613b3ac461b9fa78c7cdaef32","affectsGlobalScope":true,"impliedFormat":1},{"version":"5524481e56c48ff486f42926778c0a3cce1cc85dc46683b92b1271865bcf015a","impliedFormat":1},{"version":"47b62c294beb69daa5879f052e416b02e6518f3e4541ae98adbfb27805dd6711","impliedFormat":1},{"version":"f8375506002c556ec412c7e2a5a9ece401079ee5d9eb2c1372e9f5377fac56c7","impliedFormat":1},{"version":"8edd6482bd72eca772f9df15d05c838dd688cdbd4d62690891fca6578cfda6fe","impliedFormat":1},{"version":"07ba29a1a495b710aea48a4cf19ae12b3cbda2a8e9ac62192af477027a99e8de","impliedFormat":1},{"version":"6dead64c944504250dd2fc9095231f36887cfc1534f1ff57737c19f92d165c91","impliedFormat":1},{"version":"b9a4824bb83f25d6d227394db2ed99985308cf2a3a35f0d6d39aa72b15473982","impliedFormat":1},{"version":"6e9948b1e396106601365283680c319a9103c71a5725e7d03e26fe246df60c4c","affectsGlobalScope":true,"impliedFormat":1},{"version":"8e8e284b3832911aeede987e4d74cf0a00f2b03896b2fd3bf924344cc0f96b3c","impliedFormat":1},{"version":"37d37474a969ab1b91fc332eb6a375885dfd25279624dfa84dea48c9aedf4472","impliedFormat":1},{"version":"1ddd8c1a3ae1f8ab28affd53b13910be4afe0b35f28517b7f14c268e9e42647a","impliedFormat":1},{"version":"f1a79b6047d006548185e55478837dfbcdd234d6fe51532783f5dffd401cfb2b","impliedFormat":1},{"version":"cbc91187014fb1e738ef252751a9f84abf2989ec1c3b1637ec23b5b39cdf3d25","impliedFormat":1},{"version":"e822320b448edce0c7ede9cbeada034c72e1f1c8c8281974817030564c63dcb1","impliedFormat":1},{"version":"9d65568cba17c9db40251023406668695ad698ea4a34542364af3e78edd37811","affectsGlobalScope":true,"impliedFormat":1},{"version":"f23e3d484de54d235bf702072100b541553a1df2550bad691fe84995e15cf7be","impliedFormat":1},{"version":"821c79b046e40d54a447bebd9307e70b86399a89980a87bbc98114411169e274","impliedFormat":1},{"version":"17bc38afc78d40b2f54af216c0cc31a4bd0c6897a5945fa39945dfc43260be2c","impliedFormat":1},{"version":"d201b44ff390c220a94fb0ff6a534fe9fa15b44f8a86d0470009cdde3a3e62ab","affectsGlobalScope":true,"impliedFormat":1},{"version":"d44445141f204d5672c502a39c1124bcf1df225eba05df0d2957f79122be87b5","affectsGlobalScope":true,"impliedFormat":1},{"version":"de905bc5f7e7a81cb420e212b95ab5e3ab840f93e0cfa8ce879f6e7fa465d4a2","impliedFormat":1},{"version":"bc2ff43214898bc6d53cab92fb41b5309efec9cbb59a0650525980aee994de2b","impliedFormat":1},{"version":"bede3143eeddca3b8ec3592b09d7eb02042f9e195251040c5146eac09b173236","impliedFormat":1},{"version":"64a40cf4ec8a7a29db2b4bc35f042e5be8537c4be316e5221f40f30ca8ed7051","impliedFormat":1},{"version":"294c082d609e6523520290db4f1d54114ebc83643fb42abd965be5bcc5d9416b","impliedFormat":1},{"version":"cf7d740e39bd8adbdc7840ee91bef0af489052f6467edfcefb7197921757ec3b","impliedFormat":1},{"version":"37ba7b45141a45ce6e80e66f2a96c8a5ab1bcef0fc2d0f56bb58df96ec67e972","impliedFormat":1},{"version":"125d792ec6c0c0f657d758055c494301cc5fdb327d9d9d5960b3f129aff76093","impliedFormat":1},{"version":"b9f0681c4d2cb00a5cfe08a7be9662627b912de562926819ebddfe2ef6a9b5ee","affectsGlobalScope":true,"impliedFormat":1},{"version":"b85151402164ab7cb665e58df5c1a29aa25ea4ed3a367f84a15589e7d7a9c8ca","impliedFormat":1},{"version":"89eb8abe2b5c146fbb8f3bf72f4e91de3541f2fb559ad5fed4ad5bf223a3dedb","impliedFormat":1},{"version":"bc6cb10764a82f3025c0f4822b8ad711c16d1a5c75789be2d188d553b69b2d48","affectsGlobalScope":true,"impliedFormat":1},{"version":"41d510caf7ed692923cb6ef5932dc9cf1ed0f57de8eb518c5bab8358a21af674","impliedFormat":1},{"version":"2751c5a6b9054b61c9b03b3770b2d39b1327564672b63e3485ac03ffeb28b4f6","impliedFormat":1},{"version":"dc058956a93388aab38307b7b3b9b6379e1021e73a244aab6ac9427dc3a252a7","impliedFormat":1},{"version":"f33302cf240672359992c356f2005d395b559e176196d03f31a28cc7b01e69bc","impliedFormat":1},{"version":"3ce25041ff6ae06c08fcaccd5fcd9baf4ca6e80e6cb5a922773a1985672e74c2","affectsGlobalScope":true,"impliedFormat":1},{"version":"652c0de14329a834ff06af6ad44670fac35849654a464fd9ae36edb92a362c12","affectsGlobalScope":true,"impliedFormat":1},{"version":"3b1e178016d3fc554505ae087c249b205b1c50624d482c542be9d4682bab81fc","impliedFormat":1},{"version":"5db7c5bb02ef47aaaec6d262d50c4e9355c80937d649365c343fa5e84569621d","impliedFormat":1},{"version":"cf45d0510b661f1da461479851ff902f188edb111777c37055eff12fa986a23a","impliedFormat":1},{"version":"6831f13f06a15391dfeb2477d48ac58311ab675f85846a05499ee92d6e856933","affectsGlobalScope":true,"impliedFormat":1},{"version":"37bef1064b7d015aeaa7c0716fe23a0b3844abe2c0a3df7144153ca8445fe0da","impliedFormat":1},{"version":"83178a1174286d5f5178c5c75067e36c41b975c26be7b86d99cb18393eb30a41","impliedFormat":1}],"root":[[64,79]],"options":{"allowImportingTsExtensions":false,"allowSyntheticDefaultImports":true,"composite":true,"declaration":true,"declarationMap":true,"esModuleInterop":true,"module":199,"outDir":"./dist","rootDir":"./src","skipLibCheck":true,"strict":true,"target":9},"referencedMap":[[123,1],[124,1],[125,2],[85,3],[126,4],[127,5],[128,6],[80,7],[83,8],[81,7],[82,7],[129,9],[130,10],[131,11],[132,12],[133,13],[134,14],[135,14],[136,15],[137,16],[138,17],[139,18],[86,7],[84,7],[140,19],[141,20],[142,21],[173,22],[143,23],[144,24],[145,25],[146,26],[147,27],[148,28],[149,29],[150,30],[151,31],[152,32],[153,32],[154,33],[155,34],[157,35],[156,36],[158,37],[159,38],[160,39],[161,40],[162,41],[163,42],[164,43],[165,44],[166,45],[167,46],[168,47],[169,48],[170,49],[87,7],[88,7],[89,7],[122,50],[171,51],[172,52],[61,7],[62,7],[12,7],[10,7],[11,7],[16,7],[15,7],[2,7],[17,7],[18,7],[19,7],[20,7],[21,7],[22,7],[23,7],[24,7],[3,7],[25,7],[26,7],[4,7],[27,7],[31,7],[28,7],[29,7],[30,7],[32,7],[33,7],[34,7],[5,7],[35,7],[36,7],[37,7],[38,7],[6,7],[42,7],[39,7],[40,7],[41,7],[43,7],[7,7],[44,7],[49,7],[50,7],[45,7],[46,7],[47,7],[48,7],[8,7],[54,7],[51,7],[52,7],[53,7],[55,7],[9,7],[56,7],[63,7],[57,7],[58,7],[60,7],[59,7],[1,7],[14,7],[13,7],[105,53],[112,54],[104,53],[119,55],[96,56],[95,57],[118,58],[113,59],[116,60],[98,61],[97,62],[93,63],[92,58],[115,64],[94,65],[99,66],[100,7],[103,66],[90,7],[121,67],[120,66],[107,68],[108,69],[110,70],[106,71],[109,72],[114,58],[101,73],[102,74],[111,75],[91,76],[117,77],[66,78],[67,78],[68,78],[72,79],[73,78],[74,78],[79,80],[75,78],[64,7],[77,78],[71,81],[78,78],[76,78],[69,7],[65,82],[70,78]],"latestChangedDtsFile":"./dist/index.d.ts","version":"5.9.3"}
+{
+  "fileNames": [
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es5.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2016.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.dom.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.dom.iterable.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.dom.asynciterable.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.webworker.importscripts.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.scripthost.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.core.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.collection.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.generator.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.promise.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.proxy.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.reflect.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.symbol.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2016.array.include.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2016.intl.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.arraybuffer.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.date.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.object.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.sharedmemory.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.string.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.intl.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.typedarrays.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.asyncgenerator.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.asynciterable.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.intl.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.promise.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.regexp.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.array.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.object.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.string.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.symbol.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.intl.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.bigint.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.date.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.promise.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.sharedmemory.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.string.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.symbol.wellknown.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.intl.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.number.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.promise.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.string.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.weakref.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.intl.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.array.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.error.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.intl.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.object.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.string.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.regexp.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.decorators.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.decorators.legacy.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.full.d.ts",
+    "./src/query-builder-protocol.ts",
+    "./src/types.ts",
+    "./src/aggregations.ts",
+    "./src/validation.ts",
+    "./src/dataset.ts",
+    "./src/field.ts",
+    "./src/measure.ts",
+    "./src/relationships.ts",
+    "./src/formulas.ts",
+    "./src/query-helpers.ts",
+    "./src/registry.ts",
+    "./src/sql-utils.ts",
+    "./src/constants.ts",
+    "./src/utils/filtered-aggregation-sql.ts",
+    "./src/query-planner.ts",
+    "./src/utils/metric-handle.ts",
+    "./src/utils/derived-cte-validation.ts",
+    "./src/executor.ts",
+    "./src/index.ts",
+    "./src/api.type-test.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/compatibility/disposable.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/compatibility/indexable.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/compatibility/iterators.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/compatibility/index.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/globals.typedarray.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/buffer.buffer.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/globals.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/web-globals/abortcontroller.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/web-globals/domexception.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/web-globals/events.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/header.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/readable.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/file.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/fetch.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/formdata.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/connector.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/client.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/errors.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/dispatcher.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/global-dispatcher.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/global-origin.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/pool-stats.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/pool.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/handlers.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/balanced-pool.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/agent.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/mock-interceptor.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/mock-agent.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/mock-client.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/mock-pool.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/mock-errors.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/proxy-agent.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/api.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/cookies.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/patch.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/filereader.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/diagnostics-channel.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/websocket.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/content-type.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/cache.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/interceptors.d.ts",
+    "../../node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types/index.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/web-globals/fetch.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/assert.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/assert/strict.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/async_hooks.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/buffer.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/child_process.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/cluster.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/console.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/constants.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/crypto.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/dgram.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/diagnostics_channel.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/dns.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/dns/promises.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/domain.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/events.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/fs.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/fs/promises.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/http.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/http2.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/https.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/inspector.generated.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/module.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/net.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/os.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/path.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/perf_hooks.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/process.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/punycode.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/querystring.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/readline.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/readline/promises.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/repl.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/stream.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/stream/promises.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/stream/consumers.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/stream/web.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/string_decoder.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/test.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/timers.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/timers/promises.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/tls.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/trace_events.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/tty.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/url.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/util.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/v8.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/vm.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/wasi.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/worker_threads.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/zlib.d.ts",
+    "../../node_modules/.pnpm/@types+node@18.19.130/node_modules/@types/node/index.d.ts"
+  ],
+  "fileIdsList": [
+    [
+      89,
+      127,
+      130
+    ],
+    [
+      89,
+      129,
+      130
+    ],
+    [
+      130
+    ],
+    [
+      89,
+      130,
+      135,
+      162
+    ],
+    [
+      89,
+      130,
+      131,
+      141,
+      149,
+      159,
+      170
+    ],
+    [
+      89,
+      130,
+      131,
+      132,
+      141,
+      149
+    ],
+    [
+      89,
+      130
+    ],
+    [
+      84,
+      85,
+      86,
+      89,
+      130
+    ],
+    [
+      89,
+      130,
+      133,
+      171
+    ],
+    [
+      89,
+      130,
+      134,
+      135,
+      142,
+      150
+    ],
+    [
+      89,
+      130,
+      135,
+      159,
+      167
+    ],
+    [
+      89,
+      130,
+      136,
+      138,
+      141,
+      149
+    ],
+    [
+      89,
+      129,
+      130,
+      137
+    ],
+    [
+      89,
+      130,
+      138,
+      139
+    ],
+    [
+      89,
+      130,
+      140,
+      141
+    ],
+    [
+      89,
+      129,
+      130,
+      141
+    ],
+    [
+      89,
+      130,
+      141,
+      142,
+      143,
+      159,
+      170
+    ],
+    [
+      89,
+      130,
+      141,
+      142,
+      143,
+      156,
+      159,
+      162
+    ],
+    [
+      89,
+      130,
+      138,
+      141,
+      144,
+      149,
+      159,
+      170
+    ],
+    [
+      89,
+      130,
+      141,
+      142,
+      144,
+      145,
+      149,
+      159,
+      167,
+      170
+    ],
+    [
+      89,
+      130,
+      144,
+      146,
+      159,
+      167,
+      170
+    ],
+    [
+      87,
+      88,
+      89,
+      90,
+      91,
+      92,
+      93,
+      126,
+      127,
+      128,
+      129,
+      130,
+      131,
+      132,
+      133,
+      134,
+      135,
+      136,
+      137,
+      138,
+      139,
+      140,
+      141,
+      142,
+      143,
+      144,
+      145,
+      146,
+      147,
+      148,
+      149,
+      150,
+      151,
+      152,
+      153,
+      154,
+      155,
+      156,
+      157,
+      158,
+      159,
+      160,
+      161,
+      162,
+      163,
+      164,
+      165,
+      166,
+      167,
+      168,
+      169,
+      170,
+      171,
+      172,
+      173,
+      174,
+      175,
+      176
+    ],
+    [
+      89,
+      130,
+      141,
+      147
+    ],
+    [
+      89,
+      130,
+      148,
+      170,
+      175
+    ],
+    [
+      89,
+      130,
+      138,
+      141,
+      149,
+      159
+    ],
+    [
+      89,
+      130,
+      150
+    ],
+    [
+      89,
+      130,
+      151
+    ],
+    [
+      89,
+      129,
+      130,
+      152
+    ],
+    [
+      89,
+      130,
+      153,
+      169,
+      175
+    ],
+    [
+      89,
+      130,
+      154
+    ],
+    [
+      89,
+      130,
+      155
+    ],
+    [
+      89,
+      130,
+      141,
+      156,
+      157
+    ],
+    [
+      89,
+      130,
+      156,
+      158,
+      171,
+      173
+    ],
+    [
+      89,
+      130,
+      141,
+      159,
+      160,
+      162
+    ],
+    [
+      89,
+      130,
+      161,
+      162
+    ],
+    [
+      89,
+      130,
+      159,
+      160
+    ],
+    [
+      89,
+      130,
+      162
+    ],
+    [
+      89,
+      130,
+      163
+    ],
+    [
+      89,
+      130,
+      159,
+      164
+    ],
+    [
+      89,
+      130,
+      141,
+      165,
+      166
+    ],
+    [
+      89,
+      130,
+      165,
+      166
+    ],
+    [
+      89,
+      130,
+      135,
+      149,
+      159,
+      167
+    ],
+    [
+      89,
+      130,
+      168
+    ],
+    [
+      89,
+      130,
+      149,
+      169
+    ],
+    [
+      89,
+      130,
+      144,
+      155,
+      170
+    ],
+    [
+      89,
+      130,
+      135,
+      171
+    ],
+    [
+      89,
+      130,
+      159,
+      172
+    ],
+    [
+      89,
+      130,
+      148,
+      173
+    ],
+    [
+      89,
+      130,
+      174
+    ],
+    [
+      89,
+      125,
+      130
+    ],
+    [
+      89,
+      125,
+      130,
+      141,
+      143,
+      152,
+      159,
+      162,
+      170,
+      173,
+      175
+    ],
+    [
+      89,
+      130,
+      159,
+      176
+    ],
+    [
+      89,
+      102,
+      106,
+      130,
+      170
+    ],
+    [
+      89,
+      102,
+      130,
+      159,
+      170
+    ],
+    [
+      89,
+      97,
+      130
+    ],
+    [
+      89,
+      99,
+      102,
+      130,
+      167,
+      170
+    ],
+    [
+      89,
+      130,
+      149,
+      167
+    ],
+    [
+      89,
+      130,
+      177
+    ],
+    [
+      89,
+      97,
+      130,
+      177
+    ],
+    [
+      89,
+      99,
+      102,
+      130,
+      149,
+      170
+    ],
+    [
+      89,
+      94,
+      95,
+      98,
+      101,
+      130,
+      141,
+      159,
+      170
+    ],
+    [
+      89,
+      94,
+      100,
+      130
+    ],
+    [
+      89,
+      98,
+      102,
+      130,
+      162,
+      170,
+      177
+    ],
+    [
+      89,
+      118,
+      130,
+      177
+    ],
+    [
+      89,
+      96,
+      97,
+      130,
+      177
+    ],
+    [
+      89,
+      102,
+      130
+    ],
+    [
+      89,
+      96,
+      97,
+      98,
+      99,
+      100,
+      101,
+      102,
+      103,
+      104,
+      106,
+      107,
+      108,
+      109,
+      110,
+      111,
+      112,
+      113,
+      114,
+      115,
+      116,
+      117,
+      119,
+      120,
+      121,
+      122,
+      123,
+      124,
+      130
+    ],
+    [
+      89,
+      102,
+      109,
+      110,
+      130
+    ],
+    [
+      89,
+      100,
+      102,
+      110,
+      111,
+      130
+    ],
+    [
+      89,
+      101,
+      130
+    ],
+    [
+      89,
+      94,
+      97,
+      102,
+      130
+    ],
+    [
+      89,
+      102,
+      106,
+      110,
+      111,
+      130
+    ],
+    [
+      89,
+      106,
+      130
+    ],
+    [
+      89,
+      100,
+      102,
+      105,
+      130,
+      170
+    ],
+    [
+      89,
+      94,
+      99,
+      100,
+      102,
+      106,
+      109,
+      130
+    ],
+    [
+      89,
+      130,
+      159
+    ],
+    [
+      89,
+      97,
+      102,
+      118,
+      130,
+      175,
+      177
+    ],
+    [
+      65,
+      89,
+      130
+    ],
+    [
+      82,
+      89,
+      130
+    ],
+    [
+      65,
+      67,
+      89,
+      130
+    ],
+    [
+      64,
+      65,
+      67,
+      75,
+      78,
+      79,
+      80,
+      89,
+      130
+    ],
+    [
+      64,
+      65,
+      66,
+      67,
+      68,
+      69,
+      70,
+      71,
+      72,
+      73,
+      74,
+      75,
+      76,
+      81,
+      89,
+      130
+    ],
+    [
+      64,
+      65,
+      76,
+      77,
+      89,
+      130
+    ],
+    [
+      64,
+      89,
+      130
+    ],
+    [
+      65,
+      78,
+      89,
+      130
+    ]
+  ],
+  "fileInfos": [
+    {
+      "version": "c430d44666289dae81f30fa7b2edebf186ecc91a2d4c71266ea6ae76388792e1",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "45b7ab580deca34ae9729e97c13cfd999df04416a79116c3bfb483804f85ded4",
+      "impliedFormat": 1
+    },
+    {
+      "version": "3facaf05f0c5fc569c5649dd359892c98a85557e3e0c847964caeb67076f4d75",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e44bb8bbac7f10ecc786703fe0a6a4b952189f908707980ba8f3c8975a760962",
+      "impliedFormat": 1
+    },
+    {
+      "version": "5e1c4c362065a6b95ff952c0eab010f04dcd2c3494e813b493ecfd4fcb9fc0d8",
+      "impliedFormat": 1
+    },
+    {
+      "version": "68d73b4a11549f9c0b7d352d10e91e5dca8faa3322bfb77b661839c42b1ddec7",
+      "impliedFormat": 1
+    },
+    {
+      "version": "5efce4fc3c29ea84e8928f97adec086e3dc876365e0982cc8479a07954a3efd4",
+      "impliedFormat": 1
+    },
+    {
+      "version": "feecb1be483ed332fad555aff858affd90a48ab19ba7272ee084704eb7167569",
+      "impliedFormat": 1
+    },
+    {
+      "version": "ee7bad0c15b58988daa84371e0b89d313b762ab83cb5b31b8a2d1162e8eb41c2",
+      "impliedFormat": 1
+    },
+    {
+      "version": "080941d9f9ff9307f7e27a83bcd888b7c8270716c39af943532438932ec1d0b9",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "2e80ee7a49e8ac312cc11b77f1475804bee36b3b2bc896bead8b6e1266befb43",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "d7a3c8b952931daebdfc7a2897c53c0a1c73624593fa070e46bd537e64dcd20a",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "80e18897e5884b6723488d4f5652167e7bb5024f946743134ecc4aa4ee731f89",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "cd034f499c6cdca722b60c04b5b1b78e058487a7085a8e0d6fb50809947ee573",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "c57796738e7f83dbc4b8e65132f11a377649c00dd3eee333f672b8f0a6bea671",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "dc2df20b1bcdc8c2d34af4926e2c3ab15ffe1160a63e58b7e09833f616efff44",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "515d0b7b9bea2e31ea4ec968e9edd2c39d3eebf4a2d5cbd04e88639819ae3b71",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "0559b1f683ac7505ae451f9a96ce4c3c92bdc71411651ca6ddb0e88baaaad6a3",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "0dc1e7ceda9b8b9b455c3a2d67b0412feab00bd2f66656cd8850e8831b08b537",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "ce691fb9e5c64efb9547083e4a34091bcbe5bdb41027e310ebba8f7d96a98671",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "8d697a2a929a5fcb38b7a65594020fcef05ec1630804a33748829c5ff53640d0",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "4ff2a353abf8a80ee399af572debb8faab2d33ad38c4b4474cff7f26e7653b8d",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "fb0f136d372979348d59b3f5020b4cdb81b5504192b1cacff5d1fbba29378aa1",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "d15bea3d62cbbdb9797079416b8ac375ae99162a7fba5de2c6c505446486ac0a",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "68d18b664c9d32a7336a70235958b8997ebc1c3b8505f4f1ae2b7e7753b87618",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "eb3d66c8327153d8fa7dd03f9c58d351107fe824c79e9b56b462935176cdf12a",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "38f0219c9e23c915ef9790ab1d680440d95419ad264816fa15009a8851e79119",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "69ab18c3b76cd9b1be3d188eaf8bba06112ebbe2f47f6c322b5105a6fbc45a2e",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "a680117f487a4d2f30ea46f1b4b7f58bef1480456e18ba53ee85c2746eeca012",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "2f11ff796926e0832f9ae148008138ad583bd181899ab7dd768a2666700b1893",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "4de680d5bb41c17f7f68e0419412ca23c98d5749dcaaea1896172f06435891fc",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "954296b30da6d508a104a3a0b5d96b76495c709785c1d11610908e63481ee667",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "ac9538681b19688c8eae65811b329d3744af679e0bdfa5d842d0e32524c73e1c",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "0a969edff4bd52585473d24995c5ef223f6652d6ef46193309b3921d65dd4376",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "9e9fbd7030c440b33d021da145d3232984c8bb7916f277e8ffd3dc2e3eae2bdb",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "811ec78f7fefcabbda4bfa93b3eb67d9ae166ef95f9bff989d964061cbf81a0c",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "717937616a17072082152a2ef351cb51f98802fb4b2fdabd32399843875974ca",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "d7e7d9b7b50e5f22c915b525acc5a49a7a6584cf8f62d0569e557c5cfc4b2ac2",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "71c37f4c9543f31dfced6c7840e068c5a5aacb7b89111a4364b1d5276b852557",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "576711e016cf4f1804676043e6a0a5414252560eb57de9faceee34d79798c850",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "89c1b1281ba7b8a96efc676b11b264de7a8374c5ea1e6617f11880a13fc56dc6",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "74f7fa2d027d5b33eb0471c8e82a6c87216223181ec31247c357a3e8e2fddc5b",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "d6d7ae4d1f1f3772e2a3cde568ed08991a8ae34a080ff1151af28b7f798e22ca",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "063600664504610fe3e99b717a1223f8b1900087fab0b4cad1496a114744f8df",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "934019d7e3c81950f9a8426d093458b65d5aff2c7c1511233c0fd5b941e608ab",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "52ada8e0b6e0482b728070b7639ee42e83a9b1c22d205992756fe020fd9f4a47",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "3bdefe1bfd4d6dee0e26f928f93ccc128f1b64d5d501ff4a8cf3c6371200e5e6",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "59fb2c069260b4ba00b5643b907ef5d5341b167e7d1dbf58dfd895658bda2867",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "639e512c0dfc3fad96a84caad71b8834d66329a1f28dc95e3946c9b58176c73a",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "368af93f74c9c932edd84c58883e736c9e3d53cec1fe24c0b0ff451f529ceab1",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "af3dd424cf267428f30ccfc376f47a2c0114546b55c44d8c0f1d57d841e28d74",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "995c005ab91a498455ea8dfb63aa9f83fa2ea793c3d8aa344be4a1678d06d399",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "959d36cddf5e7d572a65045b876f2956c973a586da58e5d26cde519184fd9b8a",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "965f36eae237dd74e6cca203a43e9ca801ce38824ead814728a2807b1910117d",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "3925a6c820dcb1a06506c90b1577db1fdbf7705d65b62b99dce4be75c637e26b",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "0a3d63ef2b853447ec4f749d3f368ce642264246e02911fcb1590d8c161b8005",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "8cdf8847677ac7d20486e54dd3fcf09eda95812ac8ace44b4418da1bbbab6eb8",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "8444af78980e3b20b49324f4a16ba35024fef3ee069a0eb67616ea6ca821c47a",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "3287d9d085fbd618c3971944b65b4be57859f5415f495b33a6adc994edd2f004",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "b4b67b1a91182421f5df999988c690f14d813b9850b40acd06ed44691f6727ad",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "8e7f8264d0fb4c5339605a15daadb037bf238c10b654bb3eee14208f860a32ea",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "782dec38049b92d4e85c1585fbea5474a219c6984a35b004963b00beb1aab538",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "3cbad9a1ba4453443026ed38e4b8be018abb26565fa7c944376463ad9df07c41",
+      "impliedFormat": 1
+    },
+    {
+      "version": "7da208e2711b2e64d423f73b4c46721ab1ac5435b5041d44e18d29825bac5b81",
+      "signature": "9229744ea25e18a192f5953aa3b3f455d70eef16856888369b4a6979d0d96bae",
+      "impliedFormat": 99
+    },
+    {
+      "version": "0b4685a0c69c7ab795023807772afb511b9d9083f7eff895b83f3d0b48fc0367",
+      "signature": "0e6d650b36284c011b3d95bf35c1bb0a8595c043c104fa3969f2ae60f087a20c",
+      "impliedFormat": 99
+    },
+    {
+      "version": "eddf149fd995882b2e5f40425f7f4e10372fad7643a430ddc5395a785678d7e3",
+      "signature": "6dbb943e2651b8adaff2f73dada2bc506876926ae1a8e4dfc97d217408c98c3c",
+      "impliedFormat": 99
+    },
+    {
+      "version": "1898267e95a6abe9948dd879bd6c8e3640f1325f3a4fed45239ca68be0cc1b01",
+      "signature": "bc82f0deae147bb18c9e9a3b015f62994ed76122e09d06e3e2cce4f6b1b2c945",
+      "impliedFormat": 99
+    },
+    {
+      "version": "2bd6a405774e5f9ec870a03bd8d7c8a91f6fc206ce2bd93539b53e509ad4802b",
+      "signature": "f17daf0c5d1f20be1f983d0447e8aece97fdc198c9fa81ebe601f9e42dd1b321",
+      "impliedFormat": 99
+    },
+    {
+      "version": "2d0b8b809746cb205667d4eb4bf879018bf19b17f74870184fa10932c22785f9",
+      "signature": "0e7de46779b62e113b2266811b6d5c5f20b693d50d844447d09c6f203929a348",
+      "impliedFormat": 99
+    },
+    {
+      "version": "c7933bf2420226d46658700726752f52c6605a9a61df1a88aad7b5443d5f6534",
+      "signature": "08b97f852e158ac5d2eaa7f9e375cb74f95b044ca056b0229133b8bd80b1a5d2",
+      "impliedFormat": 99
+    },
+    {
+      "version": "7e2e1686fe75cb85541d6de4eee027c646796e2b26c2572fe6b7f525c2598139",
+      "signature": "f510cb6b6494801377cfe8acf3aeebfc94a552490a49da49f68656fc28a51ad6",
+      "impliedFormat": 99
+    },
+    {
+      "version": "5f054400971765f8d4172db3f820d57f9caef611143f7d16397a05de84633b3f",
+      "signature": "d1d300d88d14b034e0904ee5fffb82d348604e876b872a1fbb6ebcea0e00149a",
+      "impliedFormat": 99
+    },
+    {
+      "version": "fbb3c9bd5ff6c778897f7d012c5a0b9d5fef4dd7801df5e5b6f3497f483c9c0e",
+      "signature": "56ea81afc382c20b1146a4a0a31f99c430024e554e1e2192fa561b2b9a6bbd00",
+      "impliedFormat": 99
+    },
+    {
+      "version": "8d967fb174d97544dd5eaa171379461ef59b270fe46db3537fce41f9a1007c2c",
+      "signature": "62cf651f9b9b298228a5b0ffd02e9441615996f2a06e783faae3a455aa4165d9",
+      "impliedFormat": 99
+    },
+    {
+      "version": "01edbf8abf3eee6139eef3af98e304eb38a79b440632cc50d41db5107bca1743",
+      "signature": "ca37646b3fe21707e0d7c3c3276971c58105fb7abe98230b73f1fa85628300c3",
+      "impliedFormat": 99
+    },
+    {
+      "version": "da8b85075ee3ce12be8e3a36767c021a18c0582684ed4daba3615151b14a298e",
+      "signature": "155be70478040379afa4b43bcb26f95383a0014c76f5cde69db9ac40720d414e",
+      "impliedFormat": 99
+    },
+    {
+      "version": "ad64ecc475834063c69600c6f74fd45f44cc44efe4e09c31288127d5d6bc0323",
+      "signature": "5a38e9985228fc798c51f24c8a4ef04755597764157a4055e94d35655dc42b91",
+      "impliedFormat": 99
+    },
+    {
+      "version": "b579d99fc984d1bf8358dfa163cf7a0cf98079b68f00200fa331eda03c268c87",
+      "signature": "ea7a4c459a854a07a95327da63a758579e7dc395c38e7071de883fe8950faca4",
+      "impliedFormat": 99
+    },
+    {
+      "version": "8b00e3996581f165017fa2dd90e0d4b86d8accd778de8cc3accb5773af220bb0",
+      "signature": "558693d92f7acea5102845dc45d21dc6060acc6e030468147b719cfb980507cb",
+      "impliedFormat": 99
+    },
+    {
+      "version": "cd9510bd4615cf4515a682c6896f2ac17988aa41c89f4788cd1839b6d88a86be",
+      "signature": "d606028b15b3800b938359891e505be4e8644030811da5266322fc5f6e9c7d79",
+      "impliedFormat": 99
+    },
+    {
+      "version": "3394b43e7db61cd4bc2c100104220169f7bf8c29554888bb6fdbbe26770d9caf",
+      "signature": "42329453761bfa2d6a67ca90444adc84b060d6a1812875eb01cef229a07222e2",
+      "impliedFormat": 99
+    },
+    {
+      "version": "c5f8e685338625947ba3feb066c837555f7d7818b73a0fcbfb55b33721a0eb2e",
+      "signature": "1198616d56d92757e6f104cf7b67dd5fc1a97bbb1646f0935ef97b3c88295865",
+      "impliedFormat": 99
+    },
+    {
+      "version": "6a2809e96ba1a4cb70d8df5a4dafe4daffc00ec186bcc59206d55c5e28ddeabc",
+      "signature": "8e609bb71c20b858c77f0e9f90bb1319db8477b13f9f965f1a1e18524bf50881",
+      "impliedFormat": 99
+    },
+    {
+      "version": "6c7176368037af28cb72f2392010fa1cef295d6d6744bca8cfb54985f3a18c3e",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "ab41ef1f2cdafb8df48be20cd969d875602483859dc194e9c97c8a576892c052",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "437e20f2ba32abaeb7985e0afe0002de1917bc74e949ba585e49feba65da6ca1",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "21d819c173c0cf7cc3ce57c3276e77fd9a8a01d35a06ad87158781515c9a438a",
+      "impliedFormat": 1
+    },
+    {
+      "version": "a79e62f1e20467e11a904399b8b18b18c0c6eea6b50c1168bf215356d5bebfaf",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "32cb3140d0e9cee0aea7264fd6a1d297394052a18eb05ca0220d133e6c043fb5",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "362d474eb9feae178a83ead94d757c21e42d6d7090e4182f0c12e92830a3d25e",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "1db0b7dca579049ca4193d034d835f6bfe73096c73663e5ef9a0b5779939f3d0",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "9798340ffb0d067d69b1ae5b32faa17ab31b82466a3fc00d8f2f2df0c8554aaa",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "dc27badd4bf4a2b0024a0cd32a9bbf0be7073902c5177a58be14242e7d8bf2c7",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "5929864ce17fba74232584d90cb721a89b7ad277220627cc97054ba15a98ea8f",
+      "impliedFormat": 1
+    },
+    {
+      "version": "7180c03fd3cb6e22f911ce9ba0f8a7008b1a6ddbe88ccf16a9c8140ef9ac1686",
+      "impliedFormat": 1
+    },
+    {
+      "version": "25c8056edf4314820382a5fdb4bb7816999acdcb929c8f75e3f39473b87e85bc",
+      "impliedFormat": 1
+    },
+    {
+      "version": "54cb85a47d760da1c13c00add10d26b5118280d44d58e6908d8e89abbd9d7725",
+      "impliedFormat": 1
+    },
+    {
+      "version": "3e4825171442666d31c845aeb47fcd34b62e14041bb353ae2b874285d78482aa",
+      "impliedFormat": 1
+    },
+    {
+      "version": "c6fd2c5a395f2432786c9cb8deb870b9b0e8ff7e22c029954fabdd692bff6195",
+      "impliedFormat": 1
+    },
+    {
+      "version": "a967bfe3ad4e62243eb604bf956101e4c740f5921277c60debaf325c1320bf88",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e9775e97ac4877aebf963a0289c81abe76d1ec9a2a7778dbe637e5151f25c5f3",
+      "impliedFormat": 1
+    },
+    {
+      "version": "471e1da5a78350bc55ef8cef24eb3aca6174143c281b8b214ca2beda51f5e04a",
+      "impliedFormat": 1
+    },
+    {
+      "version": "cadc8aced301244057c4e7e73fbcae534b0f5b12a37b150d80e5a45aa4bebcbd",
+      "impliedFormat": 1
+    },
+    {
+      "version": "385aab901643aa54e1c36f5ef3107913b10d1b5bb8cbcd933d4263b80a0d7f20",
+      "impliedFormat": 1
+    },
+    {
+      "version": "9670d44354bab9d9982eca21945686b5c24a3f893db73c0dae0fd74217a4c219",
+      "impliedFormat": 1
+    },
+    {
+      "version": "db3435f3525cd785bf21ec6769bf8da7e8a776be1a99e2e7efb5f244a2ef5fee",
+      "impliedFormat": 1
+    },
+    {
+      "version": "c3b170c45fc031db31f782e612adf7314b167e60439d304b49e704010e7bafe5",
+      "impliedFormat": 1
+    },
+    {
+      "version": "40383ebef22b943d503c6ce2cb2e060282936b952a01bea5f9f493d5fb487cc7",
+      "impliedFormat": 1
+    },
+    {
+      "version": "4893a895ea92c85345017a04ed427cbd6a1710453338df26881a6019432febdd",
+      "impliedFormat": 1
+    },
+    {
+      "version": "3a84b7cb891141824bd00ef8a50b6a44596aded4075da937f180c90e362fe5f6",
+      "impliedFormat": 1
+    },
+    {
+      "version": "13f6f39e12b1518c6650bbb220c8985999020fe0f21d818e28f512b7771d00f9",
+      "impliedFormat": 1
+    },
+    {
+      "version": "9b5369969f6e7175740bf51223112ff209f94ba43ecd3bb09eefff9fd675624a",
+      "impliedFormat": 1
+    },
+    {
+      "version": "4fe9e626e7164748e8769bbf74b538e09607f07ed17c2f20af8d680ee49fc1da",
+      "impliedFormat": 1
+    },
+    {
+      "version": "24515859bc0b836719105bb6cc3d68255042a9f02a6022b3187948b204946bd2",
+      "impliedFormat": 1
+    },
+    {
+      "version": "33203609eba548914dc83ddf6cadbc0bcb6e8ef89f6d648ca0908ae887f9fcc5",
+      "impliedFormat": 1
+    },
+    {
+      "version": "0db18c6e78ea846316c012478888f33c11ffadab9efd1cc8bcc12daded7a60b6",
+      "impliedFormat": 1
+    },
+    {
+      "version": "89167d696a849fce5ca508032aabfe901c0868f833a8625d5a9c6e861ef935d2",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e53a3c2a9f624d90f24bf4588aacd223e7bec1b9d0d479b68d2f4a9e6011147f",
+      "impliedFormat": 1
+    },
+    {
+      "version": "339dc5265ee5ed92e536a93a04c4ebbc2128f45eeec6ed29f379e0085283542c",
+      "impliedFormat": 1
+    },
+    {
+      "version": "9f0a92164925aa37d4a5d9dd3e0134cff8177208dba55fd2310cd74beea40ee2",
+      "impliedFormat": 1
+    },
+    {
+      "version": "8bfdb79bf1a9d435ec48d9372dc93291161f152c0865b81fc0b2694aedb4578d",
+      "impliedFormat": 1
+    },
+    {
+      "version": "2e85db9e6fd73cfa3d7f28e0ab6b55417ea18931423bd47b409a96e4a169e8e6",
+      "impliedFormat": 1
+    },
+    {
+      "version": "c46e079fe54c76f95c67fb89081b3e399da2c7d109e7dca8e4b58d83e332e605",
+      "impliedFormat": 1
+    },
+    {
+      "version": "d32275be3546f252e3ad33976caf8c5e842c09cb87d468cb40d5f4cf092d1acc",
+      "impliedFormat": 1
+    },
+    {
+      "version": "4a0c3504813a3289f7fb1115db13967c8e004aa8e4f8a9021b95285502221bd1",
+      "impliedFormat": 1
+    },
+    {
+      "version": "b972357e61ef2e072f8a88b9f4f5a70984c417237e6106f6b2390414a09ce523",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "076cac5898bd833255def0f7c5717b83534212873505c9c958f1926d49f9bec6",
+      "impliedFormat": 1
+    },
+    {
+      "version": "7394959e5a741b185456e1ef5d64599c36c60a323207450991e7a42e08911419",
+      "impliedFormat": 1
+    },
+    {
+      "version": "75eb536b960b85f75e21490beeab53ea616646a995ad203e1af532d67a774fb6",
+      "impliedFormat": 1
+    },
+    {
+      "version": "36d0976d3dad74078f707af107b5082dbe42ffcadb3442ff140c36c8a33b4887",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "86e0d632e9ef88593e8724ffb6af05104e13a08f9d8df733a30f9991ac387fff",
+      "impliedFormat": 1
+    },
+    {
+      "version": "7646ad748a9ca15bf43d4c88f83cc851c67f8ec9c1186295605b59ba6bb36dcb",
+      "impliedFormat": 1
+    },
+    {
+      "version": "cef8931bc129687165253f0642427c2a72705a4613b3ac461b9fa78c7cdaef32",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "5524481e56c48ff486f42926778c0a3cce1cc85dc46683b92b1271865bcf015a",
+      "impliedFormat": 1
+    },
+    {
+      "version": "47b62c294beb69daa5879f052e416b02e6518f3e4541ae98adbfb27805dd6711",
+      "impliedFormat": 1
+    },
+    {
+      "version": "f8375506002c556ec412c7e2a5a9ece401079ee5d9eb2c1372e9f5377fac56c7",
+      "impliedFormat": 1
+    },
+    {
+      "version": "8edd6482bd72eca772f9df15d05c838dd688cdbd4d62690891fca6578cfda6fe",
+      "impliedFormat": 1
+    },
+    {
+      "version": "07ba29a1a495b710aea48a4cf19ae12b3cbda2a8e9ac62192af477027a99e8de",
+      "impliedFormat": 1
+    },
+    {
+      "version": "6dead64c944504250dd2fc9095231f36887cfc1534f1ff57737c19f92d165c91",
+      "impliedFormat": 1
+    },
+    {
+      "version": "b9a4824bb83f25d6d227394db2ed99985308cf2a3a35f0d6d39aa72b15473982",
+      "impliedFormat": 1
+    },
+    {
+      "version": "6e9948b1e396106601365283680c319a9103c71a5725e7d03e26fe246df60c4c",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "8e8e284b3832911aeede987e4d74cf0a00f2b03896b2fd3bf924344cc0f96b3c",
+      "impliedFormat": 1
+    },
+    {
+      "version": "37d37474a969ab1b91fc332eb6a375885dfd25279624dfa84dea48c9aedf4472",
+      "impliedFormat": 1
+    },
+    {
+      "version": "1ddd8c1a3ae1f8ab28affd53b13910be4afe0b35f28517b7f14c268e9e42647a",
+      "impliedFormat": 1
+    },
+    {
+      "version": "f1a79b6047d006548185e55478837dfbcdd234d6fe51532783f5dffd401cfb2b",
+      "impliedFormat": 1
+    },
+    {
+      "version": "cbc91187014fb1e738ef252751a9f84abf2989ec1c3b1637ec23b5b39cdf3d25",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e822320b448edce0c7ede9cbeada034c72e1f1c8c8281974817030564c63dcb1",
+      "impliedFormat": 1
+    },
+    {
+      "version": "9d65568cba17c9db40251023406668695ad698ea4a34542364af3e78edd37811",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "f23e3d484de54d235bf702072100b541553a1df2550bad691fe84995e15cf7be",
+      "impliedFormat": 1
+    },
+    {
+      "version": "821c79b046e40d54a447bebd9307e70b86399a89980a87bbc98114411169e274",
+      "impliedFormat": 1
+    },
+    {
+      "version": "17bc38afc78d40b2f54af216c0cc31a4bd0c6897a5945fa39945dfc43260be2c",
+      "impliedFormat": 1
+    },
+    {
+      "version": "d201b44ff390c220a94fb0ff6a534fe9fa15b44f8a86d0470009cdde3a3e62ab",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "d44445141f204d5672c502a39c1124bcf1df225eba05df0d2957f79122be87b5",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "de905bc5f7e7a81cb420e212b95ab5e3ab840f93e0cfa8ce879f6e7fa465d4a2",
+      "impliedFormat": 1
+    },
+    {
+      "version": "bc2ff43214898bc6d53cab92fb41b5309efec9cbb59a0650525980aee994de2b",
+      "impliedFormat": 1
+    },
+    {
+      "version": "bede3143eeddca3b8ec3592b09d7eb02042f9e195251040c5146eac09b173236",
+      "impliedFormat": 1
+    },
+    {
+      "version": "64a40cf4ec8a7a29db2b4bc35f042e5be8537c4be316e5221f40f30ca8ed7051",
+      "impliedFormat": 1
+    },
+    {
+      "version": "294c082d609e6523520290db4f1d54114ebc83643fb42abd965be5bcc5d9416b",
+      "impliedFormat": 1
+    },
+    {
+      "version": "cf7d740e39bd8adbdc7840ee91bef0af489052f6467edfcefb7197921757ec3b",
+      "impliedFormat": 1
+    },
+    {
+      "version": "37ba7b45141a45ce6e80e66f2a96c8a5ab1bcef0fc2d0f56bb58df96ec67e972",
+      "impliedFormat": 1
+    },
+    {
+      "version": "125d792ec6c0c0f657d758055c494301cc5fdb327d9d9d5960b3f129aff76093",
+      "impliedFormat": 1
+    },
+    {
+      "version": "b9f0681c4d2cb00a5cfe08a7be9662627b912de562926819ebddfe2ef6a9b5ee",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "b85151402164ab7cb665e58df5c1a29aa25ea4ed3a367f84a15589e7d7a9c8ca",
+      "impliedFormat": 1
+    },
+    {
+      "version": "89eb8abe2b5c146fbb8f3bf72f4e91de3541f2fb559ad5fed4ad5bf223a3dedb",
+      "impliedFormat": 1
+    },
+    {
+      "version": "bc6cb10764a82f3025c0f4822b8ad711c16d1a5c75789be2d188d553b69b2d48",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "41d510caf7ed692923cb6ef5932dc9cf1ed0f57de8eb518c5bab8358a21af674",
+      "impliedFormat": 1
+    },
+    {
+      "version": "2751c5a6b9054b61c9b03b3770b2d39b1327564672b63e3485ac03ffeb28b4f6",
+      "impliedFormat": 1
+    },
+    {
+      "version": "dc058956a93388aab38307b7b3b9b6379e1021e73a244aab6ac9427dc3a252a7",
+      "impliedFormat": 1
+    },
+    {
+      "version": "f33302cf240672359992c356f2005d395b559e176196d03f31a28cc7b01e69bc",
+      "impliedFormat": 1
+    },
+    {
+      "version": "3ce25041ff6ae06c08fcaccd5fcd9baf4ca6e80e6cb5a922773a1985672e74c2",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "652c0de14329a834ff06af6ad44670fac35849654a464fd9ae36edb92a362c12",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "3b1e178016d3fc554505ae087c249b205b1c50624d482c542be9d4682bab81fc",
+      "impliedFormat": 1
+    },
+    {
+      "version": "5db7c5bb02ef47aaaec6d262d50c4e9355c80937d649365c343fa5e84569621d",
+      "impliedFormat": 1
+    },
+    {
+      "version": "cf45d0510b661f1da461479851ff902f188edb111777c37055eff12fa986a23a",
+      "impliedFormat": 1
+    },
+    {
+      "version": "6831f13f06a15391dfeb2477d48ac58311ab675f85846a05499ee92d6e856933",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "37bef1064b7d015aeaa7c0716fe23a0b3844abe2c0a3df7144153ca8445fe0da",
+      "impliedFormat": 1
+    },
+    {
+      "version": "83178a1174286d5f5178c5c75067e36c41b975c26be7b86d99cb18393eb30a41",
+      "impliedFormat": 1
+    }
+  ],
+  "root": [
+    [
+      64,
+      83
+    ]
+  ],
+  "options": {
+    "allowImportingTsExtensions": false,
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "module": 199,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": 9
+  },
+  "referencedMap": [
+    [
+      127,
+      1
+    ],
+    [
+      128,
+      1
+    ],
+    [
+      129,
+      2
+    ],
+    [
+      89,
+      3
+    ],
+    [
+      130,
+      4
+    ],
+    [
+      131,
+      5
+    ],
+    [
+      132,
+      6
+    ],
+    [
+      84,
+      7
+    ],
+    [
+      87,
+      8
+    ],
+    [
+      85,
+      7
+    ],
+    [
+      86,
+      7
+    ],
+    [
+      133,
+      9
+    ],
+    [
+      134,
+      10
+    ],
+    [
+      135,
+      11
+    ],
+    [
+      136,
+      12
+    ],
+    [
+      137,
+      13
+    ],
+    [
+      138,
+      14
+    ],
+    [
+      139,
+      14
+    ],
+    [
+      140,
+      15
+    ],
+    [
+      141,
+      16
+    ],
+    [
+      142,
+      17
+    ],
+    [
+      143,
+      18
+    ],
+    [
+      90,
+      7
+    ],
+    [
+      88,
+      7
+    ],
+    [
+      144,
+      19
+    ],
+    [
+      145,
+      20
+    ],
+    [
+      146,
+      21
+    ],
+    [
+      177,
+      22
+    ],
+    [
+      147,
+      23
+    ],
+    [
+      148,
+      24
+    ],
+    [
+      149,
+      25
+    ],
+    [
+      150,
+      26
+    ],
+    [
+      151,
+      27
+    ],
+    [
+      152,
+      28
+    ],
+    [
+      153,
+      29
+    ],
+    [
+      154,
+      30
+    ],
+    [
+      155,
+      31
+    ],
+    [
+      156,
+      32
+    ],
+    [
+      157,
+      32
+    ],
+    [
+      158,
+      33
+    ],
+    [
+      159,
+      34
+    ],
+    [
+      161,
+      35
+    ],
+    [
+      160,
+      36
+    ],
+    [
+      162,
+      37
+    ],
+    [
+      163,
+      38
+    ],
+    [
+      164,
+      39
+    ],
+    [
+      165,
+      40
+    ],
+    [
+      166,
+      41
+    ],
+    [
+      167,
+      42
+    ],
+    [
+      168,
+      43
+    ],
+    [
+      169,
+      44
+    ],
+    [
+      170,
+      45
+    ],
+    [
+      171,
+      46
+    ],
+    [
+      172,
+      47
+    ],
+    [
+      173,
+      48
+    ],
+    [
+      174,
+      49
+    ],
+    [
+      91,
+      7
+    ],
+    [
+      92,
+      7
+    ],
+    [
+      93,
+      7
+    ],
+    [
+      126,
+      50
+    ],
+    [
+      175,
+      51
+    ],
+    [
+      176,
+      52
+    ],
+    [
+      61,
+      7
+    ],
+    [
+      62,
+      7
+    ],
+    [
+      12,
+      7
+    ],
+    [
+      10,
+      7
+    ],
+    [
+      11,
+      7
+    ],
+    [
+      16,
+      7
+    ],
+    [
+      15,
+      7
+    ],
+    [
+      2,
+      7
+    ],
+    [
+      17,
+      7
+    ],
+    [
+      18,
+      7
+    ],
+    [
+      19,
+      7
+    ],
+    [
+      20,
+      7
+    ],
+    [
+      21,
+      7
+    ],
+    [
+      22,
+      7
+    ],
+    [
+      23,
+      7
+    ],
+    [
+      24,
+      7
+    ],
+    [
+      3,
+      7
+    ],
+    [
+      25,
+      7
+    ],
+    [
+      26,
+      7
+    ],
+    [
+      4,
+      7
+    ],
+    [
+      27,
+      7
+    ],
+    [
+      31,
+      7
+    ],
+    [
+      28,
+      7
+    ],
+    [
+      29,
+      7
+    ],
+    [
+      30,
+      7
+    ],
+    [
+      32,
+      7
+    ],
+    [
+      33,
+      7
+    ],
+    [
+      34,
+      7
+    ],
+    [
+      5,
+      7
+    ],
+    [
+      35,
+      7
+    ],
+    [
+      36,
+      7
+    ],
+    [
+      37,
+      7
+    ],
+    [
+      38,
+      7
+    ],
+    [
+      6,
+      7
+    ],
+    [
+      42,
+      7
+    ],
+    [
+      39,
+      7
+    ],
+    [
+      40,
+      7
+    ],
+    [
+      41,
+      7
+    ],
+    [
+      43,
+      7
+    ],
+    [
+      7,
+      7
+    ],
+    [
+      44,
+      7
+    ],
+    [
+      49,
+      7
+    ],
+    [
+      50,
+      7
+    ],
+    [
+      45,
+      7
+    ],
+    [
+      46,
+      7
+    ],
+    [
+      47,
+      7
+    ],
+    [
+      48,
+      7
+    ],
+    [
+      8,
+      7
+    ],
+    [
+      54,
+      7
+    ],
+    [
+      51,
+      7
+    ],
+    [
+      52,
+      7
+    ],
+    [
+      53,
+      7
+    ],
+    [
+      55,
+      7
+    ],
+    [
+      9,
+      7
+    ],
+    [
+      56,
+      7
+    ],
+    [
+      63,
+      7
+    ],
+    [
+      57,
+      7
+    ],
+    [
+      58,
+      7
+    ],
+    [
+      60,
+      7
+    ],
+    [
+      59,
+      7
+    ],
+    [
+      1,
+      7
+    ],
+    [
+      14,
+      7
+    ],
+    [
+      13,
+      7
+    ],
+    [
+      109,
+      53
+    ],
+    [
+      116,
+      54
+    ],
+    [
+      108,
+      53
+    ],
+    [
+      123,
+      55
+    ],
+    [
+      100,
+      56
+    ],
+    [
+      99,
+      57
+    ],
+    [
+      122,
+      58
+    ],
+    [
+      117,
+      59
+    ],
+    [
+      120,
+      60
+    ],
+    [
+      102,
+      61
+    ],
+    [
+      101,
+      62
+    ],
+    [
+      97,
+      63
+    ],
+    [
+      96,
+      58
+    ],
+    [
+      119,
+      64
+    ],
+    [
+      98,
+      65
+    ],
+    [
+      103,
+      66
+    ],
+    [
+      104,
+      7
+    ],
+    [
+      107,
+      66
+    ],
+    [
+      94,
+      7
+    ],
+    [
+      125,
+      67
+    ],
+    [
+      124,
+      66
+    ],
+    [
+      111,
+      68
+    ],
+    [
+      112,
+      69
+    ],
+    [
+      114,
+      70
+    ],
+    [
+      110,
+      71
+    ],
+    [
+      113,
+      72
+    ],
+    [
+      118,
+      58
+    ],
+    [
+      105,
+      73
+    ],
+    [
+      106,
+      74
+    ],
+    [
+      115,
+      75
+    ],
+    [
+      95,
+      76
+    ],
+    [
+      121,
+      77
+    ],
+    [
+      66,
+      78
+    ],
+    [
+      83,
+      79
+    ],
+    [
+      76,
+      78
+    ],
+    [
+      68,
+      80
+    ],
+    [
+      81,
+      81
+    ],
+    [
+      69,
+      78
+    ],
+    [
+      72,
+      78
+    ],
+    [
+      82,
+      82
+    ],
+    [
+      70,
+      78
+    ],
+    [
+      64,
+      7
+    ],
+    [
+      73,
+      78
+    ],
+    [
+      78,
+      83
+    ],
+    [
+      74,
+      78
+    ],
+    [
+      71,
+      78
+    ],
+    [
+      75,
+      7
+    ],
+    [
+      65,
+      84
+    ],
+    [
+      80,
+      7
+    ],
+    [
+      77,
+      85
+    ],
+    [
+      79,
+      85
+    ],
+    [
+      67,
+      78
+    ]
+  ],
+  "latestChangedDtsFile": "./dist/api.type-test.d.ts",
+  "version": "5.9.3"
+}

--- a/packages/serve/src/pipeline.ts
+++ b/packages/serve/src/pipeline.ts
@@ -20,12 +20,8 @@ import type {
   TenantConfigOverride,
   MaybePromise,
 } from './types.js';
-import { createTenantScope, warnTenantMisconfiguration } from './tenant.js';
-import {
-  attachSemanticRuntime,
-  attachSemanticTenantRuntime,
-  resolveSemanticExecutionRuntime,
-} from './semantic/query-builder-context.js';
+import { warnTenantMisconfiguration } from './tenant.js';
+import { applySemanticTenantRuntime } from './semantic/utils/tenant-runtime.js';
 import { generateRequestId } from './utils.js';
 import { buildOpenApiDocument } from './openapi.js';
 import { buildDocsHtml } from './docs-ui.js';
@@ -92,7 +88,7 @@ const resolveTenantConfig = <TAuth extends AuthContext>(
       500,
       'INTERNAL_SERVER_ERROR',
       '[hypequery/serve] Tenant override requires an extract function when no global tenant config is set. ' +
-        'If you are using tenantOptional(), define a global tenant config with extract or pass extract in the per-query override.',
+      'If you are using tenantOptional(), define a global tenant config with extract or pass extract in the per-query override.',
     );
   }
 
@@ -336,10 +332,10 @@ export const executeEndpoint = async <
     if (!authContext && requiresAuth) {
       const authErrorInfo = authResult.error
         ? {
-            reason: authResult.error.reason,
-            message: authResult.error.message,
-            details: authResult.error.details,
-          }
+          reason: authResult.error.reason,
+          message: authResult.error.message,
+          details: authResult.error.details,
+        }
         : undefined;
       await safeInvokeHook('onAuthFailure', hooks.onAuthFailure, {
         requestId,
@@ -429,56 +425,13 @@ export const executeEndpoint = async <
         context.tenantId = tenantId;
         const mode = activeTenantConfig.mode ?? 'manual';
         const column = activeTenantConfig.column;
-        const usesServeTenantRuntime = Boolean(
-          metadataWithAuth.custom && (metadataWithAuth.custom as Record<string, unknown>).usesServeTenantRuntime,
-        );
-        const semanticRuntime = resolveSemanticExecutionRuntime(context as Record<string, unknown>);
-
-        if (mode === 'auto-inject' && column && semanticRuntime?.builderFactory) {
-          Object.assign(
-            context,
-            attachSemanticRuntime(context as Record<string, unknown>, {
-              builderFactory: createTenantScope(semanticRuntime.builderFactory, {
-                tenantId,
-                column,
-              }),
-              tenant: {
-                id: tenantId,
-                column,
-                handledByBuilder: true,
-              },
-            }),
-          );
-        } else {
-          Object.assign(
-            context,
-            attachSemanticTenantRuntime(context as Record<string, unknown>, {
-              tenantId,
-              tenantColumn: column,
-              tenantHandledByBuilder: false,
-            }),
-          );
-        }
-
-        if (mode === 'auto-inject' && column) {
-          const contextValues = context as Record<string, unknown>;
-          for (const key of Object.keys(contextValues)) {
-            const value = contextValues[key];
-            if (value && typeof value === 'object' && 'table' in value && typeof (value as any).table === 'function') {
-              contextValues[key] = createTenantScope(value as { table: (name: string) => any }, {
-                tenantId,
-                column,
-              });
-            }
-          }
-        } else if (mode === 'manual' && !usesServeTenantRuntime) {
-          warnTenantMisconfiguration({
-            queryKey: endpoint.key,
-            hasTenantConfig: true,
-            hasTenantId: true,
-            mode: 'manual',
-          });
-        }
+        applySemanticTenantRuntime(context as Record<string, unknown> & { tenantId?: string }, {
+          queryKey: endpoint.key,
+          metadata: metadataWithAuth,
+          tenantId,
+          mode,
+          column,
+        });
       } else if (!tenantRequired) {
         warnTenantMisconfiguration({
           queryKey: endpoint.key,

--- a/packages/serve/src/semantic/datasets/dataset-endpoint.ts
+++ b/packages/serve/src/semantic/datasets/dataset-endpoint.ts
@@ -12,32 +12,32 @@
 import { z } from 'zod';
 import type {
   AuthContext,
-  AuthStrategy,
   EndpointHandler,
   EndpointMetadata,
   ServeEndpoint,
   ServeMiddleware,
-  TenantConfigOverride,
 } from '../../types.js';
 import type {
-  DatasetInstance,
-  MetricFilter,
   TimeGrain,
   QueryBuilderFactoryLike,
-  ValidationResult,
-} from '@hypequery/datasets';
-import {
-  applyMeasureDefinition,
-  appendOrderLimitOffset,
-  buildDimensionSelectionPlan,
-  resolveFilterField,
-  validateFilterValue,
 } from '@hypequery/datasets';
 import { ServeHttpError } from '../../errors.js';
 import {
   resolveSemanticExecutionRuntime,
   resolveSemanticQueryBuilder,
+  resolveSemanticTenantHandledByBuilder,
 } from '../query-builder-context.js';
+import {
+  applyMeasureDefinition,
+  appendOrderLimitOffset,
+  buildDimensionSelectionPlan,
+  resolveFilterField,
+} from './query-planner.js';
+import { buildDatasetQueryDescription } from './utils/dataset-query-metadata.js';
+import { resolveDatasetEntry, type DatasetEntry } from './utils/dataset-entry.js';
+import { validateDatasetQuery } from './utils/dataset-query-validation.js';
+
+export type { DatasetEntry } from './utils/dataset-entry.js';
 
 // ---------------------------------------------------------------------------
 // Zod schemas for dataset query input / output
@@ -76,145 +76,6 @@ const datasetResultSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
-// Dataset entry types
-// ---------------------------------------------------------------------------
-
-/** Per-dataset entry: shorthand (just the instance) or with overrides. */
-export type DatasetEntry<TAuth extends AuthContext = AuthContext> =
-  | DatasetInstance
-  | {
-      dataset: DatasetInstance;
-      auth?: AuthStrategy<TAuth> | null;
-      tenant?: TenantConfigOverride<TAuth>;
-      cache?: number | null;
-      requiredRoles?: string[];
-      requiredScopes?: string[];
-      maxLimit?: number;
-    };
-
-function resolveDatasetEntry<TAuth extends AuthContext>(
-  entry: DatasetEntry<TAuth>,
-): {
-  dataset: DatasetInstance;
-  auth?: AuthStrategy<TAuth> | null;
-  tenant?: TenantConfigOverride<TAuth>;
-  cache?: number | null;
-  requiredRoles?: string[];
-  requiredScopes?: string[];
-  maxLimit?: number;
-} {
-  if (entry && typeof entry === 'object' && '__type' in entry && entry.__type === 'dataset') {
-    return { dataset: entry as DatasetInstance };
-  }
-  return entry as {
-      dataset: DatasetInstance;
-      auth?: AuthStrategy<TAuth> | null;
-      tenant?: TenantConfigOverride<TAuth>;
-      cache?: number | null;
-      requiredRoles?: string[];
-      requiredScopes?: string[];
-      maxLimit?: number;
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Validation
-// ---------------------------------------------------------------------------
-
-function validateDatasetQuery(
-  ds: DatasetInstance,
-  query: {
-    dimensions?: string[];
-    measures?: string[];
-    filters?: Array<{ field: string }>;
-    orderBy?: Array<{ field: string }>;
-    by?: TimeGrain;
-  },
-  maxLimit?: number,
-): ValidationResult {
-  const errors: string[] = [];
-  const dimensionNames = Object.keys(ds.dimensions);
-  const measureNames = Object.keys(ds.measures);
-  const selectedDimensions = query.dimensions ?? [];
-  const selectedMeasures = query.measures ?? measureNames;
-  const filterNames = Object.keys(ds.filters);
-  const orderableFields = new Set<string>([
-    ...selectedDimensions,
-    ...selectedMeasures,
-    ...(query.by ? ['period'] : []),
-  ]);
-
-  if (selectedDimensions.length === 0 && selectedMeasures.length === 0) {
-    errors.push(
-      `Dataset "${ds.name}" query must select at least one dimension or measure.`,
-    );
-  }
-
-  if (query.dimensions) {
-    const invalid = query.dimensions.filter(c => !dimensionNames.includes(c));
-    if (invalid.length > 0) {
-      errors.push(`Unknown dimensions: ${invalid.join(', ')}. Available: ${dimensionNames.join(', ')}`);
-    }
-  }
-
-  if (query.measures) {
-    const invalid = query.measures.filter(c => !measureNames.includes(c));
-    if (invalid.length > 0) {
-      errors.push(`Unknown measures: ${invalid.join(', ')}. Available: ${measureNames.join(', ')}`);
-    }
-  }
-
-  if (query.filters) {
-    const invalid = query.filters.filter(f => !filterNames.includes(f.field));
-    if (invalid.length > 0) {
-      errors.push(`Unknown filter fields: ${invalid.map(f => f.field).join(', ')}. Available: ${filterNames.join(', ')}`);
-    }
-
-    for (const filter of query.filters) {
-      const filterDefinition = ds.filters[filter.field];
-      if (filterDefinition?.operators && !filterDefinition.operators.includes((filter as MetricFilter).operator)) {
-        errors.push(
-          `Filter "${filter.field}" does not allow operator "${(filter as MetricFilter).operator}". Allowed: ${filterDefinition.operators.join(', ')}`,
-        );
-        continue;
-      }
-      const resolvedField = ds.filters[filter.field]?.field ?? filter.field;
-      const fieldType = ds.dimensions[resolvedField]?.fieldType;
-      if (!fieldType) continue;
-      const filterError = validateFilterValue(filter as MetricFilter, fieldType);
-      if (filterError) {
-        errors.push(filterError);
-      }
-    }
-  }
-
-  if (query.orderBy) {
-    const invalid = query.orderBy.filter(o => !orderableFields.has(o.field));
-    if (invalid.length > 0) {
-      errors.push(`Unknown orderBy fields: ${invalid.map(o => o.field).join(', ')}. Available: ${Array.from(orderableFields).join(', ')}`);
-    }
-  }
-
-  if (query.by && !ds.timeKey) {
-    errors.push(`Cannot use "by" grain — dataset "${ds.name}" has no timeKey.`);
-  }
-
-  if (ds.limits?.maxDimensions && query.dimensions && query.dimensions.length > ds.limits.maxDimensions) {
-    errors.push(`Too many dimensions: ${query.dimensions.length} (max ${ds.limits.maxDimensions})`);
-  }
-
-  if (ds.limits?.maxMeasures && query.measures && query.measures.length > ds.limits.maxMeasures) {
-    errors.push(`Too many measures: ${query.measures.length} (max ${ds.limits.maxMeasures})`);
-  }
-
-  if (ds.limits?.maxFilters && query.filters && query.filters.length > ds.limits.maxFilters) {
-    errors.push(`Too many filters: ${query.filters.length} (max ${ds.limits.maxFilters})`);
-  }
-
-  return { valid: errors.length === 0, errors };
-}
-
-// ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
 
@@ -234,7 +95,7 @@ export function createDatasetEndpoint<TAuth extends AuthContext>(
     method: 'POST',
     name: name,
     summary: `Query the "${name}" semantic dataset`,
-    description: buildDescription(ds, effectiveMaxLimit),
+    description: buildDatasetQueryDescription(ds, effectiveMaxLimit),
     tags: ['datasets'],
     requiresAuth: resolved.auth !== null ? undefined : false,
     requiredRoles: resolved.requiredRoles,
@@ -251,7 +112,7 @@ export function createDatasetEndpoint<TAuth extends AuthContext>(
     const start = Date.now();
 
     // Validate
-    const validation = validateDatasetQuery(ds, input, effectiveMaxLimit);
+    const validation = validateDatasetQuery(ds, input);
     if (!validation.valid) {
       throw new ServeHttpError(
         400,
@@ -292,15 +153,15 @@ export function createDatasetEndpoint<TAuth extends AuthContext>(
 
     // Tenant injection
     if (ctx.tenantId) {
-      if (!runtime?.tenant) {
+      if (!runtime?.tenant || !ds.tenantKey) {
         throw new ServeHttpError(
           500,
           'INTERNAL_SERVER_ERROR',
-          `Dataset endpoint "${name}" requires tenant.column in Serve tenant config when tenant isolation is enabled.`,
+          `Dataset endpoint "${name}" requires dataset tenantKey and serve tenant runtime when tenant isolation is enabled.`,
         );
       }
-      if (!runtime.tenant.handledByBuilder) {
-        builder = builder.where(runtime.tenant.column, 'eq', runtime.tenant.id);
+      if (!resolveSemanticTenantHandledByBuilder(ctx as Record<string, unknown>)) {
+        builder = builder.where(ds.tenantKey, 'eq', runtime.tenant.id);
       }
     }
 
@@ -356,18 +217,4 @@ export function createDatasetEndpoint<TAuth extends AuthContext>(
     requiredRoles: resolved.requiredRoles,
     requiredScopes: resolved.requiredScopes,
   };
-}
-
-function buildDescription(ds: DatasetInstance, maxLimit: number): string {
-  const dimensionNames = Object.keys(ds.dimensions);
-  const measureNames = Object.keys(ds.measures);
-  const lines = [
-    `Query the ${ds.name} semantic dataset (source: ${ds.source}).`,
-    '',
-    `**Dimensions:** ${dimensionNames.join(', ') || 'none'}`,
-    `**Measures:** ${measureNames.join(', ') || 'none'}`,
-    `**Max limit:** ${maxLimit}`,
-  ];
-
-  return lines.join('\n');
 }

--- a/packages/serve/src/semantic/datasets/metric-endpoint.ts
+++ b/packages/serve/src/semantic/datasets/metric-endpoint.ts
@@ -24,6 +24,7 @@ import { ServeHttpError } from '../../errors.js';
 import {
   resolveSemanticExecutionRuntime,
   resolveSemanticQueryBuilder,
+  resolveSemanticTenantHandledByBuilder,
 } from '../query-builder-context.js';
 
 // ---------------------------------------------------------------------------
@@ -130,6 +131,8 @@ export function createMetricEndpoint<TAuth extends AuthContext>(
       ctx as Record<string, unknown>,
       executor.getBuilderFactory(),
     );
+    const tenantHandledByBuilder = resolveSemanticTenantHandledByBuilder(ctx as Record<string, unknown>)
+      || (ctx.tenantId != null && runtimeBuilderFactory !== executor.getBuilderFactory());
 
     // Build the metric query
     const query = {
@@ -155,8 +158,24 @@ export function createMetricEndpoint<TAuth extends AuthContext>(
       throw new ServeHttpError(
         500,
         'INTERNAL_SERVER_ERROR',
-        `Metric endpoint "${name}" requires tenant.column in Serve tenant config when tenant isolation is enabled.`,
+        `Metric endpoint "${name}" requires serve tenant runtime when tenant isolation is enabled.`,
       );
+    }
+
+    if (ctx.tenantId && runtime?.tenant) {
+      const tenantValidation = executor.validate(metricRef, query, {
+        runtime: {
+          tenant: runtime.tenant,
+        },
+      });
+
+      if (!tenantValidation.valid) {
+        throw new ServeHttpError(
+          400,
+          'VALIDATION_ERROR',
+          tenantValidation.errors.join('; ')
+        );
+      }
     }
 
     // Execute with tenant context
@@ -164,6 +183,7 @@ export function createMetricEndpoint<TAuth extends AuthContext>(
       runtime: {
         ...runtime,
         builderFactory: runtimeBuilderFactory,
+        tenant: tenantHandledByBuilder ? undefined : runtime?.tenant,
       },
     });
 

--- a/packages/serve/src/semantic/datasets/query-planner.ts
+++ b/packages/serve/src/semantic/datasets/query-planner.ts
@@ -1,0 +1,115 @@
+import type {
+  DatasetInstance,
+  DimensionDefinition,
+  MeasureDefinition,
+  MetricOrderBy,
+  RelationshipDefinition,
+  TimeGrain,
+} from '@hypequery/datasets';
+import type { QueryBuilderLike } from '@hypequery/datasets';
+import { GRAIN_FUNCTIONS } from '@hypequery/datasets';
+import { applyFilteredAggregationExpression } from './utils/filtered-aggregation-sql.js';
+
+type DatasetShape = DatasetInstance<
+  Record<string, DimensionDefinition>,
+  Record<string, MeasureDefinition>,
+  Record<string, RelationshipDefinition>
+>;
+
+export function resolveDimensionExpression(
+  ds: DatasetShape,
+  dimensionName: string,
+): string {
+  const definition = ds.dimensions[dimensionName];
+  return definition?.sql ?? definition?.column ?? dimensionName;
+}
+
+export function resolveFilterField(
+  ds: DatasetShape,
+  filterField: string,
+): string {
+  const resolvedField = ds.filters[filterField]?.field ?? filterField;
+  return resolveDimensionExpression(ds, resolvedField);
+}
+
+export function buildDimensionSelectionPlan(
+  ds: DatasetShape,
+  dimensions: string[],
+  grain: TimeGrain | undefined,
+): { selectParts: string[]; groupByParts: string[] } {
+  const selectParts: string[] = [];
+  const groupByParts = new Set<string>();
+
+  if (grain) {
+    const fn = GRAIN_FUNCTIONS[grain];
+    selectParts.push(`${fn}(${ds.timeKey}) AS period`);
+    groupByParts.add('period');
+  }
+
+  for (const dimensionName of dimensions) {
+    const expression = resolveDimensionExpression(ds, dimensionName);
+    if (expression === dimensionName) {
+      selectParts.push(dimensionName);
+    } else {
+      selectParts.push(`${expression} AS ${dimensionName}`);
+    }
+    groupByParts.add(dimensionName);
+  }
+
+  return { selectParts, groupByParts: Array.from(groupByParts) };
+}
+
+export function applyMeasureDefinition(
+  qb: QueryBuilderLike,
+  ds: DatasetShape,
+  name: string,
+  definition: MeasureDefinition,
+): QueryBuilderLike {
+  const baseFieldOrExpr = definition.sql ?? resolveDimensionExpression(ds, definition.field);
+  const fieldOrExpr = applyFilteredAggregationExpression(ds, {
+    __type: 'aggregation_spec',
+    aggregation: definition.aggregation,
+    field: definition.field,
+    filters: definition.filters,
+  }, baseFieldOrExpr, resolveFilterField);
+
+  switch (definition.aggregation) {
+    case 'sum':
+      return qb.sum(fieldOrExpr, name);
+    case 'count':
+      return qb.count(fieldOrExpr, name);
+    case 'countDistinct':
+      return qb.countDistinct(fieldOrExpr, name);
+    case 'avg':
+      return qb.avg(fieldOrExpr, name);
+    case 'min':
+      return qb.min(fieldOrExpr, name);
+    case 'max':
+      return qb.max(fieldOrExpr, name);
+  }
+}
+
+export function appendOrderLimitOffset(
+  qb: QueryBuilderLike,
+  orderBy: MetricOrderBy[] | undefined,
+  grain: TimeGrain | undefined,
+  limit?: number,
+  offset?: number,
+): QueryBuilderLike {
+  if (orderBy && orderBy.length > 0) {
+    for (const order of orderBy) {
+      qb = qb.orderBy(order.field, order.direction.toUpperCase() as 'ASC' | 'DESC');
+    }
+  } else if (grain) {
+    qb = qb.orderBy('period', 'ASC');
+  }
+
+  if (limit != null) {
+    qb = qb.limit(limit);
+  }
+  if (offset != null) {
+    qb = qb.offset(offset);
+  }
+
+  return qb;
+}

--- a/packages/serve/src/semantic/datasets/serve-integration.test.ts
+++ b/packages/serve/src/semantic/datasets/serve-integration.test.ts
@@ -510,7 +510,7 @@ describe("Serve integration — metrics", () => {
       expect(factory._calls['where']).toContainEqual(['tenant_id', 'eq', 'tenant-123']);
     });
 
-    it("returns a clear error when tenant isolation is enabled without tenant.column", async () => {
+    it("falls back to the dataset tenantKey when tenant isolation is enabled without tenant.column", async () => {
       const factory = createMockBuilderFactory();
       const api = createAPI({
         metrics: { totalRevenue },
@@ -538,9 +538,8 @@ describe("Serve integration — metrics", () => {
         })
       );
 
-      expect(response.status).toBe(500);
-      expect((response.body as any).error.message).toContain('tenant.column');
-      expect(factory._calls['where']).toBeUndefined();
+      expect(response.status).toBe(200);
+      expect(factory._calls['where']).toContainEqual(['tenant_id', 'eq', 'tenant-123']);
     });
 
     it("prefers the Serve tenant column when auto-inject wraps the internal query builder", async () => {
@@ -575,7 +574,6 @@ describe("Serve integration — metrics", () => {
 
       expect(response.status).toBe(200);
       expect(factory._calls['where']).toContainEqual(['organization_id', 'eq', 'tenant-123']);
-      expect(factory._calls['where']).not.toContainEqual(['tenant_id', 'eq', 'tenant-123']);
     });
 
     it("does not warn about manual tenant mode for generated metric endpoints", async () => {
@@ -1235,7 +1233,7 @@ describe("Serve integration — metrics", () => {
       expect(factory._calls['where']).toContainEqual(['tenant_id', 'eq', 'tenant-123']);
     });
 
-    it("returns a clear error for dataset tenant isolation without tenant.column", async () => {
+    it("falls back to the dataset tenantKey for dataset tenant isolation without tenant.column", async () => {
       const factory = createMockBuilderFactory([
         { country: "US", revenue: 5000 },
       ]);
@@ -1268,9 +1266,8 @@ describe("Serve integration — metrics", () => {
         })
       );
 
-      expect(response.status).toBe(500);
-      expect((response.body as any).error.message).toContain('tenant.column');
-      expect(factory._calls['where']).toBeUndefined();
+      expect(response.status).toBe(200);
+      expect(factory._calls['where']).toContainEqual(['tenant_id', 'eq', 'tenant-123']);
     });
 
     it("rejects empty dataset queries instead of falling back to raw table selection", async () => {

--- a/packages/serve/src/semantic/datasets/utils/dataset-entry.ts
+++ b/packages/serve/src/semantic/datasets/utils/dataset-entry.ts
@@ -1,0 +1,44 @@
+import type {
+  AuthContext,
+  AuthStrategy,
+  TenantConfigOverride,
+} from '../../../types.js';
+import type { DatasetInstance } from '@hypequery/datasets';
+
+export type DatasetEntry<TAuth extends AuthContext = AuthContext> =
+  | DatasetInstance
+  | {
+      dataset: DatasetInstance;
+      auth?: AuthStrategy<TAuth> | null;
+      tenant?: TenantConfigOverride<TAuth>;
+      cache?: number | null;
+      requiredRoles?: string[];
+      requiredScopes?: string[];
+      maxLimit?: number;
+    };
+
+export function resolveDatasetEntry<TAuth extends AuthContext>(
+  entry: DatasetEntry<TAuth>,
+): {
+  dataset: DatasetInstance;
+  auth?: AuthStrategy<TAuth> | null;
+  tenant?: TenantConfigOverride<TAuth>;
+  cache?: number | null;
+  requiredRoles?: string[];
+  requiredScopes?: string[];
+  maxLimit?: number;
+} {
+  if (entry && typeof entry === 'object' && '__type' in entry && entry.__type === 'dataset') {
+    return { dataset: entry as DatasetInstance };
+  }
+
+  return entry as {
+    dataset: DatasetInstance;
+    auth?: AuthStrategy<TAuth> | null;
+    tenant?: TenantConfigOverride<TAuth>;
+    cache?: number | null;
+    requiredRoles?: string[];
+    requiredScopes?: string[];
+    maxLimit?: number;
+  };
+}

--- a/packages/serve/src/semantic/datasets/utils/dataset-query-metadata.ts
+++ b/packages/serve/src/semantic/datasets/utils/dataset-query-metadata.ts
@@ -1,0 +1,18 @@
+import type { DatasetInstance } from '@hypequery/datasets';
+
+export function buildDatasetQueryDescription(
+  ds: DatasetInstance,
+  maxLimit: number,
+): string {
+  const dimensionNames = Object.keys(ds.dimensions);
+  const measureNames = Object.keys(ds.measures);
+  const lines = [
+    `Query the ${ds.name} semantic dataset (source: ${ds.source}).`,
+    '',
+    `**Dimensions:** ${dimensionNames.join(', ') || 'none'}`,
+    `**Measures:** ${measureNames.join(', ') || 'none'}`,
+    `**Max limit:** ${maxLimit}`,
+  ];
+
+  return lines.join('\n');
+}

--- a/packages/serve/src/semantic/datasets/utils/dataset-query-validation.ts
+++ b/packages/serve/src/semantic/datasets/utils/dataset-query-validation.ts
@@ -1,0 +1,104 @@
+import type {
+  DatasetInstance,
+  MetricFilter,
+  TimeGrain,
+  ValidationResult,
+} from '@hypequery/datasets';
+import { validateFilterValue } from '@hypequery/datasets';
+
+export type DatasetQueryValidationInput = {
+  dimensions?: string[];
+  measures?: string[];
+  filters?: Array<{ field: string }>;
+  orderBy?: Array<{ field: string }>;
+  by?: TimeGrain;
+};
+
+export function validateDatasetQuery(
+  ds: DatasetInstance,
+  query: DatasetQueryValidationInput,
+): ValidationResult {
+  const errors: string[] = [];
+  const dimensionNames = Object.keys(ds.dimensions);
+  const measureNames = Object.keys(ds.measures);
+  const selectedDimensions = query.dimensions ?? [];
+  const selectedMeasures = query.measures ?? measureNames;
+  const filterNames = Object.keys(ds.filters);
+  const orderableFields = new Set<string>([
+    ...selectedDimensions,
+    ...selectedMeasures,
+    ...(query.by ? ['period'] : []),
+  ]);
+
+  if (selectedDimensions.length === 0 && selectedMeasures.length === 0) {
+    errors.push(`Dataset "${ds.name}" query must select at least one dimension or measure.`);
+  }
+
+  if (query.dimensions) {
+    const invalid = query.dimensions.filter(column => !dimensionNames.includes(column));
+    if (invalid.length > 0) {
+      errors.push(`Unknown dimensions: ${invalid.join(', ')}. Available: ${dimensionNames.join(', ')}`);
+    }
+  }
+
+  if (query.measures) {
+    const invalid = query.measures.filter(column => !measureNames.includes(column));
+    if (invalid.length > 0) {
+      errors.push(`Unknown measures: ${invalid.join(', ')}. Available: ${measureNames.join(', ')}`);
+    }
+  }
+
+  if (query.filters) {
+    const invalid = query.filters.filter(filter => !filterNames.includes(filter.field));
+    if (invalid.length > 0) {
+      errors.push(`Unknown filter fields: ${invalid.map(filter => filter.field).join(', ')}. Available: ${filterNames.join(', ')}`);
+    }
+
+    for (const filter of query.filters) {
+      const typedFilter = filter as MetricFilter;
+      const filterDefinition = ds.filters[filter.field];
+      if (filterDefinition?.operators && !filterDefinition.operators.includes(typedFilter.operator)) {
+        errors.push(
+          `Filter "${filter.field}" does not allow operator "${typedFilter.operator}". Allowed: ${filterDefinition.operators.join(', ')}`,
+        );
+        continue;
+      }
+
+      const resolvedField = ds.filters[filter.field]?.field ?? filter.field;
+      const fieldType = ds.dimensions[resolvedField]?.fieldType;
+      if (!fieldType) {
+        continue;
+      }
+
+      const filterError = validateFilterValue(typedFilter, fieldType);
+      if (filterError) {
+        errors.push(filterError);
+      }
+    }
+  }
+
+  if (query.orderBy) {
+    const invalid = query.orderBy.filter(order => !orderableFields.has(order.field));
+    if (invalid.length > 0) {
+      errors.push(`Unknown orderBy fields: ${invalid.map(order => order.field).join(', ')}. Available: ${Array.from(orderableFields).join(', ')}`);
+    }
+  }
+
+  if (query.by && !ds.timeKey) {
+    errors.push(`Cannot use "by" grain — dataset "${ds.name}" has no timeKey.`);
+  }
+
+  if (ds.limits?.maxDimensions && query.dimensions && query.dimensions.length > ds.limits.maxDimensions) {
+    errors.push(`Too many dimensions: ${query.dimensions.length} (max ${ds.limits.maxDimensions})`);
+  }
+
+  if (ds.limits?.maxMeasures && query.measures && query.measures.length > ds.limits.maxMeasures) {
+    errors.push(`Too many measures: ${query.measures.length} (max ${ds.limits.maxMeasures})`);
+  }
+
+  if (ds.limits?.maxFilters && query.filters && query.filters.length > ds.limits.maxFilters) {
+    errors.push(`Too many filters: ${query.filters.length} (max ${ds.limits.maxFilters})`);
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/packages/serve/src/semantic/datasets/utils/filtered-aggregation-sql.ts
+++ b/packages/serve/src/semantic/datasets/utils/filtered-aggregation-sql.ts
@@ -1,0 +1,105 @@
+import type {
+  AggregationSpec,
+  DatasetInstance,
+  DimensionDefinition,
+  MeasureDefinition,
+  MetricFilter,
+  RelationshipDefinition,
+} from '@hypequery/datasets';
+
+type DatasetShape = DatasetInstance<
+  Record<string, DimensionDefinition>,
+  Record<string, MeasureDefinition>,
+  Record<string, RelationshipDefinition>
+>;
+
+function renderMeasureFilterLiteral(value: unknown): string {
+  if (value === null) {
+    return 'NULL';
+  }
+
+  if (typeof value === 'string') {
+    return `'${value.replace(/'/g, "''")}'`;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`Invalid non-finite numeric literal in measure filter: ${value}`);
+    }
+    return String(value);
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? '1' : '0';
+  }
+
+  throw new Error(`Unsupported literal type in measure filter: ${typeof value}`);
+}
+
+function renderMeasureFilterCondition(
+  ds: DatasetShape,
+  filter: MetricFilter,
+  resolveFilterField: (dataset: DatasetShape, filterField: string) => string,
+): string {
+  const field = resolveFilterField(ds, filter.field);
+
+  switch (filter.operator) {
+    case 'eq':
+      return `${field} = ${renderMeasureFilterLiteral(filter.value)}`;
+    case 'neq':
+      return `${field} != ${renderMeasureFilterLiteral(filter.value)}`;
+    case 'gt':
+      return `${field} > ${renderMeasureFilterLiteral(filter.value)}`;
+    case 'gte':
+      return `${field} >= ${renderMeasureFilterLiteral(filter.value)}`;
+    case 'lt':
+      return `${field} < ${renderMeasureFilterLiteral(filter.value)}`;
+    case 'lte':
+      return `${field} <= ${renderMeasureFilterLiteral(filter.value)}`;
+    case 'like':
+      return `${field} LIKE ${renderMeasureFilterLiteral(filter.value)}`;
+    case 'in':
+    case 'notIn': {
+      if (!Array.isArray(filter.value) || filter.value.length === 0) {
+        throw new Error(`"${filter.operator}" measure filters require a non-empty array.`);
+      }
+
+      const values = filter.value.map(renderMeasureFilterLiteral).join(', ');
+      return `${field} ${filter.operator === 'in' ? 'IN' : 'NOT IN'} (${values})`;
+    }
+    case 'between': {
+      if (!Array.isArray(filter.value) || filter.value.length !== 2) {
+        throw new Error('"between" measure filters require a two-item array.');
+      }
+
+      return `${field} BETWEEN ${renderMeasureFilterLiteral(filter.value[0])} AND ${renderMeasureFilterLiteral(filter.value[1])}`;
+    }
+  }
+}
+
+export function applyFilteredAggregationExpression(
+  ds: DatasetShape,
+  spec: AggregationSpec,
+  fieldOrExpr: string,
+  resolveFilterField: (dataset: DatasetShape, filterField: string) => string,
+): string {
+  if (!spec.filters?.length) {
+    return fieldOrExpr;
+  }
+
+  const combinedCondition = spec.filters
+    .map(filter => renderMeasureFilterCondition(ds, filter, resolveFilterField))
+    .map(condition => `(${condition})`)
+    .join(' AND ');
+
+  switch (spec.aggregation) {
+    case 'sum':
+      return `if(${combinedCondition}, ${fieldOrExpr}, 0)`;
+    case 'count':
+    case 'countDistinct':
+    case 'avg':
+    case 'min':
+    case 'max':
+      return `if(${combinedCondition}, ${fieldOrExpr}, NULL)`;
+  }
+}

--- a/packages/serve/src/semantic/query-builder-context.ts
+++ b/packages/serve/src/semantic/query-builder-context.ts
@@ -1,6 +1,7 @@
 import type { QueryBuilderFactoryLike, SemanticExecutionRuntime } from "@hypequery/datasets";
 
 export const INTERNAL_SEMANTIC_RUNTIME_KEY = "__hypequerySemanticRuntime";
+export const INTERNAL_SEMANTIC_TENANT_HANDLED_BY_BUILDER_KEY = "__hypequerySemanticTenantHandledByBuilder";
 
 export function attachSemanticQueryBuilder<
   TContext extends Record<string, unknown>,
@@ -47,21 +48,25 @@ export function resolveSemanticQueryBuilder(
   return resolveSemanticExecutionRuntime(context)?.builderFactory ?? fallback;
 }
 
+export function resolveSemanticTenantHandledByBuilder(
+  context: Record<string, unknown>,
+): boolean {
+  return context[INTERNAL_SEMANTIC_TENANT_HANDLED_BY_BUILDER_KEY] === true;
+}
+
 export function attachSemanticTenantRuntime<TContext extends Record<string, unknown>>(
   context: TContext,
   options: {
     tenantId: string;
-    tenantColumn?: string;
     tenantHandledByBuilder?: boolean;
   },
 ): TContext {
-  return attachSemanticRuntime(context, {
-    tenant: options.tenantColumn
-      ? {
-          id: options.tenantId,
-          column: options.tenantColumn,
-          handledByBuilder: options.tenantHandledByBuilder === true,
-        }
-      : undefined,
-  });
+  return {
+    ...attachSemanticRuntime(context, {
+      tenant: {
+        id: options.tenantId,
+      },
+    }),
+    [INTERNAL_SEMANTIC_TENANT_HANDLED_BY_BUILDER_KEY]: options.tenantHandledByBuilder === true,
+  };
 }

--- a/packages/serve/src/semantic/utils/tenant-runtime.ts
+++ b/packages/serve/src/semantic/utils/tenant-runtime.ts
@@ -1,0 +1,81 @@
+import { createTenantScope, warnTenantMisconfiguration } from '../../tenant.js';
+import type { EndpointMetadata } from '../../types.js';
+import {
+  attachSemanticRuntime,
+  attachSemanticTenantRuntime,
+  resolveSemanticExecutionRuntime,
+} from '../query-builder-context.js';
+
+type QueryBuilderLikeContext = {
+  table: (name: string) => unknown;
+};
+
+function hasTableFactory(value: unknown): value is QueryBuilderLikeContext {
+  return !!value && typeof value === 'object' && 'table' in value && typeof value.table === 'function';
+}
+
+export function applySemanticTenantRuntime<TContext extends Record<string, unknown>>(
+  context: TContext & { tenantId?: string },
+  options: {
+    queryKey: string;
+    metadata: EndpointMetadata;
+    tenantId: string;
+    mode: 'manual' | 'auto-inject';
+    column?: string;
+  },
+): void {
+  const mutableContext = context as Record<string, unknown>;
+  const usesServeTenantRuntime = Boolean(
+    options.metadata.custom && (options.metadata.custom as Record<string, unknown>).usesServeTenantRuntime,
+  );
+  const semanticRuntime = resolveSemanticExecutionRuntime(context);
+
+  if (options.mode === 'auto-inject' && options.column && semanticRuntime?.builderFactory) {
+    Object.assign(
+      context,
+      attachSemanticRuntime(context, {
+        builderFactory: createTenantScope(semanticRuntime.builderFactory, {
+          tenantId: options.tenantId,
+          column: options.column,
+        }),
+        tenant: {
+          id: options.tenantId,
+        },
+      }),
+    );
+    Object.assign(
+      context,
+      attachSemanticTenantRuntime(context, {
+        tenantId: options.tenantId,
+        tenantHandledByBuilder: true,
+      }),
+    );
+  } else {
+    Object.assign(
+      context,
+      attachSemanticTenantRuntime(context, {
+        tenantId: options.tenantId,
+        tenantHandledByBuilder: false,
+      }),
+    );
+  }
+
+  if (options.mode === 'auto-inject' && options.column) {
+    for (const key of Object.keys(mutableContext)) {
+      const value = mutableContext[key];
+      if (hasTableFactory(value)) {
+        mutableContext[key] = createTenantScope(value, {
+          tenantId: options.tenantId,
+          column: options.column,
+        });
+      }
+    }
+  } else if (options.mode === 'manual' && !usesServeTenantRuntime) {
+    warnTenantMisconfiguration({
+      queryKey: options.queryKey,
+      hasTenantConfig: true,
+      hasTenantId: true,
+      mode: 'manual',
+    });
+  }
+}

--- a/packages/serve/src/type-tests/semantic.test-d.ts
+++ b/packages/serve/src/type-tests/semantic.test-d.ts
@@ -39,13 +39,5 @@ const avgOrderValue = Orders.metric('avgOrderValue', {
 });
 const monthlyRevenue = totalRevenue.by('month');
 
-const semanticQuery = Orders.query({
-  dimensions: ['status', 'createdAt'],
-  measures: ['revenue', 'orderCount'],
-  by: 'month',
-});
-
 monthlyRevenue.contract();
 avgOrderValue.contract();
-semanticQuery.contract();
-

--- a/packages/serve/tsconfig.tsbuildinfo
+++ b/packages/serve/tsconfig.tsbuildinfo
@@ -1,1 +1,5944 @@
-{"fileNames":["../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es5.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2016.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.core.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.collection.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.generator.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.iterable.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.promise.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.proxy.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.reflect.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.symbol.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2016.array.include.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2016.intl.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.arraybuffer.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.date.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.object.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.sharedmemory.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.string.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.intl.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.typedarrays.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.asyncgenerator.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.asynciterable.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.intl.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.promise.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.regexp.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.array.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.object.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.string.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.symbol.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.intl.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.bigint.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.date.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.promise.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.sharedmemory.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.string.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.symbol.wellknown.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.intl.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.number.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.promise.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.string.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.weakref.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.intl.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.array.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.error.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.intl.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.object.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.string.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.regexp.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.decorators.d.ts","../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.decorators.legacy.d.ts","../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/typeAliases.d.cts","../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/util.d.cts","../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/index.d.cts","../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/ZodError.d.cts","../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/locales/en.d.cts","../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/errors.d.cts","../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/parseUtil.d.cts","../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/enumUtil.d.cts","../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/errorUtil.d.cts","../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/partialUtil.d.cts","../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/standard-schema.d.cts","../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/types.d.cts","../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/external.d.cts","../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/index.d.cts","./src/query-logger.ts","../datasets/dist/query-builder-protocol.d.ts","../datasets/dist/types.d.ts","../datasets/dist/dataset.d.ts","../datasets/dist/field.d.ts","../datasets/dist/measure.d.ts","../datasets/dist/relationships.d.ts","../datasets/dist/aggregations.d.ts","../datasets/dist/formulas.d.ts","../datasets/dist/query-helpers.d.ts","../datasets/dist/registry.d.ts","../datasets/dist/validation.d.ts","../datasets/dist/executor.d.ts","../datasets/dist/sql-utils.d.ts","../datasets/dist/constants.d.ts","../datasets/dist/query-planner.d.ts","../datasets/dist/index.d.ts","./src/errors.ts","./src/semantic/query-builder-context.ts","./src/semantic/datasets/dataset-endpoint.ts","./src/types.ts","./src/auth.ts","./src/utils.ts","./src/builder.ts","./src/client-config.ts","./src/cors.ts","./src/adapters/utils.ts","./src/adapters/node.ts","./src/dev.ts","./src/docs-ui.ts","./src/endpoint.ts","./src/router.ts","./src/tenant.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/any.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/errorMessages.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/array.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/bigint.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/boolean.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/number.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/date.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/enum.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/intersection.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/literal.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/string.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/record.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/map.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/nativeEnum.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/never.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/null.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/nullable.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/object.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/set.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/tuple.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/undefined.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/union.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/unknown.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parseTypes.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/Refs.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/Options.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/getRelativePath.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parseDef.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/branded.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/catch.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/default.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/effects.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/optional.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/pipeline.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/promise.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/readonly.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/selectParser.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/zodToJsonSchema.d.ts","../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/index.d.ts","./src/openapi.ts","./src/pipeline.ts","./src/server/execute-query.ts","./src/server/mapper.ts","./src/server/api-builder.ts","./src/semantic/datasets/metric-endpoint.ts","./src/semantic/datasets/index.ts","./src/server/create-api.ts","./src/server/define-serve.ts","./src/serve.ts","./src/server/init-serve.ts","./src/server/builder.ts","./src/server/index.ts","./src/rate-limit.ts","./src/adapters/fetch.ts","./src/adapters/vercel.ts","./src/adapters/standalone.ts","./src/semantic/index.ts","./src/index.ts","../../node_modules/.pnpm/@vitest+pretty-format@2.1.9/node_modules/@vitest/pretty-format/dist/index.d.ts","../../node_modules/.pnpm/@vitest+utils@2.1.9/node_modules/@vitest/utils/dist/types.d.ts","../../node_modules/.pnpm/@vitest+utils@2.1.9/node_modules/@vitest/utils/dist/helpers.d.ts","../../node_modules/.pnpm/tinyrainbow@1.2.0/node_modules/tinyrainbow/dist/index-c1cfc5e9.d.ts","../../node_modules/.pnpm/tinyrainbow@1.2.0/node_modules/tinyrainbow/dist/node.d.ts","../../node_modules/.pnpm/@vitest+utils@2.1.9/node_modules/@vitest/utils/dist/index.d.ts","../../node_modules/.pnpm/@vitest+runner@2.1.9/node_modules/@vitest/runner/dist/tasks-3ZnPj1LR.d.ts","../../node_modules/.pnpm/@vitest+utils@2.1.9/node_modules/@vitest/utils/dist/types-Bxe-2Udy.d.ts","../../node_modules/.pnpm/@vitest+utils@2.1.9/node_modules/@vitest/utils/dist/diff.d.ts","../../node_modules/.pnpm/@vitest+runner@2.1.9/node_modules/@vitest/runner/dist/types.d.ts","../../node_modules/.pnpm/@vitest+utils@2.1.9/node_modules/@vitest/utils/dist/error.d.ts","../../node_modules/.pnpm/@vitest+runner@2.1.9/node_modules/@vitest/runner/dist/index.d.ts","../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/environment.LoooBwUu.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/compatibility/disposable.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/compatibility/indexable.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/compatibility/iterators.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/compatibility/index.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/globals.typedarray.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/buffer.buffer.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/globals.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/web-globals/abortcontroller.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/web-globals/domexception.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/web-globals/events.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/header.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/readable.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/file.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/fetch.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/formdata.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/connector.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/client.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/errors.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/dispatcher.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/global-dispatcher.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/global-origin.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/pool-stats.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/pool.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/handlers.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/balanced-pool.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/agent.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/mock-interceptor.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/mock-agent.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/mock-client.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/mock-pool.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/mock-errors.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/proxy-agent.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/env-http-proxy-agent.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/retry-handler.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/retry-agent.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/api.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/interceptors.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/util.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/cookies.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/patch.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/websocket.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/eventsource.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/filereader.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/diagnostics-channel.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/content-type.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/cache.d.ts","../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/index.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/web-globals/fetch.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/assert.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/assert/strict.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/async_hooks.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/buffer.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/child_process.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/cluster.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/console.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/constants.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/crypto.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/dgram.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/diagnostics_channel.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/dns.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/dns/promises.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/domain.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/events.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/fs.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/fs/promises.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/http.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/http2.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/https.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/inspector.generated.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/module.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/net.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/os.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/path.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/perf_hooks.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/process.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/punycode.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/querystring.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/readline.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/readline/promises.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/repl.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/sea.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/stream.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/stream/promises.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/stream/consumers.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/stream/web.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/string_decoder.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/test.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/timers.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/timers/promises.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/tls.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/trace_events.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/tty.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/url.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/util.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/v8.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/vm.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/wasi.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/worker_threads.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/zlib.d.ts","../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/index.d.ts","../../node_modules/.pnpm/@types+estree@1.0.8/node_modules/@types/estree/index.d.ts","../../node_modules/.pnpm/rollup@4.60.1/node_modules/rollup/dist/rollup.d.ts","../../node_modules/.pnpm/rollup@4.60.1/node_modules/rollup/dist/parseAst.d.ts","../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/types/hmrPayload.d.ts","../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/types/customEvent.d.ts","../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/types/hot.d.ts","../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/dist/node/moduleRunnerTransport.d-DJ_mE5sf.d.ts","../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/dist/node/module-runner.d.ts","../../node_modules/.pnpm/esbuild@0.25.12/node_modules/esbuild/lib/main.d.ts","../../node_modules/.pnpm/source-map-js@1.2.1/node_modules/source-map-js/source-map.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/previous-map.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/input.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/css-syntax-error.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/declaration.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/root.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/warning.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/lazy-result.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/no-work-result.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/processor.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/result.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/document.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/rule.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/node.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/comment.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/container.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/at-rule.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/list.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/postcss.d.ts","../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/postcss.d.mts","../../node_modules/.pnpm/lightningcss@1.31.1/node_modules/lightningcss/node/ast.d.ts","../../node_modules/.pnpm/lightningcss@1.31.1/node_modules/lightningcss/node/targets.d.ts","../../node_modules/.pnpm/lightningcss@1.31.1/node_modules/lightningcss/node/index.d.ts","../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/types/internal/lightningcssOptions.d.ts","../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/types/internal/cssPreprocessorOptions.d.ts","../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/types/importGlob.d.ts","../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/types/metadata.d.ts","../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/dist/node/index.d.ts","../../node_modules/.pnpm/@vitest+snapshot@2.1.9/node_modules/@vitest/snapshot/dist/environment-Ddx0EDtY.d.ts","../../node_modules/.pnpm/@vitest+snapshot@2.1.9/node_modules/@vitest/snapshot/dist/rawSnapshot-CPNkto81.d.ts","../../node_modules/.pnpm/@vitest+snapshot@2.1.9/node_modules/@vitest/snapshot/dist/index.d.ts","../../node_modules/.pnpm/@vitest+snapshot@2.1.9/node_modules/@vitest/snapshot/dist/environment.d.ts","../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/config.Cy0C388Z.d.ts","../../node_modules/.pnpm/vite-node@2.1.9_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite-node/dist/trace-mapping.d-DLVdEqOp.d.ts","../../node_modules/.pnpm/vite-node@2.1.9_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite-node/dist/index-z0R8hVRu.d.ts","../../node_modules/.pnpm/vite-node@2.1.9_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite-node/dist/index.d.ts","../../node_modules/.pnpm/@vitest+utils@2.1.9/node_modules/@vitest/utils/dist/source-map.d.ts","../../node_modules/.pnpm/vite-node@2.1.9_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite-node/dist/client.d.ts","../../node_modules/.pnpm/vite-node@2.1.9_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite-node/dist/server.d.ts","../../node_modules/.pnpm/@vitest+runner@2.1.9/node_modules/@vitest/runner/dist/utils.d.ts","../../node_modules/.pnpm/tinybench@2.9.0/node_modules/tinybench/dist/index.d.ts","../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/benchmark.geERunq4.d.ts","../../node_modules/.pnpm/@vitest+snapshot@2.1.9/node_modules/@vitest/snapshot/dist/manager.d.ts","../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/reporters.nr4dxCkA.d.ts","../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/worker.tN5KGIih.d.ts","../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/worker.B9FxPCaC.d.ts","../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/vite.CzKp4x9w.d.ts","../../node_modules/.pnpm/@vitest+expect@2.1.9/node_modules/@vitest/expect/dist/chai.d.cts","../../node_modules/.pnpm/@vitest+expect@2.1.9/node_modules/@vitest/expect/dist/index.d.ts","../../node_modules/.pnpm/@vitest+expect@2.1.9/node_modules/@vitest/expect/index.d.ts","../../node_modules/.pnpm/@vitest+spy@2.1.9/node_modules/@vitest/spy/dist/index.d.ts","../../node_modules/.pnpm/@vitest+mocker@2.1.9_vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3_/node_modules/@vitest/mocker/dist/types-DZOqTgiN.d.ts","../../node_modules/.pnpm/@vitest+mocker@2.1.9_vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3_/node_modules/@vitest/mocker/dist/index.d.ts","../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/mocker.cRtM890J.d.ts","../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/suite.B2jumIFP.d.ts","../../node_modules/.pnpm/expect-type@1.3.0/node_modules/expect-type/dist/utils.d.ts","../../node_modules/.pnpm/expect-type@1.3.0/node_modules/expect-type/dist/overloads.d.ts","../../node_modules/.pnpm/expect-type@1.3.0/node_modules/expect-type/dist/branding.d.ts","../../node_modules/.pnpm/expect-type@1.3.0/node_modules/expect-type/dist/messages.d.ts","../../node_modules/.pnpm/expect-type@1.3.0/node_modules/expect-type/dist/index.d.ts","../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/index.d.ts","./src/semantic/datasets/serve-live.integration.spec.ts","../../node_modules/.pnpm/@type-challenges+utils@0.1.1/node_modules/@type-challenges/utils/index.d.ts","./src/type-tests/builder.test-d.ts","./src/type-tests/semantic.test-d.ts"],"fileIdsList":[[181,227],[181,224,227],[181,226,227],[227],[181,227,232,260],[181,227,228,233,238,246,257,268],[181,227,228,229,238,246],[176,177,178,181,227],[181,227,230,269],[181,227,231,232,239,247],[181,227,232,257,265],[181,227,233,235,238,246],[181,226,227,234],[181,227,235,236],[181,227,237,238],[181,226,227,238],[181,227,238,239,240,257,268],[181,227,238,239,240,253,257,260],[181,227,235,238,241,246,257,268],[181,227,238,239,241,242,246,257,265,268],[181,227,241,243,257,265,268],[179,180,181,182,183,184,185,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255,256,257,258,259,260,261,262,263,264,265,266,267,268,269,270,271,272,273,274],[181,227,238,244],[181,227,245,268,273],[181,227,235,238,246,257],[181,227,247],[181,227,248],[181,226,227,249],[181,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255,256,257,258,259,260,261,262,263,264,265,266,267,268,269,270,271,272,273,274],[181,227,251],[181,227,252],[181,227,238,253,254],[181,227,253,255,269,271],[181,227,238,257,258,260],[181,227,259,260],[181,227,257,258],[181,227,260],[181,227,261],[181,224,227,257,262],[181,227,238,263,264],[181,227,263,264],[181,227,232,246,257,265],[181,227,266],[181,227,246,267],[181,227,241,252,268],[181,227,232,269],[181,227,257,270],[181,227,245,271],[181,227,272],[181,222,227],[181,222,227,238,240,249,257,260,268,271,273],[181,227,257,274],[167,168,171,181,227],[181,227,333],[181,227,336],[168,169,171,172,173,181,227],[168,181,227],[168,169,171,181,227],[168,169,181,227],[181,227,313],[163,181,227,313,314],[163,181,227,313],[163,170,181,227],[164,181,227],[163,164,165,167,181,227],[163,181,227],[181,227,340,341],[181,227,340,341,342,343],[181,227,340,342],[181,227,340],[181,227,305,306],[181,227,300],[181,227,298,300],[181,227,289,297,298,299,301,303],[181,227,287],[181,227,290,295,300,303],[181,227,286,303],[181,227,290,291,294,295,296,303],[181,227,290,291,292,294,295,303],[181,227,287,288,289,290,291,295,296,297,299,300,301,303],[181,227,303],[181,227,285,287,288,289,290,291,292,294,295,296,297,298,299,300,301,302],[181,227,285,303],[181,227,290,292,293,295,296,303],[181,227,294,303],[181,227,295,296,300,303],[181,227,288,298],[181,227,277,311,312],[181,227,276,277],[166,181,227],[181,194,198,227,268],[181,194,227,257,268],[181,189,227],[181,191,194,227,265,268],[181,227,246,265],[181,227,275],[181,189,227,275],[181,191,194,227,246,268],[181,186,187,190,193,227,238,257,268],[181,194,201,227],[181,186,192,227],[181,194,215,216,227],[181,190,194,227,260,268,275],[181,215,227,275],[181,188,189,227,275],[181,194,227],[181,188,189,190,191,192,193,194,195,196,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214,216,217,218,219,220,221,227],[181,194,209,227],[181,194,201,202,227],[181,192,194,202,203,227],[181,193,227],[181,186,189,194,227],[181,194,198,202,203,227],[181,198,227],[181,192,194,197,227,268],[181,186,191,194,201,227],[181,227,257],[181,189,194,215,227,273,275],[181,227,318,319],[181,227,318],[181,227,312,318,319,331],[181,227,238,239,241,242,243,246,257,265,268,274,275,277,278,279,280,282,283,284,304,308,309,310,311,312],[181,227,279,280,281,282],[181,227,279],[181,227,280],[181,227,307],[181,227,277,312],[174,181,227,324,325,345],[163,174,181,227,315,316,345],[181,227,337],[163,168,174,175,181,227,239,257,312,315,317,320,321,322,323,326,327,331,332,345],[174,181,227,324,325,326,345],[181,227,312,328],[181,227,273,329],[174,175,181,227,315,317,320,345],[163,168,171,174,175,181,227,239,257,273,312,315,316,317,320,321,322,323,324,325,326,327,328,329,330,331,332,334,335,337,338,339,344,345],[60,128,129,181,227],[60,128,130,181,227],[128,129,181,227],[105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,181,227],[105,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,181,227],[129,181,227],[60,106,128,129,181,227],[60,106,129,181,227],[60,106,110,129,130,181,227],[60,181,227],[60,129,181,227],[60,116,128,129,181,227],[105,129,181,227],[60,120,128,129,181,227],[60,113,128,129,181,227],[60,112,115,128,129,181,227],[70,181,227],[58,59,60,181,227],[61,62,181,227],[58,59,61,63,64,69,181,227],[59,61,181,227],[69,181,227],[61,181,227],[58,59,61,64,65,66,67,68,181,227],[74,181,227],[73,74,83,181,227],[73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,181,227],[73,74,181,227],[73,181,227],[92,98,181,227],[92,98,181,227,238,241],[92,99,158,181,227],[92,181,227],[71,92,94,181,227],[72,92,99,181,227,246],[71,92,181,227],[72,89,92,93,94,96,97,99,100,101,102,103,144,153,156,157,158,159,160,161,181,227],[71,92,143,181,227],[71,72,89,90,92,93,94,97,101,103,104,144,181,227],[71,88,89,90,92,181,227],[88,91,149,181,227],[88,92,151,181,227,345],[150,181,227],[88,181,227],[71,92,152,181,227],[72,92,94,103,147,181,227],[72,92,94,99,103,147,181,227],[72,88,90,92,94,102,103,145,146,148,150,181,227],[92,99,151,181,227],[72,92,145,181,227],[146,147,148,151,152,154,155,181,227],[92,95,152,153,181,227],[92,143,181,227],[71,162,181,227,347],[161,181,227],[71,72,88,91,181,227]],"fileInfos":[{"version":"c430d44666289dae81f30fa7b2edebf186ecc91a2d4c71266ea6ae76388792e1","affectsGlobalScope":true,"impliedFormat":1},{"version":"45b7ab580deca34ae9729e97c13cfd999df04416a79116c3bfb483804f85ded4","impliedFormat":1},{"version":"3facaf05f0c5fc569c5649dd359892c98a85557e3e0c847964caeb67076f4d75","impliedFormat":1},{"version":"e44bb8bbac7f10ecc786703fe0a6a4b952189f908707980ba8f3c8975a760962","impliedFormat":1},{"version":"5e1c4c362065a6b95ff952c0eab010f04dcd2c3494e813b493ecfd4fcb9fc0d8","impliedFormat":1},{"version":"68d73b4a11549f9c0b7d352d10e91e5dca8faa3322bfb77b661839c42b1ddec7","impliedFormat":1},{"version":"5efce4fc3c29ea84e8928f97adec086e3dc876365e0982cc8479a07954a3efd4","impliedFormat":1},{"version":"feecb1be483ed332fad555aff858affd90a48ab19ba7272ee084704eb7167569","impliedFormat":1},{"version":"ee7bad0c15b58988daa84371e0b89d313b762ab83cb5b31b8a2d1162e8eb41c2","impliedFormat":1},{"version":"c57796738e7f83dbc4b8e65132f11a377649c00dd3eee333f672b8f0a6bea671","affectsGlobalScope":true,"impliedFormat":1},{"version":"dc2df20b1bcdc8c2d34af4926e2c3ab15ffe1160a63e58b7e09833f616efff44","affectsGlobalScope":true,"impliedFormat":1},{"version":"515d0b7b9bea2e31ea4ec968e9edd2c39d3eebf4a2d5cbd04e88639819ae3b71","affectsGlobalScope":true,"impliedFormat":1},{"version":"0559b1f683ac7505ae451f9a96ce4c3c92bdc71411651ca6ddb0e88baaaad6a3","affectsGlobalScope":true,"impliedFormat":1},{"version":"0dc1e7ceda9b8b9b455c3a2d67b0412feab00bd2f66656cd8850e8831b08b537","affectsGlobalScope":true,"impliedFormat":1},{"version":"ce691fb9e5c64efb9547083e4a34091bcbe5bdb41027e310ebba8f7d96a98671","affectsGlobalScope":true,"impliedFormat":1},{"version":"8d697a2a929a5fcb38b7a65594020fcef05ec1630804a33748829c5ff53640d0","affectsGlobalScope":true,"impliedFormat":1},{"version":"4ff2a353abf8a80ee399af572debb8faab2d33ad38c4b4474cff7f26e7653b8d","affectsGlobalScope":true,"impliedFormat":1},{"version":"fb0f136d372979348d59b3f5020b4cdb81b5504192b1cacff5d1fbba29378aa1","affectsGlobalScope":true,"impliedFormat":1},{"version":"d15bea3d62cbbdb9797079416b8ac375ae99162a7fba5de2c6c505446486ac0a","affectsGlobalScope":true,"impliedFormat":1},{"version":"68d18b664c9d32a7336a70235958b8997ebc1c3b8505f4f1ae2b7e7753b87618","affectsGlobalScope":true,"impliedFormat":1},{"version":"eb3d66c8327153d8fa7dd03f9c58d351107fe824c79e9b56b462935176cdf12a","affectsGlobalScope":true,"impliedFormat":1},{"version":"38f0219c9e23c915ef9790ab1d680440d95419ad264816fa15009a8851e79119","affectsGlobalScope":true,"impliedFormat":1},{"version":"69ab18c3b76cd9b1be3d188eaf8bba06112ebbe2f47f6c322b5105a6fbc45a2e","affectsGlobalScope":true,"impliedFormat":1},{"version":"a680117f487a4d2f30ea46f1b4b7f58bef1480456e18ba53ee85c2746eeca012","affectsGlobalScope":true,"impliedFormat":1},{"version":"2f11ff796926e0832f9ae148008138ad583bd181899ab7dd768a2666700b1893","affectsGlobalScope":true,"impliedFormat":1},{"version":"4de680d5bb41c17f7f68e0419412ca23c98d5749dcaaea1896172f06435891fc","affectsGlobalScope":true,"impliedFormat":1},{"version":"954296b30da6d508a104a3a0b5d96b76495c709785c1d11610908e63481ee667","affectsGlobalScope":true,"impliedFormat":1},{"version":"ac9538681b19688c8eae65811b329d3744af679e0bdfa5d842d0e32524c73e1c","affectsGlobalScope":true,"impliedFormat":1},{"version":"0a969edff4bd52585473d24995c5ef223f6652d6ef46193309b3921d65dd4376","affectsGlobalScope":true,"impliedFormat":1},{"version":"9e9fbd7030c440b33d021da145d3232984c8bb7916f277e8ffd3dc2e3eae2bdb","affectsGlobalScope":true,"impliedFormat":1},{"version":"811ec78f7fefcabbda4bfa93b3eb67d9ae166ef95f9bff989d964061cbf81a0c","affectsGlobalScope":true,"impliedFormat":1},{"version":"717937616a17072082152a2ef351cb51f98802fb4b2fdabd32399843875974ca","affectsGlobalScope":true,"impliedFormat":1},{"version":"d7e7d9b7b50e5f22c915b525acc5a49a7a6584cf8f62d0569e557c5cfc4b2ac2","affectsGlobalScope":true,"impliedFormat":1},{"version":"71c37f4c9543f31dfced6c7840e068c5a5aacb7b89111a4364b1d5276b852557","affectsGlobalScope":true,"impliedFormat":1},{"version":"576711e016cf4f1804676043e6a0a5414252560eb57de9faceee34d79798c850","affectsGlobalScope":true,"impliedFormat":1},{"version":"89c1b1281ba7b8a96efc676b11b264de7a8374c5ea1e6617f11880a13fc56dc6","affectsGlobalScope":true,"impliedFormat":1},{"version":"74f7fa2d027d5b33eb0471c8e82a6c87216223181ec31247c357a3e8e2fddc5b","affectsGlobalScope":true,"impliedFormat":1},{"version":"d6d7ae4d1f1f3772e2a3cde568ed08991a8ae34a080ff1151af28b7f798e22ca","affectsGlobalScope":true,"impliedFormat":1},{"version":"063600664504610fe3e99b717a1223f8b1900087fab0b4cad1496a114744f8df","affectsGlobalScope":true,"impliedFormat":1},{"version":"934019d7e3c81950f9a8426d093458b65d5aff2c7c1511233c0fd5b941e608ab","affectsGlobalScope":true,"impliedFormat":1},{"version":"52ada8e0b6e0482b728070b7639ee42e83a9b1c22d205992756fe020fd9f4a47","affectsGlobalScope":true,"impliedFormat":1},{"version":"3bdefe1bfd4d6dee0e26f928f93ccc128f1b64d5d501ff4a8cf3c6371200e5e6","affectsGlobalScope":true,"impliedFormat":1},{"version":"59fb2c069260b4ba00b5643b907ef5d5341b167e7d1dbf58dfd895658bda2867","affectsGlobalScope":true,"impliedFormat":1},{"version":"639e512c0dfc3fad96a84caad71b8834d66329a1f28dc95e3946c9b58176c73a","affectsGlobalScope":true,"impliedFormat":1},{"version":"368af93f74c9c932edd84c58883e736c9e3d53cec1fe24c0b0ff451f529ceab1","affectsGlobalScope":true,"impliedFormat":1},{"version":"af3dd424cf267428f30ccfc376f47a2c0114546b55c44d8c0f1d57d841e28d74","affectsGlobalScope":true,"impliedFormat":1},{"version":"995c005ab91a498455ea8dfb63aa9f83fa2ea793c3d8aa344be4a1678d06d399","affectsGlobalScope":true,"impliedFormat":1},{"version":"959d36cddf5e7d572a65045b876f2956c973a586da58e5d26cde519184fd9b8a","affectsGlobalScope":true,"impliedFormat":1},{"version":"965f36eae237dd74e6cca203a43e9ca801ce38824ead814728a2807b1910117d","affectsGlobalScope":true,"impliedFormat":1},{"version":"3925a6c820dcb1a06506c90b1577db1fdbf7705d65b62b99dce4be75c637e26b","affectsGlobalScope":true,"impliedFormat":1},{"version":"0a3d63ef2b853447ec4f749d3f368ce642264246e02911fcb1590d8c161b8005","affectsGlobalScope":true,"impliedFormat":1},{"version":"8cdf8847677ac7d20486e54dd3fcf09eda95812ac8ace44b4418da1bbbab6eb8","affectsGlobalScope":true,"impliedFormat":1},{"version":"8444af78980e3b20b49324f4a16ba35024fef3ee069a0eb67616ea6ca821c47a","affectsGlobalScope":true,"impliedFormat":1},{"version":"3287d9d085fbd618c3971944b65b4be57859f5415f495b33a6adc994edd2f004","affectsGlobalScope":true,"impliedFormat":1},{"version":"b4b67b1a91182421f5df999988c690f14d813b9850b40acd06ed44691f6727ad","affectsGlobalScope":true,"impliedFormat":1},{"version":"8e7f8264d0fb4c5339605a15daadb037bf238c10b654bb3eee14208f860a32ea","affectsGlobalScope":true,"impliedFormat":1},{"version":"782dec38049b92d4e85c1585fbea5474a219c6984a35b004963b00beb1aab538","affectsGlobalScope":true,"impliedFormat":1},{"version":"d3cfde44f8089768ebb08098c96d01ca260b88bccf238d55eee93f1c620ff5a5","impliedFormat":1},{"version":"293eadad9dead44c6fd1db6de552663c33f215c55a1bfa2802a1bceed88ff0ec","impliedFormat":1},{"version":"833e92c058d033cde3f29a6c7603f517001d1ddd8020bc94d2067a3bc69b2a8e","impliedFormat":1},{"version":"08b2fae7b0f553ad9f79faec864b179fc58bc172e295a70943e8585dd85f600c","impliedFormat":1},{"version":"f12edf1672a94c578eca32216839604f1e1c16b40a1896198deabf99c882b340","impliedFormat":1},{"version":"e3498cf5e428e6c6b9e97bd88736f26d6cf147dedbfa5a8ad3ed8e05e059af8a","impliedFormat":1},{"version":"dba3f34531fd9b1b6e072928b6f885aa4d28dd6789cbd0e93563d43f4b62da53","impliedFormat":1},{"version":"f672c876c1a04a223cf2023b3d91e8a52bb1544c576b81bf64a8fec82be9969c","impliedFormat":1},{"version":"e4b03ddcf8563b1c0aee782a185286ed85a255ce8a30df8453aade2188bbc904","impliedFormat":1},{"version":"2329d90062487e1eaca87b5e06abcbbeeecf80a82f65f949fd332cfcf824b87b","impliedFormat":1},{"version":"25b3f581e12ede11e5739f57a86e8668fbc0124f6649506def306cad2c59d262","impliedFormat":1},{"version":"4fdb529707247a1a917a4626bfb6a293d52cd8ee57ccf03830ec91d39d606d6d","impliedFormat":1},{"version":"a9ebb67d6bbead6044b43714b50dcb77b8f7541ffe803046fdec1714c1eba206","impliedFormat":1},{"version":"5780b706cece027f0d4444fbb4e1af62dc51e19da7c3d3719f67b22b033859b9","impliedFormat":1},{"version":"d3e74b1fdc18762c91ab345cdb2a7fba18d19fcd084efb7249fa7d6107edd63a","signature":"4e4fde40cccde11abc1e36b70d2781b9c9ce9174db7ddc28254a00affab175f9","impliedFormat":99},{"version":"9229744ea25e18a192f5953aa3b3f455d70eef16856888369b4a6979d0d96bae","impliedFormat":99},{"version":"5aec75ee5fa189dc5c35748219c22244702ec0d0d966fcd3d42d490b1f48ee09","impliedFormat":99},{"version":"f17daf0c5d1f20be1f983d0447e8aece97fdc198c9fa81ebe601f9e42dd1b321","impliedFormat":99},{"version":"0e7de46779b62e113b2266811b6d5c5f20b693d50d844447d09c6f203929a348","impliedFormat":99},{"version":"08b97f852e158ac5d2eaa7f9e375cb74f95b044ca056b0229133b8bd80b1a5d2","impliedFormat":99},{"version":"f510cb6b6494801377cfe8acf3aeebfc94a552490a49da49f68656fc28a51ad6","impliedFormat":99},{"version":"6dbb943e2651b8adaff2f73dada2bc506876926ae1a8e4dfc97d217408c98c3c","impliedFormat":99},{"version":"d1d300d88d14b034e0904ee5fffb82d348604e876b872a1fbb6ebcea0e00149a","impliedFormat":99},{"version":"56ea81afc382c20b1146a4a0a31f99c430024e554e1e2192fa561b2b9a6bbd00","impliedFormat":99},{"version":"62cf651f9b9b298228a5b0ffd02e9441615996f2a06e783faae3a455aa4165d9","impliedFormat":99},{"version":"bc82f0deae147bb18c9e9a3b015f62994ed76122e09d06e3e2cce4f6b1b2c945","impliedFormat":99},{"version":"5546b8dc48d6a8b9b2487e57b7c3cbe0af7db5a8d9abb8993694fec581b07546","impliedFormat":99},{"version":"ca37646b3fe21707e0d7c3c3276971c58105fb7abe98230b73f1fa85628300c3","impliedFormat":99},{"version":"155be70478040379afa4b43bcb26f95383a0014c76f5cde69db9ac40720d414e","impliedFormat":99},{"version":"62bf81731c59340fa709e78e0dc44ad3e15d69fc2dd093abdb9926613abd3ee5","impliedFormat":99},{"version":"c2743fddf0130b0e179367a8e5491fae3b1078dccdb9105aaa6c2d4bb882a0de","impliedFormat":99},{"version":"f5b371a40fb688b72354b0f88d30b1ada4b1765952d5c3bf3c1e115f3edd4268","signature":"b15681f69aa71a25db7672eee946274bc8459ae6ae3ae392f19265a71d3194f6","impliedFormat":99},{"version":"f98a87f6bf2a7b4b3407b0f08a424e80318328a3444912e8fc39a6e42b944c87","signature":"c516953ee0cf36ef321ba488bedb0e7e5b106be7de93e5451e571e6be0567d60","impliedFormat":99},{"version":"a87fd0d75f84347bbee9075473bc748e867b610d8f0cb359df36ce6bd676430d","signature":"c9dbe0bc559736cf62b870b5901ee3158b14080391aa15eaad0b9a174c6b4185","impliedFormat":99},{"version":"90dca83c1dbcf28e60c1943e7006392aa1936f51645bc40c962017ac7394909a","signature":"e644d4a3b7b946ce1acc687e70a5ae532a3dad4297a2152022ecc04e550f76e0","impliedFormat":99},{"version":"6590ab89f5ab0abd6301df81ab27cbfd7bbc04df7e2da71b61c8afcdb8cab1d1","signature":"906f0b47dac17c3ad0a04172cb4e8d8f714d2a11d3dccca6c3d5ac8c406a42f6","impliedFormat":99},{"version":"04cec88fee746f8f754237d9ae8b626969bf115631ff25ec1781f222e4172614","signature":"99a8f0b0c1096168d96481476631ce7c015efaa1c4b0e0133e6619be1bb81813","impliedFormat":99},{"version":"a6bfc6630bb6a040236f61029c582238aa7652558f6613bd7114164e50c45552","signature":"2293b89e57f272a8d6fcf67adfa1685e69db33664644002bdd61537888929156","impliedFormat":99},{"version":"b251ad1ab2447393153333cb640ed3fb9b482bf7bae49d3e2a1ac7666849a96b","signature":"7ba37dab6069657b1b120d8cdf31163cf147bd3dc8017a6fe27df3a328d5501f","impliedFormat":99},{"version":"0af1d0ff5d6e62e96b557652342796afc998370a5c91ff86f16d70a2bcb42782","signature":"b99a1a93a698a4827a5ce22687c5ef33a97485c02da0c77c0bbcd5db7b4d825e","impliedFormat":99},{"version":"e7411ab2a31b8369f389ecd75e54a2f13d729f2f4e931fce8e80b486d4764360","signature":"98d278c0fa9e155cac631ae663a5171e2315308082abe6422beaa31b48e0961d","impliedFormat":99},{"version":"06a85227e746d425c5219d8c5dea438de250cbff2da1f10ee245ef93ed721898","signature":"db555c91c6aa8195135ad343cb69d296bd39555154f5c3803b8dd7fc9d4ff62a","impliedFormat":99},{"version":"b99d24b75bf871d95acddf8e97f5e7f042695b85837f3cd90111a7159ac4432f","signature":"b96dba8041a0bf7d0f2e2d7f87060cf5c979fad5827bd871e2e3de89f74b8f86","impliedFormat":99},{"version":"4ed8187e849a270d7373af983d54c86315772dc17215674b000f43b47e7cc7e5","signature":"be98d3f07e06eaa1096402202f78e3f40fb59f9b701231e3051972633e6dfd1b","impliedFormat":99},{"version":"755dde19a352e836a7a7644e96973a1eacf1f2dbc36b014cde7f96174fdafc58","signature":"6ecdeb610dddf916221f162746b110042b3e3c4a90cf74dd841857a30f075cf0","impliedFormat":99},{"version":"11510632e1d2649ef0832d24b669f0a22ddfea7b67163b728868c1175bd55749","signature":"3689c831f7a4d12da0052c57a7fadd181c8bcc0a8179f20306e6efecb7c4690f","impliedFormat":99},{"version":"b8b1334c905ce031f926b9f70e63777fbce423f1074f306b36f1b6295ed47816","signature":"e6e90668c7fef296464ef145892f5ece72abfe84358208abe3d28e5a1142ad3b","impliedFormat":99},{"version":"ef38456e22b0bffcd9ff28dc1a7138e84918a212e6960dd620cc3000341c0ebe","impliedFormat":1},{"version":"07a1cea63a067c0845029ea6e1933af842783efa3006510f504b1f09bd2ebff0","impliedFormat":1},{"version":"814187370f99638f6bb69c838d19dcdb20a41cb65627cfc16a04d9cc4522fc82","impliedFormat":1},{"version":"7df3ea6fcd7e74ab59724700357df41a12d8f57e22f3e5da36dc645f20753152","impliedFormat":1},{"version":"0e8edbe744dfc3ce65e9fa2283f1f0eb2c0aaaec4df19765f51c346e45452cda","impliedFormat":1},{"version":"a7559733f2f5f9ae4d071cef99c505870e167ee830c75faf121f34408b99afbe","impliedFormat":1},{"version":"9b6e899f6fa0cf536eead034fcae436ab6ecd9442153ee06a0fb5b01475bff85","impliedFormat":1},{"version":"1b399336f32abd1c83610e5c95337fdcf2dd5414cf4b44c1ff4927d2cd8f1cf2","impliedFormat":1},{"version":"55ddb00c1810d07a092af6a816f89a6e63c3c4ef04c9c27d36a7dd59bf59b5ae","impliedFormat":1},{"version":"5ecb3df85ac1c4a7e7a1e9761a5bfb52a65eef8e94e1280e1bff6389cd453099","impliedFormat":1},{"version":"9af342002e6b793ca8a69b322cf8347250c129b45dbca8731baaa66ec553561b","impliedFormat":1},{"version":"e01ab496375025f3e54f832d43f840c589e57eb2e5986421f791f51bbcbc494e","impliedFormat":1},{"version":"539cc98696e783f3fe32422a89f8a34479ce056adb211dd60b6a89550d3b9b7f","impliedFormat":1},{"version":"11d5d9c9b11fbd1537ecec72ec38f993d0358c42f7c98569998a04bbbf57d07c","impliedFormat":1},{"version":"c26c383b08e47dfbd741193ef1e7f8f002ac3b0d2f6bf3d4b6b9a99ee2d9378e","impliedFormat":1},{"version":"75473b178a514d8768d6ead4a4da267aa6bedeeb792cd9437e45b46fa2dcf608","impliedFormat":1},{"version":"e82a6fc9b90adc5270daa1e467feb3a2ae5393180839d7a347acd1d9ebe04493","impliedFormat":1},{"version":"3d877e9f51aabdb77efeea746c0c09464274dcaf7364e6e64880e9c2eaa8c990","impliedFormat":1},{"version":"9830d91d01b457b113b36b56d4534ba8fc42bc3c195a2108dc3431e9f77340c7","impliedFormat":1},{"version":"1e7d16304d31f287ec09753214b755eb78e1122432d06dc771f5c123199273b1","impliedFormat":1},{"version":"acca4486b08bf5dc91c23d65f47181bd13f82571969c85e8df474fa6bc5c2a88","impliedFormat":1},{"version":"296dcaf11fa0122dfe78a1d97bea96aa9bccb73098bc739ab253281ad192dffb","impliedFormat":1},{"version":"971dc452ac09307ee049acb21bbd30a82d1c163377465d6b33fd4d677ed2385d","impliedFormat":1},{"version":"226b58896f4f01f4c669d908f32c657bcab1a83f3aebb2f3d711a4fe7ba2a2d6","impliedFormat":1},{"version":"8a818c9cf372e5c5818d846d761ff59c531caa3b0aa62c5686be1df31dc08296","impliedFormat":1},{"version":"f01c60b06afe23316efccaaa8b6ccb5f507b8e6eadf5e2a84c6fe350aebaa1bd","impliedFormat":1},{"version":"9a447607a90667c6db7737f30d2429f6f06efde55a47a2a3eeebc52e866d153e","impliedFormat":1},{"version":"ecc6f977713316ef4339f32631ecb619a40a3061fa86ff3776591920d9977e24","impliedFormat":1},{"version":"0aea84fed0ab80d54f32a40aaf5f4d58c8a5259dd5f9fe39dbcd584575dbb100","impliedFormat":1},{"version":"a1769100f50f3e190c2ea2ed2a711e6798c70f9ad806b54c597a5b64488007b0","impliedFormat":1},{"version":"8105a77b1ce063fd0f60080d8985e01cb92516237cb4a254547ce7548e8916e5","impliedFormat":1},{"version":"dc6b3b3383218cc2c556687fd7ac7b6b1d9ad3abaf50da7f04a2d7a01abaee19","impliedFormat":1},{"version":"879443705ef53b56d8f5b944ea2c24bd5b37a1341eb0142789c2e2567d6bb6e1","impliedFormat":1},{"version":"44c18ff24c5c5b7883ca2e1b1d4236db715ca5cfd9b87705e1a7e4591b4b445e","impliedFormat":1},{"version":"3cceb8a1fe59bc1d233764bfef78e6c72a468e2af1e06a92e282b1848c78bc31","impliedFormat":1},{"version":"ed96d25fa3170958d1d376e653ade8e653638d3fb819a4792a503a5505eea849","impliedFormat":1},{"version":"a005dc547fff460703595b4c0faccb7ec68a5870a4d0e5a2932dc1fd59cc9856","impliedFormat":1},{"version":"dccbbf8ce85ea99cdbdc2269d55f75bc1fbad77d96c40fd82bd73af3fb8f39e4","impliedFormat":1},{"version":"449babe88138e129aef94c1696b527898f9e13ab62bce129daee0e85266e48a7","impliedFormat":1},{"version":"197a74fdb2a56657d8c2f74bde9fcc9075dfce0c8948ab4be3e4bf6ccdf96f04","signature":"0303f19ff487a4bd4f52c78e30fa1e6d4426af24d01134d4c996f0cdd1711424","impliedFormat":99},{"version":"37c2e4f582343f04f84636e772524f0dedf1a88d7df406ec9af2534ce4def135","signature":"ec794b19653311faac160df606de88321143ecb0c262c419443ad2df347850fd","impliedFormat":99},{"version":"6bd1a60fc8f9807a39adc94e000e63e169d32e6ad12f5df444dbb4692614c5c7","signature":"d234cfe745e66f22c1552cb2def439e22496bb6d6d4897285f46ecc2a6c83392","impliedFormat":99},{"version":"509ec521340b0dd539efbab5179b6e600d7330f3453447b82216997baedb35b2","signature":"087f21bc395308929d3938c7bf752035c45c19464fec69a46dd0742b92176b67","impliedFormat":99},{"version":"decee1e9ae8747c9b52eabf2f502e78c9a19e7b9f4ec419e68b1571646838e48","signature":"4b09018effdb1c862692b3ef4622cbc1f487fa7efff5d3ba06d064bbf7167269","impliedFormat":99},{"version":"7063bb59d941daf34237d40e329f10a2e0f700217ef86b12d8e3a6531b51ddc9","signature":"91bb5cdbeaa305ea398892d9b27b1b26f8d6746fedc5cb0d0d0e5a313ef6a3d0","impliedFormat":99},{"version":"b21650bde475647bdc443888149f39114debf0c0289184fe0db3eeeac736519c","signature":"cc02100f9a4917e5dc165ec1ff8fa4f2875407703e6fca639df82e2590c8664b","impliedFormat":99},{"version":"498999d55589f397c9f60f9d07e016a83be272007975a5af0c1a9ab676213223","signature":"b214cba0e63f4f4cd8f1027024ab7809c394af83eb64873721f3f00ff63a0523","impliedFormat":99},{"version":"2120decdf699395a1fc78c163ccbc5ed461549c8182f327fc75661cd38a2958a","signature":"ab3b5ef40bb85def1a0a65c394389679425da8f718d489f384e96a2ec74422bf","impliedFormat":99},{"version":"fabd48e7c96fc911a66f3f13f4c74554c509924ad3fb064922980c2d28f73574","signature":"43101d7d2612f89798fc843438397f196906ecf206c4c1d0c86941f4a162bfb2","impliedFormat":99},{"version":"aa95ff250fad667fdd3de7bf67e4a80dce0bccd4e66355571db5f83c57700868","signature":"80acee276cff12ea4b797eba93fef3c9ed2b6c6d2afc43fbdec089ddcb633e6f","impliedFormat":99},{"version":"5987930946d0ef17c622afbfba763d43300221a31c3e0574aac66c645e9f9f8f","signature":"f144b13ca0e87efd76f251dc34fac98246dc97a747b3acc49f8269f5f33c2a42","impliedFormat":99},{"version":"43b7ee78ed39a38ad8bf7e6d72305fbbc71f4cbd365d8ac310b78ccebbfa1869","impliedFormat":99},{"version":"86d4372181473be0e023841b5b580fe073ba764f723b11d38c6bcaa5c8423421","signature":"d8b9a86eb49f8f558ba5b4cecbf462e8138ccbee5607c148c9c426587ede4e57","impliedFormat":99},{"version":"e132cf2c89b7604c8c1e797e562dfc6c74a404c960393e28bba9c4628d1bd6da","signature":"ca4170457e8caa775891281cb9cedd03ab92b9f9fc69c845241b0f2a0d02da97","impliedFormat":99},{"version":"9412a798d71d2b05100430db2817823b54101a50e78e4a39b0e621c110c97878","signature":"210fd775316cbadf93fa5b4e26f384ccfebf2cf05e35c55e687038bf3cd0ff70","impliedFormat":99},{"version":"20753262ac906733a6e8a699b8716f12076af30d63f8fea92a58203e6efc551a","signature":"bd82078dbb143d57c14723f58b07b82dd48192935c28043aa8adb2904666a84f","impliedFormat":99},{"version":"581c746623158d1686e196ec4603c22f7e2e66f664c3868bfa27a2c05cc0ea71","signature":"f3e54114014476a0b4da7313e993dfe0be7a92eb06296f75cb5fbeb5c97ad9fb","impliedFormat":99},{"version":"7425f0ebbf8e6e5af057f91fd38bd8836725b509af6dfc157f2aceec888d7cf0","impliedFormat":99},{"version":"d2e64a6f25013b099e83bfadb2c388d7bef3e8f3fdb25528225bbc841e7e7e3a","impliedFormat":99},{"version":"369ba5259e66ca8c7d35e3234f7a2a0863a770fdb8266505747c65cf346a0804","impliedFormat":99},{"version":"64d984f55025daf604f670b7dfd090ea765f2098aee871174ef2ee3e94479098","impliedFormat":99},{"version":"f147b6710441cf3ec3234adf63b0593ce5e8c9b692959d21d3babc8454bcf743","impliedFormat":99},{"version":"e96d5373a66c2cfbbc7e6642cf274055aa2c7ff6bd37be7480c66faf9804db6d","impliedFormat":99},{"version":"02bcdd7a76c5c1c485cbf05626d24c86ac8f9a1d8dc31f8924108bbaa4cf3ba9","impliedFormat":99},{"version":"c874ab6feac6e0fdf9142727c9a876065777a5392f14b0bbcf869b1e69eb46b5","impliedFormat":99},{"version":"7c553fc9e34773ddbaabe0fa1367d4b109101d0868a008f11042bee24b5a925d","impliedFormat":99},{"version":"9962ce696fbdce2421d883ca4b062a54f982496625437ae4d3633376c5ad4a80","impliedFormat":99},{"version":"e3ea467c4a7f743f3548c9ed61300591965b1d12c08c8bb9aaff8a002ba95fce","impliedFormat":99},{"version":"4c17183a07a63bea2653fbfc0a942b027160ddbee823024789a415f9589de327","impliedFormat":99},{"version":"3e2203c892297ea44b87470fde51b3d48cfe3eeb6901995de429539462894464","impliedFormat":99},{"version":"c84bf7a4abc5e7fdf45971a71b25b0e0d34ccd5e720a866dd78bb71d60d41a3f","impliedFormat":99},{"version":"70521b6ab0dcba37539e5303104f29b721bfb2940b2776da4cc818c07e1fefc1","affectsGlobalScope":true,"impliedFormat":1},{"version":"ab41ef1f2cdafb8df48be20cd969d875602483859dc194e9c97c8a576892c052","affectsGlobalScope":true,"impliedFormat":1},{"version":"d153a11543fd884b596587ccd97aebbeed950b26933ee000f94009f1ab142848","affectsGlobalScope":true,"impliedFormat":1},{"version":"21d819c173c0cf7cc3ce57c3276e77fd9a8a01d35a06ad87158781515c9a438a","impliedFormat":1},{"version":"98cffbf06d6bab333473c70a893770dbe990783904002c4f1a960447b4b53dca","affectsGlobalScope":true,"impliedFormat":1},{"version":"ba481bca06f37d3f2c137ce343c7d5937029b2468f8e26111f3c9d9963d6568d","affectsGlobalScope":true,"impliedFormat":1},{"version":"6d9ef24f9a22a88e3e9b3b3d8c40ab1ddb0853f1bfbd5c843c37800138437b61","affectsGlobalScope":true,"impliedFormat":1},{"version":"1db0b7dca579049ca4193d034d835f6bfe73096c73663e5ef9a0b5779939f3d0","affectsGlobalScope":true,"impliedFormat":1},{"version":"9798340ffb0d067d69b1ae5b32faa17ab31b82466a3fc00d8f2f2df0c8554aaa","affectsGlobalScope":true,"impliedFormat":1},{"version":"f26b11d8d8e4b8028f1c7d618b22274c892e4b0ef5b3678a8ccbad85419aef43","affectsGlobalScope":true,"impliedFormat":1},{"version":"5929864ce17fba74232584d90cb721a89b7ad277220627cc97054ba15a98ea8f","impliedFormat":1},{"version":"763fe0f42b3d79b440a9b6e51e9ba3f3f91352469c1e4b3b67bfa4ff6352f3f4","impliedFormat":1},{"version":"25c8056edf4314820382a5fdb4bb7816999acdcb929c8f75e3f39473b87e85bc","impliedFormat":1},{"version":"c464d66b20788266e5353b48dc4aa6bc0dc4a707276df1e7152ab0c9ae21fad8","impliedFormat":1},{"version":"78d0d27c130d35c60b5e5566c9f1e5be77caf39804636bc1a40133919a949f21","impliedFormat":1},{"version":"c6fd2c5a395f2432786c9cb8deb870b9b0e8ff7e22c029954fabdd692bff6195","impliedFormat":1},{"version":"1d6e127068ea8e104a912e42fc0a110e2aa5a66a356a917a163e8cf9a65e4a75","impliedFormat":1},{"version":"5ded6427296cdf3b9542de4471d2aa8d3983671d4cac0f4bf9c637208d1ced43","impliedFormat":1},{"version":"7f182617db458e98fc18dfb272d40aa2fff3a353c44a89b2c0ccb3937709bfb5","impliedFormat":1},{"version":"cadc8aced301244057c4e7e73fbcae534b0f5b12a37b150d80e5a45aa4bebcbd","impliedFormat":1},{"version":"385aab901643aa54e1c36f5ef3107913b10d1b5bb8cbcd933d4263b80a0d7f20","impliedFormat":1},{"version":"9670d44354bab9d9982eca21945686b5c24a3f893db73c0dae0fd74217a4c219","impliedFormat":1},{"version":"0b8a9268adaf4da35e7fa830c8981cfa22adbbe5b3f6f5ab91f6658899e657a7","impliedFormat":1},{"version":"11396ed8a44c02ab9798b7dca436009f866e8dae3c9c25e8c1fbc396880bf1bb","impliedFormat":1},{"version":"ba7bc87d01492633cb5a0e5da8a4a42a1c86270e7b3d2dea5d156828a84e4882","impliedFormat":1},{"version":"4893a895ea92c85345017a04ed427cbd6a1710453338df26881a6019432febdd","impliedFormat":1},{"version":"c21dc52e277bcfc75fac0436ccb75c204f9e1b3fa5e12729670910639f27343e","impliedFormat":1},{"version":"13f6f39e12b1518c6650bbb220c8985999020fe0f21d818e28f512b7771d00f9","impliedFormat":1},{"version":"9b5369969f6e7175740bf51223112ff209f94ba43ecd3bb09eefff9fd675624a","impliedFormat":1},{"version":"4fe9e626e7164748e8769bbf74b538e09607f07ed17c2f20af8d680ee49fc1da","impliedFormat":1},{"version":"24515859bc0b836719105bb6cc3d68255042a9f02a6022b3187948b204946bd2","impliedFormat":1},{"version":"ea0148f897b45a76544ae179784c95af1bd6721b8610af9ffa467a518a086a43","impliedFormat":1},{"version":"24c6a117721e606c9984335f71711877293a9651e44f59f3d21c1ea0856f9cc9","impliedFormat":1},{"version":"dd3273ead9fbde62a72949c97dbec2247ea08e0c6952e701a483d74ef92d6a17","impliedFormat":1},{"version":"405822be75ad3e4d162e07439bac80c6bcc6dbae1929e179cf467ec0b9ee4e2e","impliedFormat":1},{"version":"0db18c6e78ea846316c012478888f33c11ffadab9efd1cc8bcc12daded7a60b6","impliedFormat":1},{"version":"e61be3f894b41b7baa1fbd6a66893f2579bfad01d208b4ff61daef21493ef0a8","impliedFormat":1},{"version":"bd0532fd6556073727d28da0edfd1736417a3f9f394877b6d5ef6ad88fba1d1a","impliedFormat":1},{"version":"89167d696a849fce5ca508032aabfe901c0868f833a8625d5a9c6e861ef935d2","impliedFormat":1},{"version":"615ba88d0128ed16bf83ef8ccbb6aff05c3ee2db1cc0f89ab50a4939bfc1943f","impliedFormat":1},{"version":"a4d551dbf8746780194d550c88f26cf937caf8d56f102969a110cfaed4b06656","impliedFormat":1},{"version":"8bd86b8e8f6a6aa6c49b71e14c4ffe1211a0e97c80f08d2c8cc98838006e4b88","impliedFormat":1},{"version":"317e63deeb21ac07f3992f5b50cdca8338f10acd4fbb7257ebf56735bf52ab00","impliedFormat":1},{"version":"4732aec92b20fb28c5fe9ad99521fb59974289ed1e45aecb282616202184064f","impliedFormat":1},{"version":"2e85db9e6fd73cfa3d7f28e0ab6b55417ea18931423bd47b409a96e4a169e8e6","impliedFormat":1},{"version":"c46e079fe54c76f95c67fb89081b3e399da2c7d109e7dca8e4b58d83e332e605","impliedFormat":1},{"version":"bf67d53d168abc1298888693338cb82854bdb2e69ef83f8a0092093c2d562107","impliedFormat":1},{"version":"2cbe0621042e2a68c7cbce5dfed3906a1862a16a7d496010636cdbdb91341c0f","affectsGlobalScope":true,"impliedFormat":1},{"version":"e2677634fe27e87348825bb041651e22d50a613e2fdf6a4a3ade971d71bac37e","impliedFormat":1},{"version":"7394959e5a741b185456e1ef5d64599c36c60a323207450991e7a42e08911419","impliedFormat":1},{"version":"8c0bcd6c6b67b4b503c11e91a1fb91522ed585900eab2ab1f61bba7d7caa9d6f","impliedFormat":1},{"version":"8cd19276b6590b3ebbeeb030ac271871b9ed0afc3074ac88a94ed2449174b776","affectsGlobalScope":true,"impliedFormat":1},{"version":"696eb8d28f5949b87d894b26dc97318ef944c794a9a4e4f62360cd1d1958014b","impliedFormat":1},{"version":"3f8fa3061bd7402970b399300880d55257953ee6d3cd408722cb9ac20126460c","impliedFormat":1},{"version":"35ec8b6760fd7138bbf5809b84551e31028fb2ba7b6dc91d95d098bf212ca8b4","affectsGlobalScope":true,"impliedFormat":1},{"version":"5524481e56c48ff486f42926778c0a3cce1cc85dc46683b92b1271865bcf015a","impliedFormat":1},{"version":"68bd56c92c2bd7d2339457eb84d63e7de3bd56a69b25f3576e1568d21a162398","affectsGlobalScope":true,"impliedFormat":1},{"version":"3e93b123f7c2944969d291b35fed2af79a6e9e27fdd5faa99748a51c07c02d28","impliedFormat":1},{"version":"9d19808c8c291a9010a6c788e8532a2da70f811adb431c97520803e0ec649991","impliedFormat":1},{"version":"87aad3dd9752067dc875cfaa466fc44246451c0c560b820796bdd528e29bef40","impliedFormat":1},{"version":"4aacb0dd020eeaef65426153686cc639a78ec2885dc72ad220be1d25f1a439df","impliedFormat":1},{"version":"f0bd7e6d931657b59605c44112eaf8b980ba7f957a5051ed21cb93d978cf2f45","impliedFormat":1},{"version":"8db0ae9cb14d9955b14c214f34dae1b9ef2baee2fe4ce794a4cd3ac2531e3255","affectsGlobalScope":true,"impliedFormat":1},{"version":"15fc6f7512c86810273af28f224251a5a879e4261b4d4c7e532abfbfc3983134","impliedFormat":1},{"version":"58adba1a8ab2d10b54dc1dced4e41f4e7c9772cbbac40939c0dc8ce2cdb1d442","impliedFormat":1},{"version":"2fd4c143eff88dabb57701e6a40e02a4dbc36d5eb1362e7964d32028056a782b","impliedFormat":1},{"version":"714435130b9015fae551788df2a88038471a5a11eb471f27c4ede86552842bc9","impliedFormat":1},{"version":"855cd5f7eb396f5f1ab1bc0f8580339bff77b68a770f84c6b254e319bbfd1ac7","impliedFormat":1},{"version":"5650cf3dace09e7c25d384e3e6b818b938f68f4e8de96f52d9c5a1b3db068e86","impliedFormat":1},{"version":"1354ca5c38bd3fd3836a68e0f7c9f91f172582ba30ab15bb8c075891b91502b7","affectsGlobalScope":true,"impliedFormat":1},{"version":"27fdb0da0daf3b337c5530c5f266efe046a6ceb606e395b346974e4360c36419","impliedFormat":1},{"version":"2d2fcaab481b31a5882065c7951255703ddbe1c0e507af56ea42d79ac3911201","impliedFormat":1},{"version":"a192fe8ec33f75edbc8d8f3ed79f768dfae11ff5735e7fe52bfa69956e46d78d","impliedFormat":1},{"version":"ca867399f7db82df981d6915bcbb2d81131d7d1ef683bc782b59f71dda59bc85","affectsGlobalScope":true,"impliedFormat":1},{"version":"0e456fd5b101271183d99a9087875a282323e3a3ff0d7bcf1881537eaa8b8e63","affectsGlobalScope":true,"impliedFormat":1},{"version":"9e043a1bc8fbf2a255bccf9bf27e0f1caf916c3b0518ea34aa72357c0afd42ec","impliedFormat":1},{"version":"b4f70ec656a11d570e1a9edce07d118cd58d9760239e2ece99306ee9dfe61d02","impliedFormat":1},{"version":"3bc2f1e2c95c04048212c569ed38e338873f6a8593930cf5a7ef24ffb38fc3b6","impliedFormat":1},{"version":"6e70e9570e98aae2b825b533aa6292b6abd542e8d9f6e9475e88e1d7ba17c866","impliedFormat":1},{"version":"f9d9d753d430ed050dc1bf2667a1bab711ccbb1c1507183d794cc195a5b085cc","impliedFormat":1},{"version":"9eece5e586312581ccd106d4853e861aaaa1a39f8e3ea672b8c3847eedd12f6e","impliedFormat":1},{"version":"47ab634529c5955b6ad793474ae188fce3e6163e3a3fb5edd7e0e48f14435333","impliedFormat":1},{"version":"37ba7b45141a45ce6e80e66f2a96c8a5ab1bcef0fc2d0f56bb58df96ec67e972","impliedFormat":1},{"version":"45650f47bfb376c8a8ed39d4bcda5902ab899a3150029684ee4c10676d9fbaee","impliedFormat":1},{"version":"fad4e3c207fe23922d0b2d06b01acbfb9714c4f2685cf80fd384c8a100c82fd0","affectsGlobalScope":true,"impliedFormat":1},{"version":"74cf591a0f63db318651e0e04cb55f8791385f86e987a67fd4d2eaab8191f730","impliedFormat":1},{"version":"5eab9b3dc9b34f185417342436ec3f106898da5f4801992d8ff38ab3aff346b5","impliedFormat":1},{"version":"12ed4559eba17cd977aa0db658d25c4047067444b51acfdcbf38470630642b23","affectsGlobalScope":true,"impliedFormat":1},{"version":"f3ffabc95802521e1e4bcba4c88d8615176dc6e09111d920c7a213bdda6e1d65","impliedFormat":1},{"version":"ddc734b4fae82a01d247e9e342d020976640b5e93b4e9b3a1e30e5518883a060","impliedFormat":1},{"version":"ae56f65caf3be91108707bd8dfbccc2a57a91feb5daabf7165a06a945545ed26","impliedFormat":1},{"version":"a136d5de521da20f31631a0a96bf712370779d1c05b7015d7019a9b2a0446ca9","impliedFormat":1},{"version":"c3b41e74b9a84b88b1dca61ec39eee25c0dbc8e7d519ba11bb070918cfacf656","affectsGlobalScope":true,"impliedFormat":1},{"version":"4737a9dc24d0e68b734e6cfbcea0c15a2cfafeb493485e27905f7856988c6b29","affectsGlobalScope":true,"impliedFormat":1},{"version":"36d8d3e7506b631c9582c251a2c0b8a28855af3f76719b12b534c6edf952748d","impliedFormat":1},{"version":"1ca69210cc42729e7ca97d3a9ad48f2e9cb0042bada4075b588ae5387debd318","impliedFormat":1},{"version":"f5ebe66baaf7c552cfa59d75f2bfba679f329204847db3cec385acda245e574e","impliedFormat":1},{"version":"ed59add13139f84da271cafd32e2171876b0a0af2f798d0c663e8eeb867732cf","affectsGlobalScope":true,"impliedFormat":1},{"version":"05db535df8bdc30d9116fe754a3473d1b6479afbc14ae8eb18b605c62677d518","impliedFormat":1},{"version":"b1810689b76fd473bd12cc9ee219f8e62f54a7d08019a235d07424afbf074d25","impliedFormat":1},{"version":"151ff381ef9ff8da2da9b9663ebf657eac35c4c9a19183420c05728f31a6761d","impliedFormat":1},{"version":"ee70b8037ecdf0de6c04f35277f253663a536d7e38f1539d270e4e916d225a3f","affectsGlobalScope":true,"impliedFormat":1},{"version":"a660aa95476042d3fdcc1343cf6bb8fdf24772d31712b1db321c5a4dcc325434","impliedFormat":1},{"version":"a7ca8df4f2931bef2aa4118078584d84a0b16539598eaadf7dce9104dfaa381c","impliedFormat":1},{"version":"11443a1dcfaaa404c68d53368b5b818712b95dd19f188cab1669c39bee8b84b3","impliedFormat":1},{"version":"36977c14a7f7bfc8c0426ae4343875689949fb699f3f84ecbe5b300ebf9a2c55","impliedFormat":1},{"version":"035d0934d304483f07148427a5bd5b98ac265dae914a6b49749fe23fbd893ec7","impliedFormat":99},{"version":"e2ed5b81cbed3a511b21a18ab2539e79ac1f4bc1d1d28f8d35d8104caa3b429f","impliedFormat":99},{"version":"161c8e0690c46021506e32fda85956d785b70f309ae97011fd27374c065cac9b","affectsGlobalScope":true,"impliedFormat":1},{"version":"402e5c534fb2b85fa771170595db3ac0dd532112c8fa44fc23f233bc6967488b","impliedFormat":1},{"version":"52dcc257df5119fb66d864625112ce5033ac51a4c2afe376a0b299d2f7f76e4a","impliedFormat":1},{"version":"e5bab5f871ef708d52d47b3e5d0aa72a08ee7a152f33931d9a60809711a2a9a3","impliedFormat":1},{"version":"e16dc2a81595736024a206c7d5c8a39bfe2e6039208ef29981d0d95434ba8fcf","impliedFormat":1},{"version":"cc4a4903fb698ca1d961d4c10dce658aa3a479faf40509d526f122b044eaf6a4","impliedFormat":1},{"version":"19ee8416e6473ed6c7adb868fa796b5653cf0fa2a337658e677eaa0d134388c3","impliedFormat":1},{"version":"1328ab4e442614b28cdb3d4b414cf68325c0da0dca07287a338d0654b7a00261","impliedFormat":1},{"version":"a039dc21f045919f3cbee2ec13812cc6cc3eebc99dae4be00973230f468d19a6","impliedFormat":1},{"version":"3fbe57af01460e49dcd29df55d6931e1672bc6f1be0fb073d11410bc16f9037d","impliedFormat":1},{"version":"f760be449e8562ec5c09bb5187e8e1eabf3c113c0c58cddda53ef8c69f3e2131","impliedFormat":1},{"version":"44325ed13294fce6ab825b82947bbeed2611db7dad9d9135260192f375e5a189","impliedFormat":1},{"version":"e392e8fb5b514eafc585601c1d781485aa6dd6a320e75daf1064a4c6918a1b45","impliedFormat":1},{"version":"46e4a36e8ddbdfb4e7330e11c81c970dc8b218611df9183d39c41c5f8c653b55","impliedFormat":1},{"version":"370bde134aa8c2abc926d0e99d3a4d5d5dba65c6ee65459137e4f02670cbf841","impliedFormat":1},{"version":"6332f565867cf4a740a70e30f31cefba37ef7cebcf74f22eab8d744fde6d193e","impliedFormat":1},{"version":"2977b7884aedc895a1d0c9c210c7cf3272c29d6959a08a6fa3ff71e0aff08175","impliedFormat":1},{"version":"17f2922d41ddd032830a91371c948cd9ce903b35c95adca72271a54584f19b0b","impliedFormat":1},{"version":"3eed76ede2a1a14d7c9bb0a642041282dcc264811139d3dd275c9fe14efc9840","impliedFormat":1},{"version":"e3cf0611709328b449ec13f8c436712d62003620ce480139fae46ce001c2ee9f","impliedFormat":1},{"version":"8d369483f0c2b9ee388129cfdb6a43bc8112b377e86a41884bd06e19ce04f4c1","impliedFormat":99},{"version":"3fd8a5aefd8c3feb3936ca66f5aa89dff7bf6e6537b4158dbd0f6e0d65ed3b9e","impliedFormat":1},{"version":"a18642ddf216f162052a16cba0944892c4c4c977d3306a87cb673d46abbb0cbf","impliedFormat":1},{"version":"509f8efdfc5f9f6b52284170e8d7413552f02d79518d1db691ee15acc0088676","impliedFormat":1},{"version":"4ec16d7a4e366c06a4573d299e15fe6207fc080f41beac5da06f4af33ea9761e","impliedFormat":1},{"version":"7870becb94cbc11d2d01b77c4422589adcba4d8e59f726246d40cd0d129784d8","affectsGlobalScope":true,"impliedFormat":1},{"version":"7f698624bbbb060ece7c0e51b7236520ebada74b747d7523c7df376453ed6fea","impliedFormat":1},{"version":"f70b8328a15ca1d10b1436b691e134a49bc30dcf3183a69bfaa7ba77e1b78ecd","impliedFormat":1},{"version":"d9030fc0c412a31e7e13d189b9ad032b5177c20217add0f24fd3fff0cf272882","impliedFormat":99},{"version":"e01ea380015ed698c3c0e2ccd0db72f3fc3ef1abc4519f122aa1c1a8d419a505","impliedFormat":99},{"version":"5ada1f8a9580c0f7478fe03ae3e07e958f0b79bdfb9dd50eeb98c1324f40011b","impliedFormat":99},{"version":"a8301dc90b4bd9fba333226ee0f1681aeeff1bd90233a8f647e687cb4b7d3521","impliedFormat":99},{"version":"e3225dc0bec183183509d290f641786245e6652bc3dce755f7ef404060693c35","impliedFormat":99},{"version":"09a03870ed8c55d7453bc9ad684df88965f2f770f987481ca71b8a09be5205bc","impliedFormat":99},{"version":"e6233e1c976265e85aa8ad76c3881febe6264cb06ae3136f0257e1eab4a6cc5a","impliedFormat":99},{"version":"2cdd50ddc49e2d608ee848fc4ab0db9a2716624fabb4209c7c683d87e54d79c5","impliedFormat":99},{"version":"e431d664338b8470abb1750d699c7dfcebb1a25434559ef85bb96f1e82de5972","impliedFormat":99},{"version":"2c4254139d037c3caca66ce291c1308c1b5092cfcb151eb25980db932dd3b01a","impliedFormat":99},{"version":"970ae00ed018cb96352dc3f37355ef9c2d9f8aa94d7174ccd6d0ed855e462097","impliedFormat":99},{"version":"d2f8dee457ef7660b604226d471d55d927c3051766bdd80353553837492635c3","impliedFormat":99},{"version":"110a503289a2ef76141ffff3ffceb9a1c3662c32748eb9f6777a2bd0866d6fb1","impliedFormat":99},{"version":"69bf2422313487956e4dacf049f30cb91b34968912058d244cb19e4baa24da97","impliedFormat":99},{"version":"310e6b62c493ce991624169a1c1904015769d947be88dc67e00adc7ebebcfa87","impliedFormat":99},{"version":"62fefda288160bf6e435b21cc03d3fbac11193d8d3bd0e82d86623cca7691c29","impliedFormat":99},{"version":"fcc46a8bcbf9bef21023bba1995160a25f0bc590ca3563ec44c315b4f4c1b18a","impliedFormat":99},{"version":"0309a01650023994ed96edbd675ea4fdc3779a823ce716ad876cc77afb792b62","impliedFormat":99},{"version":"f13d7beeea58e219daef3a40e0dc4f2bd7d9581ac04cedec236102a12dfd2090","impliedFormat":99},{"version":"669573548930fb7d0a0761b827e203dc623581e21febf0be80fb02414f217d74","impliedFormat":99},{"version":"48c411efce1848d1ed55de41d7deb93cbf7c04080912fd87aa517ed25ef42639","affectsGlobalScope":true,"impliedFormat":1},{"version":"a094636c05f3e75cb072684dd42cd25a4c1324bec4a866706c85c04cecd49613","affectsGlobalScope":true,"impliedFormat":99},{"version":"fe2d63fcfdde197391b6b70daf7be8c02a60afa90754a5f4a04bdc367f62793d","impliedFormat":99},{"version":"9a3e2c85ec1ab7a0874a19814cc73c691b716282cb727914093089c5a8475955","impliedFormat":99},{"version":"cbdc781d2429935c9c42acd680f2a53a9f633e8de03290ec6ea818e4f7bff19a","impliedFormat":99},{"version":"9f6d9f5dd710922f82f69abf9a324e28122b5f31ae6f6ce78427716db30a377e","impliedFormat":99},{"version":"ac2414a284bdecfd6ab7b87578744ab056cd04dd574b17853cd76830ef5b72f2","impliedFormat":99},{"version":"c3f921bbc9d2e65bd503a56fbc66da910e68467baedb0b9db0cc939e1876c0d7","impliedFormat":99},{"version":"c30a41267fc04c6518b17e55dcb2b810f267af4314b0b6d7df1c33a76ce1b330","impliedFormat":1},{"version":"72422d0bac4076912385d0c10911b82e4694fc106e2d70added091f88f0824ba","impliedFormat":1},{"version":"da251b82c25bee1d93f9fd80c5a61d945da4f708ca21285541d7aff83ecb8200","impliedFormat":1},{"version":"64db14db2bf37ac089766fdb3c7e1160fabc10e9929bc2deeede7237e4419fc8","impliedFormat":1},{"version":"98b94085c9f78eba36d3d2314affe973e8994f99864b8708122750788825c771","impliedFormat":1},{"version":"0cc99fbb161d78729d71fad66c6c363e3095862d6277160f29fa960744b785c6","affectsGlobalScope":true,"impliedFormat":99},{"version":"fd8671c28de1dcdea0d7b21ee5d728ac21f188e5b5c6d8858d4251642c1d3253","signature":"8e609bb71c20b858c77f0e9f90bb1319db8477b13f9f965f1a1e18524bf50881","impliedFormat":99},{"version":"5a3ca19fbe13c3611f2c360ed7a4e526cd2a732de200b8b080389599066a231e","impliedFormat":1},{"version":"4acdda8f0ca23ccac4c8e7d88082270c5feb002f727bb7fc10e215a3b23c0fea","signature":"75d4da3f39a5e1ff05e52f734397086aa3e1b8b862bcca9d378f5dfefce3abc7","impliedFormat":99},{"version":"9f92f0a3195d35fb55d4be6c1dd7688d441528129c52190652c94a07af6ddf58","signature":"8e609bb71c20b858c77f0e9f90bb1319db8477b13f9f965f1a1e18524bf50881","impliedFormat":99}],"root":[72,[89,104],[144,162],346,348,349],"options":{"allowSyntheticDefaultImports":true,"composite":true,"declaration":true,"declarationMap":true,"esModuleInterop":true,"inlineSources":false,"module":199,"noUnusedLocals":false,"noUnusedParameters":false,"outDir":"./dist","rootDir":"./src","skipLibCheck":true,"strict":true,"target":9},"referencedMap":[[347,1],[276,1],[224,2],[225,2],[226,3],[181,4],[227,5],[228,6],[229,7],[176,1],[179,8],[177,1],[178,1],[230,9],[231,10],[232,11],[233,12],[234,13],[235,14],[236,14],[237,15],[238,16],[239,17],[240,18],[182,1],[180,1],[241,19],[242,20],[243,21],[275,22],[244,23],[245,24],[246,25],[247,26],[248,27],[249,28],[250,29],[251,30],[252,31],[253,32],[254,32],[255,33],[256,1],[257,34],[259,35],[258,36],[260,37],[261,38],[262,39],[263,40],[264,41],[265,42],[266,43],[267,44],[268,45],[269,46],[270,47],[271,48],[272,49],[183,1],[184,1],[185,1],[223,50],[273,51],[274,52],[332,1],[333,53],[334,54],[337,55],[336,1],[163,1],[174,56],[169,57],[172,58],[324,59],[313,1],[316,60],[315,61],[327,61],[314,62],[335,1],[171,63],[173,63],[165,64],[168,65],[321,64],[170,66],[164,1],[284,1],[342,67],[344,68],[343,69],[341,70],[340,1],[305,1],[307,71],[306,1],[301,72],[299,73],[300,74],[288,75],[289,73],[296,76],[287,77],[292,78],[302,1],[293,79],[298,80],[304,81],[303,82],[286,83],[294,84],[295,85],[290,86],[297,72],[291,87],[278,88],[277,89],[285,1],[325,1],[166,1],[167,90],[56,1],[57,1],[11,1],[10,1],[2,1],[12,1],[13,1],[14,1],[15,1],[16,1],[17,1],[18,1],[19,1],[3,1],[20,1],[21,1],[4,1],[22,1],[26,1],[23,1],[24,1],[25,1],[27,1],[28,1],[29,1],[5,1],[30,1],[31,1],[32,1],[33,1],[6,1],[37,1],[34,1],[35,1],[36,1],[38,1],[7,1],[39,1],[44,1],[45,1],[40,1],[41,1],[42,1],[43,1],[8,1],[49,1],[46,1],[47,1],[48,1],[50,1],[9,1],[51,1],[52,1],[53,1],[55,1],[54,1],[1,1],[201,91],[211,92],[200,91],[221,93],[192,94],[191,95],[220,96],[214,97],[219,98],[194,99],[208,100],[193,101],[217,102],[189,103],[188,96],[218,104],[190,105],[195,106],[196,1],[199,106],[186,1],[222,107],[212,108],[203,109],[204,110],[206,111],[202,112],[205,113],[215,96],[197,114],[198,115],[207,116],[187,117],[210,108],[209,106],[213,1],[216,118],[322,119],[319,120],[320,119],[323,121],[318,1],[312,122],[283,123],[282,124],[280,124],[279,1],[281,125],[310,1],[309,1],[308,126],[311,127],[326,128],[317,129],[175,1],[338,130],[328,131],[339,132],[331,133],[330,134],[329,135],[345,136],[130,137],[129,138],[106,139],[131,1],[143,140],[132,137],[128,141],[105,142],[107,143],[108,144],[109,1],[133,137],[134,137],[111,145],[135,137],[136,137],[112,146],[113,137],[114,147],[117,148],[118,146],[119,149],[120,142],[121,150],[110,144],[122,137],[137,137],[138,151],[139,137],[140,137],[116,152],[123,143],[115,144],[124,137],[125,149],[126,137],[127,149],[141,137],[142,138],[71,153],[61,154],[63,155],[70,156],[65,1],[66,1],[64,157],[67,158],[58,1],[59,1],[60,153],[62,159],[68,1],[69,160],[79,161],[86,161],[75,161],[84,162],[76,161],[80,161],[88,163],[77,161],[73,1],[81,161],[87,164],[82,161],[78,161],[85,1],[74,165],[83,161],[158,166],[99,167],[160,168],[98,1],[159,168],[93,169],[95,170],[96,169],[97,169],[100,171],[101,169],[102,172],[89,169],[162,173],[144,174],[145,175],[72,1],[157,169],[103,169],[91,176],[150,177],[149,176],[346,178],[161,179],[90,180],[153,181],[148,182],[155,183],[151,184],[152,185],[146,186],[156,187],[154,188],[147,189],[104,1],[348,190],[349,191],[92,192],[94,1]],"latestChangedDtsFile":"./dist/type-tests/semantic.test-d.d.ts","version":"5.9.3"}
+{
+  "fileNames": [
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es5.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2016.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.core.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.collection.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.generator.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.promise.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.proxy.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.reflect.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.symbol.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2016.array.include.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2016.intl.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.arraybuffer.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.date.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.object.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.sharedmemory.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.string.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.intl.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2017.typedarrays.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.asyncgenerator.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.asynciterable.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.intl.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.promise.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2018.regexp.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.array.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.object.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.string.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.symbol.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2019.intl.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.bigint.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.date.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.promise.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.sharedmemory.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.string.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.symbol.wellknown.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.intl.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2020.number.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.promise.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.string.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.weakref.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2021.intl.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.array.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.error.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.intl.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.object.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.string.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.es2022.regexp.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.decorators.d.ts",
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/lib.decorators.legacy.d.ts",
+    "../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/typealiases.d.cts",
+    "../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/util.d.cts",
+    "../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/index.d.cts",
+    "../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/zoderror.d.cts",
+    "../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/locales/en.d.cts",
+    "../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/errors.d.cts",
+    "../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/parseutil.d.cts",
+    "../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/enumutil.d.cts",
+    "../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/errorutil.d.cts",
+    "../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/helpers/partialutil.d.cts",
+    "../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/standard-schema.d.cts",
+    "../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/types.d.cts",
+    "../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/external.d.cts",
+    "../../node_modules/.pnpm/zod@3.25.76/node_modules/zod/index.d.cts",
+    "./src/query-logger.ts",
+    "../datasets/dist/query-builder-protocol.d.ts",
+    "../datasets/dist/types.d.ts",
+    "../datasets/dist/dataset.d.ts",
+    "../datasets/dist/field.d.ts",
+    "../datasets/dist/measure.d.ts",
+    "../datasets/dist/relationships.d.ts",
+    "../datasets/dist/aggregations.d.ts",
+    "../datasets/dist/formulas.d.ts",
+    "../datasets/dist/query-helpers.d.ts",
+    "../datasets/dist/registry.d.ts",
+    "../datasets/dist/validation.d.ts",
+    "../datasets/dist/executor.d.ts",
+    "../datasets/dist/sql-utils.d.ts",
+    "../datasets/dist/constants.d.ts",
+    "../datasets/dist/index.d.ts",
+    "./src/errors.ts",
+    "./src/semantic/query-builder-context.ts",
+    "./src/semantic/datasets/utils/filtered-aggregation-sql.ts",
+    "./src/semantic/datasets/query-planner.ts",
+    "./src/semantic/datasets/utils/dataset-query-metadata.ts",
+    "./src/semantic/datasets/utils/dataset-entry.ts",
+    "./src/semantic/datasets/utils/dataset-query-validation.ts",
+    "./src/semantic/datasets/dataset-endpoint.ts",
+    "./src/types.ts",
+    "./src/auth.ts",
+    "./src/utils.ts",
+    "./src/builder.ts",
+    "./src/client-config.ts",
+    "./src/cors.ts",
+    "./src/adapters/utils.ts",
+    "./src/adapters/node.ts",
+    "./src/dev.ts",
+    "./src/docs-ui.ts",
+    "./src/endpoint.ts",
+    "./src/router.ts",
+    "./src/tenant.ts",
+    "./src/semantic/utils/tenant-runtime.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/any.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/errormessages.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/array.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/bigint.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/boolean.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/number.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/date.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/enum.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/intersection.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/literal.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/string.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/record.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/map.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/nativeenum.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/never.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/null.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/nullable.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/object.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/set.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/tuple.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/undefined.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/union.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/unknown.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsetypes.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/refs.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/options.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/getrelativepath.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsedef.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/branded.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/catch.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/default.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/effects.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/optional.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/pipeline.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/promise.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/parsers/readonly.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/selectparser.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/zodtojsonschema.d.ts",
+    "../../node_modules/.pnpm/zod-to-json-schema@3.25.1_zod@3.25.76/node_modules/zod-to-json-schema/dist/types/index.d.ts",
+    "./src/openapi.ts",
+    "./src/pipeline.ts",
+    "./src/server/execute-query.ts",
+    "./src/server/mapper.ts",
+    "./src/server/api-builder.ts",
+    "./src/semantic/datasets/metric-endpoint.ts",
+    "./src/semantic/datasets/index.ts",
+    "./src/server/create-api.ts",
+    "./src/server/define-serve.ts",
+    "./src/serve.ts",
+    "./src/server/init-serve.ts",
+    "./src/server/builder.ts",
+    "./src/server/index.ts",
+    "./src/rate-limit.ts",
+    "./src/adapters/fetch.ts",
+    "./src/adapters/vercel.ts",
+    "./src/adapters/standalone.ts",
+    "./src/semantic/index.ts",
+    "./src/index.ts",
+    "../../node_modules/.pnpm/@vitest+pretty-format@2.1.9/node_modules/@vitest/pretty-format/dist/index.d.ts",
+    "../../node_modules/.pnpm/@vitest+utils@2.1.9/node_modules/@vitest/utils/dist/types.d.ts",
+    "../../node_modules/.pnpm/@vitest+utils@2.1.9/node_modules/@vitest/utils/dist/helpers.d.ts",
+    "../../node_modules/.pnpm/tinyrainbow@1.2.0/node_modules/tinyrainbow/dist/index-c1cfc5e9.d.ts",
+    "../../node_modules/.pnpm/tinyrainbow@1.2.0/node_modules/tinyrainbow/dist/node.d.ts",
+    "../../node_modules/.pnpm/@vitest+utils@2.1.9/node_modules/@vitest/utils/dist/index.d.ts",
+    "../../node_modules/.pnpm/@vitest+runner@2.1.9/node_modules/@vitest/runner/dist/tasks-3znpj1lr.d.ts",
+    "../../node_modules/.pnpm/@vitest+utils@2.1.9/node_modules/@vitest/utils/dist/types-bxe-2udy.d.ts",
+    "../../node_modules/.pnpm/@vitest+utils@2.1.9/node_modules/@vitest/utils/dist/diff.d.ts",
+    "../../node_modules/.pnpm/@vitest+runner@2.1.9/node_modules/@vitest/runner/dist/types.d.ts",
+    "../../node_modules/.pnpm/@vitest+utils@2.1.9/node_modules/@vitest/utils/dist/error.d.ts",
+    "../../node_modules/.pnpm/@vitest+runner@2.1.9/node_modules/@vitest/runner/dist/index.d.ts",
+    "../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/environment.looobwuu.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/compatibility/disposable.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/compatibility/indexable.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/compatibility/iterators.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/compatibility/index.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/globals.typedarray.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/buffer.buffer.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/globals.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/web-globals/abortcontroller.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/web-globals/domexception.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/web-globals/events.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/header.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/readable.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/file.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/fetch.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/formdata.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/connector.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/client.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/errors.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/dispatcher.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/global-dispatcher.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/global-origin.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/pool-stats.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/pool.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/handlers.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/balanced-pool.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/agent.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/mock-interceptor.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/mock-agent.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/mock-client.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/mock-pool.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/mock-errors.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/proxy-agent.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/env-http-proxy-agent.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/retry-handler.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/retry-agent.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/api.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/interceptors.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/util.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/cookies.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/patch.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/websocket.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/eventsource.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/filereader.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/diagnostics-channel.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/content-type.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/cache.d.ts",
+    "../../node_modules/.pnpm/undici-types@6.21.0/node_modules/undici-types/index.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/web-globals/fetch.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/assert.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/assert/strict.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/async_hooks.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/buffer.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/child_process.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/cluster.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/console.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/constants.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/crypto.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/dgram.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/diagnostics_channel.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/dns.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/dns/promises.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/domain.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/events.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/fs.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/fs/promises.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/http.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/http2.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/https.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/inspector.generated.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/module.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/net.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/os.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/path.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/perf_hooks.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/process.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/punycode.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/querystring.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/readline.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/readline/promises.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/repl.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/sea.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/stream.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/stream/promises.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/stream/consumers.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/stream/web.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/string_decoder.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/test.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/timers.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/timers/promises.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/tls.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/trace_events.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/tty.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/url.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/util.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/v8.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/vm.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/wasi.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/worker_threads.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/zlib.d.ts",
+    "../../node_modules/.pnpm/@types+node@20.19.31/node_modules/@types/node/index.d.ts",
+    "../../node_modules/.pnpm/@types+estree@1.0.8/node_modules/@types/estree/index.d.ts",
+    "../../node_modules/.pnpm/rollup@4.60.1/node_modules/rollup/dist/rollup.d.ts",
+    "../../node_modules/.pnpm/rollup@4.60.1/node_modules/rollup/dist/parseast.d.ts",
+    "../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/types/hmrpayload.d.ts",
+    "../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/types/customevent.d.ts",
+    "../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/types/hot.d.ts",
+    "../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/dist/node/modulerunnertransport.d-dj_me5sf.d.ts",
+    "../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/dist/node/module-runner.d.ts",
+    "../../node_modules/.pnpm/esbuild@0.25.12/node_modules/esbuild/lib/main.d.ts",
+    "../../node_modules/.pnpm/source-map-js@1.2.1/node_modules/source-map-js/source-map.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/previous-map.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/input.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/css-syntax-error.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/declaration.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/root.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/warning.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/lazy-result.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/no-work-result.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/processor.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/result.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/document.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/rule.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/node.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/comment.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/container.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/at-rule.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/list.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/postcss.d.ts",
+    "../../node_modules/.pnpm/postcss@8.5.14/node_modules/postcss/lib/postcss.d.mts",
+    "../../node_modules/.pnpm/lightningcss@1.31.1/node_modules/lightningcss/node/ast.d.ts",
+    "../../node_modules/.pnpm/lightningcss@1.31.1/node_modules/lightningcss/node/targets.d.ts",
+    "../../node_modules/.pnpm/lightningcss@1.31.1/node_modules/lightningcss/node/index.d.ts",
+    "../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/types/internal/lightningcssoptions.d.ts",
+    "../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/types/internal/csspreprocessoroptions.d.ts",
+    "../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/types/importglob.d.ts",
+    "../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/types/metadata.d.ts",
+    "../../node_modules/.pnpm/vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite/dist/node/index.d.ts",
+    "../../node_modules/.pnpm/@vitest+snapshot@2.1.9/node_modules/@vitest/snapshot/dist/environment-ddx0edty.d.ts",
+    "../../node_modules/.pnpm/@vitest+snapshot@2.1.9/node_modules/@vitest/snapshot/dist/rawsnapshot-cpnkto81.d.ts",
+    "../../node_modules/.pnpm/@vitest+snapshot@2.1.9/node_modules/@vitest/snapshot/dist/index.d.ts",
+    "../../node_modules/.pnpm/@vitest+snapshot@2.1.9/node_modules/@vitest/snapshot/dist/environment.d.ts",
+    "../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/config.cy0c388z.d.ts",
+    "../../node_modules/.pnpm/vite-node@2.1.9_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite-node/dist/trace-mapping.d-dlvdeqop.d.ts",
+    "../../node_modules/.pnpm/vite-node@2.1.9_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite-node/dist/index-z0r8hvru.d.ts",
+    "../../node_modules/.pnpm/vite-node@2.1.9_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite-node/dist/index.d.ts",
+    "../../node_modules/.pnpm/@vitest+utils@2.1.9/node_modules/@vitest/utils/dist/source-map.d.ts",
+    "../../node_modules/.pnpm/vite-node@2.1.9_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite-node/dist/client.d.ts",
+    "../../node_modules/.pnpm/vite-node@2.1.9_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3/node_modules/vite-node/dist/server.d.ts",
+    "../../node_modules/.pnpm/@vitest+runner@2.1.9/node_modules/@vitest/runner/dist/utils.d.ts",
+    "../../node_modules/.pnpm/tinybench@2.9.0/node_modules/tinybench/dist/index.d.ts",
+    "../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/benchmark.geerunq4.d.ts",
+    "../../node_modules/.pnpm/@vitest+snapshot@2.1.9/node_modules/@vitest/snapshot/dist/manager.d.ts",
+    "../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/reporters.nr4dxcka.d.ts",
+    "../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/worker.tn5kgiih.d.ts",
+    "../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/worker.b9fxpcac.d.ts",
+    "../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/vite.czkp4x9w.d.ts",
+    "../../node_modules/.pnpm/@vitest+expect@2.1.9/node_modules/@vitest/expect/dist/chai.d.cts",
+    "../../node_modules/.pnpm/@vitest+expect@2.1.9/node_modules/@vitest/expect/dist/index.d.ts",
+    "../../node_modules/.pnpm/@vitest+expect@2.1.9/node_modules/@vitest/expect/index.d.ts",
+    "../../node_modules/.pnpm/@vitest+spy@2.1.9/node_modules/@vitest/spy/dist/index.d.ts",
+    "../../node_modules/.pnpm/@vitest+mocker@2.1.9_vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3_/node_modules/@vitest/mocker/dist/types-dzoqtgin.d.ts",
+    "../../node_modules/.pnpm/@vitest+mocker@2.1.9_vite@6.4.2_@types+node@20.19.31_jiti@2.6.1_lightningcss@1.31.1_tsx@4.21.0_yaml@2.8.3_/node_modules/@vitest/mocker/dist/index.d.ts",
+    "../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/mocker.crtm890j.d.ts",
+    "../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/chunks/suite.b2jumifp.d.ts",
+    "../../node_modules/.pnpm/expect-type@1.3.0/node_modules/expect-type/dist/utils.d.ts",
+    "../../node_modules/.pnpm/expect-type@1.3.0/node_modules/expect-type/dist/overloads.d.ts",
+    "../../node_modules/.pnpm/expect-type@1.3.0/node_modules/expect-type/dist/branding.d.ts",
+    "../../node_modules/.pnpm/expect-type@1.3.0/node_modules/expect-type/dist/messages.d.ts",
+    "../../node_modules/.pnpm/expect-type@1.3.0/node_modules/expect-type/dist/index.d.ts",
+    "../../node_modules/.pnpm/vitest@2.1.9_@edge-runtime+vm@3.2.0_@types+node@20.19.31_jiti@2.6.1_jsdom@27.4.0_lightn_a2bfb79c26e3439598944c760cad9670/node_modules/vitest/dist/index.d.ts",
+    "../clickhouse/dist/core/cache/types.d.ts",
+    "../clickhouse/dist/core/cache/runtime-context.d.ts",
+    "../clickhouse/dist/core/cache/controller.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/clickhouse_types.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/logger.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/parse/column_types.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/parse/json_handling.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/parse/index.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/data_formatter/formatter.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/data_formatter/format_query_params.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/data_formatter/format_query_settings.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/data_formatter/index.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/settings.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/connection.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/result.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/config.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/client.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/error/error.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/error/index.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/utils/connection.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/utils/sleep.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/utils/stream.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/utils/url.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/utils/index.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/ts_utils.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-common@1.18.3/node_modules/@clickhouse/client-common/dist/index.d.ts",
+    "../clickhouse/dist/core/adapters/database-adapter.d.ts",
+    "../clickhouse/dist/types/type-helpers.d.ts",
+    "../clickhouse/dist/types/clickhouse-types.d.ts",
+    "../clickhouse/dist/types/schema.d.ts",
+    "../clickhouse/dist/types/filters.d.ts",
+    "../clickhouse/dist/types/base.d.ts",
+    "../clickhouse/dist/types/index.d.ts",
+    "../clickhouse/dist/core/dialects/sql-dialect.d.ts",
+    "../clickhouse/dist/core/types/type-helpers.d.ts",
+    "../clickhouse/dist/core/types/builder-state.d.ts",
+    "../clickhouse/dist/core/cross-filter.d.ts",
+    "../clickhouse/dist/core/utils/logger.d.ts",
+    "../clickhouse/dist/core/features/executor.d.ts",
+    "../clickhouse/dist/core/join-relationships.d.ts",
+    "../clickhouse/dist/core/utils/sql-expressions.d.ts",
+    "../clickhouse/dist/core/types/select-types.d.ts",
+    "../clickhouse/dist/core/utils/predicate-builder.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client@1.18.3/node_modules/@clickhouse/client/dist/config.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client@1.18.3/node_modules/@clickhouse/client/dist/result_set.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client@1.18.3/node_modules/@clickhouse/client/dist/client.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client@1.18.3/node_modules/@clickhouse/client/dist/connection/stream.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client@1.18.3/node_modules/@clickhouse/client/dist/index.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-web@1.18.3/node_modules/@clickhouse/client-web/dist/config.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-web@1.18.3/node_modules/@clickhouse/client-web/dist/result_set.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-web@1.18.3/node_modules/@clickhouse/client-web/dist/client.d.ts",
+    "../../node_modules/.pnpm/@clickhouse+client-web@1.18.3/node_modules/@clickhouse/client-web/dist/index.d.ts",
+    "../clickhouse/dist/core/utils/query-config-compat.d.ts",
+    "../clickhouse/dist/core/query-builder.d.ts",
+    "../clickhouse/dist/core/connection.d.ts",
+    "../clickhouse/dist/core/adapters/clickhouse-adapter.d.ts",
+    "../clickhouse/dist/core/dialects/clickhouse-dialect.d.ts",
+    "../clickhouse/dist/core/cache/providers/memory-lru.d.ts",
+    "../clickhouse/dist/core/cache/providers/noop.d.ts",
+    "../clickhouse/src/cli/index.d.ts",
+    "../clickhouse/dist/dataset/sql-tag.d.ts",
+    "../clickhouse/dist/dataset/types.d.ts",
+    "../clickhouse/dist/dataset/helpers.d.ts",
+    "../clickhouse/dist/dataset/definition.d.ts",
+    "../clickhouse/dist/dataset/introspection.d.ts",
+    "../clickhouse/dist/index.d.ts",
+    "../clickhouse/dist/core/tests/integration/setup.d.ts",
+    "../clickhouse/dist/core/tests/integration/test-config.d.ts",
+    "./src/semantic/datasets/serve-live.integration.spec.ts",
+    "../../node_modules/.pnpm/@type-challenges+utils@0.1.1/node_modules/@type-challenges/utils/index.d.ts",
+    "./src/type-tests/builder.test-d.ts",
+    "./src/type-tests/semantic.test-d.ts"
+  ],
+  "fileIdsList": [
+    [
+      186,
+      232
+    ],
+    [
+      186,
+      232,
+      354,
+      364,
+      365,
+      366,
+      376
+    ],
+    [
+      186,
+      232,
+      354,
+      355,
+      357,
+      362,
+      363,
+      364,
+      365
+    ],
+    [
+      186,
+      232,
+      354,
+      355,
+      363,
+      376
+    ],
+    [
+      186,
+      232,
+      363
+    ],
+    [
+      186,
+      232,
+      358
+    ],
+    [
+      186,
+      232,
+      359,
+      360,
+      361
+    ],
+    [
+      186,
+      232,
+      368
+    ],
+    [
+      186,
+      232,
+      354,
+      355,
+      358,
+      362,
+      363,
+      364,
+      365,
+      366,
+      367,
+      369,
+      374,
+      375
+    ],
+    [
+      186,
+      232,
+      356,
+      357
+    ],
+    [
+      186,
+      232,
+      354,
+      362
+    ],
+    [
+      186,
+      232,
+      362
+    ],
+    [
+      186,
+      232,
+      370,
+      371,
+      372,
+      373
+    ],
+    [
+      186,
+      232,
+      376,
+      399,
+      400
+    ],
+    [
+      186,
+      232,
+      376
+    ],
+    [
+      186,
+      232,
+      376,
+      399,
+      400,
+      401
+    ],
+    [
+      186,
+      232,
+      262,
+      376,
+      394,
+      395
+    ],
+    [
+      186,
+      232,
+      246,
+      248,
+      262,
+      376
+    ],
+    [
+      186,
+      232,
+      262,
+      376
+    ],
+    [
+      186,
+      232,
+      376,
+      394,
+      395,
+      396,
+      397
+    ],
+    [
+      186,
+      229,
+      232
+    ],
+    [
+      186,
+      231,
+      232
+    ],
+    [
+      232
+    ],
+    [
+      186,
+      232,
+      237,
+      265
+    ],
+    [
+      186,
+      232,
+      233,
+      238,
+      243,
+      251,
+      262,
+      273
+    ],
+    [
+      186,
+      232,
+      233,
+      234,
+      243,
+      251
+    ],
+    [
+      181,
+      182,
+      183,
+      186,
+      232
+    ],
+    [
+      186,
+      232,
+      235,
+      274
+    ],
+    [
+      186,
+      232,
+      236,
+      237,
+      244,
+      252
+    ],
+    [
+      186,
+      232,
+      237,
+      262,
+      270
+    ],
+    [
+      186,
+      232,
+      238,
+      240,
+      243,
+      251
+    ],
+    [
+      186,
+      231,
+      232,
+      239
+    ],
+    [
+      186,
+      232,
+      240,
+      241
+    ],
+    [
+      186,
+      232,
+      242,
+      243
+    ],
+    [
+      186,
+      231,
+      232,
+      243
+    ],
+    [
+      186,
+      232,
+      243,
+      244,
+      245,
+      262,
+      273
+    ],
+    [
+      186,
+      232,
+      243,
+      244,
+      245,
+      258,
+      262,
+      265
+    ],
+    [
+      186,
+      232,
+      240,
+      243,
+      246,
+      251,
+      262,
+      273
+    ],
+    [
+      186,
+      232,
+      243,
+      244,
+      246,
+      247,
+      251,
+      262,
+      270,
+      273
+    ],
+    [
+      186,
+      232,
+      246,
+      248,
+      262,
+      270,
+      273
+    ],
+    [
+      184,
+      185,
+      186,
+      187,
+      188,
+      189,
+      190,
+      228,
+      229,
+      230,
+      231,
+      232,
+      233,
+      234,
+      235,
+      236,
+      237,
+      238,
+      239,
+      240,
+      241,
+      242,
+      243,
+      244,
+      245,
+      246,
+      247,
+      248,
+      249,
+      250,
+      251,
+      252,
+      253,
+      254,
+      255,
+      256,
+      257,
+      258,
+      259,
+      260,
+      261,
+      262,
+      263,
+      264,
+      265,
+      266,
+      267,
+      268,
+      269,
+      270,
+      271,
+      272,
+      273,
+      274,
+      275,
+      276,
+      277,
+      278,
+      279
+    ],
+    [
+      186,
+      232,
+      243,
+      249
+    ],
+    [
+      186,
+      232,
+      250,
+      273,
+      278
+    ],
+    [
+      186,
+      232,
+      240,
+      243,
+      251,
+      262
+    ],
+    [
+      186,
+      232,
+      252
+    ],
+    [
+      186,
+      232,
+      253
+    ],
+    [
+      186,
+      231,
+      232,
+      254
+    ],
+    [
+      186,
+      229,
+      230,
+      231,
+      232,
+      233,
+      234,
+      235,
+      236,
+      237,
+      238,
+      239,
+      240,
+      241,
+      242,
+      243,
+      244,
+      245,
+      246,
+      247,
+      248,
+      249,
+      250,
+      251,
+      252,
+      253,
+      254,
+      255,
+      256,
+      257,
+      258,
+      259,
+      260,
+      261,
+      262,
+      263,
+      264,
+      265,
+      266,
+      267,
+      268,
+      269,
+      270,
+      271,
+      272,
+      273,
+      274,
+      275,
+      276,
+      277,
+      278,
+      279
+    ],
+    [
+      186,
+      232,
+      256
+    ],
+    [
+      186,
+      232,
+      257
+    ],
+    [
+      186,
+      232,
+      243,
+      258,
+      259
+    ],
+    [
+      186,
+      232,
+      258,
+      260,
+      274,
+      276
+    ],
+    [
+      186,
+      232,
+      243,
+      262,
+      263,
+      265
+    ],
+    [
+      186,
+      232,
+      264,
+      265
+    ],
+    [
+      186,
+      232,
+      262,
+      263
+    ],
+    [
+      186,
+      232,
+      265
+    ],
+    [
+      186,
+      232,
+      266
+    ],
+    [
+      186,
+      229,
+      232,
+      262,
+      267
+    ],
+    [
+      186,
+      232,
+      243,
+      268,
+      269
+    ],
+    [
+      186,
+      232,
+      268,
+      269
+    ],
+    [
+      186,
+      232,
+      237,
+      251,
+      262,
+      270
+    ],
+    [
+      186,
+      232,
+      271
+    ],
+    [
+      186,
+      232,
+      251,
+      272
+    ],
+    [
+      186,
+      232,
+      246,
+      257,
+      273
+    ],
+    [
+      186,
+      232,
+      237,
+      274
+    ],
+    [
+      186,
+      232,
+      262,
+      275
+    ],
+    [
+      186,
+      232,
+      250,
+      276
+    ],
+    [
+      186,
+      232,
+      277
+    ],
+    [
+      186,
+      227,
+      232
+    ],
+    [
+      186,
+      227,
+      232,
+      243,
+      245,
+      254,
+      262,
+      265,
+      273,
+      276,
+      278
+    ],
+    [
+      186,
+      232,
+      262,
+      279
+    ],
+    [
+      172,
+      173,
+      176,
+      186,
+      232
+    ],
+    [
+      186,
+      232,
+      338
+    ],
+    [
+      186,
+      232,
+      341
+    ],
+    [
+      173,
+      174,
+      176,
+      177,
+      178,
+      186,
+      232
+    ],
+    [
+      173,
+      186,
+      232
+    ],
+    [
+      173,
+      174,
+      176,
+      186,
+      232
+    ],
+    [
+      173,
+      174,
+      186,
+      232
+    ],
+    [
+      186,
+      232,
+      318
+    ],
+    [
+      168,
+      186,
+      232,
+      318,
+      319
+    ],
+    [
+      168,
+      186,
+      232,
+      318
+    ],
+    [
+      168,
+      175,
+      186,
+      232
+    ],
+    [
+      169,
+      186,
+      232
+    ],
+    [
+      168,
+      169,
+      170,
+      172,
+      186,
+      232
+    ],
+    [
+      168,
+      186,
+      232
+    ],
+    [
+      186,
+      232,
+      345,
+      346
+    ],
+    [
+      186,
+      232,
+      345,
+      346,
+      347,
+      348
+    ],
+    [
+      186,
+      232,
+      345,
+      347
+    ],
+    [
+      186,
+      232,
+      345
+    ],
+    [
+      186,
+      232,
+      310,
+      311
+    ],
+    [
+      186,
+      232,
+      305
+    ],
+    [
+      186,
+      232,
+      303,
+      305
+    ],
+    [
+      186,
+      232,
+      294,
+      302,
+      303,
+      304,
+      306,
+      308
+    ],
+    [
+      186,
+      232,
+      292
+    ],
+    [
+      186,
+      232,
+      295,
+      300,
+      305,
+      308
+    ],
+    [
+      186,
+      232,
+      291,
+      308
+    ],
+    [
+      186,
+      232,
+      295,
+      296,
+      299,
+      300,
+      301,
+      308
+    ],
+    [
+      186,
+      232,
+      295,
+      296,
+      297,
+      299,
+      300,
+      308
+    ],
+    [
+      186,
+      232,
+      292,
+      293,
+      294,
+      295,
+      296,
+      300,
+      301,
+      302,
+      304,
+      305,
+      306,
+      308
+    ],
+    [
+      186,
+      232,
+      308
+    ],
+    [
+      186,
+      232,
+      290,
+      292,
+      293,
+      294,
+      295,
+      296,
+      297,
+      299,
+      300,
+      301,
+      302,
+      303,
+      304,
+      305,
+      306,
+      307
+    ],
+    [
+      186,
+      232,
+      290,
+      308
+    ],
+    [
+      186,
+      232,
+      295,
+      297,
+      298,
+      300,
+      301,
+      308
+    ],
+    [
+      186,
+      232,
+      299,
+      308
+    ],
+    [
+      186,
+      232,
+      300,
+      301,
+      305,
+      308
+    ],
+    [
+      186,
+      232,
+      293,
+      303
+    ],
+    [
+      186,
+      232,
+      282,
+      316,
+      317
+    ],
+    [
+      186,
+      232,
+      281,
+      282
+    ],
+    [
+      171,
+      186,
+      232
+    ],
+    [
+      186,
+      199,
+      203,
+      232,
+      273
+    ],
+    [
+      186,
+      199,
+      232,
+      262,
+      273
+    ],
+    [
+      186,
+      194,
+      232
+    ],
+    [
+      186,
+      196,
+      199,
+      232,
+      270,
+      273
+    ],
+    [
+      186,
+      232,
+      251,
+      270
+    ],
+    [
+      186,
+      232,
+      280
+    ],
+    [
+      186,
+      194,
+      232,
+      280
+    ],
+    [
+      186,
+      196,
+      199,
+      232,
+      251,
+      273
+    ],
+    [
+      186,
+      191,
+      192,
+      195,
+      198,
+      232,
+      243,
+      262,
+      273
+    ],
+    [
+      186,
+      199,
+      206,
+      232
+    ],
+    [
+      186,
+      191,
+      197,
+      232
+    ],
+    [
+      186,
+      199,
+      220,
+      221,
+      232
+    ],
+    [
+      186,
+      195,
+      199,
+      232,
+      265,
+      273,
+      280
+    ],
+    [
+      186,
+      220,
+      232,
+      280
+    ],
+    [
+      186,
+      193,
+      194,
+      232,
+      280
+    ],
+    [
+      186,
+      199,
+      232
+    ],
+    [
+      186,
+      193,
+      194,
+      195,
+      196,
+      197,
+      198,
+      199,
+      200,
+      201,
+      203,
+      204,
+      205,
+      206,
+      207,
+      208,
+      209,
+      210,
+      211,
+      212,
+      213,
+      214,
+      215,
+      216,
+      217,
+      218,
+      219,
+      221,
+      222,
+      223,
+      224,
+      225,
+      226,
+      232
+    ],
+    [
+      186,
+      199,
+      214,
+      232
+    ],
+    [
+      186,
+      199,
+      206,
+      207,
+      232
+    ],
+    [
+      186,
+      197,
+      199,
+      207,
+      208,
+      232
+    ],
+    [
+      186,
+      198,
+      232
+    ],
+    [
+      186,
+      191,
+      194,
+      199,
+      232
+    ],
+    [
+      186,
+      199,
+      203,
+      207,
+      208,
+      232
+    ],
+    [
+      186,
+      203,
+      232
+    ],
+    [
+      186,
+      197,
+      199,
+      202,
+      232,
+      273
+    ],
+    [
+      186,
+      191,
+      196,
+      199,
+      206,
+      232
+    ],
+    [
+      186,
+      232,
+      262
+    ],
+    [
+      186,
+      194,
+      199,
+      220,
+      232,
+      278,
+      280
+    ],
+    [
+      186,
+      232,
+      323,
+      324
+    ],
+    [
+      186,
+      232,
+      323
+    ],
+    [
+      186,
+      232,
+      317,
+      323,
+      324,
+      336
+    ],
+    [
+      186,
+      232,
+      243,
+      244,
+      246,
+      247,
+      248,
+      251,
+      262,
+      270,
+      273,
+      279,
+      280,
+      282,
+      283,
+      284,
+      285,
+      287,
+      288,
+      289,
+      309,
+      313,
+      314,
+      315,
+      316,
+      317
+    ],
+    [
+      186,
+      232,
+      284,
+      285,
+      286,
+      287
+    ],
+    [
+      186,
+      232,
+      284
+    ],
+    [
+      186,
+      232,
+      285
+    ],
+    [
+      186,
+      232,
+      312
+    ],
+    [
+      186,
+      232,
+      282,
+      317
+    ],
+    [
+      179,
+      186,
+      232,
+      329,
+      330,
+      350
+    ],
+    [
+      168,
+      179,
+      186,
+      232,
+      320,
+      321,
+      350
+    ],
+    [
+      186,
+      232,
+      342
+    ],
+    [
+      168,
+      173,
+      179,
+      180,
+      186,
+      232,
+      244,
+      262,
+      317,
+      320,
+      322,
+      325,
+      326,
+      327,
+      328,
+      331,
+      332,
+      336,
+      337,
+      350
+    ],
+    [
+      179,
+      186,
+      232,
+      329,
+      330,
+      331,
+      350
+    ],
+    [
+      186,
+      232,
+      317,
+      333
+    ],
+    [
+      186,
+      232,
+      278,
+      334
+    ],
+    [
+      179,
+      180,
+      186,
+      232,
+      320,
+      322,
+      325,
+      350
+    ],
+    [
+      168,
+      173,
+      176,
+      179,
+      180,
+      186,
+      232,
+      244,
+      262,
+      278,
+      317,
+      320,
+      321,
+      322,
+      325,
+      326,
+      327,
+      328,
+      329,
+      330,
+      331,
+      332,
+      333,
+      334,
+      335,
+      336,
+      337,
+      339,
+      340,
+      342,
+      343,
+      344,
+      349,
+      350
+    ],
+    [
+      133,
+      134,
+      186,
+      232
+    ],
+    [
+      110,
+      111,
+      112,
+      113,
+      114,
+      115,
+      116,
+      117,
+      118,
+      119,
+      120,
+      121,
+      122,
+      123,
+      124,
+      125,
+      126,
+      127,
+      128,
+      129,
+      130,
+      131,
+      132,
+      133,
+      134,
+      135,
+      136,
+      137,
+      138,
+      139,
+      140,
+      141,
+      142,
+      143,
+      144,
+      145,
+      146,
+      147,
+      186,
+      232
+    ],
+    [
+      60,
+      133,
+      134,
+      186,
+      232
+    ],
+    [
+      134,
+      186,
+      232
+    ],
+    [
+      60,
+      111,
+      133,
+      134,
+      186,
+      232
+    ],
+    [
+      60,
+      111,
+      134,
+      186,
+      232
+    ],
+    [
+      60,
+      111,
+      115,
+      134,
+      135,
+      186,
+      232
+    ],
+    [
+      60,
+      186,
+      232
+    ],
+    [
+      60,
+      134,
+      186,
+      232
+    ],
+    [
+      60,
+      121,
+      133,
+      134,
+      186,
+      232
+    ],
+    [
+      110,
+      134,
+      186,
+      232
+    ],
+    [
+      60,
+      125,
+      133,
+      134,
+      186,
+      232
+    ],
+    [
+      60,
+      118,
+      133,
+      134,
+      186,
+      232
+    ],
+    [
+      60,
+      117,
+      120,
+      133,
+      134,
+      186,
+      232
+    ],
+    [
+      110,
+      112,
+      113,
+      114,
+      115,
+      116,
+      117,
+      118,
+      119,
+      120,
+      121,
+      122,
+      123,
+      124,
+      125,
+      126,
+      127,
+      128,
+      129,
+      130,
+      131,
+      132,
+      186,
+      232
+    ],
+    [
+      60,
+      133,
+      135,
+      186,
+      232
+    ],
+    [
+      70,
+      186,
+      232
+    ],
+    [
+      61,
+      62,
+      186,
+      232
+    ],
+    [
+      58,
+      59,
+      61,
+      63,
+      64,
+      69,
+      186,
+      232
+    ],
+    [
+      59,
+      61,
+      186,
+      232
+    ],
+    [
+      69,
+      186,
+      232
+    ],
+    [
+      61,
+      186,
+      232
+    ],
+    [
+      58,
+      59,
+      61,
+      64,
+      65,
+      66,
+      67,
+      68,
+      186,
+      232
+    ],
+    [
+      58,
+      59,
+      60,
+      186,
+      232
+    ],
+    [
+      186,
+      232,
+      377,
+      404
+    ],
+    [
+      186,
+      232,
+      351,
+      352
+    ],
+    [
+      186,
+      232,
+      351
+    ],
+    [
+      186,
+      232,
+      376,
+      398,
+      402,
+      404
+    ],
+    [
+      186,
+      232,
+      380,
+      383,
+      386
+    ],
+    [
+      186,
+      232,
+      383,
+      384
+    ],
+    [
+      186,
+      232,
+      383
+    ],
+    [
+      186,
+      232,
+      386,
+      388,
+      404
+    ],
+    [
+      186,
+      232,
+      380,
+      383
+    ],
+    [
+      186,
+      232,
+      351,
+      352,
+      353,
+      376,
+      377,
+      380,
+      383,
+      384,
+      386,
+      387,
+      389,
+      390,
+      392,
+      393,
+      398,
+      402,
+      403
+    ],
+    [
+      186,
+      232,
+      353,
+      377,
+      384,
+      386,
+      398,
+      402,
+      404,
+      416
+    ],
+    [
+      186,
+      232,
+      380,
+      385
+    ],
+    [
+      186,
+      232,
+      380,
+      385,
+      386,
+      391
+    ],
+    [
+      186,
+      232,
+      386,
+      392
+    ],
+    [
+      186,
+      232,
+      376,
+      383
+    ],
+    [
+      186,
+      232,
+      411,
+      412
+    ],
+    [
+      186,
+      232,
+      412
+    ],
+    [
+      186,
+      232,
+      411
+    ],
+    [
+      186,
+      232,
+      351,
+      353,
+      377,
+      380,
+      381,
+      382,
+      384,
+      387,
+      388,
+      390,
+      391,
+      393,
+      404,
+      405,
+      406,
+      407,
+      408,
+      409,
+      410,
+      411,
+      412,
+      413,
+      414,
+      415
+    ],
+    [
+      186,
+      232,
+      376,
+      380,
+      381
+    ],
+    [
+      186,
+      232,
+      378
+    ],
+    [
+      186,
+      232,
+      380
+    ],
+    [
+      186,
+      232,
+      378,
+      379,
+      380,
+      381,
+      382
+    ],
+    [
+      186,
+      232,
+      379
+    ],
+    [
+      74,
+      186,
+      232
+    ],
+    [
+      73,
+      74,
+      83,
+      186,
+      232
+    ],
+    [
+      73,
+      74,
+      75,
+      76,
+      77,
+      78,
+      79,
+      80,
+      81,
+      82,
+      83,
+      84,
+      85,
+      86,
+      186,
+      232
+    ],
+    [
+      73,
+      186,
+      232
+    ],
+    [
+      96,
+      102,
+      186,
+      232
+    ],
+    [
+      96,
+      102,
+      186,
+      232,
+      243,
+      246
+    ],
+    [
+      96,
+      103,
+      163,
+      186,
+      232
+    ],
+    [
+      96,
+      186,
+      232
+    ],
+    [
+      71,
+      96,
+      98,
+      186,
+      232
+    ],
+    [
+      72,
+      96,
+      103,
+      186,
+      232,
+      251
+    ],
+    [
+      71,
+      96,
+      186,
+      232
+    ],
+    [
+      72,
+      88,
+      96,
+      97,
+      98,
+      100,
+      101,
+      103,
+      104,
+      105,
+      106,
+      107,
+      149,
+      158,
+      161,
+      162,
+      163,
+      164,
+      165,
+      166,
+      186,
+      232
+    ],
+    [
+      71,
+      96,
+      148,
+      186,
+      232
+    ],
+    [
+      71,
+      72,
+      88,
+      89,
+      96,
+      97,
+      98,
+      101,
+      105,
+      107,
+      108,
+      109,
+      149,
+      186,
+      232
+    ],
+    [
+      71,
+      87,
+      88,
+      89,
+      91,
+      92,
+      93,
+      94,
+      96,
+      186,
+      232
+    ],
+    [
+      87,
+      95,
+      154,
+      186,
+      232
+    ],
+    [
+      71,
+      87,
+      88,
+      89,
+      96,
+      186,
+      232
+    ],
+    [
+      87,
+      90,
+      186,
+      232
+    ],
+    [
+      87,
+      96,
+      156,
+      186,
+      232,
+      350,
+      417,
+      418
+    ],
+    [
+      87,
+      96,
+      186,
+      232
+    ],
+    [
+      87,
+      186,
+      232
+    ],
+    [
+      155,
+      186,
+      232
+    ],
+    [
+      89,
+      96,
+      108,
+      186,
+      232
+    ],
+    [
+      71,
+      96,
+      157,
+      186,
+      232
+    ],
+    [
+      72,
+      96,
+      98,
+      107,
+      152,
+      186,
+      232
+    ],
+    [
+      72,
+      96,
+      98,
+      103,
+      107,
+      152,
+      186,
+      232
+    ],
+    [
+      72,
+      87,
+      89,
+      96,
+      98,
+      106,
+      107,
+      150,
+      151,
+      153,
+      155,
+      186,
+      232
+    ],
+    [
+      96,
+      103,
+      156,
+      186,
+      232
+    ],
+    [
+      72,
+      96,
+      150,
+      186,
+      232
+    ],
+    [
+      151,
+      152,
+      153,
+      156,
+      157,
+      159,
+      160,
+      186,
+      232
+    ],
+    [
+      96,
+      99,
+      157,
+      158,
+      186,
+      232
+    ],
+    [
+      96,
+      148,
+      186,
+      232
+    ],
+    [
+      71,
+      167,
+      186,
+      232,
+      420
+    ],
+    [
+      166,
+      186,
+      232
+    ],
+    [
+      71,
+      72,
+      87,
+      95,
+      186,
+      232
+    ]
+  ],
+  "fileInfos": [
+    {
+      "version": "c430d44666289dae81f30fa7b2edebf186ecc91a2d4c71266ea6ae76388792e1",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "45b7ab580deca34ae9729e97c13cfd999df04416a79116c3bfb483804f85ded4",
+      "impliedFormat": 1
+    },
+    {
+      "version": "3facaf05f0c5fc569c5649dd359892c98a85557e3e0c847964caeb67076f4d75",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e44bb8bbac7f10ecc786703fe0a6a4b952189f908707980ba8f3c8975a760962",
+      "impliedFormat": 1
+    },
+    {
+      "version": "5e1c4c362065a6b95ff952c0eab010f04dcd2c3494e813b493ecfd4fcb9fc0d8",
+      "impliedFormat": 1
+    },
+    {
+      "version": "68d73b4a11549f9c0b7d352d10e91e5dca8faa3322bfb77b661839c42b1ddec7",
+      "impliedFormat": 1
+    },
+    {
+      "version": "5efce4fc3c29ea84e8928f97adec086e3dc876365e0982cc8479a07954a3efd4",
+      "impliedFormat": 1
+    },
+    {
+      "version": "feecb1be483ed332fad555aff858affd90a48ab19ba7272ee084704eb7167569",
+      "impliedFormat": 1
+    },
+    {
+      "version": "ee7bad0c15b58988daa84371e0b89d313b762ab83cb5b31b8a2d1162e8eb41c2",
+      "impliedFormat": 1
+    },
+    {
+      "version": "c57796738e7f83dbc4b8e65132f11a377649c00dd3eee333f672b8f0a6bea671",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "dc2df20b1bcdc8c2d34af4926e2c3ab15ffe1160a63e58b7e09833f616efff44",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "515d0b7b9bea2e31ea4ec968e9edd2c39d3eebf4a2d5cbd04e88639819ae3b71",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "0559b1f683ac7505ae451f9a96ce4c3c92bdc71411651ca6ddb0e88baaaad6a3",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "0dc1e7ceda9b8b9b455c3a2d67b0412feab00bd2f66656cd8850e8831b08b537",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "ce691fb9e5c64efb9547083e4a34091bcbe5bdb41027e310ebba8f7d96a98671",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "8d697a2a929a5fcb38b7a65594020fcef05ec1630804a33748829c5ff53640d0",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "4ff2a353abf8a80ee399af572debb8faab2d33ad38c4b4474cff7f26e7653b8d",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "fb0f136d372979348d59b3f5020b4cdb81b5504192b1cacff5d1fbba29378aa1",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "d15bea3d62cbbdb9797079416b8ac375ae99162a7fba5de2c6c505446486ac0a",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "68d18b664c9d32a7336a70235958b8997ebc1c3b8505f4f1ae2b7e7753b87618",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "eb3d66c8327153d8fa7dd03f9c58d351107fe824c79e9b56b462935176cdf12a",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "38f0219c9e23c915ef9790ab1d680440d95419ad264816fa15009a8851e79119",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "69ab18c3b76cd9b1be3d188eaf8bba06112ebbe2f47f6c322b5105a6fbc45a2e",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "a680117f487a4d2f30ea46f1b4b7f58bef1480456e18ba53ee85c2746eeca012",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "2f11ff796926e0832f9ae148008138ad583bd181899ab7dd768a2666700b1893",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "4de680d5bb41c17f7f68e0419412ca23c98d5749dcaaea1896172f06435891fc",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "954296b30da6d508a104a3a0b5d96b76495c709785c1d11610908e63481ee667",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "ac9538681b19688c8eae65811b329d3744af679e0bdfa5d842d0e32524c73e1c",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "0a969edff4bd52585473d24995c5ef223f6652d6ef46193309b3921d65dd4376",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "9e9fbd7030c440b33d021da145d3232984c8bb7916f277e8ffd3dc2e3eae2bdb",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "811ec78f7fefcabbda4bfa93b3eb67d9ae166ef95f9bff989d964061cbf81a0c",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "717937616a17072082152a2ef351cb51f98802fb4b2fdabd32399843875974ca",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "d7e7d9b7b50e5f22c915b525acc5a49a7a6584cf8f62d0569e557c5cfc4b2ac2",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "71c37f4c9543f31dfced6c7840e068c5a5aacb7b89111a4364b1d5276b852557",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "576711e016cf4f1804676043e6a0a5414252560eb57de9faceee34d79798c850",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "89c1b1281ba7b8a96efc676b11b264de7a8374c5ea1e6617f11880a13fc56dc6",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "74f7fa2d027d5b33eb0471c8e82a6c87216223181ec31247c357a3e8e2fddc5b",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "d6d7ae4d1f1f3772e2a3cde568ed08991a8ae34a080ff1151af28b7f798e22ca",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "063600664504610fe3e99b717a1223f8b1900087fab0b4cad1496a114744f8df",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "934019d7e3c81950f9a8426d093458b65d5aff2c7c1511233c0fd5b941e608ab",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "52ada8e0b6e0482b728070b7639ee42e83a9b1c22d205992756fe020fd9f4a47",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "3bdefe1bfd4d6dee0e26f928f93ccc128f1b64d5d501ff4a8cf3c6371200e5e6",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "59fb2c069260b4ba00b5643b907ef5d5341b167e7d1dbf58dfd895658bda2867",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "639e512c0dfc3fad96a84caad71b8834d66329a1f28dc95e3946c9b58176c73a",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "368af93f74c9c932edd84c58883e736c9e3d53cec1fe24c0b0ff451f529ceab1",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "af3dd424cf267428f30ccfc376f47a2c0114546b55c44d8c0f1d57d841e28d74",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "995c005ab91a498455ea8dfb63aa9f83fa2ea793c3d8aa344be4a1678d06d399",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "959d36cddf5e7d572a65045b876f2956c973a586da58e5d26cde519184fd9b8a",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "965f36eae237dd74e6cca203a43e9ca801ce38824ead814728a2807b1910117d",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "3925a6c820dcb1a06506c90b1577db1fdbf7705d65b62b99dce4be75c637e26b",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "0a3d63ef2b853447ec4f749d3f368ce642264246e02911fcb1590d8c161b8005",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "8cdf8847677ac7d20486e54dd3fcf09eda95812ac8ace44b4418da1bbbab6eb8",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "8444af78980e3b20b49324f4a16ba35024fef3ee069a0eb67616ea6ca821c47a",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "3287d9d085fbd618c3971944b65b4be57859f5415f495b33a6adc994edd2f004",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "b4b67b1a91182421f5df999988c690f14d813b9850b40acd06ed44691f6727ad",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "8e7f8264d0fb4c5339605a15daadb037bf238c10b654bb3eee14208f860a32ea",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "782dec38049b92d4e85c1585fbea5474a219c6984a35b004963b00beb1aab538",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "d3cfde44f8089768ebb08098c96d01ca260b88bccf238d55eee93f1c620ff5a5",
+      "impliedFormat": 1
+    },
+    {
+      "version": "293eadad9dead44c6fd1db6de552663c33f215c55a1bfa2802a1bceed88ff0ec",
+      "impliedFormat": 1
+    },
+    {
+      "version": "833e92c058d033cde3f29a6c7603f517001d1ddd8020bc94d2067a3bc69b2a8e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "08b2fae7b0f553ad9f79faec864b179fc58bc172e295a70943e8585dd85f600c",
+      "impliedFormat": 1
+    },
+    {
+      "version": "f12edf1672a94c578eca32216839604f1e1c16b40a1896198deabf99c882b340",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e3498cf5e428e6c6b9e97bd88736f26d6cf147dedbfa5a8ad3ed8e05e059af8a",
+      "impliedFormat": 1
+    },
+    {
+      "version": "dba3f34531fd9b1b6e072928b6f885aa4d28dd6789cbd0e93563d43f4b62da53",
+      "impliedFormat": 1
+    },
+    {
+      "version": "f672c876c1a04a223cf2023b3d91e8a52bb1544c576b81bf64a8fec82be9969c",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e4b03ddcf8563b1c0aee782a185286ed85a255ce8a30df8453aade2188bbc904",
+      "impliedFormat": 1
+    },
+    {
+      "version": "2329d90062487e1eaca87b5e06abcbbeeecf80a82f65f949fd332cfcf824b87b",
+      "impliedFormat": 1
+    },
+    {
+      "version": "25b3f581e12ede11e5739f57a86e8668fbc0124f6649506def306cad2c59d262",
+      "impliedFormat": 1
+    },
+    {
+      "version": "4fdb529707247a1a917a4626bfb6a293d52cd8ee57ccf03830ec91d39d606d6d",
+      "impliedFormat": 1
+    },
+    {
+      "version": "a9ebb67d6bbead6044b43714b50dcb77b8f7541ffe803046fdec1714c1eba206",
+      "impliedFormat": 1
+    },
+    {
+      "version": "5780b706cece027f0d4444fbb4e1af62dc51e19da7c3d3719f67b22b033859b9",
+      "impliedFormat": 1
+    },
+    {
+      "version": "d3e74b1fdc18762c91ab345cdb2a7fba18d19fcd084efb7249fa7d6107edd63a",
+      "signature": "4e4fde40cccde11abc1e36b70d2781b9c9ce9174db7ddc28254a00affab175f9",
+      "impliedFormat": 99
+    },
+    {
+      "version": "9229744ea25e18a192f5953aa3b3f455d70eef16856888369b4a6979d0d96bae",
+      "impliedFormat": 99
+    },
+    {
+      "version": "0e6d650b36284c011b3d95bf35c1bb0a8595c043c104fa3969f2ae60f087a20c",
+      "impliedFormat": 99
+    },
+    {
+      "version": "f17daf0c5d1f20be1f983d0447e8aece97fdc198c9fa81ebe601f9e42dd1b321",
+      "impliedFormat": 99
+    },
+    {
+      "version": "0e7de46779b62e113b2266811b6d5c5f20b693d50d844447d09c6f203929a348",
+      "impliedFormat": 99
+    },
+    {
+      "version": "08b97f852e158ac5d2eaa7f9e375cb74f95b044ca056b0229133b8bd80b1a5d2",
+      "impliedFormat": 99
+    },
+    {
+      "version": "f510cb6b6494801377cfe8acf3aeebfc94a552490a49da49f68656fc28a51ad6",
+      "impliedFormat": 99
+    },
+    {
+      "version": "6dbb943e2651b8adaff2f73dada2bc506876926ae1a8e4dfc97d217408c98c3c",
+      "impliedFormat": 99
+    },
+    {
+      "version": "d1d300d88d14b034e0904ee5fffb82d348604e876b872a1fbb6ebcea0e00149a",
+      "impliedFormat": 99
+    },
+    {
+      "version": "56ea81afc382c20b1146a4a0a31f99c430024e554e1e2192fa561b2b9a6bbd00",
+      "impliedFormat": 99
+    },
+    {
+      "version": "62cf651f9b9b298228a5b0ffd02e9441615996f2a06e783faae3a455aa4165d9",
+      "impliedFormat": 99
+    },
+    {
+      "version": "bc82f0deae147bb18c9e9a3b015f62994ed76122e09d06e3e2cce4f6b1b2c945",
+      "impliedFormat": 99
+    },
+    {
+      "version": "42329453761bfa2d6a67ca90444adc84b060d6a1812875eb01cef229a07222e2",
+      "impliedFormat": 99
+    },
+    {
+      "version": "ca37646b3fe21707e0d7c3c3276971c58105fb7abe98230b73f1fa85628300c3",
+      "impliedFormat": 99
+    },
+    {
+      "version": "155be70478040379afa4b43bcb26f95383a0014c76f5cde69db9ac40720d414e",
+      "impliedFormat": 99
+    },
+    {
+      "version": "1198616d56d92757e6f104cf7b67dd5fc1a97bbb1646f0935ef97b3c88295865",
+      "impliedFormat": 99
+    },
+    {
+      "version": "f5b371a40fb688b72354b0f88d30b1ada4b1765952d5c3bf3c1e115f3edd4268",
+      "signature": "b15681f69aa71a25db7672eee946274bc8459ae6ae3ae392f19265a71d3194f6",
+      "impliedFormat": 99
+    },
+    {
+      "version": "90c69c7fc8e52d81c2cf561e434924440a4f806eb41bf83ae1e4d28b42c5b940",
+      "signature": "fbdb3c668201eaa95c65cda00a9cd8b9b83d920aeb98daecd3c58ccc936be260",
+      "impliedFormat": 99
+    },
+    {
+      "version": "bf725d18d90f03563ec4edec266fc63ae9ea17fc43e2f1d0c5b7c3711dfae3a2",
+      "signature": "ca319454facc80f3fc3bbf1564f1ca5ae3e75a079f08e44316a7e2b63ac0848a",
+      "impliedFormat": 99
+    },
+    {
+      "version": "921f728d720180d5cdd0884be336385760493483b95523fa8feb53b648ede4fd",
+      "signature": "e750b115a7ba85380408f4f0a1495b6f52dbec6654794bc7713941b90a8ad0a9",
+      "impliedFormat": 99
+    },
+    {
+      "version": "5af1744a1a312964e76638a3675bab49eeddded4ce61609221306b9efe740e5f",
+      "signature": "3b9e3569c9b0fec571f8db36138843a3ebd977e2dbbf86500078c7c8f689f497",
+      "impliedFormat": 99
+    },
+    {
+      "version": "bf2a69668db9480e1ab108f4aee104b48e18d665d5b68c04607518022c97cdd3",
+      "signature": "f8d211542e6440547132b8e6f995c94f58e9f76b2f8db67017e8ab401c09f637",
+      "impliedFormat": 99
+    },
+    {
+      "version": "80189c8e9de4cf5b052c478073bb4d0df5473a44ca10d9006454960a55ddfa07",
+      "signature": "1cb14dd5545c6ec58c9a175a9c88fc894ef4426bb5593e28703ed1afa927ab82",
+      "impliedFormat": 99
+    },
+    {
+      "version": "e1f0fdf68e22f1a4c50a03ac998c8df7d897e95f739690037cd1ef67e693dae0",
+      "signature": "9234f1617375d1a36151ab21def3bd6ed42428b84d74ab749574bbe47c106341",
+      "impliedFormat": 99
+    },
+    {
+      "version": "90dca83c1dbcf28e60c1943e7006392aa1936f51645bc40c962017ac7394909a",
+      "signature": "e644d4a3b7b946ce1acc687e70a5ae532a3dad4297a2152022ecc04e550f76e0",
+      "impliedFormat": 99
+    },
+    {
+      "version": "6590ab89f5ab0abd6301df81ab27cbfd7bbc04df7e2da71b61c8afcdb8cab1d1",
+      "signature": "906f0b47dac17c3ad0a04172cb4e8d8f714d2a11d3dccca6c3d5ac8c406a42f6",
+      "impliedFormat": 99
+    },
+    {
+      "version": "04cec88fee746f8f754237d9ae8b626969bf115631ff25ec1781f222e4172614",
+      "signature": "99a8f0b0c1096168d96481476631ce7c015efaa1c4b0e0133e6619be1bb81813",
+      "impliedFormat": 99
+    },
+    {
+      "version": "a6bfc6630bb6a040236f61029c582238aa7652558f6613bd7114164e50c45552",
+      "signature": "2293b89e57f272a8d6fcf67adfa1685e69db33664644002bdd61537888929156",
+      "impliedFormat": 99
+    },
+    {
+      "version": "b251ad1ab2447393153333cb640ed3fb9b482bf7bae49d3e2a1ac7666849a96b",
+      "signature": "7ba37dab6069657b1b120d8cdf31163cf147bd3dc8017a6fe27df3a328d5501f",
+      "impliedFormat": 99
+    },
+    {
+      "version": "0af1d0ff5d6e62e96b557652342796afc998370a5c91ff86f16d70a2bcb42782",
+      "signature": "b99a1a93a698a4827a5ce22687c5ef33a97485c02da0c77c0bbcd5db7b4d825e",
+      "impliedFormat": 99
+    },
+    {
+      "version": "e7411ab2a31b8369f389ecd75e54a2f13d729f2f4e931fce8e80b486d4764360",
+      "signature": "98d278c0fa9e155cac631ae663a5171e2315308082abe6422beaa31b48e0961d",
+      "impliedFormat": 99
+    },
+    {
+      "version": "06a85227e746d425c5219d8c5dea438de250cbff2da1f10ee245ef93ed721898",
+      "signature": "db555c91c6aa8195135ad343cb69d296bd39555154f5c3803b8dd7fc9d4ff62a",
+      "impliedFormat": 99
+    },
+    {
+      "version": "b99d24b75bf871d95acddf8e97f5e7f042695b85837f3cd90111a7159ac4432f",
+      "signature": "b96dba8041a0bf7d0f2e2d7f87060cf5c979fad5827bd871e2e3de89f74b8f86",
+      "impliedFormat": 99
+    },
+    {
+      "version": "4ed8187e849a270d7373af983d54c86315772dc17215674b000f43b47e7cc7e5",
+      "signature": "be98d3f07e06eaa1096402202f78e3f40fb59f9b701231e3051972633e6dfd1b",
+      "impliedFormat": 99
+    },
+    {
+      "version": "755dde19a352e836a7a7644e96973a1eacf1f2dbc36b014cde7f96174fdafc58",
+      "signature": "6ecdeb610dddf916221f162746b110042b3e3c4a90cf74dd841857a30f075cf0",
+      "impliedFormat": 99
+    },
+    {
+      "version": "11510632e1d2649ef0832d24b669f0a22ddfea7b67163b728868c1175bd55749",
+      "signature": "3689c831f7a4d12da0052c57a7fadd181c8bcc0a8179f20306e6efecb7c4690f",
+      "impliedFormat": 99
+    },
+    {
+      "version": "b8b1334c905ce031f926b9f70e63777fbce423f1074f306b36f1b6295ed47816",
+      "signature": "e6e90668c7fef296464ef145892f5ece72abfe84358208abe3d28e5a1142ad3b",
+      "impliedFormat": 99
+    },
+    {
+      "version": "ae55c2eb0b788af08ac75972d5768cfa8d2d8dbda28e6a4c7c0d79b358c327af",
+      "signature": "667dfcd943cbf3ef2aa56b83085b105e83971b6861579cb026cc157bf89b93e9",
+      "impliedFormat": 99
+    },
+    {
+      "version": "ef38456e22b0bffcd9ff28dc1a7138e84918a212e6960dd620cc3000341c0ebe",
+      "impliedFormat": 1
+    },
+    {
+      "version": "07a1cea63a067c0845029ea6e1933af842783efa3006510f504b1f09bd2ebff0",
+      "impliedFormat": 1
+    },
+    {
+      "version": "814187370f99638f6bb69c838d19dcdb20a41cb65627cfc16a04d9cc4522fc82",
+      "impliedFormat": 1
+    },
+    {
+      "version": "7df3ea6fcd7e74ab59724700357df41a12d8f57e22f3e5da36dc645f20753152",
+      "impliedFormat": 1
+    },
+    {
+      "version": "0e8edbe744dfc3ce65e9fa2283f1f0eb2c0aaaec4df19765f51c346e45452cda",
+      "impliedFormat": 1
+    },
+    {
+      "version": "a7559733f2f5f9ae4d071cef99c505870e167ee830c75faf121f34408b99afbe",
+      "impliedFormat": 1
+    },
+    {
+      "version": "9b6e899f6fa0cf536eead034fcae436ab6ecd9442153ee06a0fb5b01475bff85",
+      "impliedFormat": 1
+    },
+    {
+      "version": "1b399336f32abd1c83610e5c95337fdcf2dd5414cf4b44c1ff4927d2cd8f1cf2",
+      "impliedFormat": 1
+    },
+    {
+      "version": "55ddb00c1810d07a092af6a816f89a6e63c3c4ef04c9c27d36a7dd59bf59b5ae",
+      "impliedFormat": 1
+    },
+    {
+      "version": "5ecb3df85ac1c4a7e7a1e9761a5bfb52a65eef8e94e1280e1bff6389cd453099",
+      "impliedFormat": 1
+    },
+    {
+      "version": "9af342002e6b793ca8a69b322cf8347250c129b45dbca8731baaa66ec553561b",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e01ab496375025f3e54f832d43f840c589e57eb2e5986421f791f51bbcbc494e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "539cc98696e783f3fe32422a89f8a34479ce056adb211dd60b6a89550d3b9b7f",
+      "impliedFormat": 1
+    },
+    {
+      "version": "11d5d9c9b11fbd1537ecec72ec38f993d0358c42f7c98569998a04bbbf57d07c",
+      "impliedFormat": 1
+    },
+    {
+      "version": "c26c383b08e47dfbd741193ef1e7f8f002ac3b0d2f6bf3d4b6b9a99ee2d9378e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "75473b178a514d8768d6ead4a4da267aa6bedeeb792cd9437e45b46fa2dcf608",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e82a6fc9b90adc5270daa1e467feb3a2ae5393180839d7a347acd1d9ebe04493",
+      "impliedFormat": 1
+    },
+    {
+      "version": "3d877e9f51aabdb77efeea746c0c09464274dcaf7364e6e64880e9c2eaa8c990",
+      "impliedFormat": 1
+    },
+    {
+      "version": "9830d91d01b457b113b36b56d4534ba8fc42bc3c195a2108dc3431e9f77340c7",
+      "impliedFormat": 1
+    },
+    {
+      "version": "1e7d16304d31f287ec09753214b755eb78e1122432d06dc771f5c123199273b1",
+      "impliedFormat": 1
+    },
+    {
+      "version": "acca4486b08bf5dc91c23d65f47181bd13f82571969c85e8df474fa6bc5c2a88",
+      "impliedFormat": 1
+    },
+    {
+      "version": "296dcaf11fa0122dfe78a1d97bea96aa9bccb73098bc739ab253281ad192dffb",
+      "impliedFormat": 1
+    },
+    {
+      "version": "971dc452ac09307ee049acb21bbd30a82d1c163377465d6b33fd4d677ed2385d",
+      "impliedFormat": 1
+    },
+    {
+      "version": "226b58896f4f01f4c669d908f32c657bcab1a83f3aebb2f3d711a4fe7ba2a2d6",
+      "impliedFormat": 1
+    },
+    {
+      "version": "8a818c9cf372e5c5818d846d761ff59c531caa3b0aa62c5686be1df31dc08296",
+      "impliedFormat": 1
+    },
+    {
+      "version": "f01c60b06afe23316efccaaa8b6ccb5f507b8e6eadf5e2a84c6fe350aebaa1bd",
+      "impliedFormat": 1
+    },
+    {
+      "version": "9a447607a90667c6db7737f30d2429f6f06efde55a47a2a3eeebc52e866d153e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "ecc6f977713316ef4339f32631ecb619a40a3061fa86ff3776591920d9977e24",
+      "impliedFormat": 1
+    },
+    {
+      "version": "0aea84fed0ab80d54f32a40aaf5f4d58c8a5259dd5f9fe39dbcd584575dbb100",
+      "impliedFormat": 1
+    },
+    {
+      "version": "a1769100f50f3e190c2ea2ed2a711e6798c70f9ad806b54c597a5b64488007b0",
+      "impliedFormat": 1
+    },
+    {
+      "version": "8105a77b1ce063fd0f60080d8985e01cb92516237cb4a254547ce7548e8916e5",
+      "impliedFormat": 1
+    },
+    {
+      "version": "dc6b3b3383218cc2c556687fd7ac7b6b1d9ad3abaf50da7f04a2d7a01abaee19",
+      "impliedFormat": 1
+    },
+    {
+      "version": "879443705ef53b56d8f5b944ea2c24bd5b37a1341eb0142789c2e2567d6bb6e1",
+      "impliedFormat": 1
+    },
+    {
+      "version": "44c18ff24c5c5b7883ca2e1b1d4236db715ca5cfd9b87705e1a7e4591b4b445e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "3cceb8a1fe59bc1d233764bfef78e6c72a468e2af1e06a92e282b1848c78bc31",
+      "impliedFormat": 1
+    },
+    {
+      "version": "ed96d25fa3170958d1d376e653ade8e653638d3fb819a4792a503a5505eea849",
+      "impliedFormat": 1
+    },
+    {
+      "version": "a005dc547fff460703595b4c0faccb7ec68a5870a4d0e5a2932dc1fd59cc9856",
+      "impliedFormat": 1
+    },
+    {
+      "version": "dccbbf8ce85ea99cdbdc2269d55f75bc1fbad77d96c40fd82bd73af3fb8f39e4",
+      "impliedFormat": 1
+    },
+    {
+      "version": "449babe88138e129aef94c1696b527898f9e13ab62bce129daee0e85266e48a7",
+      "impliedFormat": 1
+    },
+    {
+      "version": "197a74fdb2a56657d8c2f74bde9fcc9075dfce0c8948ab4be3e4bf6ccdf96f04",
+      "signature": "0303f19ff487a4bd4f52c78e30fa1e6d4426af24d01134d4c996f0cdd1711424",
+      "impliedFormat": 99
+    },
+    {
+      "version": "7aba126e10f9c6f0276a2d0296eb72e1c1891310c749021eda5ed86057a2214f",
+      "signature": "ec794b19653311faac160df606de88321143ecb0c262c419443ad2df347850fd",
+      "impliedFormat": 99
+    },
+    {
+      "version": "6bd1a60fc8f9807a39adc94e000e63e169d32e6ad12f5df444dbb4692614c5c7",
+      "signature": "d234cfe745e66f22c1552cb2def439e22496bb6d6d4897285f46ecc2a6c83392",
+      "impliedFormat": 99
+    },
+    {
+      "version": "509ec521340b0dd539efbab5179b6e600d7330f3453447b82216997baedb35b2",
+      "signature": "087f21bc395308929d3938c7bf752035c45c19464fec69a46dd0742b92176b67",
+      "impliedFormat": 99
+    },
+    {
+      "version": "decee1e9ae8747c9b52eabf2f502e78c9a19e7b9f4ec419e68b1571646838e48",
+      "signature": "4b09018effdb1c862692b3ef4622cbc1f487fa7efff5d3ba06d064bbf7167269",
+      "impliedFormat": 99
+    },
+    {
+      "version": "7063bb59d941daf34237d40e329f10a2e0f700217ef86b12d8e3a6531b51ddc9",
+      "signature": "91bb5cdbeaa305ea398892d9b27b1b26f8d6746fedc5cb0d0d0e5a313ef6a3d0",
+      "impliedFormat": 99
+    },
+    {
+      "version": "b21650bde475647bdc443888149f39114debf0c0289184fe0db3eeeac736519c",
+      "signature": "cc02100f9a4917e5dc165ec1ff8fa4f2875407703e6fca639df82e2590c8664b",
+      "impliedFormat": 99
+    },
+    {
+      "version": "498999d55589f397c9f60f9d07e016a83be272007975a5af0c1a9ab676213223",
+      "signature": "b214cba0e63f4f4cd8f1027024ab7809c394af83eb64873721f3f00ff63a0523",
+      "impliedFormat": 99
+    },
+    {
+      "version": "2120decdf699395a1fc78c163ccbc5ed461549c8182f327fc75661cd38a2958a",
+      "signature": "ab3b5ef40bb85def1a0a65c394389679425da8f718d489f384e96a2ec74422bf",
+      "impliedFormat": 99
+    },
+    {
+      "version": "fabd48e7c96fc911a66f3f13f4c74554c509924ad3fb064922980c2d28f73574",
+      "signature": "43101d7d2612f89798fc843438397f196906ecf206c4c1d0c86941f4a162bfb2",
+      "impliedFormat": 99
+    },
+    {
+      "version": "aa95ff250fad667fdd3de7bf67e4a80dce0bccd4e66355571db5f83c57700868",
+      "signature": "80acee276cff12ea4b797eba93fef3c9ed2b6c6d2afc43fbdec089ddcb633e6f",
+      "impliedFormat": 99
+    },
+    {
+      "version": "5987930946d0ef17c622afbfba763d43300221a31c3e0574aac66c645e9f9f8f",
+      "signature": "f144b13ca0e87efd76f251dc34fac98246dc97a747b3acc49f8269f5f33c2a42",
+      "impliedFormat": 99
+    },
+    {
+      "version": "43b7ee78ed39a38ad8bf7e6d72305fbbc71f4cbd365d8ac310b78ccebbfa1869",
+      "impliedFormat": 99
+    },
+    {
+      "version": "86d4372181473be0e023841b5b580fe073ba764f723b11d38c6bcaa5c8423421",
+      "signature": "d8b9a86eb49f8f558ba5b4cecbf462e8138ccbee5607c148c9c426587ede4e57",
+      "impliedFormat": 99
+    },
+    {
+      "version": "e132cf2c89b7604c8c1e797e562dfc6c74a404c960393e28bba9c4628d1bd6da",
+      "signature": "ca4170457e8caa775891281cb9cedd03ab92b9f9fc69c845241b0f2a0d02da97",
+      "impliedFormat": 99
+    },
+    {
+      "version": "9412a798d71d2b05100430db2817823b54101a50e78e4a39b0e621c110c97878",
+      "signature": "210fd775316cbadf93fa5b4e26f384ccfebf2cf05e35c55e687038bf3cd0ff70",
+      "impliedFormat": 99
+    },
+    {
+      "version": "20753262ac906733a6e8a699b8716f12076af30d63f8fea92a58203e6efc551a",
+      "signature": "bd82078dbb143d57c14723f58b07b82dd48192935c28043aa8adb2904666a84f",
+      "impliedFormat": 99
+    },
+    {
+      "version": "581c746623158d1686e196ec4603c22f7e2e66f664c3868bfa27a2c05cc0ea71",
+      "signature": "f3e54114014476a0b4da7313e993dfe0be7a92eb06296f75cb5fbeb5c97ad9fb",
+      "impliedFormat": 99
+    },
+    {
+      "version": "7425f0ebbf8e6e5af057f91fd38bd8836725b509af6dfc157f2aceec888d7cf0",
+      "impliedFormat": 99
+    },
+    {
+      "version": "d2e64a6f25013b099e83bfadb2c388d7bef3e8f3fdb25528225bbc841e7e7e3a",
+      "impliedFormat": 99
+    },
+    {
+      "version": "369ba5259e66ca8c7d35e3234f7a2a0863a770fdb8266505747c65cf346a0804",
+      "impliedFormat": 99
+    },
+    {
+      "version": "64d984f55025daf604f670b7dfd090ea765f2098aee871174ef2ee3e94479098",
+      "impliedFormat": 99
+    },
+    {
+      "version": "f147b6710441cf3ec3234adf63b0593ce5e8c9b692959d21d3babc8454bcf743",
+      "impliedFormat": 99
+    },
+    {
+      "version": "e96d5373a66c2cfbbc7e6642cf274055aa2c7ff6bd37be7480c66faf9804db6d",
+      "impliedFormat": 99
+    },
+    {
+      "version": "02bcdd7a76c5c1c485cbf05626d24c86ac8f9a1d8dc31f8924108bbaa4cf3ba9",
+      "impliedFormat": 99
+    },
+    {
+      "version": "c874ab6feac6e0fdf9142727c9a876065777a5392f14b0bbcf869b1e69eb46b5",
+      "impliedFormat": 99
+    },
+    {
+      "version": "7c553fc9e34773ddbaabe0fa1367d4b109101d0868a008f11042bee24b5a925d",
+      "impliedFormat": 99
+    },
+    {
+      "version": "9962ce696fbdce2421d883ca4b062a54f982496625437ae4d3633376c5ad4a80",
+      "impliedFormat": 99
+    },
+    {
+      "version": "e3ea467c4a7f743f3548c9ed61300591965b1d12c08c8bb9aaff8a002ba95fce",
+      "impliedFormat": 99
+    },
+    {
+      "version": "4c17183a07a63bea2653fbfc0a942b027160ddbee823024789a415f9589de327",
+      "impliedFormat": 99
+    },
+    {
+      "version": "3e2203c892297ea44b87470fde51b3d48cfe3eeb6901995de429539462894464",
+      "impliedFormat": 99
+    },
+    {
+      "version": "c84bf7a4abc5e7fdf45971a71b25b0e0d34ccd5e720a866dd78bb71d60d41a3f",
+      "impliedFormat": 99
+    },
+    {
+      "version": "70521b6ab0dcba37539e5303104f29b721bfb2940b2776da4cc818c07e1fefc1",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "ab41ef1f2cdafb8df48be20cd969d875602483859dc194e9c97c8a576892c052",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "d153a11543fd884b596587ccd97aebbeed950b26933ee000f94009f1ab142848",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "21d819c173c0cf7cc3ce57c3276e77fd9a8a01d35a06ad87158781515c9a438a",
+      "impliedFormat": 1
+    },
+    {
+      "version": "98cffbf06d6bab333473c70a893770dbe990783904002c4f1a960447b4b53dca",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "ba481bca06f37d3f2c137ce343c7d5937029b2468f8e26111f3c9d9963d6568d",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "6d9ef24f9a22a88e3e9b3b3d8c40ab1ddb0853f1bfbd5c843c37800138437b61",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "1db0b7dca579049ca4193d034d835f6bfe73096c73663e5ef9a0b5779939f3d0",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "9798340ffb0d067d69b1ae5b32faa17ab31b82466a3fc00d8f2f2df0c8554aaa",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "f26b11d8d8e4b8028f1c7d618b22274c892e4b0ef5b3678a8ccbad85419aef43",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "5929864ce17fba74232584d90cb721a89b7ad277220627cc97054ba15a98ea8f",
+      "impliedFormat": 1
+    },
+    {
+      "version": "763fe0f42b3d79b440a9b6e51e9ba3f3f91352469c1e4b3b67bfa4ff6352f3f4",
+      "impliedFormat": 1
+    },
+    {
+      "version": "25c8056edf4314820382a5fdb4bb7816999acdcb929c8f75e3f39473b87e85bc",
+      "impliedFormat": 1
+    },
+    {
+      "version": "c464d66b20788266e5353b48dc4aa6bc0dc4a707276df1e7152ab0c9ae21fad8",
+      "impliedFormat": 1
+    },
+    {
+      "version": "78d0d27c130d35c60b5e5566c9f1e5be77caf39804636bc1a40133919a949f21",
+      "impliedFormat": 1
+    },
+    {
+      "version": "c6fd2c5a395f2432786c9cb8deb870b9b0e8ff7e22c029954fabdd692bff6195",
+      "impliedFormat": 1
+    },
+    {
+      "version": "1d6e127068ea8e104a912e42fc0a110e2aa5a66a356a917a163e8cf9a65e4a75",
+      "impliedFormat": 1
+    },
+    {
+      "version": "5ded6427296cdf3b9542de4471d2aa8d3983671d4cac0f4bf9c637208d1ced43",
+      "impliedFormat": 1
+    },
+    {
+      "version": "7f182617db458e98fc18dfb272d40aa2fff3a353c44a89b2c0ccb3937709bfb5",
+      "impliedFormat": 1
+    },
+    {
+      "version": "cadc8aced301244057c4e7e73fbcae534b0f5b12a37b150d80e5a45aa4bebcbd",
+      "impliedFormat": 1
+    },
+    {
+      "version": "385aab901643aa54e1c36f5ef3107913b10d1b5bb8cbcd933d4263b80a0d7f20",
+      "impliedFormat": 1
+    },
+    {
+      "version": "9670d44354bab9d9982eca21945686b5c24a3f893db73c0dae0fd74217a4c219",
+      "impliedFormat": 1
+    },
+    {
+      "version": "0b8a9268adaf4da35e7fa830c8981cfa22adbbe5b3f6f5ab91f6658899e657a7",
+      "impliedFormat": 1
+    },
+    {
+      "version": "11396ed8a44c02ab9798b7dca436009f866e8dae3c9c25e8c1fbc396880bf1bb",
+      "impliedFormat": 1
+    },
+    {
+      "version": "ba7bc87d01492633cb5a0e5da8a4a42a1c86270e7b3d2dea5d156828a84e4882",
+      "impliedFormat": 1
+    },
+    {
+      "version": "4893a895ea92c85345017a04ed427cbd6a1710453338df26881a6019432febdd",
+      "impliedFormat": 1
+    },
+    {
+      "version": "c21dc52e277bcfc75fac0436ccb75c204f9e1b3fa5e12729670910639f27343e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "13f6f39e12b1518c6650bbb220c8985999020fe0f21d818e28f512b7771d00f9",
+      "impliedFormat": 1
+    },
+    {
+      "version": "9b5369969f6e7175740bf51223112ff209f94ba43ecd3bb09eefff9fd675624a",
+      "impliedFormat": 1
+    },
+    {
+      "version": "4fe9e626e7164748e8769bbf74b538e09607f07ed17c2f20af8d680ee49fc1da",
+      "impliedFormat": 1
+    },
+    {
+      "version": "24515859bc0b836719105bb6cc3d68255042a9f02a6022b3187948b204946bd2",
+      "impliedFormat": 1
+    },
+    {
+      "version": "ea0148f897b45a76544ae179784c95af1bd6721b8610af9ffa467a518a086a43",
+      "impliedFormat": 1
+    },
+    {
+      "version": "24c6a117721e606c9984335f71711877293a9651e44f59f3d21c1ea0856f9cc9",
+      "impliedFormat": 1
+    },
+    {
+      "version": "dd3273ead9fbde62a72949c97dbec2247ea08e0c6952e701a483d74ef92d6a17",
+      "impliedFormat": 1
+    },
+    {
+      "version": "405822be75ad3e4d162e07439bac80c6bcc6dbae1929e179cf467ec0b9ee4e2e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "0db18c6e78ea846316c012478888f33c11ffadab9efd1cc8bcc12daded7a60b6",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e61be3f894b41b7baa1fbd6a66893f2579bfad01d208b4ff61daef21493ef0a8",
+      "impliedFormat": 1
+    },
+    {
+      "version": "bd0532fd6556073727d28da0edfd1736417a3f9f394877b6d5ef6ad88fba1d1a",
+      "impliedFormat": 1
+    },
+    {
+      "version": "89167d696a849fce5ca508032aabfe901c0868f833a8625d5a9c6e861ef935d2",
+      "impliedFormat": 1
+    },
+    {
+      "version": "615ba88d0128ed16bf83ef8ccbb6aff05c3ee2db1cc0f89ab50a4939bfc1943f",
+      "impliedFormat": 1
+    },
+    {
+      "version": "a4d551dbf8746780194d550c88f26cf937caf8d56f102969a110cfaed4b06656",
+      "impliedFormat": 1
+    },
+    {
+      "version": "8bd86b8e8f6a6aa6c49b71e14c4ffe1211a0e97c80f08d2c8cc98838006e4b88",
+      "impliedFormat": 1
+    },
+    {
+      "version": "317e63deeb21ac07f3992f5b50cdca8338f10acd4fbb7257ebf56735bf52ab00",
+      "impliedFormat": 1
+    },
+    {
+      "version": "4732aec92b20fb28c5fe9ad99521fb59974289ed1e45aecb282616202184064f",
+      "impliedFormat": 1
+    },
+    {
+      "version": "2e85db9e6fd73cfa3d7f28e0ab6b55417ea18931423bd47b409a96e4a169e8e6",
+      "impliedFormat": 1
+    },
+    {
+      "version": "c46e079fe54c76f95c67fb89081b3e399da2c7d109e7dca8e4b58d83e332e605",
+      "impliedFormat": 1
+    },
+    {
+      "version": "bf67d53d168abc1298888693338cb82854bdb2e69ef83f8a0092093c2d562107",
+      "impliedFormat": 1
+    },
+    {
+      "version": "2cbe0621042e2a68c7cbce5dfed3906a1862a16a7d496010636cdbdb91341c0f",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "e2677634fe27e87348825bb041651e22d50a613e2fdf6a4a3ade971d71bac37e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "7394959e5a741b185456e1ef5d64599c36c60a323207450991e7a42e08911419",
+      "impliedFormat": 1
+    },
+    {
+      "version": "8c0bcd6c6b67b4b503c11e91a1fb91522ed585900eab2ab1f61bba7d7caa9d6f",
+      "impliedFormat": 1
+    },
+    {
+      "version": "8cd19276b6590b3ebbeeb030ac271871b9ed0afc3074ac88a94ed2449174b776",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "696eb8d28f5949b87d894b26dc97318ef944c794a9a4e4f62360cd1d1958014b",
+      "impliedFormat": 1
+    },
+    {
+      "version": "3f8fa3061bd7402970b399300880d55257953ee6d3cd408722cb9ac20126460c",
+      "impliedFormat": 1
+    },
+    {
+      "version": "35ec8b6760fd7138bbf5809b84551e31028fb2ba7b6dc91d95d098bf212ca8b4",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "5524481e56c48ff486f42926778c0a3cce1cc85dc46683b92b1271865bcf015a",
+      "impliedFormat": 1
+    },
+    {
+      "version": "68bd56c92c2bd7d2339457eb84d63e7de3bd56a69b25f3576e1568d21a162398",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "3e93b123f7c2944969d291b35fed2af79a6e9e27fdd5faa99748a51c07c02d28",
+      "impliedFormat": 1
+    },
+    {
+      "version": "9d19808c8c291a9010a6c788e8532a2da70f811adb431c97520803e0ec649991",
+      "impliedFormat": 1
+    },
+    {
+      "version": "87aad3dd9752067dc875cfaa466fc44246451c0c560b820796bdd528e29bef40",
+      "impliedFormat": 1
+    },
+    {
+      "version": "4aacb0dd020eeaef65426153686cc639a78ec2885dc72ad220be1d25f1a439df",
+      "impliedFormat": 1
+    },
+    {
+      "version": "f0bd7e6d931657b59605c44112eaf8b980ba7f957a5051ed21cb93d978cf2f45",
+      "impliedFormat": 1
+    },
+    {
+      "version": "8db0ae9cb14d9955b14c214f34dae1b9ef2baee2fe4ce794a4cd3ac2531e3255",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "15fc6f7512c86810273af28f224251a5a879e4261b4d4c7e532abfbfc3983134",
+      "impliedFormat": 1
+    },
+    {
+      "version": "58adba1a8ab2d10b54dc1dced4e41f4e7c9772cbbac40939c0dc8ce2cdb1d442",
+      "impliedFormat": 1
+    },
+    {
+      "version": "2fd4c143eff88dabb57701e6a40e02a4dbc36d5eb1362e7964d32028056a782b",
+      "impliedFormat": 1
+    },
+    {
+      "version": "714435130b9015fae551788df2a88038471a5a11eb471f27c4ede86552842bc9",
+      "impliedFormat": 1
+    },
+    {
+      "version": "855cd5f7eb396f5f1ab1bc0f8580339bff77b68a770f84c6b254e319bbfd1ac7",
+      "impliedFormat": 1
+    },
+    {
+      "version": "5650cf3dace09e7c25d384e3e6b818b938f68f4e8de96f52d9c5a1b3db068e86",
+      "impliedFormat": 1
+    },
+    {
+      "version": "1354ca5c38bd3fd3836a68e0f7c9f91f172582ba30ab15bb8c075891b91502b7",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "27fdb0da0daf3b337c5530c5f266efe046a6ceb606e395b346974e4360c36419",
+      "impliedFormat": 1
+    },
+    {
+      "version": "2d2fcaab481b31a5882065c7951255703ddbe1c0e507af56ea42d79ac3911201",
+      "impliedFormat": 1
+    },
+    {
+      "version": "a192fe8ec33f75edbc8d8f3ed79f768dfae11ff5735e7fe52bfa69956e46d78d",
+      "impliedFormat": 1
+    },
+    {
+      "version": "ca867399f7db82df981d6915bcbb2d81131d7d1ef683bc782b59f71dda59bc85",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "0e456fd5b101271183d99a9087875a282323e3a3ff0d7bcf1881537eaa8b8e63",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "9e043a1bc8fbf2a255bccf9bf27e0f1caf916c3b0518ea34aa72357c0afd42ec",
+      "impliedFormat": 1
+    },
+    {
+      "version": "b4f70ec656a11d570e1a9edce07d118cd58d9760239e2ece99306ee9dfe61d02",
+      "impliedFormat": 1
+    },
+    {
+      "version": "3bc2f1e2c95c04048212c569ed38e338873f6a8593930cf5a7ef24ffb38fc3b6",
+      "impliedFormat": 1
+    },
+    {
+      "version": "6e70e9570e98aae2b825b533aa6292b6abd542e8d9f6e9475e88e1d7ba17c866",
+      "impliedFormat": 1
+    },
+    {
+      "version": "f9d9d753d430ed050dc1bf2667a1bab711ccbb1c1507183d794cc195a5b085cc",
+      "impliedFormat": 1
+    },
+    {
+      "version": "9eece5e586312581ccd106d4853e861aaaa1a39f8e3ea672b8c3847eedd12f6e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "47ab634529c5955b6ad793474ae188fce3e6163e3a3fb5edd7e0e48f14435333",
+      "impliedFormat": 1
+    },
+    {
+      "version": "37ba7b45141a45ce6e80e66f2a96c8a5ab1bcef0fc2d0f56bb58df96ec67e972",
+      "impliedFormat": 1
+    },
+    {
+      "version": "45650f47bfb376c8a8ed39d4bcda5902ab899a3150029684ee4c10676d9fbaee",
+      "impliedFormat": 1
+    },
+    {
+      "version": "fad4e3c207fe23922d0b2d06b01acbfb9714c4f2685cf80fd384c8a100c82fd0",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "74cf591a0f63db318651e0e04cb55f8791385f86e987a67fd4d2eaab8191f730",
+      "impliedFormat": 1
+    },
+    {
+      "version": "5eab9b3dc9b34f185417342436ec3f106898da5f4801992d8ff38ab3aff346b5",
+      "impliedFormat": 1
+    },
+    {
+      "version": "12ed4559eba17cd977aa0db658d25c4047067444b51acfdcbf38470630642b23",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "f3ffabc95802521e1e4bcba4c88d8615176dc6e09111d920c7a213bdda6e1d65",
+      "impliedFormat": 1
+    },
+    {
+      "version": "ddc734b4fae82a01d247e9e342d020976640b5e93b4e9b3a1e30e5518883a060",
+      "impliedFormat": 1
+    },
+    {
+      "version": "ae56f65caf3be91108707bd8dfbccc2a57a91feb5daabf7165a06a945545ed26",
+      "impliedFormat": 1
+    },
+    {
+      "version": "a136d5de521da20f31631a0a96bf712370779d1c05b7015d7019a9b2a0446ca9",
+      "impliedFormat": 1
+    },
+    {
+      "version": "c3b41e74b9a84b88b1dca61ec39eee25c0dbc8e7d519ba11bb070918cfacf656",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "4737a9dc24d0e68b734e6cfbcea0c15a2cfafeb493485e27905f7856988c6b29",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "36d8d3e7506b631c9582c251a2c0b8a28855af3f76719b12b534c6edf952748d",
+      "impliedFormat": 1
+    },
+    {
+      "version": "1ca69210cc42729e7ca97d3a9ad48f2e9cb0042bada4075b588ae5387debd318",
+      "impliedFormat": 1
+    },
+    {
+      "version": "f5ebe66baaf7c552cfa59d75f2bfba679f329204847db3cec385acda245e574e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "ed59add13139f84da271cafd32e2171876b0a0af2f798d0c663e8eeb867732cf",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "05db535df8bdc30d9116fe754a3473d1b6479afbc14ae8eb18b605c62677d518",
+      "impliedFormat": 1
+    },
+    {
+      "version": "b1810689b76fd473bd12cc9ee219f8e62f54a7d08019a235d07424afbf074d25",
+      "impliedFormat": 1
+    },
+    {
+      "version": "151ff381ef9ff8da2da9b9663ebf657eac35c4c9a19183420c05728f31a6761d",
+      "impliedFormat": 1
+    },
+    {
+      "version": "ee70b8037ecdf0de6c04f35277f253663a536d7e38f1539d270e4e916d225a3f",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "a660aa95476042d3fdcc1343cf6bb8fdf24772d31712b1db321c5a4dcc325434",
+      "impliedFormat": 1
+    },
+    {
+      "version": "a7ca8df4f2931bef2aa4118078584d84a0b16539598eaadf7dce9104dfaa381c",
+      "impliedFormat": 1
+    },
+    {
+      "version": "11443a1dcfaaa404c68d53368b5b818712b95dd19f188cab1669c39bee8b84b3",
+      "impliedFormat": 1
+    },
+    {
+      "version": "36977c14a7f7bfc8c0426ae4343875689949fb699f3f84ecbe5b300ebf9a2c55",
+      "impliedFormat": 1
+    },
+    {
+      "version": "035d0934d304483f07148427a5bd5b98ac265dae914a6b49749fe23fbd893ec7",
+      "impliedFormat": 99
+    },
+    {
+      "version": "e2ed5b81cbed3a511b21a18ab2539e79ac1f4bc1d1d28f8d35d8104caa3b429f",
+      "impliedFormat": 99
+    },
+    {
+      "version": "161c8e0690c46021506e32fda85956d785b70f309ae97011fd27374c065cac9b",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "402e5c534fb2b85fa771170595db3ac0dd532112c8fa44fc23f233bc6967488b",
+      "impliedFormat": 1
+    },
+    {
+      "version": "52dcc257df5119fb66d864625112ce5033ac51a4c2afe376a0b299d2f7f76e4a",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e5bab5f871ef708d52d47b3e5d0aa72a08ee7a152f33931d9a60809711a2a9a3",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e16dc2a81595736024a206c7d5c8a39bfe2e6039208ef29981d0d95434ba8fcf",
+      "impliedFormat": 1
+    },
+    {
+      "version": "cc4a4903fb698ca1d961d4c10dce658aa3a479faf40509d526f122b044eaf6a4",
+      "impliedFormat": 1
+    },
+    {
+      "version": "19ee8416e6473ed6c7adb868fa796b5653cf0fa2a337658e677eaa0d134388c3",
+      "impliedFormat": 1
+    },
+    {
+      "version": "1328ab4e442614b28cdb3d4b414cf68325c0da0dca07287a338d0654b7a00261",
+      "impliedFormat": 1
+    },
+    {
+      "version": "a039dc21f045919f3cbee2ec13812cc6cc3eebc99dae4be00973230f468d19a6",
+      "impliedFormat": 1
+    },
+    {
+      "version": "3fbe57af01460e49dcd29df55d6931e1672bc6f1be0fb073d11410bc16f9037d",
+      "impliedFormat": 1
+    },
+    {
+      "version": "f760be449e8562ec5c09bb5187e8e1eabf3c113c0c58cddda53ef8c69f3e2131",
+      "impliedFormat": 1
+    },
+    {
+      "version": "44325ed13294fce6ab825b82947bbeed2611db7dad9d9135260192f375e5a189",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e392e8fb5b514eafc585601c1d781485aa6dd6a320e75daf1064a4c6918a1b45",
+      "impliedFormat": 1
+    },
+    {
+      "version": "46e4a36e8ddbdfb4e7330e11c81c970dc8b218611df9183d39c41c5f8c653b55",
+      "impliedFormat": 1
+    },
+    {
+      "version": "370bde134aa8c2abc926d0e99d3a4d5d5dba65c6ee65459137e4f02670cbf841",
+      "impliedFormat": 1
+    },
+    {
+      "version": "6332f565867cf4a740a70e30f31cefba37ef7cebcf74f22eab8d744fde6d193e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "2977b7884aedc895a1d0c9c210c7cf3272c29d6959a08a6fa3ff71e0aff08175",
+      "impliedFormat": 1
+    },
+    {
+      "version": "17f2922d41ddd032830a91371c948cd9ce903b35c95adca72271a54584f19b0b",
+      "impliedFormat": 1
+    },
+    {
+      "version": "3eed76ede2a1a14d7c9bb0a642041282dcc264811139d3dd275c9fe14efc9840",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e3cf0611709328b449ec13f8c436712d62003620ce480139fae46ce001c2ee9f",
+      "impliedFormat": 1
+    },
+    {
+      "version": "8d369483f0c2b9ee388129cfdb6a43bc8112b377e86a41884bd06e19ce04f4c1",
+      "impliedFormat": 99
+    },
+    {
+      "version": "3fd8a5aefd8c3feb3936ca66f5aa89dff7bf6e6537b4158dbd0f6e0d65ed3b9e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "a18642ddf216f162052a16cba0944892c4c4c977d3306a87cb673d46abbb0cbf",
+      "impliedFormat": 1
+    },
+    {
+      "version": "509f8efdfc5f9f6b52284170e8d7413552f02d79518d1db691ee15acc0088676",
+      "impliedFormat": 1
+    },
+    {
+      "version": "4ec16d7a4e366c06a4573d299e15fe6207fc080f41beac5da06f4af33ea9761e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "7870becb94cbc11d2d01b77c4422589adcba4d8e59f726246d40cd0d129784d8",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "7f698624bbbb060ece7c0e51b7236520ebada74b747d7523c7df376453ed6fea",
+      "impliedFormat": 1
+    },
+    {
+      "version": "f70b8328a15ca1d10b1436b691e134a49bc30dcf3183a69bfaa7ba77e1b78ecd",
+      "impliedFormat": 1
+    },
+    {
+      "version": "d9030fc0c412a31e7e13d189b9ad032b5177c20217add0f24fd3fff0cf272882",
+      "impliedFormat": 99
+    },
+    {
+      "version": "e01ea380015ed698c3c0e2ccd0db72f3fc3ef1abc4519f122aa1c1a8d419a505",
+      "impliedFormat": 99
+    },
+    {
+      "version": "5ada1f8a9580c0f7478fe03ae3e07e958f0b79bdfb9dd50eeb98c1324f40011b",
+      "impliedFormat": 99
+    },
+    {
+      "version": "a8301dc90b4bd9fba333226ee0f1681aeeff1bd90233a8f647e687cb4b7d3521",
+      "impliedFormat": 99
+    },
+    {
+      "version": "e3225dc0bec183183509d290f641786245e6652bc3dce755f7ef404060693c35",
+      "impliedFormat": 99
+    },
+    {
+      "version": "09a03870ed8c55d7453bc9ad684df88965f2f770f987481ca71b8a09be5205bc",
+      "impliedFormat": 99
+    },
+    {
+      "version": "e6233e1c976265e85aa8ad76c3881febe6264cb06ae3136f0257e1eab4a6cc5a",
+      "impliedFormat": 99
+    },
+    {
+      "version": "2cdd50ddc49e2d608ee848fc4ab0db9a2716624fabb4209c7c683d87e54d79c5",
+      "impliedFormat": 99
+    },
+    {
+      "version": "e431d664338b8470abb1750d699c7dfcebb1a25434559ef85bb96f1e82de5972",
+      "impliedFormat": 99
+    },
+    {
+      "version": "2c4254139d037c3caca66ce291c1308c1b5092cfcb151eb25980db932dd3b01a",
+      "impliedFormat": 99
+    },
+    {
+      "version": "970ae00ed018cb96352dc3f37355ef9c2d9f8aa94d7174ccd6d0ed855e462097",
+      "impliedFormat": 99
+    },
+    {
+      "version": "d2f8dee457ef7660b604226d471d55d927c3051766bdd80353553837492635c3",
+      "impliedFormat": 99
+    },
+    {
+      "version": "110a503289a2ef76141ffff3ffceb9a1c3662c32748eb9f6777a2bd0866d6fb1",
+      "impliedFormat": 99
+    },
+    {
+      "version": "69bf2422313487956e4dacf049f30cb91b34968912058d244cb19e4baa24da97",
+      "impliedFormat": 99
+    },
+    {
+      "version": "310e6b62c493ce991624169a1c1904015769d947be88dc67e00adc7ebebcfa87",
+      "impliedFormat": 99
+    },
+    {
+      "version": "62fefda288160bf6e435b21cc03d3fbac11193d8d3bd0e82d86623cca7691c29",
+      "impliedFormat": 99
+    },
+    {
+      "version": "fcc46a8bcbf9bef21023bba1995160a25f0bc590ca3563ec44c315b4f4c1b18a",
+      "impliedFormat": 99
+    },
+    {
+      "version": "0309a01650023994ed96edbd675ea4fdc3779a823ce716ad876cc77afb792b62",
+      "impliedFormat": 99
+    },
+    {
+      "version": "f13d7beeea58e219daef3a40e0dc4f2bd7d9581ac04cedec236102a12dfd2090",
+      "impliedFormat": 99
+    },
+    {
+      "version": "669573548930fb7d0a0761b827e203dc623581e21febf0be80fb02414f217d74",
+      "impliedFormat": 99
+    },
+    {
+      "version": "48c411efce1848d1ed55de41d7deb93cbf7c04080912fd87aa517ed25ef42639",
+      "affectsGlobalScope": true,
+      "impliedFormat": 1
+    },
+    {
+      "version": "a094636c05f3e75cb072684dd42cd25a4c1324bec4a866706c85c04cecd49613",
+      "affectsGlobalScope": true,
+      "impliedFormat": 99
+    },
+    {
+      "version": "fe2d63fcfdde197391b6b70daf7be8c02a60afa90754a5f4a04bdc367f62793d",
+      "impliedFormat": 99
+    },
+    {
+      "version": "9a3e2c85ec1ab7a0874a19814cc73c691b716282cb727914093089c5a8475955",
+      "impliedFormat": 99
+    },
+    {
+      "version": "cbdc781d2429935c9c42acd680f2a53a9f633e8de03290ec6ea818e4f7bff19a",
+      "impliedFormat": 99
+    },
+    {
+      "version": "9f6d9f5dd710922f82f69abf9a324e28122b5f31ae6f6ce78427716db30a377e",
+      "impliedFormat": 99
+    },
+    {
+      "version": "ac2414a284bdecfd6ab7b87578744ab056cd04dd574b17853cd76830ef5b72f2",
+      "impliedFormat": 99
+    },
+    {
+      "version": "c3f921bbc9d2e65bd503a56fbc66da910e68467baedb0b9db0cc939e1876c0d7",
+      "impliedFormat": 99
+    },
+    {
+      "version": "c30a41267fc04c6518b17e55dcb2b810f267af4314b0b6d7df1c33a76ce1b330",
+      "impliedFormat": 1
+    },
+    {
+      "version": "72422d0bac4076912385d0c10911b82e4694fc106e2d70added091f88f0824ba",
+      "impliedFormat": 1
+    },
+    {
+      "version": "da251b82c25bee1d93f9fd80c5a61d945da4f708ca21285541d7aff83ecb8200",
+      "impliedFormat": 1
+    },
+    {
+      "version": "64db14db2bf37ac089766fdb3c7e1160fabc10e9929bc2deeede7237e4419fc8",
+      "impliedFormat": 1
+    },
+    {
+      "version": "98b94085c9f78eba36d3d2314affe973e8994f99864b8708122750788825c771",
+      "impliedFormat": 1
+    },
+    {
+      "version": "0cc99fbb161d78729d71fad66c6c363e3095862d6277160f29fa960744b785c6",
+      "affectsGlobalScope": true,
+      "impliedFormat": 99
+    },
+    {
+      "version": "22d18948781b296611af9cc7243490b4ff8023b1d25f4e955c4ac2b8a8267a1d",
+      "impliedFormat": 99
+    },
+    {
+      "version": "c194dbae2806475f8e24b81aace6f505723ecc89157517df8122b3d82a6bdd4e",
+      "impliedFormat": 99
+    },
+    {
+      "version": "016e5f8ba06df54afc970b8279f2d3c0105ea664677d17b15ba7aba6932fedbe",
+      "impliedFormat": 99
+    },
+    {
+      "version": "1e05836a196caec812b6a8c0d277d4f809f5c5969cb12ba09992147ba8c99aef",
+      "impliedFormat": 1
+    },
+    {
+      "version": "6723b49d91f0619e50d24eab07fead687ffe352c480e5cdb5858a2c38651ab3b",
+      "impliedFormat": 1
+    },
+    {
+      "version": "01daa7293a50a87fccffc98cd114c294c57898c60f1e484118b48ed2b33c2f37",
+      "impliedFormat": 1
+    },
+    {
+      "version": "04b1321658e7f6b2d789014b26726ede213a3b4acb6fbb1dc9bac908752def1c",
+      "impliedFormat": 1
+    },
+    {
+      "version": "d780720f73bd8de9460995190cd2b7e5b36ea2b5d22e98f8d90400689af0e1fe",
+      "impliedFormat": 1
+    },
+    {
+      "version": "d30b93baca310e4cb29aff043cbdedf7ce5658ea2517f37b4dd02dad9b380559",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e4d5fb67ecba12366da08713d5af961ce4c08ce8b01328490110cd490e8429b7",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e53ba91ed31e0666d50288ec29a4c1137ba95a666e5bc8489522efcb796da45a",
+      "impliedFormat": 1
+    },
+    {
+      "version": "bdd125e8226c4e516a99c581a5ad3cb4c1e0d3a43333b40f6d5b4f5f2421d501",
+      "impliedFormat": 1
+    },
+    {
+      "version": "4e135922c46a32f773406edfcfee1f014c08fae9f5147896e1c05872628b2f34",
+      "impliedFormat": 1
+    },
+    {
+      "version": "c40ff8b13fec527151f684c83a9d93749a48e85d81d845bba05f99c498284a26",
+      "impliedFormat": 1
+    },
+    {
+      "version": "89e02aeb1f182cbd0dc18a976d2c5ba3ab3b19f357f68daec169526cd046ee47",
+      "impliedFormat": 1
+    },
+    {
+      "version": "bf9747e1ed50bb3146828d92e591c737332c223520e3c260749f96ede58a18c9",
+      "impliedFormat": 1
+    },
+    {
+      "version": "9fabc6e90a39ead18afd236c8d516d3d196d20659a6332285b1e3b0da4c5439d",
+      "impliedFormat": 1
+    },
+    {
+      "version": "fa6dcc8d747aeeffb355c3f536d574a1f01088fc18f077a7240a8f20251a6700",
+      "impliedFormat": 1
+    },
+    {
+      "version": "039cd54028eb988297e189275764df06c18f9299b14c063e93bd3f30c046fee6",
+      "impliedFormat": 1
+    },
+    {
+      "version": "e1430f9bafcc5c35962ed3ee4a6ecbfdd37dd6cba8ac814143fb44f72a1b64c7",
+      "impliedFormat": 1
+    },
+    {
+      "version": "db60e4028bc490b0ce1ac7a7d9e3cb5c59fc318efbf2739b11443787624a1255",
+      "impliedFormat": 1
+    },
+    {
+      "version": "f30159cde3a63489abe84721dcc8a8909fbc97eac0722f5aca1355430b13b169",
+      "impliedFormat": 1
+    },
+    {
+      "version": "2967057cf2ecabab5ae8c2b54359081fce27e71c6a7e06befda6366a23732b1d",
+      "impliedFormat": 1
+    },
+    {
+      "version": "16896b6595fa2487555d14976adbd097d6dc6f802464278ea1e7c447975c22b5",
+      "impliedFormat": 1
+    },
+    {
+      "version": "3145e4e1b94a662089199c10003e171d515a48708b2e828cc01b29ecc32f2d98",
+      "impliedFormat": 1
+    },
+    {
+      "version": "89135b123c4c00522ceba993b201a0e825e3927a1bc0b1dbf6edac86c2f38bde",
+      "impliedFormat": 1
+    },
+    {
+      "version": "c7673f055a0d7fa6c549923342125aaf50856f7a0751de96e17b4a92bf8198e9",
+      "impliedFormat": 99
+    },
+    {
+      "version": "4b13bbb168b7e6539417dee85e5eab5774c673103563be53ccceebecb10004c5",
+      "impliedFormat": 99
+    },
+    {
+      "version": "4c1e134504707551644451ad2ab2545c8b024c24b973b6dfa8c3ed1596afae35",
+      "impliedFormat": 99
+    },
+    {
+      "version": "590909bd7faba91a374fbbf66731f0a08b57ff543e225e30550a0e0e39a5c3ec",
+      "impliedFormat": 99
+    },
+    {
+      "version": "5c4af805d1ced1336905095a90e46ab07d0548c584a2f936792a418c6577e390",
+      "impliedFormat": 99
+    },
+    {
+      "version": "581e2855bcae7912eab4663966c6e96dbc0d67b2881febcededac42950c075c1",
+      "impliedFormat": 99
+    },
+    {
+      "version": "945cfb1209efb1d061601eae413e035d63c5e7cd6a9bae3c455403cd85f718f7",
+      "impliedFormat": 99
+    },
+    {
+      "version": "fd5b1d2d9fbc502ea621e6c663e00baf6bea34bb784ce5682a0c8d8c8ee31e48",
+      "impliedFormat": 99
+    },
+    {
+      "version": "0f46a4ce530f46fdf7a09ecfcba7a88406b4489deafb6547d56c5f03b1063134",
+      "impliedFormat": 99
+    },
+    {
+      "version": "cdda4c3b5e7ed1df64255f9c298be87d57222ee12e9e1ce6e4ce3bf2ea26f87b",
+      "impliedFormat": 99
+    },
+    {
+      "version": "10d683ec1ecc60c4563b47232f4b633282c48f861aed858858f544d77dfa7e3d",
+      "impliedFormat": 99
+    },
+    {
+      "version": "db3200538ba1133ffad616a050f6e67f4e056cb2835b8948a5cfa949760bed0e",
+      "impliedFormat": 99
+    },
+    {
+      "version": "c7a061656785c0ade42ffd36cf3c5af2ac48231bb71ccfb5d60b71ec997e361a",
+      "impliedFormat": 99
+    },
+    {
+      "version": "1fbdf69c09c7ac4e848a2fa4f369159a7dd1000762063116122d771590726dc1",
+      "impliedFormat": 99
+    },
+    {
+      "version": "f0808dcc34b5ca0195689ef11fb4c8ed93afd7e5029a202c406adbd0d9597b63",
+      "impliedFormat": 99
+    },
+    {
+      "version": "9a3f90a7cc5ad88687d000c7529bf1a7e466442eca1d19a0d1b46e91a7e711bd",
+      "impliedFormat": 99
+    },
+    {
+      "version": "84614f7725f06536ac3ab32c60be40e6276dcbcad60325417f7127780eeaca84",
+      "impliedFormat": 99
+    },
+    {
+      "version": "ebc3998265e92886db77e635c3142f49dca4efeeb8dd6d9a75baa24d771b9f73",
+      "impliedFormat": 1
+    },
+    {
+      "version": "c038569cc89742fca8a451a0d44b530d7ed3c0d9a1971271564e0d46e6894cfc",
+      "impliedFormat": 1
+    },
+    {
+      "version": "88670e7f59d7d49aa06d241be46da90028b1094817f7c6723851f5b33f85f28c",
+      "impliedFormat": 1
+    },
+    {
+      "version": "8fbf416b002ba2d7fc0578878e6e0bb1eb28abef459a00492d1d7d3b160f6fa1",
+      "impliedFormat": 1
+    },
+    {
+      "version": "21592b0a4b7e7dd2b2381fe857153bf5b1681aa8651bb2daacde5e39371e0679",
+      "impliedFormat": 1
+    },
+    {
+      "version": "d74b5e8785076b5d37533c964039ba718063317fafffebf87e703ab37748122b",
+      "impliedFormat": 1
+    },
+    {
+      "version": "dee7caddf8ea59c9370426fa46b829b848f951e2dffec0cb182f2e2617a345f2",
+      "impliedFormat": 1
+    },
+    {
+      "version": "47775d8ae6c3d0b05ceb7ac93734a1e2327ed95df0096f9f2e2434aa8cf7e46e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "cd090d973764939fa04b023e82a58b1d2ff142e0a63b4fdea0aee843fa631892",
+      "impliedFormat": 1
+    },
+    {
+      "version": "29326dacfb34c196d9048254ee067bfcc8530177e7ada3edcde347ad1e384d3f",
+      "impliedFormat": 99
+    },
+    {
+      "version": "5afa4099c4f58035b6e9cea33e3804936fe6637637020b7f89d08398e5b10a0a",
+      "impliedFormat": 99
+    },
+    {
+      "version": "e088bfd423e791313928c241b32c4c9f028c6803ecead607a5d2d7add1a51e6e",
+      "impliedFormat": 99
+    },
+    {
+      "version": "22fbd2f080a8384fcef3643e715ec5b6117233e53643784b62d5cde83b2a528b",
+      "impliedFormat": 99
+    },
+    {
+      "version": "e350bfd1c8fbd438b9e40f3c3f13f71916dd5263875a4e2fed284482386f9f20",
+      "impliedFormat": 99
+    },
+    {
+      "version": "d1564ddb9303f408cd4052d64fb7174f2224cb033f2be7251619dd97cedfbd46",
+      "impliedFormat": 99
+    },
+    {
+      "version": "bd49cff5374b7fb371b288d1fbb35ebdaaf1bbe84ef974575a7b6e4636c9eb8a",
+      "impliedFormat": 99
+    },
+    {
+      "version": "08dd471f327582ca76c11ffd19e7729e3d3d51c270c4cd1ae615fd8d01a07a6d",
+      "impliedFormat": 99
+    },
+    {
+      "version": "ed0675df6869c2762433d66281a9c3e1a830fed2a900073fb5d3d3bb55385a21",
+      "impliedFormat": 99
+    },
+    {
+      "version": "f1680b260f4e33564cec0d8cd7ef07cca4ec55870a6b60651b978185da29653a",
+      "impliedFormat": 99
+    },
+    {
+      "version": "8c8343c085aeed2ce265e721c6c51121077ff0b00bb05f3147e62e336f175761",
+      "impliedFormat": 99
+    },
+    {
+      "version": "2f5f79f7af9463cb348ff6d4a1d37ff045b348f7826b317239b955d43e3f63f8",
+      "impliedFormat": 99
+    },
+    {
+      "version": "383f788c5492df40df1953a58e7ac7700698e610e9c39292c398a70e4d67a07e",
+      "impliedFormat": 99
+    },
+    {
+      "version": "c5d217f335b1227cb150f24c1e71a14b07ea9c6e64fd1de012424996ae15c182",
+      "impliedFormat": 99
+    },
+    {
+      "version": "2f97c4ca62d50d66e113f9b289088fef7d164740a00fb68a5ec46ed1b280b75c",
+      "impliedFormat": 99
+    },
+    {
+      "version": "c84520f1b54ef52e1ba9016a48b1ae681dd705d05213f7ff7fbd5349b3f05b84",
+      "impliedFormat": 99
+    },
+    {
+      "version": "fd8671c28de1dcdea0d7b21ee5d728ac21f188e5b5c6d8858d4251642c1d3253",
+      "signature": "8e609bb71c20b858c77f0e9f90bb1319db8477b13f9f965f1a1e18524bf50881",
+      "impliedFormat": 99
+    },
+    {
+      "version": "5a3ca19fbe13c3611f2c360ed7a4e526cd2a732de200b8b080389599066a231e",
+      "impliedFormat": 1
+    },
+    {
+      "version": "4acdda8f0ca23ccac4c8e7d88082270c5feb002f727bb7fc10e215a3b23c0fea",
+      "signature": "75d4da3f39a5e1ff05e52f734397086aa3e1b8b862bcca9d378f5dfefce3abc7",
+      "impliedFormat": 99
+    },
+    {
+      "version": "5cef5815e281b37a33f75e9492b395c7cda94eb2e4a588646737c53116cbf70c",
+      "signature": "8e609bb71c20b858c77f0e9f90bb1319db8477b13f9f965f1a1e18524bf50881",
+      "impliedFormat": 99
+    }
+  ],
+  "root": [
+    72,
+    [
+      88,
+      109
+    ],
+    [
+      149,
+      167
+    ],
+    419,
+    421,
+    422
+  ],
+  "options": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "inlineSources": false,
+    "module": 199,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": 9
+  },
+  "referencedMap": [
+    [
+      354,
+      1
+    ],
+    [
+      367,
+      2
+    ],
+    [
+      366,
+      3
+    ],
+    [
+      364,
+      4
+    ],
+    [
+      360,
+      1
+    ],
+    [
+      361,
+      5
+    ],
+    [
+      359,
+      6
+    ],
+    [
+      362,
+      7
+    ],
+    [
+      368,
+      1
+    ],
+    [
+      369,
+      8
+    ],
+    [
+      376,
+      9
+    ],
+    [
+      355,
+      1
+    ],
+    [
+      356,
+      1
+    ],
+    [
+      358,
+      10
+    ],
+    [
+      357,
+      1
+    ],
+    [
+      365,
+      11
+    ],
+    [
+      363,
+      12
+    ],
+    [
+      375,
+      1
+    ],
+    [
+      370,
+      5
+    ],
+    [
+      374,
+      13
+    ],
+    [
+      371,
+      1
+    ],
+    [
+      372,
+      1
+    ],
+    [
+      373,
+      5
+    ],
+    [
+      401,
+      14
+    ],
+    [
+      399,
+      15
+    ],
+    [
+      402,
+      16
+    ],
+    [
+      400,
+      15
+    ],
+    [
+      396,
+      17
+    ],
+    [
+      394,
+      18
+    ],
+    [
+      397,
+      19
+    ],
+    [
+      398,
+      20
+    ],
+    [
+      395,
+      19
+    ],
+    [
+      420,
+      1
+    ],
+    [
+      281,
+      1
+    ],
+    [
+      229,
+      21
+    ],
+    [
+      230,
+      21
+    ],
+    [
+      231,
+      22
+    ],
+    [
+      186,
+      23
+    ],
+    [
+      232,
+      24
+    ],
+    [
+      233,
+      25
+    ],
+    [
+      234,
+      26
+    ],
+    [
+      181,
+      1
+    ],
+    [
+      184,
+      27
+    ],
+    [
+      182,
+      1
+    ],
+    [
+      183,
+      1
+    ],
+    [
+      235,
+      28
+    ],
+    [
+      236,
+      29
+    ],
+    [
+      237,
+      30
+    ],
+    [
+      238,
+      31
+    ],
+    [
+      239,
+      32
+    ],
+    [
+      240,
+      33
+    ],
+    [
+      241,
+      33
+    ],
+    [
+      242,
+      34
+    ],
+    [
+      243,
+      35
+    ],
+    [
+      244,
+      36
+    ],
+    [
+      245,
+      37
+    ],
+    [
+      187,
+      1
+    ],
+    [
+      185,
+      1
+    ],
+    [
+      246,
+      38
+    ],
+    [
+      247,
+      39
+    ],
+    [
+      248,
+      40
+    ],
+    [
+      280,
+      41
+    ],
+    [
+      249,
+      42
+    ],
+    [
+      250,
+      43
+    ],
+    [
+      251,
+      44
+    ],
+    [
+      252,
+      45
+    ],
+    [
+      253,
+      46
+    ],
+    [
+      254,
+      47
+    ],
+    [
+      255,
+      48
+    ],
+    [
+      256,
+      49
+    ],
+    [
+      257,
+      50
+    ],
+    [
+      258,
+      51
+    ],
+    [
+      259,
+      51
+    ],
+    [
+      260,
+      52
+    ],
+    [
+      261,
+      1
+    ],
+    [
+      262,
+      53
+    ],
+    [
+      264,
+      54
+    ],
+    [
+      263,
+      55
+    ],
+    [
+      265,
+      56
+    ],
+    [
+      266,
+      57
+    ],
+    [
+      267,
+      58
+    ],
+    [
+      268,
+      59
+    ],
+    [
+      269,
+      60
+    ],
+    [
+      270,
+      61
+    ],
+    [
+      271,
+      62
+    ],
+    [
+      272,
+      63
+    ],
+    [
+      273,
+      64
+    ],
+    [
+      274,
+      65
+    ],
+    [
+      275,
+      66
+    ],
+    [
+      276,
+      67
+    ],
+    [
+      277,
+      68
+    ],
+    [
+      188,
+      1
+    ],
+    [
+      189,
+      1
+    ],
+    [
+      190,
+      1
+    ],
+    [
+      228,
+      69
+    ],
+    [
+      278,
+      70
+    ],
+    [
+      279,
+      71
+    ],
+    [
+      337,
+      1
+    ],
+    [
+      338,
+      72
+    ],
+    [
+      339,
+      73
+    ],
+    [
+      342,
+      74
+    ],
+    [
+      341,
+      1
+    ],
+    [
+      168,
+      1
+    ],
+    [
+      179,
+      75
+    ],
+    [
+      174,
+      76
+    ],
+    [
+      177,
+      77
+    ],
+    [
+      329,
+      78
+    ],
+    [
+      318,
+      1
+    ],
+    [
+      321,
+      79
+    ],
+    [
+      320,
+      80
+    ],
+    [
+      332,
+      80
+    ],
+    [
+      319,
+      81
+    ],
+    [
+      340,
+      1
+    ],
+    [
+      176,
+      82
+    ],
+    [
+      178,
+      82
+    ],
+    [
+      170,
+      83
+    ],
+    [
+      173,
+      84
+    ],
+    [
+      326,
+      83
+    ],
+    [
+      175,
+      85
+    ],
+    [
+      169,
+      1
+    ],
+    [
+      289,
+      1
+    ],
+    [
+      347,
+      86
+    ],
+    [
+      349,
+      87
+    ],
+    [
+      348,
+      88
+    ],
+    [
+      346,
+      89
+    ],
+    [
+      345,
+      1
+    ],
+    [
+      310,
+      1
+    ],
+    [
+      312,
+      90
+    ],
+    [
+      311,
+      1
+    ],
+    [
+      306,
+      91
+    ],
+    [
+      304,
+      92
+    ],
+    [
+      305,
+      93
+    ],
+    [
+      293,
+      94
+    ],
+    [
+      294,
+      92
+    ],
+    [
+      301,
+      95
+    ],
+    [
+      292,
+      96
+    ],
+    [
+      297,
+      97
+    ],
+    [
+      307,
+      1
+    ],
+    [
+      298,
+      98
+    ],
+    [
+      303,
+      99
+    ],
+    [
+      309,
+      100
+    ],
+    [
+      308,
+      101
+    ],
+    [
+      291,
+      102
+    ],
+    [
+      299,
+      103
+    ],
+    [
+      300,
+      104
+    ],
+    [
+      295,
+      105
+    ],
+    [
+      302,
+      91
+    ],
+    [
+      296,
+      106
+    ],
+    [
+      283,
+      107
+    ],
+    [
+      282,
+      108
+    ],
+    [
+      290,
+      1
+    ],
+    [
+      330,
+      1
+    ],
+    [
+      171,
+      1
+    ],
+    [
+      172,
+      109
+    ],
+    [
+      56,
+      1
+    ],
+    [
+      57,
+      1
+    ],
+    [
+      11,
+      1
+    ],
+    [
+      10,
+      1
+    ],
+    [
+      2,
+      1
+    ],
+    [
+      12,
+      1
+    ],
+    [
+      13,
+      1
+    ],
+    [
+      14,
+      1
+    ],
+    [
+      15,
+      1
+    ],
+    [
+      16,
+      1
+    ],
+    [
+      17,
+      1
+    ],
+    [
+      18,
+      1
+    ],
+    [
+      19,
+      1
+    ],
+    [
+      3,
+      1
+    ],
+    [
+      20,
+      1
+    ],
+    [
+      21,
+      1
+    ],
+    [
+      4,
+      1
+    ],
+    [
+      22,
+      1
+    ],
+    [
+      26,
+      1
+    ],
+    [
+      23,
+      1
+    ],
+    [
+      24,
+      1
+    ],
+    [
+      25,
+      1
+    ],
+    [
+      27,
+      1
+    ],
+    [
+      28,
+      1
+    ],
+    [
+      29,
+      1
+    ],
+    [
+      5,
+      1
+    ],
+    [
+      30,
+      1
+    ],
+    [
+      31,
+      1
+    ],
+    [
+      32,
+      1
+    ],
+    [
+      33,
+      1
+    ],
+    [
+      6,
+      1
+    ],
+    [
+      37,
+      1
+    ],
+    [
+      34,
+      1
+    ],
+    [
+      35,
+      1
+    ],
+    [
+      36,
+      1
+    ],
+    [
+      38,
+      1
+    ],
+    [
+      7,
+      1
+    ],
+    [
+      39,
+      1
+    ],
+    [
+      44,
+      1
+    ],
+    [
+      45,
+      1
+    ],
+    [
+      40,
+      1
+    ],
+    [
+      41,
+      1
+    ],
+    [
+      42,
+      1
+    ],
+    [
+      43,
+      1
+    ],
+    [
+      8,
+      1
+    ],
+    [
+      49,
+      1
+    ],
+    [
+      46,
+      1
+    ],
+    [
+      47,
+      1
+    ],
+    [
+      48,
+      1
+    ],
+    [
+      50,
+      1
+    ],
+    [
+      9,
+      1
+    ],
+    [
+      51,
+      1
+    ],
+    [
+      52,
+      1
+    ],
+    [
+      53,
+      1
+    ],
+    [
+      55,
+      1
+    ],
+    [
+      54,
+      1
+    ],
+    [
+      1,
+      1
+    ],
+    [
+      206,
+      110
+    ],
+    [
+      216,
+      111
+    ],
+    [
+      205,
+      110
+    ],
+    [
+      226,
+      112
+    ],
+    [
+      197,
+      113
+    ],
+    [
+      196,
+      114
+    ],
+    [
+      225,
+      115
+    ],
+    [
+      219,
+      116
+    ],
+    [
+      224,
+      117
+    ],
+    [
+      199,
+      118
+    ],
+    [
+      213,
+      119
+    ],
+    [
+      198,
+      120
+    ],
+    [
+      222,
+      121
+    ],
+    [
+      194,
+      122
+    ],
+    [
+      193,
+      115
+    ],
+    [
+      223,
+      123
+    ],
+    [
+      195,
+      124
+    ],
+    [
+      200,
+      125
+    ],
+    [
+      201,
+      1
+    ],
+    [
+      204,
+      125
+    ],
+    [
+      191,
+      1
+    ],
+    [
+      227,
+      126
+    ],
+    [
+      217,
+      127
+    ],
+    [
+      208,
+      128
+    ],
+    [
+      209,
+      129
+    ],
+    [
+      211,
+      130
+    ],
+    [
+      207,
+      131
+    ],
+    [
+      210,
+      132
+    ],
+    [
+      220,
+      115
+    ],
+    [
+      202,
+      133
+    ],
+    [
+      203,
+      134
+    ],
+    [
+      212,
+      135
+    ],
+    [
+      192,
+      136
+    ],
+    [
+      215,
+      127
+    ],
+    [
+      214,
+      125
+    ],
+    [
+      218,
+      1
+    ],
+    [
+      221,
+      137
+    ],
+    [
+      327,
+      138
+    ],
+    [
+      324,
+      139
+    ],
+    [
+      325,
+      138
+    ],
+    [
+      328,
+      140
+    ],
+    [
+      323,
+      1
+    ],
+    [
+      317,
+      141
+    ],
+    [
+      288,
+      142
+    ],
+    [
+      287,
+      143
+    ],
+    [
+      285,
+      143
+    ],
+    [
+      284,
+      1
+    ],
+    [
+      286,
+      144
+    ],
+    [
+      315,
+      1
+    ],
+    [
+      314,
+      1
+    ],
+    [
+      313,
+      145
+    ],
+    [
+      316,
+      146
+    ],
+    [
+      331,
+      147
+    ],
+    [
+      322,
+      148
+    ],
+    [
+      180,
+      1
+    ],
+    [
+      343,
+      149
+    ],
+    [
+      333,
+      150
+    ],
+    [
+      344,
+      151
+    ],
+    [
+      336,
+      152
+    ],
+    [
+      335,
+      153
+    ],
+    [
+      334,
+      154
+    ],
+    [
+      350,
+      155
+    ],
+    [
+      111,
+      156
+    ],
+    [
+      136,
+      1
+    ],
+    [
+      148,
+      157
+    ],
+    [
+      135,
+      158
+    ],
+    [
+      137,
+      158
+    ],
+    [
+      110,
+      159
+    ],
+    [
+      112,
+      160
+    ],
+    [
+      113,
+      161
+    ],
+    [
+      114,
+      1
+    ],
+    [
+      138,
+      158
+    ],
+    [
+      139,
+      158
+    ],
+    [
+      116,
+      162
+    ],
+    [
+      140,
+      158
+    ],
+    [
+      141,
+      158
+    ],
+    [
+      117,
+      163
+    ],
+    [
+      118,
+      158
+    ],
+    [
+      119,
+      164
+    ],
+    [
+      122,
+      165
+    ],
+    [
+      123,
+      163
+    ],
+    [
+      124,
+      166
+    ],
+    [
+      125,
+      159
+    ],
+    [
+      126,
+      167
+    ],
+    [
+      115,
+      161
+    ],
+    [
+      127,
+      158
+    ],
+    [
+      142,
+      158
+    ],
+    [
+      143,
+      168
+    ],
+    [
+      144,
+      158
+    ],
+    [
+      145,
+      158
+    ],
+    [
+      121,
+      169
+    ],
+    [
+      128,
+      160
+    ],
+    [
+      120,
+      161
+    ],
+    [
+      129,
+      158
+    ],
+    [
+      130,
+      166
+    ],
+    [
+      131,
+      158
+    ],
+    [
+      132,
+      166
+    ],
+    [
+      133,
+      170
+    ],
+    [
+      134,
+      171
+    ],
+    [
+      146,
+      158
+    ],
+    [
+      147,
+      171
+    ],
+    [
+      71,
+      172
+    ],
+    [
+      63,
+      173
+    ],
+    [
+      70,
+      174
+    ],
+    [
+      65,
+      1
+    ],
+    [
+      66,
+      1
+    ],
+    [
+      64,
+      175
+    ],
+    [
+      67,
+      176
+    ],
+    [
+      58,
+      1
+    ],
+    [
+      59,
+      1
+    ],
+    [
+      60,
+      172
+    ],
+    [
+      62,
+      177
+    ],
+    [
+      68,
+      1
+    ],
+    [
+      69,
+      178
+    ],
+    [
+      61,
+      179
+    ],
+    [
+      406,
+      180
+    ],
+    [
+      377,
+      15
+    ],
+    [
+      353,
+      181
+    ],
+    [
+      408,
+      182
+    ],
+    [
+      409,
+      182
+    ],
+    [
+      352,
+      182
+    ],
+    [
+      351,
+      1
+    ],
+    [
+      405,
+      183
+    ],
+    [
+      387,
+      184
+    ],
+    [
+      407,
+      185
+    ],
+    [
+      384,
+      186
+    ],
+    [
+      389,
+      187
+    ],
+    [
+      390,
+      188
+    ],
+    [
+      404,
+      189
+    ],
+    [
+      417,
+      190
+    ],
+    [
+      418,
+      1
+    ],
+    [
+      386,
+      191
+    ],
+    [
+      392,
+      192
+    ],
+    [
+      385,
+      1
+    ],
+    [
+      388,
+      182
+    ],
+    [
+      393,
+      193
+    ],
+    [
+      403,
+      194
+    ],
+    [
+      391,
+      1
+    ],
+    [
+      414,
+      195
+    ],
+    [
+      413,
+      195
+    ],
+    [
+      415,
+      196
+    ],
+    [
+      411,
+      1
+    ],
+    [
+      412,
+      197
+    ],
+    [
+      416,
+      198
+    ],
+    [
+      382,
+      199
+    ],
+    [
+      379,
+      200
+    ],
+    [
+      381,
+      201
+    ],
+    [
+      383,
+      202
+    ],
+    [
+      380,
+      203
+    ],
+    [
+      378,
+      1
+    ],
+    [
+      410,
+      1
+    ],
+    [
+      79,
+      204
+    ],
+    [
+      86,
+      204
+    ],
+    [
+      75,
+      204
+    ],
+    [
+      84,
+      205
+    ],
+    [
+      76,
+      204
+    ],
+    [
+      80,
+      204
+    ],
+    [
+      87,
+      206
+    ],
+    [
+      77,
+      204
+    ],
+    [
+      73,
+      1
+    ],
+    [
+      81,
+      204
+    ],
+    [
+      82,
+      204
+    ],
+    [
+      78,
+      204
+    ],
+    [
+      85,
+      1
+    ],
+    [
+      74,
+      207
+    ],
+    [
+      83,
+      204
+    ],
+    [
+      163,
+      208
+    ],
+    [
+      103,
+      209
+    ],
+    [
+      165,
+      210
+    ],
+    [
+      102,
+      1
+    ],
+    [
+      164,
+      210
+    ],
+    [
+      97,
+      211
+    ],
+    [
+      99,
+      212
+    ],
+    [
+      100,
+      211
+    ],
+    [
+      101,
+      211
+    ],
+    [
+      104,
+      213
+    ],
+    [
+      105,
+      211
+    ],
+    [
+      106,
+      214
+    ],
+    [
+      88,
+      211
+    ],
+    [
+      167,
+      215
+    ],
+    [
+      149,
+      216
+    ],
+    [
+      150,
+      217
+    ],
+    [
+      72,
+      1
+    ],
+    [
+      162,
+      211
+    ],
+    [
+      107,
+      211
+    ],
+    [
+      95,
+      218
+    ],
+    [
+      155,
+      219
+    ],
+    [
+      154,
+      220
+    ],
+    [
+      91,
+      221
+    ],
+    [
+      419,
+      222
+    ],
+    [
+      93,
+      223
+    ],
+    [
+      92,
+      224
+    ],
+    [
+      94,
+      224
+    ],
+    [
+      90,
+      224
+    ],
+    [
+      166,
+      225
+    ],
+    [
+      89,
+      224
+    ],
+    [
+      109,
+      226
+    ],
+    [
+      158,
+      227
+    ],
+    [
+      153,
+      228
+    ],
+    [
+      160,
+      229
+    ],
+    [
+      156,
+      230
+    ],
+    [
+      157,
+      231
+    ],
+    [
+      151,
+      232
+    ],
+    [
+      161,
+      233
+    ],
+    [
+      159,
+      234
+    ],
+    [
+      152,
+      235
+    ],
+    [
+      108,
+      1
+    ],
+    [
+      421,
+      236
+    ],
+    [
+      422,
+      237
+    ],
+    [
+      96,
+      238
+    ],
+    [
+      98,
+      1
+    ]
+  ],
+  "latestChangedDtsFile": "./dist/semantic/datasets/dataset-endpoint.d.ts",
+  "version": "5.9.3"
+}

--- a/plans/datasets-semantic-layer-fix-plan.md
+++ b/plans/datasets-semantic-layer-fix-plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-21
 Owner: TBD
-Status: Draft
+Status: In Progress
 
 ## Pre-Release Bias
 
@@ -28,6 +28,8 @@ This package is still pre-release. Breaking changes are encouraged in this imple
 - `@hypequery/clickhouse` query builder is the SQL construction and execution backend.
 - Planner correctness must not depend on query-builder inference behavior.
 - Public docs must match the published npm package exactly.
+- This is not a query-builder change.
+- The biggest residual architecture risk is duplicated planner logic between `@hypequery/datasets` and `@hypequery/serve`, not the tenant runtime simplification itself.
 
 ## Decisions Locked For This Pass
 
@@ -37,6 +39,32 @@ This package is still pre-release. Breaking changes are encouraged in this imple
 - Serve runtime owns tenancy. Datasets should not expose a public API that pushes tenant ownership decisions onto consumers.
 - Simplify the public tenancy runtime shape in this pass.
 - Focus helper typing work on the existing generic helpers only. Do not introduce additive dataset-aware helper variants in this pass.
+
+## Progress Snapshot
+
+### Completed
+
+- Fixed derived metric SQL generation so ungrouped derived metrics do not emit invalid grouping.
+- Added planner-level derived query validation before execution.
+- Added filtered measure support to `@hypequery/datasets`.
+- Removed `dataset.query(...)` from the datasets public API.
+- Simplified `SemanticTenantRuntime` to tenant identity only.
+- Rejected explicit tenant filters when runtime tenancy is active.
+- Cleaned the datasets root export surface.
+- Updated `@hypequery/serve` to stop depending on removed datasets planner exports.
+- Moved serve semantic/planner runtime helpers into `utils` files to reduce endpoint and pipeline bulk.
+
+### In Progress
+
+- Lock the intended datasets public surface with stronger type-test coverage.
+- Assess whether compile-time restrictions for derived metrics and generic helpers can be tightened without disproportionate type complexity.
+
+### Remaining
+
+- Broader type-safety tightening for derived metrics and generic helpers.
+- Docs and guide alignment across the repo.
+- Fresh-consumer smoke coverage.
+- Wider integration coverage for datasets and serve semantic endpoints.
 
 ## Workstreams
 
@@ -227,6 +255,7 @@ Add CI checks for:
 
 - Derived metric typing tightening
 - Query typing improvements
+- Current-surface type-test expansion
 - Docs and examples rewrite
 - Fresh-consumer smoke tests
 
@@ -258,6 +287,7 @@ Add CI checks for:
 
 - Tightening the export surface may break undocumented consumer usage.
 - Tightening derived metric typing may reject code that currently compiles.
+- Duplicated planner behavior across `datasets` and `serve` can drift over time unless we either centralize that logic behind a deliberate public contract or keep mirrored coverage strong in both packages.
 - Adding filtered measure support expands the semantic API and test matrix materially.
 - `dataset.query(...)` changes require a deliberate compatibility decision.
 

--- a/plans/datasets-semantic-layer-fix-plan.md
+++ b/plans/datasets-semantic-layer-fix-plan.md
@@ -1,0 +1,266 @@
+# Datasets Semantic Layer Fix Plan
+
+Date: 2026-05-21
+Owner: TBD
+Status: Draft
+
+## Pre-Release Bias
+
+This package is still pre-release. Breaking changes are encouraged in this implementation pass when they materially improve API clarity, semantic correctness, and long-term maintainability. We should prefer a cleaner public surface over preserving accidental or weakly-defined pre-release behavior.
+
+## Goals
+
+- Fix broken derived metric SQL generation in `@hypequery/datasets`.
+- Catch invalid semantic plans before query execution.
+- Align the public docs with the actual published package surface.
+- Clarify the intended public API boundary for datasets.
+- Add enough type, unit, integration, and DX coverage to keep the surface stable.
+
+## Non-Goals
+
+- Rebuild the ClickHouse query builder architecture in this pass.
+- Add broad write support to Hypequery.
+- Ship speculative API expansion without deciding the intended public surface first.
+
+## Architecture Direction
+
+- `@hypequery/datasets` owns semantic planning, invariants, and public API behavior.
+- `@hypequery/clickhouse` query builder is the SQL construction and execution backend.
+- Planner correctness must not depend on query-builder inference behavior.
+- Public docs must match the published npm package exactly.
+
+## Decisions Locked For This Pass
+
+- `dataset.query(...)` will be removed from the public API for now.
+- Filtered measures will be supported in this pass.
+- Export-surface cleanup should happen now because the package is still pre-release.
+- Serve runtime owns tenancy. Datasets should not expose a public API that pushes tenant ownership decisions onto consumers.
+- Simplify the public tenancy runtime shape in this pass.
+- Focus helper typing work on the existing generic helpers only. Do not introduce additive dataset-aware helper variants in this pass.
+
+## Workstreams
+
+### 1. Derived Metric Planning and Validation
+
+Objective:
+Fix derived metric SQL generation and add planner-level safety checks.
+
+Implementation:
+- Patch `packages/datasets/src/executor.ts`.
+- Make `buildDerivedSQLViaBuilder()` compute the intended grouping shape explicitly.
+- Ensure ungrouped derived metrics emit no `GROUP BY`.
+- Ensure grouped and grained derived metrics only group by user-selected dimensions and `period`.
+- Add planner invariants before SQL execution:
+  - no aggregate alias may appear in `GROUP BY`
+  - no duplicate `GROUP BY` expressions
+  - no derived-metric CTE should contain grouping unless the user query groups or grains
+- Extend `MetricExecutor.validate()` so it validates the planned query shape, not just the input contract.
+- Fail invalid plans before execution and before `toSQL()` returns misleading SQL.
+
+Acceptance criteria:
+- `executor.toSQL(derivedMetric, {})` emits valid ungrouped SQL.
+- `executor.run(derivedMetric, {})` executes successfully for base-aggregation-derived metrics.
+- `executor.validate(...)` returns invalid for derived plans that violate planner invariants.
+
+### 2. Public API Boundary Cleanup
+
+Objective:
+Make the datasets package surface deliberate and coherent.
+
+Implementation:
+- Remove `query()` and `DatasetQueryRef` from the published surface for now.
+- Make unsupported query-ref-shaped inputs fail with explicit public errors instead of runtime crashes where defensive handling is still needed internally.
+- Tighten `packages/datasets/src/index.ts` and `packages/datasets/package.json` exports.
+- Stop exporting planner internals by default unless they are intentionally public and documented.
+
+Acceptance criteria:
+- No unsupported public API crashes with `TypeError`.
+- Root exports are intentional, documented, and covered by type tests.
+- Docs do not rely on unpublished deep imports.
+
+### 3. Measure Options and Filtered Measure Decision
+
+Objective:
+Resolve the docs/API mismatch around filtered measures.
+
+Implementation:
+- Support filtered measures in this pass.
+- Extend `MeasureOptions` in `packages/datasets/src/types.ts`.
+- Update `packages/datasets/src/measure.ts`.
+- Propagate measure-level filters through planning and execution.
+- Define merge semantics between measure-level filters, query-level filters, and runtime tenant filters.
+- Document the supported behavior and add tests.
+
+Acceptance criteria:
+- The docs match the shipped API.
+- Measure filters are fully typed, planned, and executed correctly.
+
+### 4. Derived Metric and Query Typing Tightening
+
+Objective:
+Move intended API guarantees from runtime checks into compile-time checks where practical.
+
+Implementation:
+- Tighten `DerivedMetricConfig.uses` in `packages/datasets/src/types.ts` so derived metrics only accept base metrics from the same dataset.
+- Prevent cross-dataset metric references at compile time where possible.
+- Prevent derived-from-derived references at compile time where possible.
+- Improve typing around query dimensions, `orderBy.field`, and grain usage.
+- Assess feasibility of tightening the existing generic helpers like `eq()` and `desc()`.
+- Improve the generic helper typing if it stays reasonably simple and understandable.
+- If the type-level complexity becomes disproportionate, keep the current generic helper behavior and document that limitation clearly.
+
+Acceptance criteria:
+- Invalid derived metric wiring fails in type tests.
+- Invalid query fields fail in type tests where the API intends strong typing.
+- If helper functions stay generic, docs clearly describe that limitation.
+
+### 5. Tenant Filter Semantics
+
+Objective:
+Handle runtime tenant injection without duplicate predicates or ambiguous semantics.
+
+Implementation:
+- Patch tenant handling in `packages/datasets/src/executor.ts`.
+- Make serve runtime tenancy authoritative.
+- Reject explicit tenant filters in semantic queries when runtime tenancy enforcement is active.
+- Simplify the public runtime tenant contract so consumers provide tenant identity, not tenant column policy.
+- Remove public reliance on `ExecutionContext.runtime.tenant.column` and `handledByBuilder`.
+- Derive tenant column behavior from dataset configuration plus serve-owned runtime semantics.
+- Document the chosen rule.
+
+Acceptance criteria:
+- SQL does not emit duplicate tenant predicates.
+- Conflicting tenant assumptions are rejected consistently.
+- Tenant ownership is clear in the public API and docs.
+
+### 6. Documentation and Fresh-Consumer DX Alignment
+
+Objective:
+Make copy-paste docs work against the published package.
+
+Implementation:
+- Update docs to import `MetricExecutor` from `@hypequery/datasets`.
+- Replace outdated measure execution examples with the current `dataset.metric(...)` flow.
+- Remove or rewrite write-based setup instructions that imply native write support.
+- Prefer `url` over deprecated `host` in examples where applicable.
+- Add explicit fixture-seeding guidance using external tooling when writes are required.
+
+Acceptance criteria:
+- A fresh consumer can follow the guide without immediate TypeScript failure.
+- The guide does not imply unsupported write workflows through Hypequery.
+
+## Test Plan
+
+### Type Tests
+
+Add dedicated datasets type tests covering:
+- metric construction success/failure
+- same-dataset base-metric-only derived metrics
+- valid/invalid dimensions
+- valid/invalid `orderBy.field`
+- grain behavior with and without `timeKey`
+- measure options support/rejection
+- root export surface
+- guide snippets as compile tests
+
+### Unit Tests
+
+Add datasets unit tests covering:
+- base metric SQL generation
+- derived metric SQL generation:
+  - ungrouped
+  - grouped
+  - grained
+  - grouped + grained
+  - filtered
+  - tenant-scoped
+- validation failures:
+  - unknown dimension
+  - unknown filter field
+  - invalid order field
+  - invalid grain usage
+  - invalid derived plans
+- planner invariants
+- removed/unsupported `DatasetQueryRef` behavior
+- query-builder protocol compatibility
+- tenant predicate behavior
+
+### Integration Tests
+
+Add ClickHouse-backed integration tests covering:
+- connection smoke tests
+- fixture lifecycle
+- base metric execution
+- derived metric execution
+- grouped and grained derived metrics
+- pre-execution validation failures
+- one real-dataset semantic query
+- fresh-consumer package importability checks
+
+### DX and Docs Checks
+
+Add CI checks for:
+- fresh temp project install
+- root import compile test
+- unsupported subpath import rejection
+- Node 22 ESM importability
+- guide snippet compile checks
+
+## Proposed Sequencing
+
+### Phase 1: Critical Bug Fixes
+
+- Derived metric planning fix
+- Planner invariants
+- Validation upgrade
+- `DatasetQueryRef` removal / crash prevention
+- Tenant filter duplication handling
+
+### Phase 2: Surface Decisions
+
+- Remove `dataset.query(...)` surface
+- Implement filtered measure support
+- Decide helper typing scope based on feasibility assessment
+- Trim root exports
+
+### Phase 3: Type Safety and Docs Alignment
+
+- Derived metric typing tightening
+- Query typing improvements
+- Docs and examples rewrite
+- Fresh-consumer smoke tests
+
+### Phase 4: Coverage Expansion
+
+- Dedicated type tests
+- Focused unit tests
+- Real integration tests
+- CI hardening
+
+## Release Scoping
+
+### Patch-suitable items
+
+- Derived metric SQL fix
+- Validation for invalid derived plans
+- `DatasetQueryRef` crash-to-error behavior
+- Tenant predicate rejection when runtime tenancy is active
+- Docs corrections for current published API
+
+### Likely minor-release items
+
+- `dataset.query(...)` public execution path
+- Derived metric compile-time restriction overhaul
+- Helper typing redesign
+- Export surface contraction if it removes previously exported APIs
+
+## Risks
+
+- Tightening the export surface may break undocumented consumer usage.
+- Tightening derived metric typing may reject code that currently compiles.
+- Adding filtered measure support expands the semantic API and test matrix materially.
+- `dataset.query(...)` changes require a deliberate compatibility decision.
+
+## Open Questions
+
+1. If tightening the existing generic helpers becomes too complex, should we explicitly defer helper typing improvements in this pass rather than force a brittle solution?


### PR DESCRIPTION
# Title

  Fix datasets semantic-layer planning, filtered measures, and public API cleanup

  # Summary

  This PR fixes the main semantic-layer correctness issues in @hypequery/datasets and tightens the pre-release public surface.

  The biggest runtime bug was derived metric planning: ungrouped derived metrics could inherit invalid GROUP BY behavior from the
  underlying builder and generate broken SQL. This PR adds planner-level validation and invariants so derived metrics only group
  when the semantic query actually asks for grouping or graining.

  It also cleans up the datasets API surface by removing unsupported dataset.query(...), simplifying tenant runtime handling, and
  adding first-class filtered measure support.

  # What Changed

  - Fixed derived metric planning and validation in packages/datasets/src/executor.ts
  - Added planner invariants to reject:
  - GROUP BY on ungrouped derived metrics
  - aggregate aliases in GROUP BY
  - duplicate or unexpected grouping expressions in derived CTEs
  - Made MetricExecutor.validate() validate planned query shape, not just input fields
  - Removed dataset.query(...) and related public dataset query types from the datasets API
  - Simplified tenant runtime to tenant identity only
  - Made serve/runtime tenancy authoritative and reject explicit tenant filters when runtime tenancy is active
  - Added filtered measure support:
  - MeasureOptions.filters
  - measure filter validation
  - measure filter SQL compilation into aggregation expressions
  - Removed planner internals from root exports
  - Added API compile-lock coverage and regression/unit coverage
  - Refactored executor/planner helper logic into src/utils/ for readability

  # Behavior Changes

  - dataset.query(...) is no longer part of the public datasets API
  - ExecutionContext.runtime.tenant now only accepts:

  { id: string }

  - It no longer accepts column or handledByBuilder
  - Explicit tenant filters are rejected when runtime tenancy is active
  - Measure filters are now supported:

  measure.sum('amount', {
    filters: [eq('status', 'completed')],
  })

  # Examples

  Derived metric planning now produces valid ungrouped SQL.

  Before:

  WITH base AS (
    SELECT SUM(amount) AS revenue, COUNT(id) AS orderCount
    FROM test_orders
    GROUP BY revenue
  )
  SELECT (revenue) / (NULLIF(orderCount, 0)) AS avgOrderValue
  FROM base

  After:

  WITH base AS (
    SELECT SUM(amount) AS revenue, COUNT(id) AS orderCount
    FROM test_orders
  )
  SELECT (revenue) / (NULLIF(orderCount, 0)) AS avgOrderValue
  FROM base

  Filtered measures now compile through the planner:

  measure.sum('amount', {
    filters: [eq('status', 'completed')],
  })

  # Tests

  Ran:

  - pnpm exec tsc --project tsconfig.type-tests.json
  - pnpm exec tsc --project tsconfig.json
  - pnpm exec vitest run --config vitest.config.ts src/datasets.test.ts

  # Scope Note

  This PR stops at the core datasets bugfix and API cleanup slice. It does not yet include:

  - stronger generic helper typing for eq(), desc(), etc.
  - full compile-time tightening for derived metric wiring
  - broader docs refresh across the site/specs
  - fresh-consumer smoke tests
  - real ClickHouse integration coverage for datasets