### PR TITLE
feat: (migration) migration integrity groundwork

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,6 +3,8 @@ import { initCommand } from './commands/init.js';
 import { devCommand, type DevOptions } from './commands/dev.js';
 import { generateCommand, type GenerateOptions } from './commands/generate.js';
 import { generateMigrationCommand, type GenerateMigrationOptions } from './commands/generate-migration.js';
+import { migrationCheckCommand, type MigrationCheckOptions } from './commands/migration-check.js';
+import { migrationStatusCommand, type MigrationStatusOptions } from './commands/migration-status.js';
 import { pullCommand, type PullOptions } from './commands/pull.js';
 
 const program = new Command();
@@ -101,6 +103,22 @@ program
     await pullCommand(options);
   }));
 
+program
+  .command('migrate:status')
+  .description('Show local ClickHouse migration status')
+  .option('-c, --config <path>', 'Config file (default: hypequery.config.ts)')
+  .action(runCommand(async (options: MigrationStatusOptions) => {
+    await migrationStatusCommand(options);
+  }));
+
+program
+  .command('migrate:check')
+  .description('Verify local ClickHouse migration checksums')
+  .option('-c, --config <path>', 'Config file (default: hypequery.config.ts)')
+  .action(runCommand(async (options: MigrationCheckOptions) => {
+    await migrationCheckCommand(options);
+  }));
+
 // Help command
 program
   .command('help [command]')
@@ -130,6 +148,8 @@ program.on('--help', () => {
   console.log('  hypequery generate:types --output analytics/schema.ts');
   console.log('  hypequery generate:migration add_orders_table');
   console.log('  hypequery pull');
+  console.log('  hypequery migrate:status');
+  console.log('  hypequery migrate:check');
   console.log('');
   console.log('Docs: https://hypequery.com/docs');
 });

--- a/packages/cli/src/commands/generate-migration.test.ts
+++ b/packages/cli/src/commands/generate-migration.test.ts
@@ -82,6 +82,7 @@ describe('generate:migration command', () => {
     await expect(readFile(path.join(migrationDir, 'up.sql'), 'utf8')).resolves.toContain('CREATE TABLE `events`');
     await expect(readFile(path.join(migrationDir, 'down.sql'), 'utf8')).resolves.toContain('DROP TABLE `events`');
     await expect(readFile(path.join(migrationDir, 'snapshot.json'), 'utf8')).resolves.toContain('"events"');
+    await expect(readFile(path.join(migrationDir, 'hypequery.sum'), 'utf8')).resolves.toContain('"algorithm": "sha256"');
 
     const meta = JSON.parse(await readFile(path.join(migrationDir, 'meta.json'), 'utf8'));
     expect(meta).toMatchObject({
@@ -102,6 +103,7 @@ describe('generate:migration command', () => {
       expect.objectContaining({
         name: '20260525120000_add_events',
         custom: false,
+        checksum: expect.any(String),
       }),
     ]);
   });
@@ -117,6 +119,7 @@ describe('generate:migration command', () => {
 
     const migrationDir = path.join(tempDir, 'migrations', '20260525120500_backfill_events');
     await expect(readFile(path.join(migrationDir, 'up.sql'), 'utf8')).resolves.toContain('custom migration SQL');
+    await expect(readFile(path.join(migrationDir, 'hypequery.sum'), 'utf8')).resolves.toContain('"algorithm": "sha256"');
 
     const meta = JSON.parse(await readFile(path.join(migrationDir, 'meta.json'), 'utf8'));
     expect(meta).toMatchObject({

--- a/packages/cli/src/commands/generate-migration.ts
+++ b/packages/cli/src/commands/generate-migration.ts
@@ -13,6 +13,7 @@ import { loadHypequeryConfig } from '../utils/load-hypequery-config.js';
 import { logger } from '../utils/logger.js';
 import { assertValidMigrationSlug, createMigrationTimestamp, formatMigrationName } from '../utils/migration-names.js';
 import { loadMigrationSchema } from '../utils/migration-schema.js';
+import { writeMigrationChecksumFile } from '../utils/migration-checksums.js';
 import {
   appendMigrationJournalEntry,
   assertMigrationDoesNotExist,
@@ -95,6 +96,7 @@ export async function generateMigrationCommand(
       `${snapshotToStableJson(nextSnapshot)}\n`,
       'utf8',
     );
+    const checksumFile = await writeMigrationChecksumFile(written.migrationDir);
     await writeLatestMigrationSnapshot(migrationsOutDir, nextSnapshot);
     await appendMigrationJournalEntry(migrationsOutDir, {
       name: migrationName,
@@ -102,6 +104,7 @@ export async function generateMigrationCommand(
       custom: false,
       sourceSnapshotHash: plan.sourceSnapshotHash,
       targetSnapshotHash: plan.targetSnapshotHash,
+      checksum: checksumFile.checksum,
     }, nextSnapshot.contentHash);
     writeSpinner.succeed('Wrote migration files');
 

--- a/packages/cli/src/commands/migration-check.test.ts
+++ b/packages/cli/src/commands/migration-check.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMigrationFilesFixture, mockProcessExit, ProcessExitError } from '../test-utils.js';
+import { writeMigrationChecksumFile } from '../utils/migration-checksums.js';
+
+type LoadModule = typeof import('../utils/load-api.js')['loadModule'];
+
+vi.mock('../utils/load-api.js', () => ({
+  loadModule: vi.fn(),
+}));
+
+const mockLogger = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  reload: vi.fn(),
+  header: vi.fn(),
+  newline: vi.fn(),
+  indent: vi.fn(),
+  box: vi.fn(),
+  table: vi.fn(),
+  raw: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: mockLogger,
+}));
+
+const mockSpinner = vi.hoisted(() => ({
+  start: vi.fn().mockReturnThis(),
+  succeed: vi.fn().mockReturnThis(),
+  fail: vi.fn().mockReturnThis(),
+  stop: vi.fn().mockReturnThis(),
+}));
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => mockSpinner),
+}));
+
+let tempDir: string;
+let previousCwd: string;
+
+describe('migrate:check command', () => {
+  let exitHandler: ReturnType<typeof mockProcessExit>;
+  let loadModule: ReturnType<typeof vi.mocked<LoadModule>>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    previousCwd = process.cwd();
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'hypequery-migration-check-'));
+    process.chdir(tempDir);
+    exitHandler = mockProcessExit();
+
+    ({ loadModule } = await import('../utils/load-api.js'));
+    loadModule.mockResolvedValue({ default: configFixture() });
+  });
+
+  afterEach(async () => {
+    exitHandler.restore();
+    process.chdir(previousCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('succeeds when all migration checksums match', async () => {
+    await createMigration('20260525120000_add_events');
+    const { migrationCheckCommand } = await import('./migration-check.js');
+
+    await migrationCheckCommand();
+
+    expect(mockLogger.success).toHaveBeenCalledWith('Verified 1 migration');
+  });
+
+  it('exits when a migration file changed', async () => {
+    const migrationDir = await createMigration('20260525120000_add_events');
+    await writeFile(path.join(migrationDir, 'up.sql'), 'SELECT 2;\n', 'utf8');
+    const { migrationCheckCommand } = await import('./migration-check.js');
+
+    await expect(migrationCheckCommand()).rejects.toBeInstanceOf(ProcessExitError);
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('changed up.sql'));
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('failed integrity checks'));
+  });
+
+  it('reports no local migrations', async () => {
+    const { migrationCheckCommand } = await import('./migration-check.js');
+
+    await migrationCheckCommand();
+
+    expect(mockLogger.info).toHaveBeenCalledWith('No local migrations found.');
+  });
+});
+
+async function createMigration(name: string) {
+  const migrationDir = await createMigrationFilesFixture(tempDir, name);
+  await writeMigrationChecksumFile(migrationDir);
+  return migrationDir;
+}
+
+function configFixture() {
+  return {
+    dialect: 'clickhouse',
+    schema: './schema.ts',
+    migrations: { out: './migrations' },
+    dbCredentials: {
+      host: 'localhost',
+      username: 'default',
+      database: 'analytics',
+    },
+  };
+}

--- a/packages/cli/src/commands/migration-check.ts
+++ b/packages/cli/src/commands/migration-check.ts
@@ -1,0 +1,67 @@
+import path from 'node:path';
+import ora from 'ora';
+import { loadHypequeryConfig } from '../utils/load-hypequery-config.js';
+import { logger } from '../utils/logger.js';
+import { verifyMigrationIntegrity } from '../utils/migration-checksums.js';
+
+export interface MigrationCheckOptions {
+  config?: string;
+}
+
+export async function migrationCheckCommand(options: MigrationCheckOptions = {}) {
+  logger.newline();
+  logger.header('hypequery migrate:check');
+
+  try {
+    const config = await loadHypequeryConfig(options.config);
+    const migrationsOutDir = path.resolve(process.cwd(), config.migrations.out);
+
+    const spinner = ora('Checking migration files...').start();
+    const results = await verifyMigrationIntegrity(migrationsOutDir);
+    spinner.succeed('Checked migration files');
+
+    if (results.length === 0) {
+      logger.info('No local migrations found.');
+      logger.newline();
+      return;
+    }
+
+    const failures = results.filter(result => !result.ok);
+    if (failures.length === 0) {
+      logger.success(`Verified ${results.length} migration${results.length === 1 ? '' : 's'}`);
+      logger.newline();
+      return;
+    }
+
+    for (const failure of failures) {
+      logger.warn(formatIntegrityFailure(failure));
+    }
+
+    throw new Error(`${failures.length} migration${failures.length === 1 ? '' : 's'} failed integrity checks.`);
+  } catch (error) {
+    logger.newline();
+    logger.error(error instanceof Error ? error.message : String(error));
+    logger.newline();
+    process.exit(1);
+  }
+}
+
+function formatIntegrityFailure(failure: {
+  migrationName: string;
+  missingChecksumFile: boolean;
+  changedFiles: string[];
+  missingFiles: string[];
+  extraFiles: string[];
+}) {
+  if (failure.missingChecksumFile) {
+    return `${failure.migrationName}: missing hypequery.sum`;
+  }
+
+  const details = [
+    ...failure.changedFiles.map(file => `changed ${file}`),
+    ...failure.missingFiles.map(file => `missing ${file}`),
+    ...failure.extraFiles.map(file => `extra ${file}`),
+  ];
+
+  return `${failure.migrationName}: ${details.join(', ')}`;
+}

--- a/packages/cli/src/commands/migration-status.test.ts
+++ b/packages/cli/src/commands/migration-status.test.ts
@@ -1,0 +1,121 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMigrationFilesFixture, mockProcessExit } from '../test-utils.js';
+import { writeMigrationChecksumFile } from '../utils/migration-checksums.js';
+import {
+  appendMigrationJournalEntry,
+  initializeMigrationJournal,
+} from '../utils/migration-state.js';
+
+type LoadModule = typeof import('../utils/load-api.js')['loadModule'];
+
+vi.mock('../utils/load-api.js', () => ({
+  loadModule: vi.fn(),
+}));
+
+const mockLogger = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  reload: vi.fn(),
+  header: vi.fn(),
+  newline: vi.fn(),
+  indent: vi.fn(),
+  box: vi.fn(),
+  table: vi.fn(),
+  raw: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: mockLogger,
+}));
+
+const mockSpinner = vi.hoisted(() => ({
+  start: vi.fn().mockReturnThis(),
+  succeed: vi.fn().mockReturnThis(),
+  fail: vi.fn().mockReturnThis(),
+  stop: vi.fn().mockReturnThis(),
+}));
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => mockSpinner),
+}));
+
+let tempDir: string;
+let previousCwd: string;
+
+describe('migrate:status command', () => {
+  let exitHandler: ReturnType<typeof mockProcessExit>;
+  let loadModule: ReturnType<typeof vi.mocked<LoadModule>>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    previousCwd = process.cwd();
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'hypequery-migration-status-'));
+    process.chdir(tempDir);
+    exitHandler = mockProcessExit();
+
+    ({ loadModule } = await import('../utils/load-api.js'));
+    loadModule.mockResolvedValue({ default: configFixture() });
+  });
+
+  afterEach(async () => {
+    exitHandler.restore();
+    process.chdir(previousCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('shows pending local migrations with checksum status', async () => {
+    await createJournaledMigration('20260525120000_add_events');
+    const { migrationStatusCommand } = await import('./migration-status.js');
+
+    await migrationStatusCommand();
+
+    expect(mockLogger.table).toHaveBeenCalledWith(
+      ['Migration', 'Type', 'State', 'Checksum'],
+      [['20260525120000_add_events', 'generated', 'pending', 'ok']],
+    );
+    expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('Apply-state tracking is not implemented yet'));
+  });
+
+  it('reports no local migrations', async () => {
+    await initializeMigrationJournal(path.join(tempDir, 'migrations'), 'snapshot-hash');
+    const { migrationStatusCommand } = await import('./migration-status.js');
+
+    await migrationStatusCommand();
+
+    expect(mockLogger.info).toHaveBeenCalledWith('No local migrations found.');
+  });
+});
+
+async function createJournaledMigration(name: string) {
+  const migrationDir = await createMigrationFilesFixture(tempDir, name);
+  const checksumFile = await writeMigrationChecksumFile(migrationDir);
+  await initializeMigrationJournal(path.join(tempDir, 'migrations'), 'snapshot-hash');
+  await appendMigrationJournalEntry(path.join(tempDir, 'migrations'), {
+    name,
+    timestamp: '20260525120000',
+    custom: false,
+    sourceSnapshotHash: 'source',
+    targetSnapshotHash: 'target',
+    checksum: checksumFile.checksum,
+  }, 'target');
+}
+
+function configFixture() {
+  return {
+    dialect: 'clickhouse',
+    schema: './schema.ts',
+    migrations: { out: './migrations' },
+    dbCredentials: {
+      host: 'localhost',
+      username: 'default',
+      database: 'analytics',
+    },
+  };
+}

--- a/packages/cli/src/commands/migration-status.ts
+++ b/packages/cli/src/commands/migration-status.ts
@@ -1,0 +1,47 @@
+import path from 'node:path';
+import ora from 'ora';
+import { loadHypequeryConfig } from '../utils/load-hypequery-config.js';
+import { logger } from '../utils/logger.js';
+import { getLocalMigrationStatuses } from '../utils/migration-state.js';
+
+export interface MigrationStatusOptions {
+  config?: string;
+}
+
+export async function migrationStatusCommand(options: MigrationStatusOptions = {}) {
+  logger.newline();
+  logger.header('hypequery migrate:status');
+
+  try {
+    const config = await loadHypequeryConfig(options.config);
+    const migrationsOutDir = path.resolve(process.cwd(), config.migrations.out);
+
+    const spinner = ora('Reading migration metadata...').start();
+    const statuses = await getLocalMigrationStatuses(migrationsOutDir);
+    spinner.succeed('Read migration metadata');
+
+    if (statuses.length === 0) {
+      logger.info('No local migrations found.');
+      logger.newline();
+      return;
+    }
+
+    logger.table(
+      ['Migration', 'Type', 'State', 'Checksum'],
+      statuses.map(status => [
+        status.name,
+        status.custom ? 'custom' : 'generated',
+        status.state,
+        status.checksum,
+      ]),
+    );
+    logger.newline();
+    logger.info('Apply-state tracking is not implemented yet; local migrations are shown as pending.');
+    logger.newline();
+  } catch (error) {
+    logger.newline();
+    logger.error(error instanceof Error ? error.message : String(error));
+    logger.newline();
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/test-utils.ts
+++ b/packages/cli/src/test-utils.ts
@@ -1,3 +1,5 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
 import { vi } from 'vitest';
 import type { Mock } from 'vitest';
 
@@ -136,4 +138,14 @@ export function mockProcessExit() {
       process.exit = originalExit;
     },
   };
+}
+
+export async function createMigrationFilesFixture(rootDir: string, name: string) {
+  const migrationDir = path.join(rootDir, 'migrations', name);
+  await mkdir(migrationDir, { recursive: true });
+  await writeFile(path.join(migrationDir, 'up.sql'), 'SELECT 1;\n', 'utf8');
+  await writeFile(path.join(migrationDir, 'down.sql'), 'SELECT 0;\n', 'utf8');
+  await writeFile(path.join(migrationDir, 'meta.json'), '{}\n', 'utf8');
+  await writeFile(path.join(migrationDir, 'plan.json'), '{}\n', 'utf8');
+  return migrationDir;
 }

--- a/packages/cli/src/utils/migration-checksums.ts
+++ b/packages/cli/src/utils/migration-checksums.ts
@@ -1,0 +1,175 @@
+import { createHash } from 'node:crypto';
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { isRecord } from './runtime-guards.js';
+
+export interface MigrationChecksumFile {
+  version: 1;
+  algorithm: 'sha256';
+  checksum: string;
+  files: Record<string, string>;
+}
+
+export interface MigrationIntegrityResult {
+  migrationName: string;
+  ok: boolean;
+  checksum?: string;
+  expectedChecksum?: string;
+  actualChecksum?: string;
+  missingChecksumFile: boolean;
+  changedFiles: string[];
+  missingFiles: string[];
+  extraFiles: string[];
+}
+
+const META_DIR_NAME = 'meta';
+const CHECKSUM_FILE = 'hypequery.sum';
+
+export async function writeMigrationChecksumFile(migrationDir: string): Promise<MigrationChecksumFile> {
+  const checksumFile = await calculateMigrationChecksum(migrationDir);
+  await writeFile(
+    path.join(migrationDir, CHECKSUM_FILE),
+    `${JSON.stringify(checksumFile, null, 2)}\n`,
+    'utf8',
+  );
+  return checksumFile;
+}
+
+export async function calculateMigrationChecksum(migrationDir: string): Promise<MigrationChecksumFile> {
+  const filePaths = await listMigrationFiles(migrationDir);
+  const files: Record<string, string> = {};
+
+  for (const filePath of filePaths) {
+    const contents = await readFile(path.join(migrationDir, filePath));
+    files[filePath] = createHash('sha256').update(contents).digest('hex');
+  }
+
+  const checksum = createHash('sha256');
+  for (const [filePath, fileHash] of Object.entries(files).sort(([left], [right]) => left.localeCompare(right))) {
+    checksum.update(`${filePath}\0${fileHash}\0`);
+  }
+
+  return {
+    version: 1,
+    algorithm: 'sha256',
+    checksum: checksum.digest('hex'),
+    files,
+  };
+}
+
+export async function verifyMigrationIntegrity(migrationsOutDir: string): Promise<MigrationIntegrityResult[]> {
+  const migrationNames = await listMigrationDirectories(migrationsOutDir);
+
+  return Promise.all(migrationNames.map(async migrationName => {
+    const migrationDir = path.join(migrationsOutDir, migrationName);
+    const actual = await calculateMigrationChecksum(migrationDir);
+    const expected = await readMigrationChecksumFile(migrationDir);
+
+    if (!expected) {
+      return {
+        migrationName,
+        ok: false,
+        checksum: actual.checksum,
+        actualChecksum: actual.checksum,
+        missingChecksumFile: true,
+        changedFiles: [],
+        missingFiles: [],
+        extraFiles: Object.keys(actual.files),
+      };
+    }
+
+    const expectedFiles = new Set(Object.keys(expected.files));
+    const actualFiles = new Set(Object.keys(actual.files));
+    const changedFiles = Object.entries(expected.files)
+      .filter(([filePath, fileHash]) => actual.files[filePath] !== undefined && actual.files[filePath] !== fileHash)
+      .map(([filePath]) => filePath);
+    const missingFiles = Array.from(expectedFiles).filter(filePath => !actualFiles.has(filePath));
+    const extraFiles = Array.from(actualFiles).filter(filePath => !expectedFiles.has(filePath));
+    const ok = expected.checksum === actual.checksum &&
+      changedFiles.length === 0 &&
+      missingFiles.length === 0 &&
+      extraFiles.length === 0;
+
+    return {
+      migrationName,
+      ok,
+      checksum: actual.checksum,
+      expectedChecksum: expected.checksum,
+      actualChecksum: actual.checksum,
+      missingChecksumFile: false,
+      changedFiles,
+      missingFiles,
+      extraFiles,
+    };
+  }));
+}
+
+async function listMigrationDirectories(migrationsOutDir: string) {
+  try {
+    const entries = await readdir(migrationsOutDir, { withFileTypes: true });
+    return entries
+      .filter(entry => entry.isDirectory() && entry.name !== META_DIR_NAME)
+      .map(entry => entry.name)
+      .sort();
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function listMigrationFiles(migrationDir: string, relativeDir = ''): Promise<string[]> {
+  const entries = await readdir(path.join(migrationDir, relativeDir), { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const relativePath = path.join(relativeDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await listMigrationFiles(migrationDir, relativePath));
+      continue;
+    }
+    if (entry.isFile() && relativePath !== CHECKSUM_FILE) {
+      files.push(relativePath);
+    }
+  }
+
+  return files.sort();
+}
+
+async function readMigrationChecksumFile(migrationDir: string): Promise<MigrationChecksumFile | null> {
+  const checksumPath = path.join(migrationDir, CHECKSUM_FILE);
+
+  try {
+    const contents = await readFile(checksumPath, 'utf8');
+    const parsed: unknown = JSON.parse(contents);
+    if (
+      isRecord(parsed) &&
+      parsed.version === 1 &&
+      parsed.algorithm === 'sha256' &&
+      typeof parsed.checksum === 'string' &&
+      isStringRecord(parsed.files)
+    ) {
+      return {
+        version: 1,
+        algorithm: 'sha256',
+        checksum: parsed.checksum,
+        files: parsed.files,
+      };
+    }
+    throw new Error(`Invalid migration checksum file: ${path.relative(process.cwd(), checksumPath)}`);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return isRecord(value) && Object.values(value).every(item => typeof item === 'string');
+}
+
+function isNotFoundError(error: unknown) {
+  return isRecord(error) && error.code === 'ENOENT';
+}

--- a/packages/cli/src/utils/migration-state.test.ts
+++ b/packages/cli/src/utils/migration-state.test.ts
@@ -1,0 +1,99 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  getLocalMigrationStatuses,
+  initializeMigrationJournal,
+  appendMigrationJournalEntry,
+} from './migration-state.js';
+import {
+  calculateMigrationChecksum,
+  verifyMigrationIntegrity,
+  writeMigrationChecksumFile,
+} from './migration-checksums.js';
+import { createMigrationFilesFixture } from '../test-utils.js';
+
+let tempDir: string;
+let previousCwd: string;
+
+describe('migration-state checksums', () => {
+  beforeEach(async () => {
+    previousCwd = process.cwd();
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'hypequery-migration-state-'));
+    process.chdir(tempDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(previousCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes and verifies a migration checksum file', async () => {
+    const migrationDir = await createMigrationDir('20260525120000_add_events');
+
+    const checksumFile = await writeMigrationChecksumFile(migrationDir);
+    const written = JSON.parse(await readFile(path.join(migrationDir, 'hypequery.sum'), 'utf8'));
+    const results = await verifyMigrationIntegrity(path.join(tempDir, 'migrations'));
+
+    expect(written.checksum).toEqual(checksumFile.checksum);
+    expect(Object.keys(written.files).sort()).toEqual(['down.sql', 'meta.json', 'plan.json', 'up.sql']);
+    expect(results).toEqual([
+      expect.objectContaining({
+        migrationName: '20260525120000_add_events',
+        ok: true,
+        missingChecksumFile: false,
+      }),
+    ]);
+  });
+
+  it('detects changed migration files', async () => {
+    const migrationDir = await createMigrationDir('20260525120000_add_events');
+    await writeMigrationChecksumFile(migrationDir);
+    await writeFile(path.join(migrationDir, 'up.sql'), 'SELECT 2;\n', 'utf8');
+
+    const results = await verifyMigrationIntegrity(path.join(tempDir, 'migrations'));
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        ok: false,
+        changedFiles: ['up.sql'],
+      }),
+    ]);
+  });
+
+  it('reports local journal migrations as pending with checksum status', async () => {
+    const migrationDir = await createMigrationDir('20260525120000_add_events');
+    const checksumFile = await writeMigrationChecksumFile(migrationDir);
+    await initializeMigrationJournal(path.join(tempDir, 'migrations'), 'snapshot-hash');
+    await appendMigrationJournalEntry(path.join(tempDir, 'migrations'), {
+      name: '20260525120000_add_events',
+      timestamp: '20260525120000',
+      custom: false,
+      sourceSnapshotHash: 'source',
+      targetSnapshotHash: 'target',
+      checksum: checksumFile.checksum,
+    }, 'target');
+
+    await expect(getLocalMigrationStatuses(path.join(tempDir, 'migrations'))).resolves.toEqual([
+      {
+        name: '20260525120000_add_events',
+        custom: false,
+        state: 'pending',
+        checksum: 'ok',
+      },
+    ]);
+  });
+
+  it('does not include hypequery.sum in the canonical checksum', async () => {
+    const migrationDir = await createMigrationDir('20260525120000_add_events');
+    const first = await writeMigrationChecksumFile(migrationDir);
+    const second = await calculateMigrationChecksum(migrationDir);
+
+    expect(second.checksum).toEqual(first.checksum);
+  });
+});
+
+async function createMigrationDir(name: string) {
+  return createMigrationFilesFixture(tempDir, name);
+}

--- a/packages/cli/src/utils/migration-state.ts
+++ b/packages/cli/src/utils/migration-state.ts
@@ -8,6 +8,7 @@ import {
   type MigrationPlan,
   type Snapshot,
 } from '@hypequery/schema';
+import { verifyMigrationIntegrity, writeMigrationChecksumFile } from './migration-checksums.js';
 import { isRecord } from './runtime-guards.js';
 
 export interface MigrationJournalEntry {
@@ -16,13 +17,21 @@ export interface MigrationJournalEntry {
   custom: boolean;
   sourceSnapshotHash: string;
   targetSnapshotHash: string;
+  checksum?: string;
 }
 
-interface MigrationJournal {
+export interface MigrationJournal {
   version: 1;
   dialect: 'clickhouse';
   latestSnapshotHash: string;
   migrations: MigrationJournalEntry[];
+}
+
+export interface LocalMigrationStatus {
+  name: string;
+  custom: boolean;
+  state: 'pending';
+  checksum: 'ok' | 'missing' | 'mismatch';
 }
 
 const META_DIR_NAME = 'meta';
@@ -77,6 +86,10 @@ export async function appendMigrationJournalEntry(
   };
 
   await writeFile(journalPath, `${JSON.stringify(nextJournal, null, 2)}\n`, 'utf8');
+}
+
+export async function readMigrationJournal(migrationsOutDir: string) {
+  return readJournal(path.join(migrationsOutDir, META_DIR_NAME, JOURNAL_FILE));
 }
 
 export async function initializeMigrationJournal(
@@ -134,6 +147,7 @@ export async function writeCustomMigration(input: {
   await writeFile(path.join(migrationDir, 'down.sql'), '-- Write best-effort rollback SQL here.\n', 'utf8');
   await writeFile(path.join(migrationDir, 'meta.json'), `${JSON.stringify(meta, null, 2)}\n`, 'utf8');
   await writeFile(path.join(migrationDir, 'plan.json'), `${JSON.stringify(plan, null, 2)}\n`, 'utf8');
+  const checksumFile = await writeMigrationChecksumFile(migrationDir);
 
   await appendMigrationJournalEntry(input.outDir, {
     name: input.migrationName,
@@ -141,6 +155,7 @@ export async function writeCustomMigration(input: {
     custom: true,
     sourceSnapshotHash: input.previousSnapshot.contentHash,
     targetSnapshotHash: input.previousSnapshot.contentHash,
+    checksum: checksumFile.checksum,
   }, input.previousSnapshot.contentHash);
 }
 
@@ -156,6 +171,22 @@ export async function assertMigrationDoesNotExist(migrationsOutDir: string, migr
   }
 
   throw new Error(`Migration already exists: ${path.relative(process.cwd(), migrationDir)}`);
+}
+
+export async function getLocalMigrationStatuses(migrationsOutDir: string): Promise<LocalMigrationStatus[]> {
+  const journal = await readMigrationJournal(migrationsOutDir);
+  const integrityResults = await verifyMigrationIntegrity(migrationsOutDir);
+  const integrityByName = new Map(integrityResults.map(result => [result.migrationName, result]));
+
+  return journal.migrations.map(entry => {
+    const integrity = integrityByName.get(entry.name);
+    return {
+      name: entry.name,
+      custom: entry.custom,
+      state: 'pending',
+      checksum: !integrity || integrity.missingChecksumFile ? 'missing' : integrity.ok ? 'ok' : 'mismatch',
+    };
+  });
 }
 
 async function readJournal(journalPath: string): Promise<MigrationJournal> {
@@ -207,7 +238,8 @@ function isMigrationJournalEntry(value: unknown): value is MigrationJournalEntry
     typeof value.timestamp === 'string' &&
     typeof value.custom === 'boolean' &&
     typeof value.sourceSnapshotHash === 'string' &&
-    typeof value.targetSnapshotHash === 'string';
+    typeof value.targetSnapshotHash === 'string' &&
+    (value.checksum === undefined || typeof value.checksum === 'string');
 }
 
 function isNotFoundError(error: unknown) {


### PR DESCRIPTION
 ## Summary

  Adds local migration integrity groundwork for the ClickHouse schema migration workflow.

  This introduces checksum files for generated/custom migrations and adds local `migrate:status` / `migrate:check` commands
before the later PR that applies migrations to ClickHouse.

  ## What’s Included

  - Adds `hypequery migrate:status`
    - Reads local migration journal metadata
    - Shows migration name, type, local state, and checksum status
    - Clearly marks migrations as pending because DB apply-state tracking is not implemented yet

  - Adds `hypequery migrate:check`
    - Verifies local migration files against `hypequery.sum`
    - Detects changed, missing, extra, or missing-checksum files
    - Exits with an error when integrity checks fail

  - Adds canonical migration checksums
    - Writes `hypequery.sum` into migration folders
    - Uses SHA-256 over canonical migration file contents
    - Excludes `hypequery.sum` itself from the checksum
    - Stores generated checksum values in `migrations/meta/migrations.json`

  - Updates migration generation
    - `generate:migration` now writes checksum files for generated migrations
    - Custom migrations also get checksum files and journal checksum metadata

  - Keeps implementation split clean
    - Checksum calculation/verification lives in `migration-checksums`
    - Journal/status handling stays in `migration-state`