### PR TITLE
feat: (datasets) Expand schema compatibility checks and improve tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,14 @@ jobs:
           NODE_OPTIONS: "--experimental-vm-modules --experimental-global-webcrypto --no-warnings"
       - name: Run Datasets integration tests
         run: pnpm --filter @hypequery/datasets test:integration
+      - name: Run Serve semantic live integration tests
+        run: pnpm --filter @hypequery/serve test:integration
+        env:
+          CLICKHOUSE_TEST_HOST: http://localhost:8123
+          CLICKHOUSE_TEST_USER: default
+          CLICKHOUSE_TEST_PASSWORD: hypequery_test
+          CLICKHOUSE_TEST_DB: test_db
+          NODE_OPTIONS: "--experimental-vm-modules --experimental-global-webcrypto --no-warnings"
       - name: Run smoke tests
         run: pnpm smoke:examples
   canary-release:

--- a/packages/schema/src/compat/check.test.ts
+++ b/packages/schema/src/compat/check.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { dataset, dimension, eq, measure } from '../../../datasets/dist/index.js';
+import { belongsTo, dataset, dimension, eq, measure } from '../../../datasets/dist/index.js';
 import { checkDatasetsAgainstSchema } from './index.js';
 import { sql } from '../index.js';
 import { column, defineMaterializedView, defineSchema, defineTable } from '../schema/index.js';
@@ -325,5 +325,128 @@ describe('check datasets against schema', () => {
       valid: true,
       diagnostics: [],
     });
+  });
+
+  it('fails when relationship source or target join columns are missing', () => {
+    const Customers = dataset('customers', {
+      source: 'customers',
+      dimensions: {
+        id: dimension.number(),
+      },
+    });
+
+    const Orders = dataset('orders', {
+      source: 'orders',
+      dimensions: {
+        id: dimension.number(),
+        customerId: dimension.number({ column: 'customer_id' }),
+      },
+      relationships: {
+        customer: belongsTo(() => Customers, { from: 'customerId', to: 'id' }),
+      },
+    });
+
+    const snapshot = serializeSchemaToSnapshot(
+      defineSchema({
+        tables: [
+          defineTable('orders', {
+            columns: {
+              id: column.UInt64(),
+            },
+            engine: {
+              type: 'MergeTree',
+              orderBy: ['id'],
+            },
+          }),
+          defineTable('customers', {
+            columns: {
+              name: column.String(),
+            },
+            engine: {
+              type: 'MergeTree',
+              orderBy: ['name'],
+            },
+          }),
+        ],
+      }),
+    );
+
+    const report = checkDatasetsAgainstSchema({ snapshot, datasets: [Orders] });
+
+    expect(report.valid).toBe(false);
+    expect(report.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'MissingRelationshipSourceColumn',
+          fieldName: 'customer.from',
+          physicalColumnName: 'customer_id',
+        }),
+        expect.objectContaining({
+          code: 'MissingRelationshipTargetColumn',
+          fieldName: 'customer.to',
+          physicalColumnName: 'id',
+        }),
+      ]),
+    );
+  });
+
+  it('reports SQL-expression compatibility limitations and checks simple SQL column references', () => {
+    const Orders = dataset('orders', {
+      source: 'orders',
+      dimensions: {
+        netAmount: dimension.number({ sql: 'missing_amount' }),
+        amountBucket: dimension.string({ sql: 'multiIf(amount > 100, "large", "small")' }),
+      },
+      measures: {
+        netRevenue: measure.sum('amount', { sql: 'missing_amount' }),
+        computedRevenue: measure.sum('amount', { sql: 'amount - discount' }),
+      },
+    });
+
+    const snapshot = serializeSchemaToSnapshot(
+      defineSchema({
+        tables: [
+          defineTable('orders', {
+            columns: {
+              id: column.UInt64(),
+              amount: column.Float64(),
+              discount: column.Float64(),
+            },
+            engine: {
+              type: 'MergeTree',
+              orderBy: ['id'],
+            },
+          }),
+        ],
+      }),
+    );
+
+    const report = checkDatasetsAgainstSchema({ snapshot, datasets: [Orders] });
+
+    expect(report.valid).toBe(false);
+    expect(report.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'LimitedSqlExpressionCompatibility',
+          level: 'warning',
+          fieldName: 'netAmount',
+        }),
+        expect.objectContaining({
+          code: 'LimitedSqlExpressionCompatibility',
+          level: 'warning',
+          fieldName: 'amountBucket',
+        }),
+        expect.objectContaining({
+          code: 'MissingDimensionColumn',
+          fieldName: 'netAmount',
+          physicalColumnName: 'missing_amount',
+        }),
+        expect.objectContaining({
+          code: 'MissingMeasureField',
+          fieldName: 'netRevenue',
+          physicalColumnName: 'missing_amount',
+        }),
+      ]),
+    );
   });
 });

--- a/packages/schema/src/compat/check.ts
+++ b/packages/schema/src/compat/check.ts
@@ -4,6 +4,7 @@ import type {
   CompatibilityDimensionDefinition,
   CompatibilityMeasureDefinition,
   CompatibilityMetricFilter,
+  CompatibilityRelationshipTarget,
   DatasetSchemaCompatibilityDiagnostic,
   DatasetSchemaCompatibilityReport,
   SemanticCompatibilityPlanOptions,
@@ -59,6 +60,33 @@ function findSnapshotColumn(table: SnapshotTable, columnName: string): SnapshotC
   return table.columns.find(column => column.name === columnName);
 }
 
+function extractSimpleSqlColumn(sql: string): string | undefined {
+  const identifier = String.raw`(?:[A-Za-z_][A-Za-z0-9_]*|` + '`[^`]+`' + String.raw`|"[^"]+")`;
+  const pattern = new RegExp(String.raw`^\s*(${identifier})(?:\.(${identifier}))?\s*$`);
+  const match = pattern.exec(sql);
+  if (!match) {
+    return undefined;
+  }
+
+  const rawIdentifier = match[2] ?? match[1];
+  return rawIdentifier.replace(/^`(.*)`$/, '$1').replace(/^"(.*)"$/, '$1');
+}
+
+function createSqlExpressionLimitationDiagnostic(
+  ds: CompatibilityDatasetInstance,
+  fieldName: string,
+  expressionKind: 'dimension' | 'measure',
+): DatasetSchemaCompatibilityDiagnostic {
+  return createDiagnostic({
+    level: 'warning',
+    code: 'LimitedSqlExpressionCompatibility',
+    datasetName: ds.name,
+    fieldName,
+    sourceName: ds.source,
+    message: `Schema compatibility for SQL-backed ${expressionKind} "${fieldName}" is limited; complex SQL lineage is not fully analyzed.`,
+  });
+}
+
 function resolveDimensionPhysicalColumn(
   dimensionName: string,
   definition: CompatibilityDimensionDefinition | undefined,
@@ -68,7 +96,7 @@ function resolveDimensionPhysicalColumn(
   }
 
   if (definition.sql) {
-    return undefined;
+    return extractSimpleSqlColumn(definition.sql);
   }
 
   return definition.column ?? dimensionName;
@@ -89,6 +117,13 @@ function resolveMeasureFilterPhysicalColumn(
   return resolveFieldPhysicalColumn(ds, resolvedField);
 }
 
+function resolveRelationshipTargetPhysicalColumn(
+  target: CompatibilityRelationshipTarget,
+  fieldName: string,
+): string | undefined {
+  return resolveDimensionPhysicalColumn(fieldName, target.dimensions?.[fieldName]);
+}
+
 function checkDimensionColumns(
   ds: CompatibilityDatasetInstance,
   sourceTable: SnapshotTable,
@@ -96,6 +131,10 @@ function checkDimensionColumns(
   const diagnostics: DatasetSchemaCompatibilityDiagnostic[] = [];
 
   for (const [dimensionName, definition] of Object.entries(ds.dimensions)) {
+    if (definition.sql) {
+      diagnostics.push(createSqlExpressionLimitationDiagnostic(ds, dimensionName, 'dimension'));
+    }
+
     const columnName = resolveDimensionPhysicalColumn(dimensionName, definition);
     if (!columnName) {
       continue;
@@ -149,7 +188,7 @@ function resolveMeasurePhysicalColumn(
   definition: CompatibilityMeasureDefinition,
 ): string | undefined {
   if (definition.sql) {
-    return undefined;
+    return extractSimpleSqlColumn(definition.sql);
   }
 
   return resolveFieldPhysicalColumn(ds, definition.field);
@@ -196,6 +235,10 @@ function checkMeasureDefinition(
   definition: CompatibilityMeasureDefinition,
 ): DatasetSchemaCompatibilityDiagnostic[] {
   const diagnostics = checkMeasureFilters(ds, sourceTable, measureName, definition.filters);
+  if (definition.sql) {
+    diagnostics.push(createSqlExpressionLimitationDiagnostic(ds, measureName, 'measure'));
+  }
+
   const columnName = resolveMeasurePhysicalColumn(ds, definition);
 
   if (!columnName) {
@@ -231,6 +274,69 @@ function checkMeasureDefinition(
   return diagnostics;
 }
 
+function checkRelationshipDefinitions(
+  snapshot: Snapshot,
+  ds: CompatibilityDatasetInstance,
+  sourceTable: SnapshotTable,
+): DatasetSchemaCompatibilityDiagnostic[] {
+  const diagnostics: DatasetSchemaCompatibilityDiagnostic[] = [];
+
+  for (const [relationshipName, relationship] of Object.entries(ds.relationships ?? {})) {
+    const sourceColumnName = resolveFieldPhysicalColumn(ds, relationship.from) ?? relationship.from;
+    if (!findSnapshotColumn(sourceTable, sourceColumnName)) {
+      diagnostics.push(createDiagnostic({
+        level: 'error',
+        code: 'MissingRelationshipSourceColumn',
+        datasetName: ds.name,
+        fieldName: `${relationshipName}.from`,
+        physicalColumnName: sourceColumnName,
+        sourceName: ds.source,
+        message: `Relationship "${relationshipName}" references missing source column "${sourceColumnName}" on dataset "${ds.name}" source "${ds.source}".`,
+      }));
+    }
+
+    const target = relationship.target();
+    if (!target.source) {
+      diagnostics.push(createDiagnostic({
+        level: 'error',
+        code: 'MissingRelationshipTargetSource',
+        datasetName: ds.name,
+        fieldName: `${relationshipName}.target`,
+        message: `Relationship "${relationshipName}" points to target dataset "${target.name}" without schema compatibility source metadata.`,
+      }));
+      continue;
+    }
+
+    const targetTable = resolveSourceTable(snapshot, target.source);
+    if (!targetTable) {
+      diagnostics.push(createDiagnostic({
+        level: 'error',
+        code: 'MissingRelationshipTargetSource',
+        datasetName: ds.name,
+        fieldName: `${relationshipName}.target`,
+        sourceName: target.source,
+        message: `Relationship "${relationshipName}" points to target dataset "${target.name}" with missing source "${target.source}".`,
+      }));
+      continue;
+    }
+
+    const targetColumnName = resolveRelationshipTargetPhysicalColumn(target, relationship.to) ?? relationship.to;
+    if (!findSnapshotColumn(targetTable, targetColumnName)) {
+      diagnostics.push(createDiagnostic({
+        level: 'error',
+        code: 'MissingRelationshipTargetColumn',
+        datasetName: ds.name,
+        fieldName: `${relationshipName}.to`,
+        physicalColumnName: targetColumnName,
+        sourceName: target.source,
+        message: `Relationship "${relationshipName}" references missing target column "${targetColumnName}" on dataset "${target.name}" source "${target.source}".`,
+      }));
+    }
+  }
+
+  return diagnostics;
+}
+
 function checkDatasetAgainstSchema(
   snapshot: Snapshot,
   ds: CompatibilityDatasetInstance,
@@ -256,6 +362,7 @@ function checkDatasetAgainstSchema(
     ...checkDimensionColumns(ds, sourceTable),
     ...checkKeyColumn(ds, sourceTable, ds.tenantKey, 'MissingTenantKey', 'tenantKey'),
     ...checkKeyColumn(ds, sourceTable, ds.timeKey, 'MissingTimeKey', 'timeKey'),
+    ...checkRelationshipDefinitions(snapshot, ds, sourceTable),
   ];
 
   for (const [measureName, definition] of Object.entries(ds.measures)) {

--- a/packages/schema/src/compat/types.ts
+++ b/packages/schema/src/compat/types.ts
@@ -18,6 +18,19 @@ export interface CompatibilityMeasureDefinition {
   filters?: CompatibilityMetricFilter[];
 }
 
+export interface CompatibilityRelationshipTarget {
+  name: string;
+  source?: string;
+  dimensions?: Record<string, CompatibilityDimensionDefinition>;
+}
+
+export interface CompatibilityRelationshipDefinition {
+  kind: 'belongsTo' | 'hasMany' | 'hasOne';
+  target: () => CompatibilityRelationshipTarget;
+  from: string;
+  to: string;
+}
+
 export interface CompatibilitySemanticFilterDefinition {
   field: string;
 }
@@ -30,6 +43,7 @@ export interface CompatibilityDatasetInstance {
   dimensions: Record<string, CompatibilityDimensionDefinition>;
   measures: Record<string, CompatibilityMeasureDefinition>;
   filters: Record<string, CompatibilitySemanticFilterDefinition>;
+  relationships?: Record<string, CompatibilityRelationshipDefinition>;
 }
 
 export interface CheckDatasetsAgainstSchemaInput {
@@ -44,7 +58,11 @@ export type DatasetSchemaCompatibilityDiagnosticCode =
   | 'MissingTenantKey'
   | 'MissingTimeKey'
   | 'InvalidMeasureFilterField'
-  | 'IncompatibleNumericMeasureType';
+  | 'IncompatibleNumericMeasureType'
+  | 'MissingRelationshipSourceColumn'
+  | 'MissingRelationshipTargetSource'
+  | 'MissingRelationshipTargetColumn'
+  | 'LimitedSqlExpressionCompatibility';
 
 export interface DatasetSchemaCompatibilityDiagnostic {
   level: 'error' | 'warning';

--- a/packages/serve/src/semantic/datasets/serve-live.integration.spec.ts
+++ b/packages/serve/src/semantic/datasets/serve-live.integration.spec.ts
@@ -141,19 +141,35 @@ async function connectToDatabase(
   throw lastError;
 }
 
+async function clickHouseIsReachable(): Promise<boolean> {
+  try {
+    await waitForClickHouse({
+      config: TEST_CONNECTION_CONFIG,
+      maxAttempts: 3,
+      retryDelayMs: 500,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 describe("Serve live integration — datasets", () => {
   (SKIP_INTEGRATION_TESTS ? describe.skip : describe)("ClickHouse-backed dataset endpoints", () => {
     let db: Awaited<ReturnType<typeof initializeTestConnection>>;
     let startedContainer = false;
 
     beforeAll(async () => {
-      const containerRunning = await isContainerRunning(CLICKHOUSE_CONTAINER_NAME);
-      if (!containerRunning) {
-        await startClickHouseContainer();
-        startedContainer = true;
+      if (!await clickHouseIsReachable()) {
+        const containerRunning = await isContainerRunning(CLICKHOUSE_CONTAINER_NAME);
+        if (!containerRunning) {
+          await startClickHouseContainer();
+          startedContainer = true;
+        }
+
+        await waitForClickHouse({ config: TEST_CONNECTION_CONFIG });
       }
 
-      await waitForClickHouse({ config: TEST_CONNECTION_CONFIG });
       await seedClickHouseDatabase({
         config: TEST_CONNECTION_CONFIG,
         data: TEST_DATA,


### PR DESCRIPTION
## Summary

Hardens the pre-release semantic datasets work by expanding schema compatibility checks and wiring the live Serve semantic integration suite into CI.

  ## Changes

  - Add schema compatibility diagnostics for relationship join columns:
    - missing source join columns
    - missing target dataset sources
    - missing target join columns
  - Add explicit warnings for SQL-backed dimensions/measures where compatibility analysis is limited.
  - Still check simple SQL column references when they resolve to a single physical column.
  - Harden Serve live semantic integration setup so it reuses an already reachable ClickHouse service before starting Docker
  compose.
  - Run `@hypequery/serve` live semantic integration tests in CI.