### PR TITLE
feat: migration generate command

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,8 @@
 import { Command } from 'commander';
 import { initCommand } from './commands/init.js';
-import { devCommand } from './commands/dev.js';
-import { generateCommand } from './commands/generate.js';
+import { devCommand, type DevOptions } from './commands/dev.js';
+import { generateCommand, type GenerateOptions } from './commands/generate.js';
+import { generateMigrationCommand, type GenerateMigrationOptions } from './commands/generate-migration.js';
 
 const program = new Command();
 
@@ -17,6 +18,27 @@ program
   .description('Type-safe analytics layer for ClickHouse')
   .version('0.0.1');
 
+function runCommand<TArgs extends unknown[]>(
+  action: (...args: TArgs) => Promise<void>,
+): (...args: TArgs) => Promise<void> {
+  return async (...args) => {
+    try {
+      await action(...args);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  };
+}
+
+function addTypeGenerationOptions(command: Command) {
+  return command
+    .description('Regenerate types from ClickHouse')
+    .option('-o, --output <path>', 'Output file (default: analytics/schema.ts)')
+    .option('--tables <names>', 'Only generate for specific tables (comma-separated)')
+    .option('--database <type>', 'Database driver to use (default: auto-detect)');
+}
+
 // Init command
 program
   .command('init')
@@ -26,14 +48,9 @@ program
   .option('--no-interactive', 'Non-interactive mode (use env vars)')
   .option('--force', 'Overwrite existing files')
   .option('--skip-connection', 'Skip database connectivity test')
-  .action(async (options) => {
-    try {
-      await initCommand(normalizeInitOptions(options));
-    } catch (error) {
-      console.error(error instanceof Error ? error.message : error);
-      process.exit(1);
-    }
-  });
+  .action(runCommand(async (options: Record<string, unknown>) => {
+    await initCommand(normalizeInitOptions(options));
+  }));
 
 // Dev command
 program
@@ -48,30 +65,29 @@ program
   .option('--open', 'Open browser automatically')
   .option('--cors', 'Enable CORS')
   .option('-q, --quiet', 'Suppress startup messages')
-  .action(async (file, options) => {
-    try {
-      await devCommand(file, options);
-    } catch (error) {
-      console.error(error instanceof Error ? error.message : error);
-      process.exit(1);
-    }
-  });
+  .action(runCommand(async (file: string | undefined, options: DevOptions) => {
+    await devCommand(file, options);
+  }));
 
 // Generate command
+addTypeGenerationOptions(program.command('generate'))
+  .action(runCommand(async (options: GenerateOptions) => {
+    await generateCommand(options);
+  }));
+
+addTypeGenerationOptions(program.command('generate:types'))
+  .action(runCommand(async (options: GenerateOptions) => {
+    await generateCommand({ ...options, commandName: 'hypequery generate:types' });
+  }));
+
 program
-  .command('generate')
-  .description('Regenerate types from ClickHouse')
-  .option('-o, --output <path>', 'Output file (default: analytics/schema.ts)')
-  .option('--tables <names>', 'Only generate for specific tables (comma-separated)')
-  .option('--database <type>', 'Database driver to use (default: auto-detect)')
-  .action(async (options) => {
-    try {
-      await generateCommand(options);
-    } catch (error) {
-      console.error(error instanceof Error ? error.message : error);
-      process.exit(1);
-    }
-  });
+  .command('generate:migration <name>')
+  .description('Generate a ClickHouse schema migration')
+  .option('-c, --config <path>', 'Config file (default: hypequery.config.ts)')
+  .option('--custom', 'Create a custom SQL migration without advancing the schema snapshot')
+  .action(runCommand(async (name: string, options: GenerateMigrationOptions) => {
+    await generateMigrationCommand(name, options);
+  }));
 
 // Help command
 program
@@ -99,6 +115,8 @@ program.on('--help', () => {
   console.log('  hypequery dev');
   console.log('  hypequery dev --port 3000');
   console.log('  hypequery generate --output analytics/schema.ts');
+  console.log('  hypequery generate:types --output analytics/schema.ts');
+  console.log('  hypequery generate:migration add_orders_table');
   console.log('');
   console.log('Docs: https://hypequery.com/docs');
 });

--- a/packages/cli/src/commands/generate-migration.test.ts
+++ b/packages/cli/src/commands/generate-migration.test.ts
@@ -1,0 +1,263 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  column,
+  defineSchema,
+  defineTable,
+  serializeSchemaToSnapshot,
+  snapshotToStableJson,
+  type ClickHouseSchemaAst,
+} from '@hypequery/schema';
+import { mockProcessExit, ProcessExitError } from '../test-utils.js';
+
+type LoadModule = typeof import('../utils/load-api.js')['loadModule'];
+
+vi.mock('../utils/load-api.js', () => ({
+  loadModule: vi.fn(),
+}));
+
+const mockLogger = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  reload: vi.fn(),
+  header: vi.fn(),
+  newline: vi.fn(),
+  indent: vi.fn(),
+  box: vi.fn(),
+  table: vi.fn(),
+  raw: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: mockLogger,
+}));
+
+const mockSpinner = vi.hoisted(() => ({
+  start: vi.fn().mockReturnThis(),
+  succeed: vi.fn().mockReturnThis(),
+  fail: vi.fn().mockReturnThis(),
+  stop: vi.fn().mockReturnThis(),
+}));
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => mockSpinner),
+}));
+
+let tempDir: string;
+let loadModule: ReturnType<typeof vi.mocked<LoadModule>>;
+
+describe('generate:migration command', () => {
+  let previousCwd: string;
+  let exitHandler: ReturnType<typeof mockProcessExit>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    previousCwd = process.cwd();
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'hypequery-generate-migration-'));
+    process.chdir(tempDir);
+    exitHandler = mockProcessExit();
+
+    ({ loadModule } = await import('../utils/load-api.js'));
+  });
+
+  afterEach(async () => {
+    exitHandler.restore();
+    process.chdir(previousCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('generates migration artifacts from a schema diff', async () => {
+    mockConfigAndSchema(eventsSchema());
+
+    const { generateMigrationCommand } = await import('./generate-migration.js');
+    await generateMigrationCommand('add_events', { timestamp: '20260525120000' });
+
+    const migrationDir = path.join(tempDir, 'migrations', '20260525120000_add_events');
+    await expect(readFile(path.join(migrationDir, 'up.sql'), 'utf8')).resolves.toContain('CREATE TABLE `events`');
+    await expect(readFile(path.join(migrationDir, 'down.sql'), 'utf8')).resolves.toContain('DROP TABLE `events`');
+    await expect(readFile(path.join(migrationDir, 'snapshot.json'), 'utf8')).resolves.toContain('"events"');
+
+    const meta = JSON.parse(await readFile(path.join(migrationDir, 'meta.json'), 'utf8'));
+    expect(meta).toMatchObject({
+      name: '20260525120000_add_events',
+      custom: false,
+      containsManualSteps: false,
+    });
+
+    const latestSnapshot = JSON.parse(
+      await readFile(path.join(tempDir, 'migrations', 'meta', 'latest_snapshot.json'), 'utf8'),
+    );
+    expect(latestSnapshot.tables).toHaveLength(1);
+
+    const journal = JSON.parse(
+      await readFile(path.join(tempDir, 'migrations', 'meta', 'migrations.json'), 'utf8'),
+    );
+    expect(journal.migrations).toEqual([
+      expect.objectContaining({
+        name: '20260525120000_add_events',
+        custom: false,
+      }),
+    ]);
+  });
+
+  it('creates custom SQL migrations without advancing the latest snapshot', async () => {
+    mockConfigAndSchema(eventsSchema());
+
+    const { generateMigrationCommand } = await import('./generate-migration.js');
+    await generateMigrationCommand('backfill_events', {
+      custom: true,
+      timestamp: '20260525120500',
+    });
+
+    const migrationDir = path.join(tempDir, 'migrations', '20260525120500_backfill_events');
+    await expect(readFile(path.join(migrationDir, 'up.sql'), 'utf8')).resolves.toContain('custom migration SQL');
+
+    const meta = JSON.parse(await readFile(path.join(migrationDir, 'meta.json'), 'utf8'));
+    expect(meta).toMatchObject({
+      custom: true,
+      unsafe: true,
+      containsManualSteps: true,
+    });
+
+    await expect(
+      readFile(path.join(tempDir, 'migrations', 'meta', 'latest_snapshot.json'), 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('exits for invalid migration names', async () => {
+    const { generateMigrationCommand } = await import('./generate-migration.js');
+
+    await expect(generateMigrationCommand('../bad', { timestamp: '20260525120000' }))
+      .rejects
+      .toBeInstanceOf(ProcessExitError);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Invalid migration name'));
+  });
+
+  it('does not write migration files when the schema matches the latest snapshot', async () => {
+    const schema = eventsSchema();
+    mockConfigAndSchema(schema);
+    await writeLatestSnapshotFixture(schema);
+
+    const { generateMigrationCommand } = await import('./generate-migration.js');
+    await generateMigrationCommand('noop', { timestamp: '20260525121000' });
+
+    await expect(
+      readFile(path.join(tempDir, 'migrations', '20260525121000_noop', 'up.sql'), 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(mockLogger.info).toHaveBeenCalledWith('No migration was generated.');
+  });
+
+  it('diffs against the latest saved snapshot for incremental migrations', async () => {
+    await writeLatestSnapshotFixture(eventsSchema());
+    mockConfigAndSchema(eventsSchemaWithNameColumn());
+
+    const { generateMigrationCommand } = await import('./generate-migration.js');
+    await generateMigrationCommand('add_event_name', { timestamp: '20260525121500' });
+
+    const migrationDir = path.join(tempDir, 'migrations', '20260525121500_add_event_name');
+    const upSql = await readFile(path.join(migrationDir, 'up.sql'), 'utf8');
+    const meta = JSON.parse(await readFile(path.join(migrationDir, 'meta.json'), 'utf8'));
+
+    expect(upSql).toContain('ALTER TABLE `events` ADD COLUMN `name` String');
+    expect(upSql).not.toContain('CREATE TABLE `events`');
+    expect(meta.operations).toEqual([
+      expect.objectContaining({
+        kind: 'AddColumn',
+        classification: 'metadata',
+      }),
+    ]);
+  });
+
+  it('exits when the schema module does not export a schema', async () => {
+    loadModule.mockImplementation(async (modulePath) => {
+      if (modulePath === 'hypequery.config.ts') {
+        return { default: configFixture() };
+      }
+
+      return { notSchema: true };
+    });
+
+    const { generateMigrationCommand } = await import('./generate-migration.js');
+    await expect(generateMigrationCommand('bad_schema', { timestamp: '20260525122000' }))
+      .rejects
+      .toBeInstanceOf(ProcessExitError);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Invalid schema module'));
+  });
+});
+
+function mockConfigAndSchema(schema: ClickHouseSchemaAst) {
+  loadModule.mockImplementation(async (modulePath) => {
+    if (modulePath === 'hypequery.config.ts') {
+      return { default: configFixture() };
+    }
+
+    return { default: schema };
+  });
+}
+
+function configFixture() {
+  return {
+    dialect: 'clickhouse',
+    schema: './schema.ts',
+    migrations: { out: './migrations' },
+    dbCredentials: {
+      host: 'localhost',
+      username: 'default',
+      database: 'analytics',
+    },
+  };
+}
+
+async function writeLatestSnapshotFixture(schema: ClickHouseSchemaAst) {
+  const snapshot = serializeSchemaToSnapshot(schema);
+  const metaDir = path.join(tempDir, 'migrations', 'meta');
+  await mkdir(metaDir, { recursive: true });
+  await writeFile(
+    path.join(metaDir, 'latest_snapshot.json'),
+    `${snapshotToStableJson(snapshot)}\n`,
+    'utf8',
+  );
+}
+
+function eventsSchema() {
+  return defineSchema({
+    tables: [
+      defineTable('events', {
+        columns: {
+          id: column.UUID(),
+          created_at: column.DateTime(),
+        },
+        engine: {
+          type: 'MergeTree',
+          orderBy: ['created_at'],
+        },
+      }),
+    ],
+  });
+}
+
+function eventsSchemaWithNameColumn() {
+  return defineSchema({
+    tables: [
+      defineTable('events', {
+        columns: {
+          id: column.UUID(),
+          created_at: column.DateTime(),
+          name: column.String(),
+        },
+        engine: {
+          type: 'MergeTree',
+          orderBy: ['created_at'],
+        },
+      }),
+    ],
+  });
+}

--- a/packages/cli/src/commands/generate-migration.ts
+++ b/packages/cli/src/commands/generate-migration.ts
@@ -1,45 +1,31 @@
-import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import ora from 'ora';
 import {
   createMigrationPlan,
-  defineSchema,
   diffSnapshots,
   renderMigrationArtifacts,
   serializeSchemaToSnapshot,
   snapshotToStableJson,
   writeMigrationArtifacts,
-  type ClickHouseSchemaAst,
-  type MigrationMeta,
-  type MigrationPlan,
-  type Snapshot,
 } from '@hypequery/schema';
-import { loadModule } from '../utils/load-api.js';
 import { loadHypequeryConfig } from '../utils/load-hypequery-config.js';
 import { logger } from '../utils/logger.js';
+import { assertValidMigrationSlug, createMigrationTimestamp, formatMigrationName } from '../utils/migration-names.js';
+import { loadMigrationSchema } from '../utils/migration-schema.js';
+import {
+  appendMigrationJournalEntry,
+  assertMigrationDoesNotExist,
+  readLatestMigrationSnapshot,
+  writeCustomMigration,
+  writeLatestMigrationSnapshot,
+} from '../utils/migration-state.js';
 
 export interface GenerateMigrationOptions {
   config?: string;
   custom?: boolean;
   timestamp?: string;
 }
-
-interface MigrationJournal {
-  version: 1;
-  dialect: 'clickhouse';
-  latestSnapshotHash: string;
-  migrations: Array<{
-    name: string;
-    timestamp: string;
-    custom: boolean;
-    sourceSnapshotHash: string;
-    targetSnapshotHash: string;
-  }>;
-}
-
-const META_DIR_NAME = 'meta';
-const LATEST_SNAPSHOT_FILE = 'latest_snapshot.json';
-const JOURNAL_FILE = 'migrations.json';
 
 export async function generateMigrationCommand(
   migrationSlug: string | undefined,
@@ -53,13 +39,13 @@ export async function generateMigrationCommand(
 
     const config = await loadHypequeryConfig(options.config);
     const migrationsOutDir = path.resolve(process.cwd(), config.migrations.out);
-    const timestamp = options.timestamp ?? createTimestamp();
-    const migrationName = `${timestamp}_${migrationSlug}`;
+    const timestamp = options.timestamp ?? createMigrationTimestamp();
+    const migrationName = formatMigrationName(timestamp, migrationSlug);
 
     await assertMigrationDoesNotExist(migrationsOutDir, migrationName);
 
     const loadSpinner = ora('Loading migration config...').start();
-    const previousSnapshot = await readLatestSnapshot(migrationsOutDir);
+    const previousSnapshot = await readLatestMigrationSnapshot(migrationsOutDir);
     loadSpinner.succeed('Loaded migration config');
 
     if (options.custom) {
@@ -76,7 +62,7 @@ export async function generateMigrationCommand(
     }
 
     const schemaSpinner = ora('Loading schema...').start();
-    const schema = await loadSchema(config.schema);
+    const schema = await loadMigrationSchema(config.schema);
     const nextSnapshot = serializeSchemaToSnapshot(schema);
     schemaSpinner.succeed('Loaded schema');
 
@@ -109,8 +95,8 @@ export async function generateMigrationCommand(
       `${snapshotToStableJson(nextSnapshot)}\n`,
       'utf8',
     );
-    await writeLatestSnapshot(migrationsOutDir, nextSnapshot);
-    await appendJournalEntry(migrationsOutDir, {
+    await writeLatestMigrationSnapshot(migrationsOutDir, nextSnapshot);
+    await appendMigrationJournalEntry(migrationsOutDir, {
       name: migrationName,
       timestamp,
       custom: false,
@@ -130,220 +116,4 @@ export async function generateMigrationCommand(
     logger.newline();
     process.exit(1);
   }
-}
-
-async function loadSchema(schemaPath: string): Promise<ClickHouseSchemaAst> {
-  const mod = await loadModule(schemaPath);
-  const schema = mod.default ?? mod.schema;
-
-  if (isClickHouseSchemaAst(schema)) {
-    return defineSchema({
-      tables: schema.tables,
-      ...(schema.materializedViews !== undefined ? { materializedViews: schema.materializedViews } : {}),
-    });
-  }
-
-  const relativePath = path.relative(process.cwd(), path.resolve(process.cwd(), schemaPath));
-  const availableExports = Object.keys(mod).filter(key => key !== '__esModule');
-  throw new Error(
-    `Invalid schema module: ${relativePath}\n\n` +
-    `The module must export a defineSchema() result as the default export or as "schema".` +
-    (availableExports.length > 0 ? `\n\nFound exports: ${availableExports.join(', ')}` : ''),
-  );
-}
-
-function isClickHouseSchemaAst(value: unknown): value is ClickHouseSchemaAst {
-  if (!isRecord(value) || !Array.isArray(value.tables)) {
-    return false;
-  }
-
-  return value.materializedViews === undefined || Array.isArray(value.materializedViews);
-}
-
-async function readLatestSnapshot(migrationsOutDir: string): Promise<Snapshot> {
-  const snapshotPath = path.join(migrationsOutDir, META_DIR_NAME, LATEST_SNAPSHOT_FILE);
-
-  try {
-    const contents = await readFile(snapshotPath, 'utf8');
-    const parsed: unknown = JSON.parse(contents);
-    if (isSnapshot(parsed)) {
-      return parsed;
-    }
-    throw new Error(`Invalid latest snapshot file: ${path.relative(process.cwd(), snapshotPath)}`);
-  } catch (error) {
-    if (isNotFoundError(error)) {
-      return serializeSchemaToSnapshot(defineSchema({ tables: [] }));
-    }
-    throw error;
-  }
-}
-
-async function writeLatestSnapshot(migrationsOutDir: string, snapshot: Snapshot) {
-  const metaDir = path.join(migrationsOutDir, META_DIR_NAME);
-  await mkdir(metaDir, { recursive: true });
-  await writeFile(
-    path.join(metaDir, LATEST_SNAPSHOT_FILE),
-    `${snapshotToStableJson(snapshot)}\n`,
-    'utf8',
-  );
-}
-
-async function appendJournalEntry(
-  migrationsOutDir: string,
-  entry: MigrationJournal['migrations'][number],
-  latestSnapshotHash: string,
-) {
-  const metaDir = path.join(migrationsOutDir, META_DIR_NAME);
-  const journalPath = path.join(metaDir, JOURNAL_FILE);
-  await mkdir(metaDir, { recursive: true });
-
-  const journal = await readJournal(journalPath);
-  const nextJournal: MigrationJournal = {
-    ...journal,
-    latestSnapshotHash,
-    migrations: [
-      ...journal.migrations.filter(migration => migration.name !== entry.name),
-      entry,
-    ],
-  };
-
-  await writeFile(journalPath, `${JSON.stringify(nextJournal, null, 2)}\n`, 'utf8');
-}
-
-async function readJournal(journalPath: string): Promise<MigrationJournal> {
-  try {
-    const contents = await readFile(journalPath, 'utf8');
-    const parsed: unknown = JSON.parse(contents);
-    if (
-      isRecord(parsed) &&
-      parsed.version === 1 &&
-      parsed.dialect === 'clickhouse' &&
-      Array.isArray(parsed.migrations) &&
-      typeof parsed.latestSnapshotHash === 'string' &&
-      parsed.migrations.every(isMigrationJournalEntry)
-    ) {
-      return {
-        version: parsed.version,
-        dialect: parsed.dialect,
-        latestSnapshotHash: parsed.latestSnapshotHash,
-        migrations: parsed.migrations,
-      };
-    }
-    throw new Error(`Invalid migration journal: ${path.relative(process.cwd(), journalPath)}`);
-  } catch (error) {
-    if (isNotFoundError(error)) {
-      return {
-        version: 1,
-        dialect: 'clickhouse',
-        latestSnapshotHash: '',
-        migrations: [],
-      };
-    }
-    throw error;
-  }
-}
-
-async function writeCustomMigration(input: {
-  outDir: string;
-  migrationName: string;
-  timestamp: string;
-  previousSnapshot: Snapshot;
-}) {
-  const migrationDir = path.join(input.outDir, input.migrationName);
-  await mkdir(migrationDir, { recursive: true });
-
-  const meta: MigrationMeta = {
-    name: input.migrationName,
-    timestamp: input.timestamp,
-    operations: [],
-    sourceSnapshotHash: input.previousSnapshot.contentHash,
-    targetSnapshotHash: input.previousSnapshot.contentHash,
-    custom: true,
-    unsafe: true,
-    containsManualSteps: true,
-  };
-
-  const plan: MigrationPlan = {
-    previousSnapshot: input.previousSnapshot,
-    nextSnapshot: input.previousSnapshot,
-    sourceSnapshotHash: input.previousSnapshot.contentHash,
-    targetSnapshotHash: input.previousSnapshot.contentHash,
-    operations: [],
-    diagnostics: [],
-    blockers: [],
-    requiredConfirmations: [],
-    recommendedSyncSettings: [],
-    requiredSyncSettings: [],
-  };
-
-  await writeFile(path.join(migrationDir, 'up.sql'), '-- Write custom migration SQL here.\n', 'utf8');
-  await writeFile(path.join(migrationDir, 'down.sql'), '-- Write best-effort rollback SQL here.\n', 'utf8');
-  await writeFile(path.join(migrationDir, 'meta.json'), `${JSON.stringify(meta, null, 2)}\n`, 'utf8');
-  await writeFile(path.join(migrationDir, 'plan.json'), `${JSON.stringify(plan, null, 2)}\n`, 'utf8');
-
-  await appendJournalEntry(input.outDir, {
-    name: input.migrationName,
-    timestamp: input.timestamp,
-    custom: true,
-    sourceSnapshotHash: input.previousSnapshot.contentHash,
-    targetSnapshotHash: input.previousSnapshot.contentHash,
-  }, input.previousSnapshot.contentHash);
-}
-
-async function assertMigrationDoesNotExist(migrationsOutDir: string, migrationName: string) {
-  const migrationDir = path.join(migrationsOutDir, migrationName);
-  try {
-    await access(migrationDir);
-  } catch (error) {
-    if (isNotFoundError(error)) {
-      return;
-    }
-    throw error;
-  }
-
-  throw new Error(`Migration already exists: ${path.relative(process.cwd(), migrationDir)}`);
-}
-
-function assertValidMigrationSlug(migrationSlug: string | undefined): asserts migrationSlug is string {
-  if (!migrationSlug) {
-    throw new Error('Migration name is required. Usage: hypequery generate:migration <name>');
-  }
-
-  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(migrationSlug)) {
-    throw new Error(
-      `Invalid migration name "${migrationSlug}". ` +
-      'Use only letters, numbers, underscores, and hyphens.',
-    );
-  }
-}
-
-function createTimestamp(date = new Date()): string {
-  return date.toISOString().replace(/\D/g, '').slice(0, 14);
-}
-
-function isSnapshot(value: unknown): value is Snapshot {
-  return isRecord(value) &&
-    value.version === 1 &&
-    value.dialect === 'clickhouse' &&
-    Array.isArray(value.tables) &&
-    Array.isArray(value.materializedViews) &&
-    Array.isArray(value.dependencies) &&
-    typeof value.contentHash === 'string';
-}
-
-function isMigrationJournalEntry(value: unknown): value is MigrationJournal['migrations'][number] {
-  return isRecord(value) &&
-    typeof value.name === 'string' &&
-    typeof value.timestamp === 'string' &&
-    typeof value.custom === 'boolean' &&
-    typeof value.sourceSnapshotHash === 'string' &&
-    typeof value.targetSnapshotHash === 'string';
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object';
-}
-
-function isNotFoundError(error: unknown) {
-  return isRecord(error) && error.code === 'ENOENT';
 }

--- a/packages/cli/src/commands/generate-migration.ts
+++ b/packages/cli/src/commands/generate-migration.ts
@@ -1,0 +1,349 @@
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import ora from 'ora';
+import {
+  createMigrationPlan,
+  defineSchema,
+  diffSnapshots,
+  renderMigrationArtifacts,
+  serializeSchemaToSnapshot,
+  snapshotToStableJson,
+  writeMigrationArtifacts,
+  type ClickHouseSchemaAst,
+  type MigrationMeta,
+  type MigrationPlan,
+  type Snapshot,
+} from '@hypequery/schema';
+import { loadModule } from '../utils/load-api.js';
+import { loadHypequeryConfig } from '../utils/load-hypequery-config.js';
+import { logger } from '../utils/logger.js';
+
+export interface GenerateMigrationOptions {
+  config?: string;
+  custom?: boolean;
+  timestamp?: string;
+}
+
+interface MigrationJournal {
+  version: 1;
+  dialect: 'clickhouse';
+  latestSnapshotHash: string;
+  migrations: Array<{
+    name: string;
+    timestamp: string;
+    custom: boolean;
+    sourceSnapshotHash: string;
+    targetSnapshotHash: string;
+  }>;
+}
+
+const META_DIR_NAME = 'meta';
+const LATEST_SNAPSHOT_FILE = 'latest_snapshot.json';
+const JOURNAL_FILE = 'migrations.json';
+
+export async function generateMigrationCommand(
+  migrationSlug: string | undefined,
+  options: GenerateMigrationOptions = {},
+) {
+  logger.newline();
+  logger.header('hypequery generate:migration');
+
+  try {
+    assertValidMigrationSlug(migrationSlug);
+
+    const config = await loadHypequeryConfig(options.config);
+    const migrationsOutDir = path.resolve(process.cwd(), config.migrations.out);
+    const timestamp = options.timestamp ?? createTimestamp();
+    const migrationName = `${timestamp}_${migrationSlug}`;
+
+    await assertMigrationDoesNotExist(migrationsOutDir, migrationName);
+
+    const loadSpinner = ora('Loading migration config...').start();
+    const previousSnapshot = await readLatestSnapshot(migrationsOutDir);
+    loadSpinner.succeed('Loaded migration config');
+
+    if (options.custom) {
+      await writeCustomMigration({
+        outDir: migrationsOutDir,
+        migrationName,
+        timestamp,
+        previousSnapshot,
+      });
+
+      logger.success(`Created custom migration ${path.relative(process.cwd(), path.join(migrationsOutDir, migrationName))}`);
+      logger.newline();
+      return;
+    }
+
+    const schemaSpinner = ora('Loading schema...').start();
+    const schema = await loadSchema(config.schema);
+    const nextSnapshot = serializeSchemaToSnapshot(schema);
+    schemaSpinner.succeed('Loaded schema');
+
+    const planSpinner = ora('Planning migration...').start();
+    const diff = diffSnapshots(previousSnapshot, nextSnapshot);
+    const plan = createMigrationPlan(diff);
+
+    if (plan.operations.length === 0) {
+      planSpinner.succeed('No schema changes detected');
+      logger.info('No migration was generated.');
+      logger.newline();
+      return;
+    }
+
+    const artifacts = renderMigrationArtifacts(plan, {
+      name: migrationName,
+      timestamp,
+      cluster: config.cluster?.name,
+    });
+    planSpinner.succeed(`Planned ${plan.operations.length} operations`);
+
+    const writeSpinner = ora('Writing migration files...').start();
+    const written = await writeMigrationArtifacts({
+      outDir: migrationsOutDir,
+      migrationName,
+      artifacts,
+    });
+    await writeFile(
+      path.join(written.migrationDir, 'snapshot.json'),
+      `${snapshotToStableJson(nextSnapshot)}\n`,
+      'utf8',
+    );
+    await writeLatestSnapshot(migrationsOutDir, nextSnapshot);
+    await appendJournalEntry(migrationsOutDir, {
+      name: migrationName,
+      timestamp,
+      custom: false,
+      sourceSnapshotHash: plan.sourceSnapshotHash,
+      targetSnapshotHash: plan.targetSnapshotHash,
+    }, nextSnapshot.contentHash);
+    writeSpinner.succeed('Wrote migration files');
+
+    logger.success(`Created migration ${path.relative(process.cwd(), written.migrationDir)}`);
+    if (artifacts.meta.unsafe || plan.requiredConfirmations.length > 0) {
+      logger.warn('Migration contains operations that require review before execution.');
+    }
+    logger.newline();
+  } catch (error) {
+    logger.newline();
+    logger.error(error instanceof Error ? error.message : String(error));
+    logger.newline();
+    process.exit(1);
+  }
+}
+
+async function loadSchema(schemaPath: string): Promise<ClickHouseSchemaAst> {
+  const mod = await loadModule(schemaPath);
+  const schema = mod.default ?? mod.schema;
+
+  if (isClickHouseSchemaAst(schema)) {
+    return defineSchema({
+      tables: schema.tables,
+      ...(schema.materializedViews !== undefined ? { materializedViews: schema.materializedViews } : {}),
+    });
+  }
+
+  const relativePath = path.relative(process.cwd(), path.resolve(process.cwd(), schemaPath));
+  const availableExports = Object.keys(mod).filter(key => key !== '__esModule');
+  throw new Error(
+    `Invalid schema module: ${relativePath}\n\n` +
+    `The module must export a defineSchema() result as the default export or as "schema".` +
+    (availableExports.length > 0 ? `\n\nFound exports: ${availableExports.join(', ')}` : ''),
+  );
+}
+
+function isClickHouseSchemaAst(value: unknown): value is ClickHouseSchemaAst {
+  if (!isRecord(value) || !Array.isArray(value.tables)) {
+    return false;
+  }
+
+  return value.materializedViews === undefined || Array.isArray(value.materializedViews);
+}
+
+async function readLatestSnapshot(migrationsOutDir: string): Promise<Snapshot> {
+  const snapshotPath = path.join(migrationsOutDir, META_DIR_NAME, LATEST_SNAPSHOT_FILE);
+
+  try {
+    const contents = await readFile(snapshotPath, 'utf8');
+    const parsed: unknown = JSON.parse(contents);
+    if (isSnapshot(parsed)) {
+      return parsed;
+    }
+    throw new Error(`Invalid latest snapshot file: ${path.relative(process.cwd(), snapshotPath)}`);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return serializeSchemaToSnapshot(defineSchema({ tables: [] }));
+    }
+    throw error;
+  }
+}
+
+async function writeLatestSnapshot(migrationsOutDir: string, snapshot: Snapshot) {
+  const metaDir = path.join(migrationsOutDir, META_DIR_NAME);
+  await mkdir(metaDir, { recursive: true });
+  await writeFile(
+    path.join(metaDir, LATEST_SNAPSHOT_FILE),
+    `${snapshotToStableJson(snapshot)}\n`,
+    'utf8',
+  );
+}
+
+async function appendJournalEntry(
+  migrationsOutDir: string,
+  entry: MigrationJournal['migrations'][number],
+  latestSnapshotHash: string,
+) {
+  const metaDir = path.join(migrationsOutDir, META_DIR_NAME);
+  const journalPath = path.join(metaDir, JOURNAL_FILE);
+  await mkdir(metaDir, { recursive: true });
+
+  const journal = await readJournal(journalPath);
+  const nextJournal: MigrationJournal = {
+    ...journal,
+    latestSnapshotHash,
+    migrations: [
+      ...journal.migrations.filter(migration => migration.name !== entry.name),
+      entry,
+    ],
+  };
+
+  await writeFile(journalPath, `${JSON.stringify(nextJournal, null, 2)}\n`, 'utf8');
+}
+
+async function readJournal(journalPath: string): Promise<MigrationJournal> {
+  try {
+    const contents = await readFile(journalPath, 'utf8');
+    const parsed: unknown = JSON.parse(contents);
+    if (
+      isRecord(parsed) &&
+      parsed.version === 1 &&
+      parsed.dialect === 'clickhouse' &&
+      Array.isArray(parsed.migrations) &&
+      typeof parsed.latestSnapshotHash === 'string' &&
+      parsed.migrations.every(isMigrationJournalEntry)
+    ) {
+      return {
+        version: parsed.version,
+        dialect: parsed.dialect,
+        latestSnapshotHash: parsed.latestSnapshotHash,
+        migrations: parsed.migrations,
+      };
+    }
+    throw new Error(`Invalid migration journal: ${path.relative(process.cwd(), journalPath)}`);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return {
+        version: 1,
+        dialect: 'clickhouse',
+        latestSnapshotHash: '',
+        migrations: [],
+      };
+    }
+    throw error;
+  }
+}
+
+async function writeCustomMigration(input: {
+  outDir: string;
+  migrationName: string;
+  timestamp: string;
+  previousSnapshot: Snapshot;
+}) {
+  const migrationDir = path.join(input.outDir, input.migrationName);
+  await mkdir(migrationDir, { recursive: true });
+
+  const meta: MigrationMeta = {
+    name: input.migrationName,
+    timestamp: input.timestamp,
+    operations: [],
+    sourceSnapshotHash: input.previousSnapshot.contentHash,
+    targetSnapshotHash: input.previousSnapshot.contentHash,
+    custom: true,
+    unsafe: true,
+    containsManualSteps: true,
+  };
+
+  const plan: MigrationPlan = {
+    previousSnapshot: input.previousSnapshot,
+    nextSnapshot: input.previousSnapshot,
+    sourceSnapshotHash: input.previousSnapshot.contentHash,
+    targetSnapshotHash: input.previousSnapshot.contentHash,
+    operations: [],
+    diagnostics: [],
+    blockers: [],
+    requiredConfirmations: [],
+    recommendedSyncSettings: [],
+    requiredSyncSettings: [],
+  };
+
+  await writeFile(path.join(migrationDir, 'up.sql'), '-- Write custom migration SQL here.\n', 'utf8');
+  await writeFile(path.join(migrationDir, 'down.sql'), '-- Write best-effort rollback SQL here.\n', 'utf8');
+  await writeFile(path.join(migrationDir, 'meta.json'), `${JSON.stringify(meta, null, 2)}\n`, 'utf8');
+  await writeFile(path.join(migrationDir, 'plan.json'), `${JSON.stringify(plan, null, 2)}\n`, 'utf8');
+
+  await appendJournalEntry(input.outDir, {
+    name: input.migrationName,
+    timestamp: input.timestamp,
+    custom: true,
+    sourceSnapshotHash: input.previousSnapshot.contentHash,
+    targetSnapshotHash: input.previousSnapshot.contentHash,
+  }, input.previousSnapshot.contentHash);
+}
+
+async function assertMigrationDoesNotExist(migrationsOutDir: string, migrationName: string) {
+  const migrationDir = path.join(migrationsOutDir, migrationName);
+  try {
+    await access(migrationDir);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return;
+    }
+    throw error;
+  }
+
+  throw new Error(`Migration already exists: ${path.relative(process.cwd(), migrationDir)}`);
+}
+
+function assertValidMigrationSlug(migrationSlug: string | undefined): asserts migrationSlug is string {
+  if (!migrationSlug) {
+    throw new Error('Migration name is required. Usage: hypequery generate:migration <name>');
+  }
+
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(migrationSlug)) {
+    throw new Error(
+      `Invalid migration name "${migrationSlug}". ` +
+      'Use only letters, numbers, underscores, and hyphens.',
+    );
+  }
+}
+
+function createTimestamp(date = new Date()): string {
+  return date.toISOString().replace(/\D/g, '').slice(0, 14);
+}
+
+function isSnapshot(value: unknown): value is Snapshot {
+  return isRecord(value) &&
+    value.version === 1 &&
+    value.dialect === 'clickhouse' &&
+    Array.isArray(value.tables) &&
+    Array.isArray(value.materializedViews) &&
+    Array.isArray(value.dependencies) &&
+    typeof value.contentHash === 'string';
+}
+
+function isMigrationJournalEntry(value: unknown): value is MigrationJournal['migrations'][number] {
+  return isRecord(value) &&
+    typeof value.name === 'string' &&
+    typeof value.timestamp === 'string' &&
+    typeof value.custom === 'boolean' &&
+    typeof value.sourceSnapshotHash === 'string' &&
+    typeof value.targetSnapshotHash === 'string';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object';
+}
+
+function isNotFoundError(error: unknown) {
+  return isRecord(error) && error.code === 'ENOENT';
+}

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -79,6 +79,12 @@ describe('generate command', () => {
       expect(logger.header).toHaveBeenCalledWith('Types regenerated successfully!');
     });
 
+    it('uses an explicit command name for generate:types alias output', async () => {
+      await generateCommand({ commandName: 'hypequery generate:types' });
+
+      expect(logger.header).toHaveBeenCalledWith('hypequery generate:types');
+    });
+
     it('uses custom output path when provided', async () => {
       await generateCommand({ output: 'custom/schema.ts' });
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -9,6 +9,7 @@ export interface GenerateOptions {
   output?: string;
   tables?: string;
   database?: DatabaseType;
+  commandName?: string;
 }
 
 export async function generateCommand(options: GenerateOptions = {}) {
@@ -39,7 +40,7 @@ export async function generateCommand(options: GenerateOptions = {}) {
   const dbType = requestedDbType ?? (await detectDatabase());
 
   logger.newline();
-  logger.header('hypequery generate');
+  logger.header(options.commandName ?? 'hypequery generate');
 
   const spinner = ora(`Connecting to ${dbType}...`).start();
 

--- a/packages/cli/src/utils/migration-names.ts
+++ b/packages/cli/src/utils/migration-names.ts
@@ -1,0 +1,20 @@
+export function assertValidMigrationSlug(migrationSlug: string | undefined): asserts migrationSlug is string {
+  if (!migrationSlug) {
+    throw new Error('Migration name is required. Usage: hypequery generate:migration <name>');
+  }
+
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(migrationSlug)) {
+    throw new Error(
+      `Invalid migration name "${migrationSlug}". ` +
+      'Use only letters, numbers, underscores, and hyphens.',
+    );
+  }
+}
+
+export function createMigrationTimestamp(date = new Date()): string {
+  return date.toISOString().replace(/\D/g, '').slice(0, 14);
+}
+
+export function formatMigrationName(timestamp: string, migrationSlug: string): string {
+  return `${timestamp}_${migrationSlug}`;
+}

--- a/packages/cli/src/utils/migration-schema.ts
+++ b/packages/cli/src/utils/migration-schema.ts
@@ -1,0 +1,32 @@
+import path from 'node:path';
+import { defineSchema, type ClickHouseSchemaAst } from '@hypequery/schema';
+import { loadModule } from './load-api.js';
+import { isRecord } from './runtime-guards.js';
+
+export async function loadMigrationSchema(schemaPath: string): Promise<ClickHouseSchemaAst> {
+  const mod = await loadModule(schemaPath);
+  const schema = mod.default ?? mod.schema;
+
+  if (isClickHouseSchemaAst(schema)) {
+    return defineSchema({
+      tables: schema.tables,
+      ...(schema.materializedViews !== undefined ? { materializedViews: schema.materializedViews } : {}),
+    });
+  }
+
+  const relativePath = path.relative(process.cwd(), path.resolve(process.cwd(), schemaPath));
+  const availableExports = Object.keys(mod).filter(key => key !== '__esModule');
+  throw new Error(
+    `Invalid schema module: ${relativePath}\n\n` +
+    `The module must export a defineSchema() result as the default export or as "schema".` +
+    (availableExports.length > 0 ? `\n\nFound exports: ${availableExports.join(', ')}` : ''),
+  );
+}
+
+function isClickHouseSchemaAst(value: unknown): value is ClickHouseSchemaAst {
+  if (!isRecord(value) || !Array.isArray(value.tables)) {
+    return false;
+  }
+
+  return value.materializedViews === undefined || Array.isArray(value.materializedViews);
+}

--- a/packages/cli/src/utils/migration-state.ts
+++ b/packages/cli/src/utils/migration-state.ts
@@ -1,0 +1,197 @@
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  defineSchema,
+  serializeSchemaToSnapshot,
+  snapshotToStableJson,
+  type MigrationMeta,
+  type MigrationPlan,
+  type Snapshot,
+} from '@hypequery/schema';
+import { isRecord } from './runtime-guards.js';
+
+export interface MigrationJournalEntry {
+  name: string;
+  timestamp: string;
+  custom: boolean;
+  sourceSnapshotHash: string;
+  targetSnapshotHash: string;
+}
+
+interface MigrationJournal {
+  version: 1;
+  dialect: 'clickhouse';
+  latestSnapshotHash: string;
+  migrations: MigrationJournalEntry[];
+}
+
+const META_DIR_NAME = 'meta';
+const LATEST_SNAPSHOT_FILE = 'latest_snapshot.json';
+const JOURNAL_FILE = 'migrations.json';
+
+export async function readLatestMigrationSnapshot(migrationsOutDir: string): Promise<Snapshot> {
+  const snapshotPath = path.join(migrationsOutDir, META_DIR_NAME, LATEST_SNAPSHOT_FILE);
+
+  try {
+    const contents = await readFile(snapshotPath, 'utf8');
+    const parsed: unknown = JSON.parse(contents);
+    if (isSnapshot(parsed)) {
+      return parsed;
+    }
+    throw new Error(`Invalid latest snapshot file: ${path.relative(process.cwd(), snapshotPath)}`);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return serializeSchemaToSnapshot(defineSchema({ tables: [] }));
+    }
+    throw error;
+  }
+}
+
+export async function writeLatestMigrationSnapshot(migrationsOutDir: string, snapshot: Snapshot) {
+  const metaDir = path.join(migrationsOutDir, META_DIR_NAME);
+  await mkdir(metaDir, { recursive: true });
+  await writeFile(
+    path.join(metaDir, LATEST_SNAPSHOT_FILE),
+    `${snapshotToStableJson(snapshot)}\n`,
+    'utf8',
+  );
+}
+
+export async function appendMigrationJournalEntry(
+  migrationsOutDir: string,
+  entry: MigrationJournalEntry,
+  latestSnapshotHash: string,
+) {
+  const metaDir = path.join(migrationsOutDir, META_DIR_NAME);
+  const journalPath = path.join(metaDir, JOURNAL_FILE);
+  await mkdir(metaDir, { recursive: true });
+
+  const journal = await readJournal(journalPath);
+  const nextJournal: MigrationJournal = {
+    ...journal,
+    latestSnapshotHash,
+    migrations: [
+      ...journal.migrations.filter(migration => migration.name !== entry.name),
+      entry,
+    ],
+  };
+
+  await writeFile(journalPath, `${JSON.stringify(nextJournal, null, 2)}\n`, 'utf8');
+}
+
+export async function writeCustomMigration(input: {
+  outDir: string;
+  migrationName: string;
+  timestamp: string;
+  previousSnapshot: Snapshot;
+}) {
+  const migrationDir = path.join(input.outDir, input.migrationName);
+  await mkdir(migrationDir, { recursive: true });
+
+  const meta: MigrationMeta = {
+    name: input.migrationName,
+    timestamp: input.timestamp,
+    operations: [],
+    sourceSnapshotHash: input.previousSnapshot.contentHash,
+    targetSnapshotHash: input.previousSnapshot.contentHash,
+    custom: true,
+    unsafe: true,
+    containsManualSteps: true,
+  };
+
+  const plan: MigrationPlan = {
+    previousSnapshot: input.previousSnapshot,
+    nextSnapshot: input.previousSnapshot,
+    sourceSnapshotHash: input.previousSnapshot.contentHash,
+    targetSnapshotHash: input.previousSnapshot.contentHash,
+    operations: [],
+    diagnostics: [],
+    blockers: [],
+    requiredConfirmations: [],
+    recommendedSyncSettings: [],
+    requiredSyncSettings: [],
+  };
+
+  await writeFile(path.join(migrationDir, 'up.sql'), '-- Write custom migration SQL here.\n', 'utf8');
+  await writeFile(path.join(migrationDir, 'down.sql'), '-- Write best-effort rollback SQL here.\n', 'utf8');
+  await writeFile(path.join(migrationDir, 'meta.json'), `${JSON.stringify(meta, null, 2)}\n`, 'utf8');
+  await writeFile(path.join(migrationDir, 'plan.json'), `${JSON.stringify(plan, null, 2)}\n`, 'utf8');
+
+  await appendMigrationJournalEntry(input.outDir, {
+    name: input.migrationName,
+    timestamp: input.timestamp,
+    custom: true,
+    sourceSnapshotHash: input.previousSnapshot.contentHash,
+    targetSnapshotHash: input.previousSnapshot.contentHash,
+  }, input.previousSnapshot.contentHash);
+}
+
+export async function assertMigrationDoesNotExist(migrationsOutDir: string, migrationName: string) {
+  const migrationDir = path.join(migrationsOutDir, migrationName);
+  try {
+    await access(migrationDir);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return;
+    }
+    throw error;
+  }
+
+  throw new Error(`Migration already exists: ${path.relative(process.cwd(), migrationDir)}`);
+}
+
+async function readJournal(journalPath: string): Promise<MigrationJournal> {
+  try {
+    const contents = await readFile(journalPath, 'utf8');
+    const parsed: unknown = JSON.parse(contents);
+    if (
+      isRecord(parsed) &&
+      parsed.version === 1 &&
+      parsed.dialect === 'clickhouse' &&
+      Array.isArray(parsed.migrations) &&
+      typeof parsed.latestSnapshotHash === 'string' &&
+      parsed.migrations.every(isMigrationJournalEntry)
+    ) {
+      return {
+        version: 1,
+        dialect: 'clickhouse',
+        latestSnapshotHash: parsed.latestSnapshotHash,
+        migrations: parsed.migrations,
+      };
+    }
+    throw new Error(`Invalid migration journal: ${path.relative(process.cwd(), journalPath)}`);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return {
+        version: 1,
+        dialect: 'clickhouse',
+        latestSnapshotHash: '',
+        migrations: [],
+      };
+    }
+    throw error;
+  }
+}
+
+function isSnapshot(value: unknown): value is Snapshot {
+  return isRecord(value) &&
+    value.version === 1 &&
+    value.dialect === 'clickhouse' &&
+    Array.isArray(value.tables) &&
+    Array.isArray(value.materializedViews) &&
+    Array.isArray(value.dependencies) &&
+    typeof value.contentHash === 'string';
+}
+
+function isMigrationJournalEntry(value: unknown): value is MigrationJournalEntry {
+  return isRecord(value) &&
+    typeof value.name === 'string' &&
+    typeof value.timestamp === 'string' &&
+    typeof value.custom === 'boolean' &&
+    typeof value.sourceSnapshotHash === 'string' &&
+    typeof value.targetSnapshotHash === 'string';
+}
+
+function isNotFoundError(error: unknown) {
+  return isRecord(error) && error.code === 'ENOENT';
+}

--- a/packages/cli/src/utils/runtime-guards.ts
+++ b/packages/cli/src/utils/runtime-guards.ts
@@ -1,0 +1,3 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object';
+}


### PR DESCRIPTION
 - CLI command naming updates:
      - generate remains type-generation compatible
      - generate:types added
      - generate:migration added
  - Phase 5 generation path is implemented with tests.