### PR TITLE
task: semantic layer cleanup pass

### DIFF
--- a/packages/clickhouse/src/core/tests/integration/setup.ts
+++ b/packages/clickhouse/src/core/tests/integration/setup.ts
@@ -11,7 +11,6 @@ import {
   startClickHouseContainer as sharedStartClickHouseContainer,
   stopClickHouseContainer as sharedStopClickHouseContainer,
   waitForClickHouse as sharedWaitForClickHouse,
-  // @ts-expect-error: shared test harness is plain JS
 } from '../../../../../../testing/clickhouse/harness.mjs';
 
 // Disable the hypequery logger to prevent "logs after tests" errors

--- a/packages/datasets/package.json
+++ b/packages/datasets/package.json
@@ -10,6 +10,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.js"
+    },
+    "./internal": {
+      "types": "./dist/internal.d.ts",
+      "import": "./dist/internal.js",
+      "require": "./dist/internal.js"
     }
   },
   "license": "Apache-2.0",

--- a/packages/datasets/src/api.type-test.ts
+++ b/packages/datasets/src/api.type-test.ts
@@ -17,6 +17,7 @@ type Equal<A, B> =
     : false;
 type HasKey<T, K extends PropertyKey> = K extends keyof T ? true : false;
 type DatasetModule = typeof import('./index.js');
+type DatasetInternalModule = typeof import('./internal.js');
 
 const Orders = dataset('orders', {
   source: 'orders',
@@ -73,6 +74,28 @@ type _DatasetHasNoQueryMethod = Assert<
 >;
 type _RootExportOmitsDatasetQueryRef = Assert<
   Equal<HasKey<DatasetModule, 'DatasetQueryRef'>, false>
+>;
+type _RootExportOmitsDatasetQuery = Assert<
+  Equal<HasKey<DatasetModule, 'DatasetQuery'>, false>
+>;
+type _RootExportOmitsDatasetQueryResult = Assert<
+  Equal<HasKey<DatasetModule, 'DatasetQueryResult'>, false>
+>;
+type _RootExportOmitsBuildDatasetQueryBuilder = Assert<
+  Equal<HasKey<DatasetModule, 'buildDatasetQueryBuilder'>, false>
+>;
+type _RootExportOmitsRunDatasetQuery = Assert<
+  Equal<HasKey<DatasetModule, 'runDatasetQuery'>, false>
+>;
+type _RootExportOmitsValidateDatasetQuery = Assert<
+  Equal<HasKey<DatasetModule, 'validateDatasetQuery'>, false>
+>;
+type _InternalDatasetQueryTypeCompiles = import('./internal.js').DatasetQuery;
+type _InternalExportIncludesBuildDatasetQueryBuilder = Assert<
+  Equal<HasKey<DatasetInternalModule, 'buildDatasetQueryBuilder'>, true>
+>;
+type _InternalExportIncludesRunDatasetQuery = Assert<
+  Equal<HasKey<DatasetInternalModule, 'runDatasetQuery'>, true>
 >;
 type _RootExportOmitsPlannerHelper = Assert<
   Equal<HasKey<DatasetModule, 'applyMeasureDefinition'>, false>

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -264,7 +264,7 @@ export class MetricExecutor {
     // Base metrics: fully use the builder's execute()
     const builder = this.buildBaseQuery(ref, spec, ref.dataset, query, grain, context);
     const { sql } = builder.toSQLWithParams();
-    const data = await builder.execute() as T[];
+    const data = await builder.execute<T>();
     const timingMs = Date.now() - start;
     return { data, meta: { sql, timingMs, tenant: context?.runtime?.tenant?.id } };
   }

--- a/packages/datasets/src/index.ts
+++ b/packages/datasets/src/index.ts
@@ -34,12 +34,6 @@ export { createDatasetRegistry } from './registry.js';
 // Executor
 export { MetricExecutor } from './executor.js';
 export type { MetricExecutorOptions } from './executor.js';
-export {
-  buildDatasetQueryBuilder,
-  runDatasetQuery,
-  validateDatasetQuery,
-} from './dataset-query.js';
-export type { DatasetQueryExecutionOptions } from './dataset-query.js';
 
 // Validation
 export type { ValidationResult } from './validation.js';
@@ -79,10 +73,8 @@ export type {
   MetricFilter,
   MetricOrderBy,
   MetricQuery,
-  DatasetQuery,
   MetricResultMeta,
   MetricResult,
-  DatasetQueryResult,
   MetricHandle,
   ExecutionContext,
   SemanticExecutionRuntime,

--- a/packages/datasets/src/internal.ts
+++ b/packages/datasets/src/internal.ts
@@ -1,0 +1,10 @@
+export {
+  buildDatasetQueryBuilder,
+  runDatasetQuery,
+  validateDatasetQuery,
+} from './dataset-query.js';
+export type { DatasetQueryExecutionOptions } from './dataset-query.js';
+export type {
+  DatasetQuery,
+  DatasetQueryResult,
+} from './types.js';

--- a/packages/datasets/src/query-builder-protocol.ts
+++ b/packages/datasets/src/query-builder-protocol.ts
@@ -34,7 +34,7 @@ export interface QueryBuilderLike {
 
   // Terminal operations
   toSQLWithParams(): { sql: string; parameters: unknown[] };
-  execute(): Promise<Record<string, unknown>[]>;
+  execute<T = Record<string, unknown>>(): Promise<T[]>;
 }
 
 /** A query builder factory (what `createQueryBuilder(config)` returns). */

--- a/packages/serve/DATASETS_AND_METRICS_SPEC.md
+++ b/packages/serve/DATASETS_AND_METRICS_SPEC.md
@@ -16,7 +16,7 @@ When these packages are ready for public docs, the first docs pass should focus 
   - `.by(grain)`
   - runtime tenancy shape
   - `MetricExecutor`
-  - dataset query helpers used by serve-backed dataset endpoints
+  - intentional root exports only; serve-only helpers should stay under `@hypequery/datasets/internal`
 - `@hypequery/serve`
   - generated metric endpoints
   - generated dataset endpoints
@@ -668,13 +668,16 @@ class MetricExecutor {
 }
 ```
 
-Related implemented helper surface:
+Related implemented internal helper surface:
 
 ```ts
+// @hypequery/datasets/internal
 validateDatasetQuery(dataset, query, context?)
 buildDatasetQueryBuilder(dataset, query, options)
 runDatasetQuery(dataset, query, options)
 ```
+
+These helpers are for package integration, primarily serve-backed dataset endpoints. They should not be documented as the user-facing datasets API unless we deliberately promote them later.
 
 ### 4.3 How MetricExecutor Builds Queries
 

--- a/packages/serve/src/semantic/datasets/dataset-endpoint.ts
+++ b/packages/serve/src/semantic/datasets/dataset-endpoint.ts
@@ -18,13 +18,13 @@ import type {
   ServeMiddleware,
 } from '../../types.js';
 import type {
-  DatasetQuery,
   QueryBuilderFactoryLike,
 } from '@hypequery/datasets';
+import type { DatasetQuery } from '@hypequery/datasets/internal';
 import {
   runDatasetQuery,
   validateDatasetQuery,
-} from '@hypequery/datasets';
+} from '@hypequery/datasets/internal';
 import { ServeHttpError } from '../../errors.js';
 import {
   resolveSemanticExecutionRuntime,

--- a/packages/serve/src/semantic/datasets/serve-live.integration.spec.ts
+++ b/packages/serve/src/semantic/datasets/serve-live.integration.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createAPI } from "../../server/create-api.js";
 import {
@@ -65,6 +64,30 @@ const avgOrderValue = Orders.metric("avgOrderValue", {
 const monthlyRevenue = totalRevenue.by("month");
 
 const BASE_PATH = "/api/analytics";
+
+type SemanticResponseBody = {
+  data: Record<string, unknown>[];
+  meta?: {
+    sql?: string;
+    timingMs?: number;
+  };
+};
+
+function isSemanticResponseBody(value: unknown): value is SemanticResponseBody {
+  return (
+    typeof value === "object"
+    && value !== null
+    && Array.isArray(Reflect.get(value, "data"))
+  );
+}
+
+function semanticBody(response: { body: unknown }): SemanticResponseBody {
+  if (!isSemanticResponseBody(response.body)) {
+    throw new Error("Expected semantic response body with data rows.");
+  }
+
+  return response.body;
+}
 
 function createRequest(overrides: Partial<ServeRequest> = {}): ServeRequest {
   const path = overrides.path ?? "/";
@@ -162,7 +185,8 @@ describe("Serve live integration — datasets", () => {
       );
 
       expect(response.status).toBe(200);
-      const rows = (response.body as any).data.map((row: Record<string, unknown>) => ({
+      const body = semanticBody(response);
+      const rows = body.data.map((row) => ({
         status: String(row.status),
         revenue: toNumber(row.revenue),
         orderCount: toNumber(row.orderCount),
@@ -174,7 +198,7 @@ describe("Serve live integration — datasets", () => {
         { status: "completed", revenue: 66, orderCount: 3, uniqueUsers: 2 },
         { status: "pending", revenue: 62.25, orderCount: 1, uniqueUsers: 1 },
       ]);
-      expect(Object.keys((response.body as any).data[0])).toEqual([
+      expect(Object.keys(body.data[0])).toEqual([
         "status",
         "revenue",
         "orderCount",
@@ -202,7 +226,8 @@ describe("Serve live integration — datasets", () => {
       );
 
       expect(response.status).toBe(200);
-      const rows = (response.body as any).data.map((row: Record<string, unknown>) => ({
+      const body = semanticBody(response);
+      const rows = body.data.map((row) => ({
         userId: toNumber(row.userId),
         revenue: toNumber(row.revenue),
         orderCount: toNumber(row.orderCount),
@@ -212,7 +237,7 @@ describe("Serve live integration — datasets", () => {
       expect(rows).toEqual([
         { userId: 1, revenue: 36, orderCount: 2, uniqueUsers: 1 },
       ]);
-      expect(Object.keys((response.body as any).data[0])).toEqual([
+      expect(Object.keys(body.data[0])).toEqual([
         "userId",
         "revenue",
         "orderCount",
@@ -242,7 +267,8 @@ describe("Serve live integration — datasets", () => {
       );
 
       expect(response.status).toBe(200);
-      const rows = (response.body as any).data.map((row: Record<string, unknown>) => ({
+      const body = semanticBody(response);
+      const rows = body.data.map((row) => ({
         period: toDateString(row.period),
         revenue: toNumber(row.revenue),
         orderCount: toNumber(row.orderCount),
@@ -252,16 +278,16 @@ describe("Serve live integration — datasets", () => {
       expect(rows).toEqual([
         { period: "2023-01-01", revenue: 144.75, orderCount: TEST_DATA.orders.length, uniqueUsers: 3 },
       ]);
-      expect(Object.keys((response.body as any).data[0])).toEqual([
+      expect(Object.keys(body.data[0])).toEqual([
         "period",
         "revenue",
         "orderCount",
         "uniqueUsers",
       ]);
-      expect((response.body as any).meta).toMatchObject({
+      expect(body.meta).toMatchObject({
         sql: expect.stringContaining("COUNT(DISTINCT"),
       });
-      expect(typeof (response.body as any).meta.timingMs).toBe("number");
+      expect(typeof body.meta?.timingMs).toBe("number");
     });
 
     it("executes base metric endpoints with real countDistinct aggregation", async () => {
@@ -281,7 +307,8 @@ describe("Serve live integration — datasets", () => {
       );
 
       expect(response.status).toBe(200);
-      const rows = (response.body as any).data.map((row: Record<string, unknown>) => ({
+      const body = semanticBody(response);
+      const rows = body.data.map((row) => ({
         status: String(row.status),
         uniqueUsers: toNumber(row.uniqueUsers),
       }));
@@ -291,7 +318,7 @@ describe("Serve live integration — datasets", () => {
         { status: "completed", uniqueUsers: 2 },
         { status: "pending", uniqueUsers: 1 },
       ]);
-      expect(Object.keys((response.body as any).data[0])).toEqual([
+      expect(Object.keys(body.data[0])).toEqual([
         "status",
         "uniqueUsers",
       ]);
@@ -314,7 +341,8 @@ describe("Serve live integration — datasets", () => {
       );
 
       expect(response.status).toBe(200);
-      const rows = (response.body as any).data.map((row: Record<string, unknown>) => ({
+      const body = semanticBody(response);
+      const rows = body.data.map((row) => ({
         status: String(row.status),
         avgOrderValue: toNumber(row.avgOrderValue),
       }));
@@ -324,7 +352,7 @@ describe("Serve live integration — datasets", () => {
         { status: "completed", avgOrderValue: 22 },
         { status: "pending", avgOrderValue: 62.25 },
       ]);
-      expect(Object.keys((response.body as any).data[0])).toEqual([
+      expect(Object.keys(body.data[0])).toEqual([
         "status",
         "avgOrderValue",
       ]);
@@ -348,7 +376,8 @@ describe("Serve live integration — datasets", () => {
       );
 
       expect(response.status).toBe(200);
-      const rows = (response.body as any).data.map((row: Record<string, unknown>) => ({
+      const body = semanticBody(response);
+      const rows = body.data.map((row) => ({
         period: toDateString(row.period),
         totalRevenue: toNumber(row.totalRevenue),
       }));
@@ -356,14 +385,14 @@ describe("Serve live integration — datasets", () => {
       expect(rows).toEqual([
         { period: "2023-01-01", totalRevenue: 144.75 },
       ]);
-      expect(Object.keys((response.body as any).data[0])).toEqual([
+      expect(Object.keys(body.data[0])).toEqual([
         "period",
         "totalRevenue",
       ]);
-      expect((response.body as any).meta).toMatchObject({
+      expect(body.meta).toMatchObject({
         sql: expect.stringContaining("toStartOfMonth"),
       });
-      expect(typeof (response.body as any).meta.timingMs).toBe("number");
+      expect(typeof body.meta?.timingMs).toBe("number");
     });
   });
 });

--- a/packages/serve/tsconfig.json
+++ b/packages/serve/tsconfig.json
@@ -16,7 +16,8 @@
   "exclude": [
     "node_modules",
     "dist",
-    "src/**/*.test.ts"
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts"
   ],
   "references": [
     { "path": "../datasets" },

--- a/plans/datasets-semantic-layer-fix-plan.md
+++ b/plans/datasets-semantic-layer-fix-plan.md
@@ -55,10 +55,14 @@ This package is still pre-release. Breaking changes are encouraged in this imple
 - Updated `@hypequery/serve` to stop depending on removed datasets planner exports.
 - Moved serve semantic/planner runtime helpers into `utils` files to reduce endpoint and pipeline bulk.
 - Centralized dataset endpoint query planning in `@hypequery/datasets` so serve no longer maintains a duplicate semantic query planner.
-- Added dataset query helper APIs as the intentional datasets/serve planning boundary.
+- Added dataset query helper APIs under `@hypequery/datasets/internal` as the intentional datasets/serve planning boundary.
 - Added schema-to-datasets compatibility checks so physical schema changes can be checked against semantic models.
 - Added semantic architecture/spec notes for datasets, serve, and schema.
 - Removed new production casts from the dataset-query path and cleaned the touched serve semantic test helpers.
+- Locked the root datasets export surface so dataset-query helpers and types do not appear as public user-facing APIs.
+- Made the query-builder protocol execute path generic so metric execution does not need a result cast.
+- Removed file-level type suppression and response `any` casts from the serve live semantic integration spec.
+- Added types for the shared ClickHouse integration harness used by serve live tests.
 
 ### Verified In This Pass
 
@@ -66,13 +70,13 @@ This package is still pre-release. Breaking changes are encouraged in this imple
 - `npm test -- --run src/semantic/datasets/serve-integration.test.ts`
 - `pnpm build` in `packages/datasets`
 - `pnpm build` in `packages/serve`
+- `SKIP_INTEGRATION_TESTS=true pnpm exec vitest run --config vitest.integration.config.ts src/semantic/datasets/serve-live.integration.spec.ts`
 - `git diff --cached --check`
 
 ### In Progress
 
 - Lock the intended datasets/schema public surface with stronger type-test coverage.
 - Keep the semantic architecture spec current while implementation stabilizes.
-- Decide whether `buildDatasetQueryBuilder` and `runDatasetQuery` are documented as public APIs or explicitly positioned as package-internal serve integration APIs.
 
 ### Remaining
 
@@ -281,7 +285,6 @@ Add CI checks for:
 - Query typing improvements
 - Current-surface type-test expansion
 - Schema compatibility type-test expansion
-- Confirm dataset-query helper export positioning
 - Existing generic helper typing improvements where practical
 
 ### Phase 5: Docs and Consumer DX - After API Hardening
@@ -324,14 +327,14 @@ Add CI checks for:
 - Derived metric compile-time restriction overhaul
 - Existing generic helper typing tightening
 - Fresh-consumer smoke tests
-- Wider live ClickHouse semantic integration coverage
+- Live ClickHouse semantic integration execution in an environment with Docker access
 - Relationship-aware planning design
 
 ## Risks
 
 - Tightening the export surface may break undocumented consumer usage, but this is acceptable while the packages are pre-release.
 - Tightening derived metric typing may reject code that currently compiles.
-- Dataset-query helper exports may look like public user-facing APIs unless docs clearly position them.
+- The `@hypequery/datasets/internal` subpath is still technically importable, so docs should clearly position it as unsupported package-integration surface rather than user-facing API.
 - Schema compatibility can still miss deeper SQL-expression dependencies until the checker grows beyond direct column references.
 - Adding filtered measure support expands the semantic API and test matrix materially.
 - Relationship metadata remains non-executing until relationship-aware planning is deliberately designed.

--- a/plans/datasets-semantic-layer-fix-plan.md
+++ b/plans/datasets-semantic-layer-fix-plan.md
@@ -1,6 +1,6 @@
 # Datasets Semantic Layer Fix Plan
 
-Date: 2026-05-24
+Date: 2026-05-25
 Owner: TBD
 Status: Implementation pass complete; follow-up hardening remains
 
@@ -75,7 +75,7 @@ This package is still pre-release. Breaking changes are encouraged in this imple
 
 ### In Progress
 
-- Lock the intended datasets/schema public surface with stronger type-test coverage.
+- Prepare the next hardening pass around compile-time guarantees and consumer smoke coverage.
 - Keep the semantic architecture spec current while implementation stabilizes.
 
 ### Remaining
@@ -87,64 +87,9 @@ This package is still pre-release. Breaking changes are encouraged in this imple
 - Deeper schema compatibility for SQL expressions and relationship join columns.
 - Relationship-aware semantic execution remains out of scope until the base semantic surface is stable.
 
-## Workstreams
+## Next Workstreams
 
-### 1. Derived Metric Planning and Validation
-
-Objective:
-Fix derived metric SQL generation and add planner-level safety checks.
-
-Implementation:
-- Patch `packages/datasets/src/executor.ts`.
-- Make `buildDerivedSQLViaBuilder()` compute the intended grouping shape explicitly.
-- Ensure ungrouped derived metrics emit no `GROUP BY`.
-- Ensure grouped and grained derived metrics only group by user-selected dimensions and `period`.
-- Add planner invariants before SQL execution:
-  - no aggregate alias may appear in `GROUP BY`
-  - no duplicate `GROUP BY` expressions
-  - no derived-metric CTE should contain grouping unless the user query groups or grains
-- Extend `MetricExecutor.validate()` so it validates the planned query shape, not just the input contract.
-- Fail invalid plans before execution and before `toSQL()` returns misleading SQL.
-
-Acceptance criteria:
-- `executor.toSQL(derivedMetric, {})` emits valid ungrouped SQL.
-- `executor.run(derivedMetric, {})` executes successfully for base-aggregation-derived metrics.
-- `executor.validate(...)` returns invalid for derived plans that violate planner invariants.
-
-### 2. Public API Boundary Cleanup
-
-Objective:
-Make the datasets package surface deliberate and coherent.
-
-Implementation:
-- Remove `query()` and `DatasetQueryRef` from the published surface for now.
-- Make unsupported query-ref-shaped inputs fail with explicit public errors instead of runtime crashes where defensive handling is still needed internally.
-- Tighten `packages/datasets/src/index.ts` and `packages/datasets/package.json` exports.
-- Stop exporting planner internals by default unless they are intentionally public and documented.
-
-Acceptance criteria:
-- No unsupported public API crashes with `TypeError`.
-- Root exports are intentional, documented, and covered by type tests.
-- Docs do not rely on unpublished deep imports.
-
-### 3. Measure Options and Filtered Measure Decision
-
-Objective:
-Resolve the docs/API mismatch around filtered measures.
-
-Implementation:
-- Support filtered measures in this pass.
-- Extend `MeasureOptions` in `packages/datasets/src/types.ts`.
-- Update `packages/datasets/src/measure.ts`.
-- Propagate measure-level filters through planning and execution.
-- Define merge semantics between measure-level filters, query-level filters, and runtime tenant filters.
-- Document the supported behavior and add tests.
-
-Acceptance criteria:
-- The docs match the shipped API.
-- Measure filters are fully typed, planned, and executed correctly.
-
-### 4. Derived Metric and Query Typing Tightening
+### 1. Derived Metric and Query Typing Tightening
 
 Objective:
 Move intended API guarantees from runtime checks into compile-time checks where practical.
@@ -163,33 +108,48 @@ Acceptance criteria:
 - Invalid query fields fail in type tests where the API intends strong typing.
 - If helper functions stay generic, docs clearly describe that limitation.
 
-### 5. Tenant Filter Semantics
+### 2. Fresh-Consumer DX Coverage
 
 Objective:
-Handle runtime tenant injection without duplicate predicates or ambiguous semantics.
+Make the published package boundary enforceable before writing public docs.
 
 Implementation:
-- Patch tenant handling in `packages/datasets/src/executor.ts`.
-- Make serve runtime tenancy authoritative.
-- Reject explicit tenant filters in semantic queries when runtime tenancy enforcement is active.
-- Simplify the public runtime tenant contract so consumers provide tenant identity, not tenant column policy.
-- Remove public reliance on `ExecutionContext.runtime.tenant.column` and `handledByBuilder`.
-- Derive tenant column behavior from dataset configuration plus serve-owned runtime semantics.
-- Document the chosen rule.
+- Add a temporary fresh project that installs/builds against local package artifacts.
+- Verify root imports compile for `@hypequery/datasets`, `@hypequery/schema`, and `@hypequery/serve`.
+- Verify unsupported deep/subpath imports fail except intentionally exported package-integration subpaths.
+- Verify Node 22 ESM importability.
+- Keep docs snippets out of this pass unless needed to define the smoke target.
 
 Acceptance criteria:
-- SQL does not emit duplicate tenant predicates.
-- Conflicting tenant assumptions are rejected consistently.
-- Tenant ownership is clear in the public API and docs.
+- A fresh consumer can import the intended root APIs without TypeScript or ESM failures.
+- Accidental internals are not reachable from documented root imports.
+- The smoke test can run in CI without live ClickHouse.
 
-### 6. Documentation and Fresh-Consumer DX Alignment
+### 3. Schema Compatibility Depth
 
 Objective:
-Make copy-paste docs work against the published package.
+Move schema compatibility beyond direct field references where it is practical.
+
+Implementation:
+- Extend compatibility checks for SQL-expression dimensions/measures where dependency extraction is safe.
+- Add checks for relationship join columns.
+- Add focused tests for removed/renamed join columns and unsupported SQL-expression cases.
+- Clearly report limitations instead of pretending full SQL lineage exists.
+
+Acceptance criteria:
+- Direct relationship join-column breakages are reported before migration application.
+- SQL-expression compatibility either reports known dependencies or emits an explicit limitation.
+
+### 4. Docs and Guide Alignment
+
+Objective:
+Make copy-paste docs work against the finalized package boundary.
 
 Implementation:
 - Update docs to import `MetricExecutor` from `@hypequery/datasets`.
 - Replace outdated measure execution examples with the current `dataset.metric(...)` flow.
+- Document filtered measures and runtime tenancy behavior.
+- Avoid documenting `@hypequery/datasets/internal` as user-facing API.
 - Remove or rewrite write-based setup instructions that imply native write support.
 - Prefer `url` over deprecated `host` in examples where applicable.
 - Add explicit fixture-seeding guidance using external tooling when writes are required.
@@ -287,22 +247,27 @@ Add CI checks for:
 - Schema compatibility type-test expansion
 - Existing generic helper typing improvements where practical
 
-### Phase 5: Docs and Consumer DX - After API Hardening
+### Phase 5: Fresh-Consumer DX Coverage - Next
 
-- Docs and examples rewrite
 - Fresh-consumer smoke tests
 - Root import compile test
 - Unsupported subpath import rejection test
 - Node 22 ESM importability test
 
-### Phase 6: Coverage Expansion
+### Phase 6: Docs and Guide Alignment - After API Hardening
+
+- Docs and examples rewrite
+- Guide snippet compile checks
+- Public positioning cleanup
+
+### Phase 7: Coverage Expansion
 
 - Dedicated type tests
 - Focused unit tests
 - Real integration tests
 - CI hardening
 
-### Phase 7: Relationship-Aware Semantics
+### Phase 8: Relationship-Aware Semantics
 
 - Define how dataset relationships participate in planning.
 - Decide whether joins are query-time only, materialized/planned elsewhere, or initially metadata-only.

--- a/testing/clickhouse/harness.d.mts
+++ b/testing/clickhouse/harness.d.mts
@@ -1,0 +1,87 @@
+export interface ClickHouseTestConnectionConfig {
+  host: string;
+  user: string;
+  password: string;
+  database: string;
+}
+
+export interface ClickHouseTestData {
+  test_table: Array<Record<string, unknown>>;
+  users: Array<Record<string, unknown>>;
+  orders: Array<Record<string, unknown>>;
+}
+
+export interface ComposeCommand {
+  command: string;
+  args: string[];
+}
+
+export interface CommandResult {
+  code: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+export const REPO_ROOT: string;
+export const DEFAULT_COMPOSE_PATH: string;
+export const DEFAULT_TEST_DATA_PATH: string;
+export const CLICKHOUSE_CONTAINER_NAME: string;
+export const TEST_CONNECTION_CONFIG: ClickHouseTestConnectionConfig;
+export const TEST_DATA: ClickHouseTestData;
+
+export function normalizeDateValue(value: unknown): unknown;
+export function loadTestData(testDataPath?: string): ClickHouseTestData;
+export function logIntegrationMessage(message: string): void;
+export function runCommand(
+  command: string,
+  args: string[],
+  options?: {
+    cwd?: string;
+    capture?: boolean;
+    env?: NodeJS.ProcessEnv;
+  },
+): Promise<CommandResult>;
+export function checkPortAvailability(port: number): Promise<boolean>;
+export function findFreePort(): Promise<number>;
+export function ensurePort(
+  envVar: string,
+  defaultPort: number,
+  logger?: (message: string) => void,
+): Promise<number>;
+export function detectComposeCommand(): Promise<ComposeCommand>;
+export function ensureDockerDaemon(): Promise<void>;
+export function isContainerRunning(containerName?: string): Promise<boolean>;
+export function startClickHouseContainer(options?: {
+  compose?: ComposeCommand;
+  composeFile?: string;
+  logger?: (message: string) => void;
+}): Promise<void>;
+export function stopClickHouseContainer(options?: {
+  compose?: ComposeCommand;
+  composeFile?: string;
+  logger?: (message: string) => void;
+}): Promise<void>;
+export function sleep(ms: number): Promise<void>;
+export function waitForClickHouse(options?: {
+  config?: ClickHouseTestConnectionConfig;
+  maxAttempts?: number;
+  retryDelayMs?: number;
+  logger?: (message: string) => void;
+}): Promise<void>;
+export function runSql(
+  sql: string,
+  options?: {
+    config?: ClickHouseTestConnectionConfig;
+    includeDatabase?: boolean;
+  },
+): Promise<void>;
+export function insertRows(
+  table: string,
+  rows: Array<Record<string, unknown>>,
+  config?: ClickHouseTestConnectionConfig,
+): Promise<void>;
+export function seedClickHouseDatabase(options?: {
+  config?: ClickHouseTestConnectionConfig;
+  data?: ClickHouseTestData;
+  logger?: (message: string) => void;
+}): Promise<void>;


### PR DESCRIPTION
## Summary

  This PR completes the current semantic-layer backend cleanup pass across `@hypequery/datasets`, `@hypequery/
  serve`, and schema compatibility planning.

  The core architecture change is that semantic dataset planning now lives in `@hypequery/datasets`, while
  `@hypequery/serve` delegates to a deliberate internal integration boundary instead of maintaining duplicate
  planner logic.

  ## What Changed

  - Fixed derived metric planning so aggregate aliases are not inferred as `GROUP BY` dimensions.
  - Added planner validation so invalid derived metric plans fail before execution.
  - Added filtered measure support in datasets planning.
  - Simplified semantic tenant runtime to tenant identity only.
  - Rejected explicit tenant filters when runtime tenancy is active.
  - Removed `dataset.query(...)` from the public datasets API.
  - Moved dataset endpoint planning behind `@hypequery/datasets/internal`.
  - Removed accidental root exports for dataset-query helpers and types.
  - Updated serve dataset endpoints to use datasets-owned planning.
  - Removed duplicated serve-side semantic planner utilities.
  - Added schema-to-datasets compatibility planning notes.
  - Added type tests for the intended public/internal export boundary.
  - Made `QueryBuilderLike.execute<T>()` generic so semantic execution does not need result casts.
  - Removed new casts/type suppressions from touched semantic code.
  - Added declarations for the shared ClickHouse integration harness.
  - Updated the implementation plan/spec to reflect the current architecture and next work.
