### PR TITLE
task: (datasets) API boundary hardening

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "smoke:vite-starter": "bash scripts/smoke-vite-starter.sh",
     "smoke:node-embedded": "bash scripts/smoke-node-embedded.sh",
     "smoke:serve-adapters": "bash scripts/smoke-serve-adapters.sh",
-    "smoke:examples": "pnpm smoke:cli && pnpm smoke:next-starter && pnpm smoke:vite-starter && pnpm smoke:node-embedded && pnpm smoke:next-dashboard && pnpm smoke:serve-adapters",
+    "smoke:semantic-consumer": "bash scripts/smoke-semantic-consumer.sh",
+    "smoke:examples": "pnpm smoke:cli && pnpm smoke:next-starter && pnpm smoke:vite-starter && pnpm smoke:node-embedded && pnpm smoke:next-dashboard && pnpm smoke:serve-adapters && pnpm smoke:semantic-consumer",
     "changeset": "changeset",
     "release:version": "changeset version",
     "release:publish": "changeset publish"

--- a/packages/datasets/src/api.type-test.ts
+++ b/packages/datasets/src/api.type-test.ts
@@ -122,14 +122,31 @@ type _EqPreservesFieldLiteral = Assert<
   Equal<typeof statusFilter['field'], 'status'>
 >;
 type _EqPreservesValueLiteral = Assert<
-  Equal<typeof statusFilter['value'], string>
+  Equal<typeof statusFilter['value'], 'completed'>
 >;
 type _BetweenPreservesTupleValue = Assert<
-  Equal<typeof createdAtRange['value'], [string, string]>
+  Equal<typeof createdAtRange['value'], ['2025-01-01', '2025-01-31']>
 >;
 type _DescPreservesFieldLiteral = Assert<
   Equal<typeof revenueSort['field'], 'revenueMetric'>
 >;
+
+Orders.metric('validDerivedMetric', {
+  uses: { revenue: revenueMetric },
+  formula: ({ revenue }) => add(revenue, revenue),
+});
+
+// @ts-expect-error derived metrics can only use base metrics from the same dataset.
+Orders.metric('invalidCrossDatasetDerivedMetric', {
+  uses: { customerCount: customerCountMetric },
+  formula: () => add('customerCount', 'customerCount'),
+});
+
+// @ts-expect-error derived metrics can only use base metrics, not derived metric refs.
+Orders.metric('invalidDerivedFromDerivedMetric', {
+  uses: { averageRevenue: averageRevenueMetric },
+  formula: () => add('averageRevenue', 'averageRevenue'),
+});
 
 const runtimeContext: ExecutionContext = {
   runtime: {

--- a/packages/datasets/src/query-helpers.ts
+++ b/packages/datasets/src/query-helpers.ts
@@ -1,6 +1,6 @@
 import type { MetricFilter, MetricOrderBy } from './types.js';
 
-function createFilter<TField extends string, TValue>(
+function createFilter<const TField extends string, const TValue>(
   field: TField,
   operator: MetricFilter['operator'],
   value: TValue,
@@ -8,51 +8,51 @@ function createFilter<TField extends string, TValue>(
   return { field, operator, value };
 }
 
-export function eq<TField extends string, TValue>(field: TField, value: TValue): MetricFilter<TField, TValue> {
+export function eq<const TField extends string, const TValue>(field: TField, value: TValue): MetricFilter<TField, TValue> {
   return createFilter(field, 'eq', value);
 }
 
-export function neq<TField extends string, TValue>(field: TField, value: TValue): MetricFilter<TField, TValue> {
+export function neq<const TField extends string, const TValue>(field: TField, value: TValue): MetricFilter<TField, TValue> {
   return createFilter(field, 'neq', value);
 }
 
-export function gt<TField extends string, TValue>(field: TField, value: TValue): MetricFilter<TField, TValue> {
+export function gt<const TField extends string, const TValue>(field: TField, value: TValue): MetricFilter<TField, TValue> {
   return createFilter(field, 'gt', value);
 }
 
-export function gte<TField extends string, TValue>(field: TField, value: TValue): MetricFilter<TField, TValue> {
+export function gte<const TField extends string, const TValue>(field: TField, value: TValue): MetricFilter<TField, TValue> {
   return createFilter(field, 'gte', value);
 }
 
-export function lt<TField extends string, TValue>(field: TField, value: TValue): MetricFilter<TField, TValue> {
+export function lt<const TField extends string, const TValue>(field: TField, value: TValue): MetricFilter<TField, TValue> {
   return createFilter(field, 'lt', value);
 }
 
-export function lte<TField extends string, TValue>(field: TField, value: TValue): MetricFilter<TField, TValue> {
+export function lte<const TField extends string, const TValue>(field: TField, value: TValue): MetricFilter<TField, TValue> {
   return createFilter(field, 'lte', value);
 }
 
-export function inList<TField extends string, TValue>(field: TField, value: TValue[]): MetricFilter<TField, TValue[]> {
+export function inList<const TField extends string, const TValue>(field: TField, value: TValue[]): MetricFilter<TField, TValue[]> {
   return createFilter(field, 'in', value);
 }
 
-export function notInList<TField extends string, TValue>(field: TField, value: TValue[]): MetricFilter<TField, TValue[]> {
+export function notInList<const TField extends string, const TValue>(field: TField, value: TValue[]): MetricFilter<TField, TValue[]> {
   return createFilter(field, 'notIn', value);
 }
 
-export function between<TField extends string, TValue>(field: TField, lower: TValue, upper: TValue): MetricFilter<TField, [TValue, TValue]> {
+export function between<const TField extends string, const TLower, const TUpper>(field: TField, lower: TLower, upper: TUpper): MetricFilter<TField, [TLower, TUpper]> {
   return createFilter(field, 'between', [lower, upper]);
 }
 
-export function like<TField extends string>(field: TField, value: string): MetricFilter<TField, string> {
+export function like<const TField extends string>(field: TField, value: string): MetricFilter<TField, string> {
   return createFilter(field, 'like', value);
 }
 
-export function asc<TField extends string>(field: TField): MetricOrderBy<TField> {
+export function asc<const TField extends string>(field: TField): MetricOrderBy<TField> {
   return { field, direction: 'asc' };
 }
 
-export function desc<TField extends string>(field: TField): MetricOrderBy<TField> {
+export function desc<const TField extends string>(field: TField): MetricOrderBy<TField> {
   return { field, direction: 'desc' };
 }
 

--- a/plans/datasets-semantic-layer-fix-plan.md
+++ b/plans/datasets-semantic-layer-fix-plan.md
@@ -2,308 +2,139 @@
 
 Date: 2026-05-25
 Owner: TBD
-Status: Implementation pass complete; follow-up hardening remains
+Status: Semantic API boundary and first type-hardening pass complete; schema depth, live CI, and docs remain
 
 ## Pre-Release Bias
 
-This package is still pre-release. Breaking changes are encouraged in this implementation pass when they materially improve API clarity, semantic correctness, and long-term maintainability. We should prefer a cleaner public surface over preserving accidental or weakly-defined pre-release behavior.
-
-## Goals
-
-- Fix broken derived metric SQL generation in `@hypequery/datasets`.
-- Catch invalid semantic plans before query execution.
-- Clarify the intended public API boundary for datasets.
-- Centralize semantic planning so `@hypequery/serve` delegates to `@hypequery/datasets`.
-- Connect `@hypequery/schema` physical truth to datasets compatibility checks.
-- Add enough type, unit, integration, and DX coverage to keep the surface stable.
-
-## Non-Goals
-
-- Rebuild the ClickHouse query builder architecture in this pass.
-- Add broad write support to Hypequery.
-- Ship speculative API expansion without deciding the intended public surface first.
+`@hypequery/datasets` and the semantic package boundary are still pre-release. Breaking changes are encouraged when they improve API clarity, semantic correctness, and maintainability.
 
 ## Architecture Direction
 
-- `@hypequery/datasets` owns semantic planning, invariants, and public API behavior.
-- `@hypequery/clickhouse` query builder is the SQL construction and execution backend.
-- Planner correctness must not depend on query-builder inference behavior.
-- Public docs must match the published npm package exactly.
-- This is not a query-builder change.
-- The biggest residual architecture risk is duplicated planner logic between `@hypequery/datasets` and `@hypequery/serve`, not the tenant runtime simplification itself.
+- `@hypequery/datasets` owns semantic planning, validation, and metric behavior.
+- `@hypequery/serve` owns runtime delivery, auth, tenancy, transport, and endpoint policy.
+- `@hypequery/schema` owns physical schema truth, snapshots, migration planning, and semantic compatibility checks.
+- `@hypequery/clickhouse` owns relational query construction and execution.
+- Dataset endpoint planning is a package-integration concern exposed through `@hypequery/datasets/internal`, not the public root datasets API.
 
-## Decisions Locked For This Pass
+## Completed
 
-- `dataset.query(...)` will be removed from the public API for now.
-- Filtered measures will be supported in this pass.
-- Export-surface cleanup should happen now because the package is still pre-release.
-- Serve runtime owns tenancy. Datasets should not expose a public API that pushes tenant ownership decisions onto consumers.
-- Simplify the public tenancy runtime shape in this pass.
-- Focus helper typing work on the existing generic helpers only. Do not introduce additive dataset-aware helper variants in this pass.
-
-## Progress Snapshot
-
-### Completed
-
-- Fixed derived metric SQL generation so ungrouped derived metrics do not emit invalid grouping.
+- Fixed derived metric SQL generation so ungrouped derived metrics no longer emit invalid `GROUP BY` clauses.
 - Added planner-level derived query validation before execution.
 - Added filtered measure support to `@hypequery/datasets`.
-- Removed `dataset.query(...)` from the datasets public API.
+- Removed `dataset.query(...)` from the public datasets API.
 - Simplified `SemanticTenantRuntime` to tenant identity only.
 - Rejected explicit tenant filters when runtime tenancy is active.
-- Cleaned the datasets root export surface and removed accidental planner-internal exports.
-- Updated `@hypequery/serve` to stop depending on removed datasets planner exports.
-- Moved serve semantic/planner runtime helpers into `utils` files to reduce endpoint and pipeline bulk.
-- Centralized dataset endpoint query planning in `@hypequery/datasets` so serve no longer maintains a duplicate semantic query planner.
-- Added dataset query helper APIs under `@hypequery/datasets/internal` as the intentional datasets/serve planning boundary.
-- Added schema-to-datasets compatibility checks so physical schema changes can be checked against semantic models.
+- Cleaned the root datasets export surface and removed accidental planner-internal exports.
+- Added `@hypequery/datasets/internal` for the intentional datasets-to-serve planning boundary.
+- Updated serve dataset endpoints to use datasets-owned planning instead of duplicated serve planner logic.
+- Removed duplicated serve semantic planner utilities.
+- Added schema-to-datasets compatibility checks for physical schema changes.
 - Added semantic architecture/spec notes for datasets, serve, and schema.
-- Removed new production casts from the dataset-query path and cleaned the touched serve semantic test helpers.
-- Locked the root datasets export surface so dataset-query helpers and types do not appear as public user-facing APIs.
-- Made the query-builder protocol execute path generic so metric execution does not need a result cast.
-- Removed file-level type suppression and response `any` casts from the serve live semantic integration spec.
-- Added types for the shared ClickHouse integration harness used by serve live tests.
+- Made `QueryBuilderLike.execute<T>()` generic so metric execution does not need result casts.
+- Removed file-level type suppression and response `any` casts from touched semantic tests.
+- Added types for the shared ClickHouse integration harness.
+- Added fresh-consumer semantic smoke coverage for root imports, internal package-integration imports, unsupported deep imports, and Node ESM importability.
+- Tightened existing generic query helpers so field/value literals are preserved more accurately.
+- Added negative type tests for cross-dataset and derived-from-derived metric wiring.
+- Split semantic consumer smoke fixture generation into `scripts/utils/write-semantic-consumer-fixtures.mjs`.
 
-### Verified In This Pass
+## Verified
 
-- `pnpm exec vitest run --config vitest.config.ts src/datasets.test.ts`
-- `npm test -- --run src/semantic/datasets/serve-integration.test.ts`
+- `npm test --workspace=@hypequery/datasets`
+- `npm test --workspace=@hypequery/serve -- --run src/semantic/datasets/serve-integration.test.ts`
 - `pnpm build` in `packages/datasets`
 - `pnpm build` in `packages/serve`
 - `SKIP_INTEGRATION_TESTS=true pnpm exec vitest run --config vitest.integration.config.ts src/semantic/datasets/serve-live.integration.spec.ts`
+- `pnpm smoke:semantic-consumer`
 - `git diff --cached --check`
 
-### In Progress
+## Current Caveat
 
-- Prepare the next hardening pass around compile-time guarantees and consumer smoke coverage.
-- Keep the semantic architecture spec current while implementation stabilizes.
+Live ClickHouse execution has not been run in this environment because Docker socket access is blocked. The live semantic spec type-checks and can run in CI or a local environment with Docker access.
 
-### Remaining
+## Next Work
 
-- Broader type-safety tightening for derived metrics and existing generic helpers where it remains understandable.
-- Docs and guide alignment across the repo.
-- Fresh-consumer smoke coverage.
-- Wider integration coverage for datasets and serve semantic endpoints.
-- Deeper schema compatibility for SQL expressions and relationship join columns.
-- Relationship-aware semantic execution remains out of scope until the base semantic surface is stable.
-
-## Next Workstreams
-
-### 1. Derived Metric and Query Typing Tightening
+### 1. Schema Compatibility Depth
 
 Objective:
-Move intended API guarantees from runtime checks into compile-time checks where practical.
+Make schema compatibility catch more semantic breakage before migrations ship.
 
 Implementation:
-- Tighten `DerivedMetricConfig.uses` in `packages/datasets/src/types.ts` so derived metrics only accept base metrics from the same dataset.
-- Prevent cross-dataset metric references at compile time where possible.
-- Prevent derived-from-derived references at compile time where possible.
-- Improve typing around query dimensions, `orderBy.field`, and grain usage.
-- Assess feasibility of tightening the existing generic helpers like `eq()` and `desc()`.
-- Improve the generic helper typing if it stays reasonably simple and understandable.
-- If the type-level complexity becomes disproportionate, keep the current generic helper behavior and document that limitation clearly.
+- Add compatibility checks for relationship join columns.
+- Add safe dependency extraction for simple SQL-expression dimensions/measures where practical.
+- Report explicit limitations for complex SQL expressions instead of pretending full SQL lineage exists.
+- Add focused tests for removed/renamed join columns and SQL-expression limitations.
 
 Acceptance criteria:
-- Invalid derived metric wiring fails in type tests.
-- Invalid query fields fail in type tests where the API intends strong typing.
-- If helper functions stay generic, docs clearly describe that limitation.
+- Broken relationship join columns produce compatibility diagnostics.
+- SQL-expression compatibility is either checked safely or reported as limited.
 
-### 2. Fresh-Consumer DX Coverage
-
-Objective:
-Make the published package boundary enforceable before writing public docs.
-
-Implementation:
-- Add a temporary fresh project that installs/builds against local package artifacts.
-- Verify root imports compile for `@hypequery/datasets`, `@hypequery/schema`, and `@hypequery/serve`.
-- Verify unsupported deep/subpath imports fail except intentionally exported package-integration subpaths.
-- Verify Node 22 ESM importability.
-- Keep docs snippets out of this pass unless needed to define the smoke target.
-
-Acceptance criteria:
-- A fresh consumer can import the intended root APIs without TypeScript or ESM failures.
-- Accidental internals are not reachable from documented root imports.
-- The smoke test can run in CI without live ClickHouse.
-
-### 3. Schema Compatibility Depth
+### 2. Docs and Guide Alignment
 
 Objective:
-Move schema compatibility beyond direct field references where it is practical.
+Make public docs match the finalized package boundary.
 
 Implementation:
-- Extend compatibility checks for SQL-expression dimensions/measures where dependency extraction is safe.
-- Add checks for relationship join columns.
-- Add focused tests for removed/renamed join columns and unsupported SQL-expression cases.
-- Clearly report limitations instead of pretending full SQL lineage exists.
-
-Acceptance criteria:
-- Direct relationship join-column breakages are reported before migration application.
-- SQL-expression compatibility either reports known dependencies or emits an explicit limitation.
-
-### 4. Docs and Guide Alignment
-
-Objective:
-Make copy-paste docs work against the finalized package boundary.
-
-Implementation:
-- Update docs to import `MetricExecutor` from `@hypequery/datasets`.
-- Replace outdated measure execution examples with the current `dataset.metric(...)` flow.
-- Document filtered measures and runtime tenancy behavior.
+- Document dataset definition, measures, filtered measures, metrics, derived metrics, `.by(grain)`, and `MetricExecutor`.
+- Document serve-generated metric and dataset endpoints.
+- Document runtime tenancy behavior and tenant-filter rejection.
 - Avoid documenting `@hypequery/datasets/internal` as user-facing API.
-- Remove or rewrite write-based setup instructions that imply native write support.
-- Prefer `url` over deprecated `host` in examples where applicable.
-- Add explicit fixture-seeding guidance using external tooling when writes are required.
+- Remove write-based setup assumptions or move fixture seeding to external tooling such as `@clickhouse/client`.
+- Add guide snippet compile checks after docs examples stabilize.
 
 Acceptance criteria:
-- A fresh consumer can follow the guide without immediate TypeScript failure.
-- The guide does not imply unsupported write workflows through Hypequery.
+- Copy-paste examples compile from a fresh consumer project.
+- Docs do not rely on removed root exports or unsupported deep imports.
+- Docs do not imply Hypequery provides native write support.
 
-## Test Plan
+### 3. Live Integration and CI Hardening
 
-### Type Tests
+Objective:
+Make semantic behavior continuously verifiable beyond unit tests.
 
-Add dedicated datasets type tests covering:
-- metric construction success/failure
-- same-dataset base-metric-only derived metrics
-- valid/invalid dimensions
-- valid/invalid `orderBy.field`
-- grain behavior with and without `timeKey`
-- measure options support/rejection
-- root export surface
-- guide snippets as compile tests
+Implementation:
+- Run the live ClickHouse semantic integration suite in Docker-capable CI.
+- Add CI coverage for `pnpm smoke:semantic-consumer`.
+- Keep fast unit/type checks separate from Docker-backed integration checks.
 
-### Unit Tests
+Acceptance criteria:
+- CI catches public API drift.
+- CI catches live ClickHouse regressions for base, derived, grouped, grained, and filtered semantic queries.
 
-Add datasets unit tests covering:
-- base metric SQL generation
-- derived metric SQL generation:
-  - ungrouped
-  - grouped
-  - grained
-  - grouped + grained
-  - filtered
-  - tenant-scoped
-- validation failures:
-  - unknown dimension
-  - unknown filter field
-  - invalid order field
-  - invalid grain usage
-  - invalid derived plans
-- planner invariants
-- removed/unsupported `DatasetQueryRef` behavior
-- query-builder protocol compatibility
-- tenant predicate behavior
+### 4. Relationship-Aware Semantics
 
-### Integration Tests
+Objective:
+Decide how dataset relationships participate in planning and execution.
 
-Add ClickHouse-backed integration tests covering:
-- connection smoke tests
-- fixture lifecycle
-- base metric execution
-- derived metric execution
-- grouped and grained derived metrics
-- pre-execution validation failures
-- one real-dataset semantic query
-- fresh-consumer package importability checks
+Implementation:
+- Define whether relationships are metadata-only, query-time joins, or a separate planned feature.
+- Decide join semantics for dimensions, measures, filters, and derived metrics.
+- Extend schema compatibility around relationship join columns before enabling execution.
 
-### DX and Docs Checks
-
-Add CI checks for:
-- fresh temp project install
-- root import compile test
-- unsupported subpath import rejection
-- Node 22 ESM importability
-- guide snippet compile checks
-
-## Proposed Sequencing
-
-### Phase 1: Critical Bug Fixes - Complete
-
-- Derived metric planning fix
-- Planner invariants
-- Validation upgrade
-- `DatasetQueryRef` removal / crash prevention
-- Tenant filter duplication handling
-
-### Phase 2: Surface Decisions - Complete For This Pass
-
-- Remove `dataset.query(...)` surface
-- Implement filtered measure support
-- Decide helper typing scope based on feasibility assessment
-- Trim root exports
-
-### Phase 3: Planner Ownership and Schema Compatibility - Complete For This Pass
-
-- Move dataset endpoint planning ownership into `@hypequery/datasets`
-- Remove duplicated serve semantic planner code
-- Add schema-to-datasets compatibility checks
-- Document the package ownership model in the draft spec
-
-### Phase 4: Type Safety and API Boundary Hardening - Next
-
-- Derived metric typing tightening
-- Query typing improvements
-- Current-surface type-test expansion
-- Schema compatibility type-test expansion
-- Existing generic helper typing improvements where practical
-
-### Phase 5: Fresh-Consumer DX Coverage - Next
-
-- Fresh-consumer smoke tests
-- Root import compile test
-- Unsupported subpath import rejection test
-- Node 22 ESM importability test
-
-### Phase 6: Docs and Guide Alignment - After API Hardening
-
-- Docs and examples rewrite
-- Guide snippet compile checks
-- Public positioning cleanup
-
-### Phase 7: Coverage Expansion
-
-- Dedicated type tests
-- Focused unit tests
-- Real integration tests
-- CI hardening
-
-### Phase 8: Relationship-Aware Semantics
-
-- Define how dataset relationships participate in planning.
-- Decide whether joins are query-time only, materialized/planned elsewhere, or initially metadata-only.
-- Add compatibility checks for relationship join columns before enabling relationship-aware execution.
+Acceptance criteria:
+- Relationship behavior is explicitly designed before being exposed as executable semantics.
 
 ## Release Scoping
 
 ### This PR
 
-- Derived metric SQL fix
-- Validation for invalid derived plans
-- `dataset.query(...)` public surface removal
-- Filtered measure support
-- Tenant runtime simplification and explicit tenant-filter rejection
-- Serve planner unification around datasets-owned planning
-- Schema-to-datasets compatibility checks
-- Semantic architecture/spec notes
+- Datasets public API boundary hardening.
+- Internal datasets-to-serve planner boundary.
+- Fresh-consumer semantic smoke coverage.
+- Generic helper type preservation improvements.
+- Derived metric type-test coverage for invalid wiring.
 
-### Follow-up Hardening
+### Follow-Up Hardening
 
-- Docs corrections for current published API
-- Derived metric compile-time restriction overhaul
-- Existing generic helper typing tightening
-- Fresh-consumer smoke tests
-- Live ClickHouse semantic integration execution in an environment with Docker access
-- Relationship-aware planning design
+- Deeper schema compatibility for relationships and SQL expressions.
+- Live ClickHouse semantic integration execution in Docker-capable CI.
+- Docs corrections for current public API.
+- Relationship-aware planning design.
 
 ## Risks
 
 - Tightening the export surface may break undocumented consumer usage, but this is acceptable while the packages are pre-release.
 - Tightening derived metric typing may reject code that currently compiles.
-- The `@hypequery/datasets/internal` subpath is still technically importable, so docs should clearly position it as unsupported package-integration surface rather than user-facing API.
+- The `@hypequery/datasets/internal` subpath is technically importable, so docs should clearly position it as unsupported package-integration surface rather than user-facing API.
 - Schema compatibility can still miss deeper SQL-expression dependencies until the checker grows beyond direct column references.
-- Adding filtered measure support expands the semantic API and test matrix materially.
 - Relationship metadata remains non-executing until relationship-aware planning is deliberately designed.
-
-## Open Questions
-
-1. If tightening the existing generic helpers becomes too complex, should we explicitly defer helper typing improvements in this pass rather than force a brittle solution?

--- a/scripts/smoke-semantic-consumer.sh
+++ b/scripts/smoke-semantic-consumer.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo '--- smoke: semantic consumer ---'
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+mkdir -p "$ROOT_DIR/tmp"
+WORKDIR="$(mktemp -d "$ROOT_DIR/tmp/hq-semantic-consumer-XXXXXX")"
+
+cleanup() {
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+pnpm --filter @hypequery/datasets build >/dev/null
+pnpm --filter @hypequery/schema build >/dev/null
+pnpm --filter @hypequery/serve build >/dev/null
+
+mkdir -p "$WORKDIR/node_modules/@hypequery"
+ln -s "$ROOT_DIR/packages/datasets" "$WORKDIR/node_modules/@hypequery/datasets"
+ln -s "$ROOT_DIR/packages/schema" "$WORKDIR/node_modules/@hypequery/schema"
+ln -s "$ROOT_DIR/packages/serve" "$WORKDIR/node_modules/@hypequery/serve"
+
+node "$ROOT_DIR/scripts/utils/write-semantic-consumer-fixtures.mjs" "$WORKDIR"
+
+TSC="$ROOT_DIR/packages/datasets/node_modules/typescript/bin/tsc"
+
+(
+  cd "$WORKDIR"
+  "$TSC" --noEmit --project tsconfig.json
+  node runtime.mjs
+
+  if "$TSC" --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --skipLibCheck --noEmit invalid-root-dataset-query.ts >/tmp/hq-invalid-root.log 2>&1; then
+    cat /tmp/hq-invalid-root.log
+    echo 'Expected root dataset-query helper import to fail, but it compiled.'
+    exit 1
+  fi
+
+  if "$TSC" --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --skipLibCheck --noEmit invalid-deep-import.ts >/tmp/hq-invalid-deep.log 2>&1; then
+    cat /tmp/hq-invalid-deep.log
+    echo 'Expected deep serve import to fail, but it compiled.'
+    exit 1
+  fi
+)
+
+echo 'semantic consumer smoke passed'

--- a/scripts/utils/write-semantic-consumer-fixtures.mjs
+++ b/scripts/utils/write-semantic-consumer-fixtures.mjs
@@ -1,0 +1,136 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const files = {
+  'package.json': `{
+  "name": "hypequery-semantic-consumer-smoke",
+  "private": true,
+  "type": "module"
+}
+`,
+  'tsconfig.json': `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["valid-*.ts"]
+}
+`,
+  'valid-root-imports.ts': `import { dataset, dimension, measure, MetricExecutor } from '@hypequery/datasets';
+import type { MetricQuery } from '@hypequery/datasets';
+import {
+  checkDatasetsAgainstSchema,
+  column,
+  defineSchema,
+  defineTable,
+  serializeSchemaToSnapshot,
+} from '@hypequery/schema';
+import { createAPI } from '@hypequery/serve';
+
+const Orders = dataset('orders', {
+  source: 'orders',
+  timeKey: 'created_at',
+  dimensions: {
+    id: dimension.number(),
+    status: dimension.string(),
+    amount: dimension.number(),
+    createdAt: dimension.timestamp({ column: 'created_at' }),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+  },
+});
+
+const revenue = Orders.metric('revenue', { measure: 'revenue' });
+const query: MetricQuery = { dimensions: ['status'] };
+
+const ordersTable = defineTable('orders', {
+  columns: {
+    id: column.UInt64(),
+    status: column.String(),
+    amount: column.Float64(),
+    created_at: column.DateTime(),
+  },
+  engine: {
+    type: 'MergeTree',
+    orderBy: ['id'],
+  },
+});
+
+const snapshot = serializeSchemaToSnapshot(defineSchema({ tables: [ordersTable] }));
+const compatibility = checkDatasetsAgainstSchema({ snapshot, datasets: [Orders] });
+const api = createAPI({});
+
+void revenue;
+void query;
+void MetricExecutor;
+void compatibility;
+void api;
+`,
+  'valid-internal-import.ts': `import { runDatasetQuery } from '@hypequery/datasets/internal';
+import type { DatasetQuery } from '@hypequery/datasets/internal';
+
+const query: DatasetQuery = { measures: ['revenue'] };
+
+void runDatasetQuery;
+void query;
+`,
+  'invalid-root-dataset-query.ts': `import { runDatasetQuery } from '@hypequery/datasets';
+
+void runDatasetQuery;
+`,
+  'invalid-deep-import.ts': `import { createAPI } from '@hypequery/serve/dist/server/create-api.js';
+
+void createAPI;
+`,
+  'runtime.mjs': `import { dataset, dimension, measure } from '@hypequery/datasets';
+import { column, defineSchema, defineTable, serializeSchemaToSnapshot } from '@hypequery/schema';
+import { createAPI } from '@hypequery/serve';
+
+const Orders = dataset('orders', {
+  source: 'orders',
+  dimensions: {
+    id: dimension.number(),
+    amount: dimension.number(),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+  },
+});
+
+const table = defineTable('orders', {
+  columns: {
+    id: column.UInt64(),
+    amount: column.Float64(),
+  },
+  engine: {
+    type: 'MergeTree',
+    orderBy: ['id'],
+  },
+});
+
+const snapshot = serializeSchemaToSnapshot(defineSchema({ tables: [table] }));
+const api = createAPI({});
+
+if (Orders.name !== 'orders' || snapshot.tables.length !== 1 || typeof api.describe !== 'function') {
+  throw new Error('semantic consumer runtime import smoke failed');
+}
+`,
+};
+
+const targetDirectory = process.argv[2];
+if (!targetDirectory) {
+  throw new Error('Usage: node scripts/utils/write-semantic-consumer-fixtures.mjs <target-directory>');
+}
+
+await mkdir(targetDirectory, { recursive: true });
+
+await Promise.all(
+  Object.entries(files).map(([fileName, contents]) =>
+    writeFile(path.join(targetDirectory, fileName), contents),
+  ),
+);


### PR DESCRIPTION
## Summary

  This PR completes the current semantic-layer backend cleanup and API-boundary hardening pass across `@hypequery/
  datasets`, `@hypequery/serve`, and schema compatibility planning.

  The core architecture change is that semantic dataset planning now lives in `@hypequery/datasets`, while `@hypequery/
  serve` delegates to a deliberate internal integration boundary instead of maintaining duplicate planner logic.

  ## What Changed

  - Fixed derived metric planning so aggregate aliases are not inferred as `GROUP BY` dimensions.
  - Added planner validation so invalid derived metric plans fail before execution.
  - Added filtered measure support in datasets planning.
  - Simplified semantic tenant runtime to tenant identity only.
  - Rejected explicit tenant filters when runtime tenancy is active.
  - Removed `dataset.query(...)` from the public datasets API.
  - Moved dataset endpoint planning behind `@hypequery/datasets/internal`.
  - Removed accidental root exports for dataset-query helpers and types.
  - Updated serve dataset endpoints to use datasets-owned planning.
  - Removed duplicated serve-side semantic planner utilities.
  - Added schema-to-datasets compatibility planning notes.
  - Made `QueryBuilderLike.execute<T>()` generic so semantic execution does not need result casts.
  - Tightened existing query helper typing so field/value literals are preserved more accurately.
  - Added type tests for public/internal export boundaries and invalid derived metric wiring.
  - Added fresh-consumer smoke coverage for root imports, internal integration imports, unsupported deep imports, and Node
  ESM importability.
  - Removed new casts/type suppressions from touched semantic code.
  - Added declarations for the shared ClickHouse integration harness.
  - Updated the implementation plan to reflect current architecture and next work.