### PR TITLE
feat: (migrations) migrations executions support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,14 @@ jobs:
           CLICKHOUSE_TEST_PASSWORD: hypequery_test
           CLICKHOUSE_TEST_DB: test_db
           NODE_OPTIONS: "--experimental-vm-modules --experimental-global-webcrypto --no-warnings"
+      - name: Run CLI migration integration tests
+        run: pnpm --filter @hypequery/cli test:integration
+        env:
+          CLICKHOUSE_TEST_HOST: http://localhost:8123
+          CLICKHOUSE_TEST_USER: default
+          CLICKHOUSE_TEST_PASSWORD: hypequery_test
+          CLICKHOUSE_TEST_DB: test_db
+          NODE_OPTIONS: "--experimental-vm-modules --experimental-global-webcrypto --no-warnings"
       - name: Run Datasets integration tests
         run: pnpm --filter @hypequery/datasets test:integration
       - name: Run smoke tests

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,8 @@
     "build": "tsc --project tsconfig.json",
     "dev": "tsc --project tsconfig.json --watch",
     "lint": "eslint --ext .ts \"src/**/*.ts\"",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
     "@clickhouse/client": "^1.18.3",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,6 +4,7 @@ import { devCommand, type DevOptions } from './commands/dev.js';
 import { generateCommand, type GenerateOptions } from './commands/generate.js';
 import { generateMigrationCommand, type GenerateMigrationOptions } from './commands/generate-migration.js';
 import { migrationCheckCommand, type MigrationCheckOptions } from './commands/migration-check.js';
+import { migrationDeployCommand, type MigrationDeployOptions } from './commands/migration-deploy.js';
 import { migrationStatusCommand, type MigrationStatusOptions } from './commands/migration-status.js';
 import { pullCommand, type PullOptions } from './commands/pull.js';
 
@@ -104,6 +105,14 @@ program
   }));
 
 program
+  .command('migrate:deploy')
+  .description('Apply pending ClickHouse migrations')
+  .option('-c, --config <path>', 'Config file (default: hypequery.config.ts)')
+  .action(runCommand(async (options: MigrationDeployOptions) => {
+    await migrationDeployCommand(options);
+  }));
+
+program
   .command('migrate:status')
   .description('Show local ClickHouse migration status')
   .option('-c, --config <path>', 'Config file (default: hypequery.config.ts)')
@@ -148,6 +157,7 @@ program.on('--help', () => {
   console.log('  hypequery generate:types --output analytics/schema.ts');
   console.log('  hypequery generate:migration add_orders_table');
   console.log('  hypequery pull');
+  console.log('  hypequery migrate:deploy');
   console.log('  hypequery migrate:status');
   console.log('  hypequery migrate:check');
   console.log('');

--- a/packages/cli/src/commands/migration-check.test.ts
+++ b/packages/cli/src/commands/migration-check.test.ts
@@ -11,6 +11,20 @@ vi.mock('../utils/load-api.js', () => ({
   loadModule: vi.fn(),
 }));
 
+const mockClient = vi.hoisted(() => ({
+  close: vi.fn(),
+}));
+
+const mockFetchAppliedMigrationsIfTableExists = vi.hoisted(() => vi.fn());
+
+vi.mock('../utils/clickhouse-migration-introspection.js', () => ({
+  createMigrationClickHouseClient: vi.fn(() => mockClient),
+}));
+
+vi.mock('../utils/migration-remote-state.js', () => ({
+  fetchAppliedMigrationsIfTableExists: mockFetchAppliedMigrationsIfTableExists,
+}));
+
 const mockLogger = vi.hoisted(() => ({
   success: vi.fn(),
   error: vi.fn(),
@@ -50,6 +64,7 @@ describe('migrate:check command', () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockFetchAppliedMigrationsIfTableExists.mockResolvedValue([]);
 
     previousCwd = process.cwd();
     tempDir = await mkdtemp(path.join(os.tmpdir(), 'hypequery-migration-check-'));
@@ -75,8 +90,47 @@ describe('migrate:check command', () => {
     expect(mockLogger.success).toHaveBeenCalledWith('Verified 1 migration');
   });
 
+  it('exits when an applied remote checksum differs', async () => {
+    const { checksum } = await createMigration('20260525120000_add_events');
+    mockFetchAppliedMigrationsIfTableExists.mockResolvedValue([
+      {
+        name: '20260525120000_add_events',
+        checksum: `${checksum}-remote`,
+        status: 'applied',
+        appliedStepCount: 1,
+        totalSteps: 1,
+      },
+    ]);
+    const { initializeMigrationJournal, appendMigrationJournalEntry } = await import('../utils/migration-state.js');
+    await initializeMigrationJournal(path.join(tempDir, 'migrations'), 'snapshot-hash');
+    await appendMigrationJournalEntry(path.join(tempDir, 'migrations'), {
+      name: '20260525120000_add_events',
+      timestamp: '20260525120000',
+      custom: false,
+      sourceSnapshotHash: 'source',
+      targetSnapshotHash: 'target',
+      checksum,
+    }, 'target');
+    const { migrationCheckCommand } = await import('./migration-check.js');
+
+    await expect(migrationCheckCommand()).rejects.toBeInstanceOf(ProcessExitError);
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('applied checksum does not match'));
+  });
+
+  it('succeeds with local checks when remote state is unavailable', async () => {
+    await createMigration('20260525120000_add_events');
+    mockFetchAppliedMigrationsIfTableExists.mockRejectedValue(new Error('connection refused'));
+    const { migrationCheckCommand } = await import('./migration-check.js');
+
+    await migrationCheckCommand();
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('checked local files only'));
+    expect(mockLogger.success).toHaveBeenCalledWith('Verified 1 migration');
+  });
+
   it('exits when a migration file changed', async () => {
-    const migrationDir = await createMigration('20260525120000_add_events');
+    const { migrationDir } = await createMigration('20260525120000_add_events');
     await writeFile(path.join(migrationDir, 'up.sql'), 'SELECT 2;\n', 'utf8');
     const { migrationCheckCommand } = await import('./migration-check.js');
 
@@ -97,8 +151,8 @@ describe('migrate:check command', () => {
 
 async function createMigration(name: string) {
   const migrationDir = await createMigrationFilesFixture(tempDir, name);
-  await writeMigrationChecksumFile(migrationDir);
-  return migrationDir;
+  const checksum = await writeMigrationChecksumFile(migrationDir);
+  return { migrationDir, checksum: checksum.checksum };
 }
 
 function configFixture() {

--- a/packages/cli/src/commands/migration-check.ts
+++ b/packages/cli/src/commands/migration-check.ts
@@ -1,8 +1,11 @@
 import path from 'node:path';
 import ora from 'ora';
+import { createMigrationClickHouseClient } from '../utils/clickhouse-migration-introspection.js';
 import { loadHypequeryConfig } from '../utils/load-hypequery-config.js';
 import { logger } from '../utils/logger.js';
+import { fetchAppliedMigrationsIfTableExists } from '../utils/migration-remote-state.js';
 import { verifyMigrationIntegrity } from '../utils/migration-checksums.js';
+import { readMigrationJournal } from '../utils/migration-state.js';
 
 export interface MigrationCheckOptions {
   config?: string;
@@ -17,7 +20,10 @@ export async function migrationCheckCommand(options: MigrationCheckOptions = {})
     const migrationsOutDir = path.resolve(process.cwd(), config.migrations.out);
 
     const spinner = ora('Checking migration files...').start();
-    const results = await verifyMigrationIntegrity(migrationsOutDir);
+    const [results, journal] = await Promise.all([
+      verifyMigrationIntegrity(migrationsOutDir),
+      readMigrationJournal(migrationsOutDir),
+    ]);
     spinner.succeed('Checked migration files');
 
     if (results.length === 0) {
@@ -28,6 +34,27 @@ export async function migrationCheckCommand(options: MigrationCheckOptions = {})
 
     const failures = results.filter(result => !result.ok);
     if (failures.length === 0) {
+      const remoteSpinner = ora('Checking applied migration checksums...').start();
+      const remoteResult = await checkRemoteMigrationChecksums({
+        migrationTable: config.migrations.table,
+        credentials: config.dbCredentials,
+        journal,
+      });
+      remoteSpinner.succeed(remoteResult.checkedRemote
+        ? 'Checked applied migration checksums'
+        : 'Skipped applied migration checksums');
+
+      if (remoteResult.warning) {
+        logger.warn(remoteResult.warning);
+      }
+
+      if (remoteResult.mismatches.length > 0) {
+        for (const mismatch of remoteResult.mismatches) {
+          logger.warn(`${mismatch.name}: applied checksum does not match local files`);
+        }
+        throw new Error(`${remoteResult.mismatches.length} applied migration${remoteResult.mismatches.length === 1 ? '' : 's'} failed remote checksum checks.`);
+      }
+
       logger.success(`Verified ${results.length} migration${results.length === 1 ? '' : 's'}`);
       logger.newline();
       return;
@@ -64,4 +91,38 @@ function formatIntegrityFailure(failure: {
   ];
 
   return `${failure.migrationName}: ${details.join(', ')}`;
+}
+
+async function checkRemoteMigrationChecksums(input: {
+  migrationTable: string;
+  credentials: Parameters<typeof createMigrationClickHouseClient>[0];
+  journal: Awaited<ReturnType<typeof readMigrationJournal>>;
+}) {
+  const client = createMigrationClickHouseClient(input.credentials);
+  try {
+    const applied = await fetchAppliedMigrationsIfTableExists({
+      client,
+      migrationTable: input.migrationTable,
+    });
+    const journalByName = new Map(input.journal.migrations.map(entry => [entry.name, entry]));
+    return {
+      checkedRemote: true,
+      mismatches: applied.filter(entry => {
+        const local = journalByName.get(entry.name);
+        return entry.status === 'applied' && local?.checksum !== undefined && local.checksum !== entry.checksum;
+      }),
+    };
+  } catch (error) {
+    return {
+      checkedRemote: false,
+      mismatches: [],
+      warning: `Remote migration state unavailable; checked local files only. ${formatError(error)}`,
+    };
+  } finally {
+    await client.close();
+  }
+}
+
+function formatError(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/cli/src/commands/migration-deploy.test.ts
+++ b/packages/cli/src/commands/migration-deploy.test.ts
@@ -1,0 +1,119 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockProcessExit, ProcessExitError } from '../test-utils.js';
+
+type LoadModule = typeof import('../utils/load-api.js')['loadModule'];
+
+vi.mock('../utils/load-api.js', () => ({
+  loadModule: vi.fn(),
+}));
+
+const mockApplyPendingMigrations = vi.hoisted(() => vi.fn());
+
+vi.mock('../utils/migration-execution.js', () => ({
+  applyPendingMigrations: mockApplyPendingMigrations,
+}));
+
+const mockLogger = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  reload: vi.fn(),
+  header: vi.fn(),
+  newline: vi.fn(),
+  indent: vi.fn(),
+  box: vi.fn(),
+  table: vi.fn(),
+  raw: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: mockLogger,
+}));
+
+const mockSpinner = vi.hoisted(() => ({
+  start: vi.fn().mockReturnThis(),
+  succeed: vi.fn().mockReturnThis(),
+  fail: vi.fn().mockReturnThis(),
+  stop: vi.fn().mockReturnThis(),
+}));
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => mockSpinner),
+}));
+
+let tempDir: string;
+let previousCwd: string;
+
+describe('migrate:deploy command', () => {
+  let exitHandler: ReturnType<typeof mockProcessExit>;
+  let loadModule: ReturnType<typeof vi.mocked<LoadModule>>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    previousCwd = process.cwd();
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'hypequery-migration-deploy-'));
+    process.chdir(tempDir);
+    exitHandler = mockProcessExit();
+
+    ({ loadModule } = await import('../utils/load-api.js'));
+    loadModule.mockResolvedValue({ default: configFixture() });
+  });
+
+  afterEach(async () => {
+    exitHandler.restore();
+    process.chdir(previousCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('applies pending migrations', async () => {
+    mockApplyPendingMigrations.mockResolvedValue([
+      {
+        name: '20260525120000_add_events',
+        state: 'applied',
+        appliedStepCount: 1,
+        totalSteps: 1,
+      },
+    ]);
+    const { migrationDeployCommand } = await import('./migration-deploy.js');
+
+    await migrationDeployCommand();
+
+    expect(mockApplyPendingMigrations).toHaveBeenCalledWith(expect.objectContaining({
+      migrationsOutDir: expect.stringMatching(/hypequery-migration-deploy-.+\/migrations$/),
+      migrationTable: '_hypequery_migrations',
+    }));
+    expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Distributed migration locking'));
+    expect(mockLogger.success).toHaveBeenCalledWith('Applied 1 migration.');
+  });
+
+  it('exits when apply fails', async () => {
+    mockApplyPendingMigrations.mockRejectedValue(new Error('apply failed'));
+    const { migrationDeployCommand } = await import('./migration-deploy.js');
+
+    await expect(migrationDeployCommand()).rejects.toBeInstanceOf(ProcessExitError);
+
+    expect(mockLogger.error).toHaveBeenCalledWith('apply failed');
+  });
+});
+
+function configFixture() {
+  return {
+    dialect: 'clickhouse',
+    schema: './schema.ts',
+    migrations: {
+      out: './migrations',
+      table: '_hypequery_migrations',
+    },
+    dbCredentials: {
+      host: 'localhost',
+      username: 'default',
+      database: 'analytics',
+    },
+  };
+}

--- a/packages/cli/src/commands/migration-deploy.ts
+++ b/packages/cli/src/commands/migration-deploy.ts
@@ -1,0 +1,67 @@
+import path from 'node:path';
+import ora from 'ora';
+import { applyPendingMigrations } from '../utils/migration-execution.js';
+import { loadHypequeryConfig } from '../utils/load-hypequery-config.js';
+import { logger } from '../utils/logger.js';
+
+export interface MigrationDeployOptions {
+  config?: string;
+}
+
+export async function migrationDeployCommand(options: MigrationDeployOptions = {}) {
+  logger.newline();
+  logger.header('hypequery migrate:deploy');
+
+  try {
+    const config = await loadHypequeryConfig(options.config);
+    const migrationsOutDir = path.resolve(process.cwd(), config.migrations.out);
+
+    logger.warn('Distributed migration locking is not implemented yet; run only one deploy process at a time.');
+    logger.warn('ClickHouse DDL is not transactional. Failed migrations may leave partial side effects.');
+
+    const spinner = ora('Applying pending migrations...').start();
+    const results = await applyPendingMigrations({
+      migrationsOutDir,
+      migrationTable: config.migrations.table,
+      credentials: config.dbCredentials,
+      cluster: config.cluster?.name,
+    });
+    spinner.succeed('Checked remote migration state');
+
+    const applied = results.filter(result => result.state === 'applied');
+    const skipped = results.filter(result => result.state === 'skipped');
+
+    if (results.length === 0) {
+      logger.info('No local migrations found.');
+      logger.newline();
+      return;
+    }
+
+    if (applied.length > 0) {
+      logger.table(
+        ['Migration', 'State', 'Steps'],
+        applied.map(result => [
+          result.name,
+          result.state,
+          `${result.appliedStepCount}/${result.totalSteps}`,
+        ]),
+      );
+    }
+
+    if (skipped.length > 0) {
+      logger.info(`Skipped ${skipped.length} already-applied migration${skipped.length === 1 ? '' : 's'}.`);
+    }
+
+    if (applied.length === 0) {
+      logger.success('No pending migrations.');
+    } else {
+      logger.success(`Applied ${applied.length} migration${applied.length === 1 ? '' : 's'}.`);
+    }
+    logger.newline();
+  } catch (error) {
+    logger.newline();
+    logger.error(error instanceof Error ? error.message : String(error));
+    logger.newline();
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/commands/migration-status.test.ts
+++ b/packages/cli/src/commands/migration-status.test.ts
@@ -15,6 +15,20 @@ vi.mock('../utils/load-api.js', () => ({
   loadModule: vi.fn(),
 }));
 
+const mockClient = vi.hoisted(() => ({
+  close: vi.fn(),
+}));
+
+const mockFetchAppliedMigrationsIfTableExists = vi.hoisted(() => vi.fn());
+
+vi.mock('../utils/clickhouse-migration-introspection.js', () => ({
+  createMigrationClickHouseClient: vi.fn(() => mockClient),
+}));
+
+vi.mock('../utils/migration-remote-state.js', () => ({
+  fetchAppliedMigrationsIfTableExists: mockFetchAppliedMigrationsIfTableExists,
+}));
+
 const mockLogger = vi.hoisted(() => ({
   success: vi.fn(),
   error: vi.fn(),
@@ -54,6 +68,7 @@ describe('migrate:status command', () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockFetchAppliedMigrationsIfTableExists.mockResolvedValue([]);
 
     previousCwd = process.cwd();
     tempDir = await mkdtemp(path.join(os.tmpdir(), 'hypequery-migration-status-'));
@@ -77,10 +92,44 @@ describe('migrate:status command', () => {
     await migrationStatusCommand();
 
     expect(mockLogger.table).toHaveBeenCalledWith(
-      ['Migration', 'Type', 'State', 'Checksum'],
-      [['20260525120000_add_events', 'generated', 'pending', 'ok']],
+      ['Migration', 'Type', 'State', 'Checksum', 'Remote', 'Steps'],
+      [['20260525120000_add_events', 'generated', 'pending', 'ok', '-', '-']],
     );
-    expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('Apply-state tracking is not implemented yet'));
+  });
+
+  it('shows applied remote migrations with step progress', async () => {
+    const checksum = await createJournaledMigration('20260525120000_add_events');
+    mockFetchAppliedMigrationsIfTableExists.mockResolvedValue([
+      {
+        name: '20260525120000_add_events',
+        checksum,
+        status: 'applied',
+        appliedStepCount: 2,
+        totalSteps: 2,
+      },
+    ]);
+    const { migrationStatusCommand } = await import('./migration-status.js');
+
+    await migrationStatusCommand();
+
+    expect(mockLogger.table).toHaveBeenCalledWith(
+      ['Migration', 'Type', 'State', 'Checksum', 'Remote', 'Steps'],
+      [['20260525120000_add_events', 'generated', 'applied', 'ok', 'ok', '2/2']],
+    );
+  });
+
+  it('falls back to local status when remote state is unavailable', async () => {
+    await createJournaledMigration('20260525120000_add_events');
+    mockFetchAppliedMigrationsIfTableExists.mockRejectedValue(new Error('connection refused'));
+    const { migrationStatusCommand } = await import('./migration-status.js');
+
+    await migrationStatusCommand();
+
+    expect(mockLogger.table).toHaveBeenCalledWith(
+      ['Migration', 'Type', 'State', 'Checksum', 'Remote', 'Steps'],
+      [['20260525120000_add_events', 'generated', 'pending', 'ok', '-', '-']],
+    );
+    expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('showing local status only'));
   });
 
   it('reports no local migrations', async () => {
@@ -105,6 +154,7 @@ async function createJournaledMigration(name: string) {
     targetSnapshotHash: 'target',
     checksum: checksumFile.checksum,
   }, 'target');
+  return checksumFile.checksum;
 }
 
 function configFixture() {

--- a/packages/cli/src/commands/migration-status.ts
+++ b/packages/cli/src/commands/migration-status.ts
@@ -1,7 +1,9 @@
 import path from 'node:path';
 import ora from 'ora';
+import { createMigrationClickHouseClient } from '../utils/clickhouse-migration-introspection.js';
 import { loadHypequeryConfig } from '../utils/load-hypequery-config.js';
 import { logger } from '../utils/logger.js';
+import { fetchAppliedMigrationsIfTableExists } from '../utils/migration-remote-state.js';
 import { getLocalMigrationStatuses } from '../utils/migration-state.js';
 
 export interface MigrationStatusOptions {
@@ -17,7 +19,11 @@ export async function migrationStatusCommand(options: MigrationStatusOptions = {
     const migrationsOutDir = path.resolve(process.cwd(), config.migrations.out);
 
     const spinner = ora('Reading migration metadata...').start();
-    const statuses = await getLocalMigrationStatuses(migrationsOutDir);
+    const remoteState = await readRemoteMigrationState({
+      migrationTable: config.migrations.table,
+      credentials: config.dbCredentials,
+    });
+    const statuses = await getLocalMigrationStatuses(migrationsOutDir, remoteState.appliedMigrations);
     spinner.succeed('Read migration metadata');
 
     if (statuses.length === 0) {
@@ -27,16 +33,19 @@ export async function migrationStatusCommand(options: MigrationStatusOptions = {
     }
 
     logger.table(
-      ['Migration', 'Type', 'State', 'Checksum'],
+      ['Migration', 'Type', 'State', 'Checksum', 'Remote', 'Steps'],
       statuses.map(status => [
         status.name,
         status.custom ? 'custom' : 'generated',
         status.state,
         status.checksum,
+        status.remoteChecksum ?? '-',
+        status.progress ?? '-',
       ]),
     );
-    logger.newline();
-    logger.info('Apply-state tracking is not implemented yet; local migrations are shown as pending.');
+    if (remoteState.warning) {
+      logger.warn(remoteState.warning);
+    }
     logger.newline();
   } catch (error) {
     logger.newline();
@@ -44,4 +53,30 @@ export async function migrationStatusCommand(options: MigrationStatusOptions = {
     logger.newline();
     process.exit(1);
   }
+}
+
+async function readRemoteMigrationState(input: {
+  migrationTable: string;
+  credentials: Parameters<typeof createMigrationClickHouseClient>[0];
+}) {
+  const client = createMigrationClickHouseClient(input.credentials);
+  try {
+    return {
+      appliedMigrations: await fetchAppliedMigrationsIfTableExists({
+        client,
+        migrationTable: input.migrationTable,
+      }),
+    };
+  } catch (error) {
+    return {
+      appliedMigrations: [],
+      warning: `Remote migration state unavailable; showing local status only. ${formatError(error)}`,
+    };
+  } finally {
+    await client.close();
+  }
+}
+
+function formatError(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -6,7 +6,7 @@ import { loadHypequeryConfig } from '../utils/load-hypequery-config.js';
 import { logger } from '../utils/logger.js';
 import { relativeSchemaPath, writeSchemaFileFromSnapshot } from '../utils/migration-schema-emitter.js';
 import { initializeMigrationJournal, writeLatestMigrationSnapshot } from '../utils/migration-state.js';
-import { isRecord } from '../utils/runtime-guards.js';
+import { isNotFoundError } from '../utils/runtime-guards.js';
 
 export interface PullOptions {
   config?: string;
@@ -93,8 +93,4 @@ function parseTableList(value: string | undefined) {
     ?.split(',')
     .map(table => table.trim())
     .filter(Boolean);
-}
-
-function isNotFoundError(error: unknown) {
-  return isRecord(error) && error.code === 'ENOENT';
 }

--- a/packages/cli/src/utils/clickhouse-migration-introspection.ts
+++ b/packages/cli/src/utils/clickhouse-migration-introspection.ts
@@ -1,6 +1,7 @@
 import { createClient, type ClickHouseClient } from '@clickhouse/client';
 import type { ClickHouseMigrationDbCredentials, Snapshot, SnapshotColumn, SnapshotTable } from '@hypequery/schema';
 import { hashSnapshot } from '@hypequery/schema';
+import { sqlString } from './clickhouse-sql.js';
 import { splitTopLevelArgs } from './clickhouse-type-utils.js';
 
 export interface IntrospectClickHouseSchemaOptions {
@@ -185,8 +186,4 @@ function parseEngineSettings(engineFull: string): Record<string, string> {
       .map(setting => setting.split(/\s*=\s*/, 2))
       .filter((entry): entry is [string, string] => entry.length === 2 && entry[0].length > 0),
   );
-}
-
-function sqlString(value: string) {
-  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
 }

--- a/packages/cli/src/utils/clickhouse-sql.test.ts
+++ b/packages/cli/src/utils/clickhouse-sql.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertValidIdentifier,
+  quoteIdentifier,
+  sqlDateTime,
+  sqlString,
+  sqlStringArray,
+} from './clickhouse-sql.js';
+
+describe('clickhouse sql helpers', () => {
+  it('quotes safe identifiers', () => {
+    expect(quoteIdentifier('_hypequery_migrations')).toBe('`_hypequery_migrations`');
+  });
+
+  it('rejects unsafe identifiers', () => {
+    expect(() => assertValidIdentifier('system.tables')).toThrow('Invalid ClickHouse identifier');
+  });
+
+  it('escapes string literals', () => {
+    expect(sqlString("can't\\stop")).toBe("'can\\'t\\\\stop'");
+  });
+
+  it('renders arrays and dates', () => {
+    expect(sqlStringArray(['a', 'b'])).toBe("['a', 'b']");
+    expect(sqlDateTime(new Date('2026-05-26T10:00:00.000Z')))
+      .toBe("parseDateTime64BestEffort('2026-05-26T10:00:00.000Z', 3)");
+  });
+});

--- a/packages/cli/src/utils/clickhouse-sql.ts
+++ b/packages/cli/src/utils/clickhouse-sql.ts
@@ -1,0 +1,22 @@
+export function quoteIdentifier(identifier: string): string {
+  assertValidIdentifier(identifier);
+  return `\`${identifier.replace(/`/g, '``')}\``;
+}
+
+export function assertValidIdentifier(identifier: string) {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier)) {
+    throw new Error(`Invalid ClickHouse identifier: ${identifier}`);
+  }
+}
+
+export function sqlString(value: string) {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+export function sqlStringArray(values: string[]) {
+  return `[${values.map(sqlString).join(', ')}]`;
+}
+
+export function sqlDateTime(value: Date) {
+  return `parseDateTime64BestEffort(${sqlString(value.toISOString())}, 3)`;
+}

--- a/packages/cli/src/utils/migration-checksums.ts
+++ b/packages/cli/src/utils/migration-checksums.ts
@@ -1,7 +1,7 @@
-import { createHash } from 'node:crypto';
 import { readFile, readdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { isRecord } from './runtime-guards.js';
+import { isNotFoundError, isRecord } from './runtime-guards.js';
+import { sha256 } from './sha256.js';
 
 export interface MigrationChecksumFile {
   version: 1;
@@ -41,18 +41,18 @@ export async function calculateMigrationChecksum(migrationDir: string): Promise<
 
   for (const filePath of filePaths) {
     const contents = await readFile(path.join(migrationDir, filePath));
-    files[filePath] = createHash('sha256').update(contents).digest('hex');
+    files[filePath] = sha256(contents);
   }
 
-  const checksum = createHash('sha256');
+  let checksumInput = '';
   for (const [filePath, fileHash] of Object.entries(files).sort(([left], [right]) => left.localeCompare(right))) {
-    checksum.update(`${filePath}\0${fileHash}\0`);
+    checksumInput += `${filePath}\0${fileHash}\0`;
   }
 
   return {
     version: 1,
     algorithm: 'sha256',
-    checksum: checksum.digest('hex'),
+    checksum: sha256(checksumInput),
     files,
   };
 }
@@ -168,8 +168,4 @@ async function readMigrationChecksumFile(migrationDir: string): Promise<Migratio
 
 function isStringRecord(value: unknown): value is Record<string, string> {
   return isRecord(value) && Object.values(value).every(item => typeof item === 'string');
-}
-
-function isNotFoundError(error: unknown) {
-  return isRecord(error) && error.code === 'ENOENT';
 }

--- a/packages/cli/src/utils/migration-execution.integration.test.ts
+++ b/packages/cli/src/utils/migration-execution.integration.test.ts
@@ -1,0 +1,166 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { applyPendingMigrations } from './migration-execution.js';
+import { fetchAppliedMigrations } from './migration-remote-state.js';
+import { createMigrationClickHouseClient } from './clickhouse-migration-introspection.js';
+import { writeMigrationChecksumFile } from './migration-checksums.js';
+import {
+  appendMigrationJournalEntry,
+  initializeMigrationJournal,
+} from './migration-state.js';
+import { quoteIdentifier } from './clickhouse-sql.js';
+import type { ClickHouseMigrationDbCredentials } from '@hypequery/schema';
+
+const shouldSkipIntegration = process.env.SKIP_INTEGRATION_TESTS === 'true' ||
+  (!process.env.CLICKHOUSE_TEST_HOST && !process.env.CLICKHOUSE_URL);
+
+const testSuite = shouldSkipIntegration ? describe.skip : describe;
+
+testSuite('migration execution integration', () => {
+  const suffix = `${Date.now()}_${process.pid}`;
+  const migrationTable = `_hq_migrations_${suffix}`;
+  const successTable = `hq_migration_success_${suffix}`;
+  const failedTable = `hq_migration_failed_${suffix}`;
+  let tempDir: string;
+  let client: ReturnType<typeof createMigrationClickHouseClient>;
+
+  beforeAll(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'hypequery-cli-migrations-live-'));
+    client = createMigrationClickHouseClient(clickhouseCredentials());
+    await client.ping();
+  });
+
+  afterAll(async () => {
+    if (client) {
+      await client.command({ query: `DROP TABLE IF EXISTS ${quoteIdentifier(successTable)}` }).catch(ignoreCleanupError);
+      await client.command({ query: `DROP TABLE IF EXISTS ${quoteIdentifier(failedTable)}` }).catch(ignoreCleanupError);
+      await client.command({ query: `DROP TABLE IF EXISTS ${quoteIdentifier(migrationTable)}` }).catch(ignoreCleanupError);
+      await client.close();
+    }
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('applies and records a migration against ClickHouse', async () => {
+    const migrationsOutDir = path.join(tempDir, 'success');
+    const migrationName = '20260526120000_create_success_table';
+    await writeMigrationFixture({
+      migrationsOutDir,
+      migrationName,
+      upSql: [
+        `CREATE TABLE ${quoteIdentifier(successTable)} (id UInt64, name String) ENGINE = MergeTree ORDER BY id;`,
+        '-- hypequery:breakpoint',
+        `INSERT INTO ${quoteIdentifier(successTable)} VALUES (1, 'ok');`,
+      ].join('\n'),
+    });
+
+    await expect(applyPendingMigrations({
+      migrationsOutDir,
+      migrationTable,
+      credentials: clickhouseCredentials(),
+      appliedUser: 'integration-test',
+    })).resolves.toEqual([
+      {
+        name: migrationName,
+        state: 'applied',
+        appliedStepCount: 2,
+        totalSteps: 2,
+      },
+    ]);
+
+    const countResult = await client.query({
+      query: `SELECT count() AS count FROM ${quoteIdentifier(successTable)}`,
+      format: 'JSONEachRow',
+    });
+    const countRows = await countResult.json<{ count: string | number }>();
+    expect(Number(countRows[0].count)).toBe(1);
+
+    const applied = await fetchAppliedMigrations({ client, migrationTable });
+    expect(applied).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: migrationName,
+        status: 'applied',
+        appliedStepCount: 2,
+        totalSteps: 2,
+      }),
+    ]));
+  });
+
+  it('records dirty state after a real ClickHouse statement failure', async () => {
+    const migrationsOutDir = path.join(tempDir, 'failure');
+    const migrationName = '20260526120500_fail_after_create';
+    await writeMigrationFixture({
+      migrationsOutDir,
+      migrationName,
+      upSql: [
+        `CREATE TABLE ${quoteIdentifier(failedTable)} (id UInt64) ENGINE = MergeTree ORDER BY id;`,
+        '-- hypequery:breakpoint',
+        `ALTER TABLE ${quoteIdentifier(failedTable)} ADD COLUMN id UInt64;`,
+      ].join('\n'),
+    });
+
+    await expect(applyPendingMigrations({
+      migrationsOutDir,
+      migrationTable,
+      credentials: clickhouseCredentials(),
+      appliedUser: 'integration-test',
+    })).rejects.toThrow('failed at statement 2/2');
+
+    const applied = await fetchAppliedMigrations({ client, migrationTable });
+    expect(applied).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: migrationName,
+        status: 'failed',
+        appliedStepCount: 1,
+        totalSteps: 2,
+      }),
+    ]));
+
+    await expect(applyPendingMigrations({
+      migrationsOutDir,
+      migrationTable,
+      credentials: clickhouseCredentials(),
+      appliedUser: 'integration-test',
+    })).rejects.toThrow('Remote migration state is dirty');
+  });
+});
+
+async function writeMigrationFixture(input: {
+  migrationsOutDir: string;
+  migrationName: string;
+  upSql: string;
+}) {
+  const migrationDir = path.join(input.migrationsOutDir, input.migrationName);
+  await mkdir(migrationDir, { recursive: true });
+  await writeFile(path.join(migrationDir, 'up.sql'), `${input.upSql}\n`, 'utf8');
+  await writeFile(path.join(migrationDir, 'down.sql'), '-- no down migration\n', 'utf8');
+  await writeFile(path.join(migrationDir, 'meta.json'), '{}\n', 'utf8');
+  await writeFile(path.join(migrationDir, 'plan.json'), '{}\n', 'utf8');
+
+  const checksum = await writeMigrationChecksumFile(migrationDir);
+  await initializeMigrationJournal(input.migrationsOutDir, 'source-snapshot');
+  await appendMigrationJournalEntry(input.migrationsOutDir, {
+    name: input.migrationName,
+    timestamp: input.migrationName.slice(0, 14),
+    custom: false,
+    sourceSnapshotHash: 'source-snapshot',
+    targetSnapshotHash: 'target-snapshot',
+    checksum: checksum.checksum,
+  }, 'target-snapshot');
+}
+
+function clickhouseCredentials(): ClickHouseMigrationDbCredentials {
+  return {
+    host: process.env.CLICKHOUSE_TEST_HOST ?? process.env.CLICKHOUSE_URL ?? 'http://localhost:8123',
+    username: process.env.CLICKHOUSE_TEST_USER ?? process.env.CLICKHOUSE_USERNAME ?? 'default',
+    password: process.env.CLICKHOUSE_TEST_PASSWORD ?? process.env.CLICKHOUSE_PASSWORD ?? '',
+    database: process.env.CLICKHOUSE_TEST_DB ?? process.env.CLICKHOUSE_DATABASE ?? 'default',
+  };
+}
+
+function ignoreCleanupError(error: unknown) {
+  void error;
+}

--- a/packages/cli/src/utils/migration-execution.test.ts
+++ b/packages/cli/src/utils/migration-execution.test.ts
@@ -1,0 +1,184 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMigrationFilesFixture } from '../test-utils.js';
+import { writeMigrationChecksumFile } from './migration-checksums.js';
+import { appendMigrationJournalEntry, initializeMigrationJournal } from './migration-state.js';
+import {
+  applyPendingMigrations,
+  splitMigrationStatements,
+  type MigrationExecutionClient,
+} from './migration-execution.js';
+
+let tempDir: string;
+let previousCwd: string;
+
+describe('migration execution', () => {
+  beforeEach(async () => {
+    previousCwd = process.cwd();
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'hypequery-migration-execution-'));
+    process.chdir(tempDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(previousCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('splits statements by explicit breakpoints', () => {
+    expect(splitMigrationStatements([
+      'CREATE TABLE events (id UInt64);',
+      '-- hypequery:breakpoint',
+      'ALTER TABLE events ADD COLUMN name String;',
+    ].join('\n'))).toEqual([
+      'CREATE TABLE events (id UInt64);',
+      'ALTER TABLE events ADD COLUMN name String;',
+    ]);
+  });
+
+  it('splits semicolons outside string literals', () => {
+    expect(splitMigrationStatements("SELECT ';';\nSELECT 2;")).toEqual([
+      "SELECT ';';",
+      'SELECT 2;',
+    ]);
+  });
+
+  it('skips comment-only statements', () => {
+    expect(splitMigrationStatements([
+      '-- Write custom migration SQL here.',
+      '/* block comment with ; semicolon */',
+    ].join('\n'))).toEqual([
+    ]);
+  });
+
+  it('applies pending migrations and records execution rows', async () => {
+    const name = '20260525120000_add_events';
+    const migrationDir = await createMigrationFilesFixture(tempDir, name);
+    const checksum = await writeMigrationChecksumFile(migrationDir);
+    await initializeMigrationJournal(path.join(tempDir, 'migrations'), 'snapshot-hash');
+    await appendMigrationJournalEntry(path.join(tempDir, 'migrations'), {
+      name,
+      timestamp: '20260525120000',
+      custom: false,
+      sourceSnapshotHash: 'source',
+      targetSnapshotHash: 'target',
+      checksum: checksum.checksum,
+    }, 'target');
+    const command = vi.fn().mockResolvedValue(undefined);
+    const client: MigrationExecutionClient = {
+      command,
+      query: vi.fn().mockResolvedValue({
+        json: async () => [],
+      }),
+    };
+
+    await expect(applyPendingMigrations({
+      migrationsOutDir: path.join(tempDir, 'migrations'),
+      migrationTable: '_hypequery_migrations',
+      credentials: {
+        host: 'localhost',
+        username: 'default',
+        database: 'analytics',
+      },
+      appliedUser: 'tester',
+      client,
+    })).resolves.toEqual([
+      {
+        name,
+        state: 'applied',
+        appliedStepCount: 1,
+        totalSteps: 1,
+      },
+    ]);
+
+    expect(command).toHaveBeenCalledWith(expect.objectContaining({
+      query: expect.stringContaining('CREATE TABLE IF NOT EXISTS `_hypequery_migrations`'),
+    }));
+    expect(command).toHaveBeenCalledWith({ query: 'SELECT 1;' });
+    expect(command).toHaveBeenCalledWith(expect.objectContaining({
+      query: expect.stringContaining("'applied'"),
+    }));
+  });
+
+  it('rejects pending migrations when the journal checksum is stale', async () => {
+    const name = '20260525120000_add_events';
+    const migrationDir = await createMigrationFilesFixture(tempDir, name);
+    await writeMigrationChecksumFile(migrationDir);
+    await initializeMigrationJournal(path.join(tempDir, 'migrations'), 'snapshot-hash');
+    await appendMigrationJournalEntry(path.join(tempDir, 'migrations'), {
+      name,
+      timestamp: '20260525120000',
+      custom: false,
+      sourceSnapshotHash: 'source',
+      targetSnapshotHash: 'target',
+      checksum: 'stale',
+    }, 'target');
+    const client: MigrationExecutionClient = {
+      command: vi.fn().mockResolvedValue(undefined),
+      query: vi.fn().mockResolvedValue({
+        json: async () => [],
+      }),
+    };
+
+    await expect(applyPendingMigrations({
+      migrationsOutDir: path.join(tempDir, 'migrations'),
+      migrationTable: '_hypequery_migrations',
+      credentials: {
+        host: 'localhost',
+        username: 'default',
+        database: 'analytics',
+      },
+      client,
+    })).rejects.toThrow('journal checksum mismatch');
+  });
+
+  it('records failed state with partial progress', async () => {
+    const name = '20260525120000_add_events';
+    const migrationDir = await createMigrationFilesFixture(tempDir, name);
+    await writeFile(
+      path.join(migrationDir, 'up.sql'),
+      'SELECT 1;\nSELECT 2;\n',
+      'utf8',
+    );
+    const checksum = await writeMigrationChecksumFile(migrationDir);
+    await initializeMigrationJournal(path.join(tempDir, 'migrations'), 'snapshot-hash');
+    await appendMigrationJournalEntry(path.join(tempDir, 'migrations'), {
+      name,
+      timestamp: '20260525120000',
+      custom: false,
+      sourceSnapshotHash: 'source',
+      targetSnapshotHash: 'target',
+      checksum: checksum.checksum,
+    }, 'target');
+    const command = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined);
+    const client: MigrationExecutionClient = {
+      command,
+      query: vi.fn().mockResolvedValue({
+        json: async () => [],
+      }),
+    };
+
+    await expect(applyPendingMigrations({
+      migrationsOutDir: path.join(tempDir, 'migrations'),
+      migrationTable: '_hypequery_migrations',
+      credentials: {
+        host: 'localhost',
+        username: 'default',
+        database: 'analytics',
+      },
+      client,
+    })).rejects.toThrow('failed at statement 1/2');
+
+    expect(command).toHaveBeenCalledWith(expect.objectContaining({
+      query: expect.stringContaining("'failed'"),
+    }));
+    expect(command).toHaveBeenCalledWith(expect.objectContaining({
+      query: expect.stringContaining('boom'),
+    }));
+  });
+});

--- a/packages/cli/src/utils/migration-execution.ts
+++ b/packages/cli/src/utils/migration-execution.ts
@@ -1,0 +1,197 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { ClickHouseMigrationDbCredentials } from '@hypequery/schema';
+import { createMigrationClickHouseClient } from './clickhouse-migration-introspection.js';
+import { calculateMigrationChecksum, verifyMigrationIntegrity } from './migration-checksums.js';
+import {
+  ensureMigrationTable,
+  fetchAppliedMigrations,
+  insertMigrationExecutionRow,
+  type MigrationExecutionClient,
+} from './migration-remote-state.js';
+import { hashStatement, splitMigrationStatements } from './migration-statements.js';
+import { readMigrationJournal, type MigrationJournalEntry } from './migration-state.js';
+import { sha256 } from './sha256.js';
+
+export type { MigrationExecutionClient } from './migration-remote-state.js';
+export { splitMigrationStatements } from './migration-statements.js';
+
+export interface MigrationApplyResult {
+  name: string;
+  state: 'skipped' | 'applied';
+  appliedStepCount: number;
+  totalSteps: number;
+}
+
+export interface ApplyPendingMigrationsOptions {
+  migrationsOutDir: string;
+  migrationTable: string;
+  credentials: ClickHouseMigrationDbCredentials;
+  cluster?: string;
+  appliedUser?: string;
+  hypequeryVersion?: string;
+  client?: MigrationExecutionClient;
+}
+
+const DEFAULT_HYPEQUERY_VERSION = '0.0.1';
+
+export async function applyPendingMigrations(
+  options: ApplyPendingMigrationsOptions,
+): Promise<MigrationApplyResult[]> {
+  const client = options.client ?? createMigrationClickHouseClient(options.credentials);
+  const shouldClose = options.client === undefined;
+
+  try {
+    await ensureMigrationTable(client, options.migrationTable);
+    await assertLocalMigrationIntegrity(options.migrationsOutDir);
+
+    const journal = await readMigrationJournal(options.migrationsOutDir);
+    const applied = await fetchAppliedMigrations({
+      client,
+      migrationTable: options.migrationTable,
+    });
+    const appliedByName = new Map(applied.filter(row => row.status === 'applied').map(row => [row.name, row]));
+    const failed = applied.find(row => row.status === 'failed');
+    if (failed) {
+      throw new Error(
+        `Remote migration state is dirty at ${failed.name}. ` +
+        'Resolve the partial ClickHouse side effects manually before applying more migrations.',
+      );
+    }
+
+    const results: MigrationApplyResult[] = [];
+    for (let index = 0; index < journal.migrations.length; index += 1) {
+      const entry = journal.migrations[index];
+      const appliedEntry = appliedByName.get(entry.name);
+      if (appliedEntry) {
+        if (entry.checksum && appliedEntry.checksum !== entry.checksum) {
+          throw new Error(
+            `Applied migration checksum mismatch for ${entry.name}. ` +
+            'The local migration files no longer match the checksum stored in ClickHouse.',
+          );
+        }
+        results.push({
+          name: entry.name,
+          state: 'skipped',
+          appliedStepCount: appliedEntry.appliedStepCount,
+          totalSteps: appliedEntry.totalSteps,
+        });
+        continue;
+      }
+
+      results.push(await applyMigration({
+        client,
+        migrationsOutDir: options.migrationsOutDir,
+        migrationTable: options.migrationTable,
+        entry,
+        version: index + 1,
+        cluster: options.cluster,
+        appliedUser: options.appliedUser ?? process.env.USER ?? process.env.USERNAME ?? 'unknown',
+        hypequeryVersion: options.hypequeryVersion ?? DEFAULT_HYPEQUERY_VERSION,
+      }));
+    }
+
+    return results;
+  } finally {
+    if (shouldClose) {
+      await client.close?.();
+    }
+  }
+}
+
+async function assertLocalMigrationIntegrity(migrationsOutDir: string) {
+  const integrity = await verifyMigrationIntegrity(migrationsOutDir);
+  const failedIntegrity = integrity.filter(result => !result.ok);
+  if (failedIntegrity.length > 0) {
+    throw new Error(
+      `Migration integrity check failed for ${failedIntegrity.map(result => result.migrationName).join(', ')}.`,
+    );
+  }
+}
+
+async function applyMigration(input: {
+  client: MigrationExecutionClient;
+  migrationsOutDir: string;
+  migrationTable: string;
+  entry: MigrationJournalEntry;
+  version: number;
+  cluster?: string;
+  appliedUser: string;
+  hypequeryVersion: string;
+}): Promise<MigrationApplyResult> {
+  const migrationDir = path.join(input.migrationsOutDir, input.entry.name);
+  const checksumFile = await calculateMigrationChecksum(migrationDir);
+  if (input.entry.checksum && input.entry.checksum !== checksumFile.checksum) {
+    throw new Error(
+      `Migration journal checksum mismatch for ${input.entry.name}. ` +
+      'Run migrate:check and reconcile the local migration metadata before applying.',
+    );
+  }
+
+  const upSql = await readFile(path.join(migrationDir, 'up.sql'), 'utf8');
+  const statements = splitMigrationStatements(upSql);
+  const statementHashes = statements.map(statement => hashStatement(statement));
+  const startedAt = new Date();
+  const executionId = sha256(`${input.entry.name}\0${startedAt.toISOString()}`);
+
+  await insertMigrationExecutionRow({
+    ...input,
+    id: executionId,
+    checksum: checksumFile.checksum,
+    status: 'started',
+    startedAt,
+    finishedAt: null,
+    appliedStepCount: 0,
+    totalSteps: statements.length,
+    statementHashes,
+    executionTimeMs: 0,
+  });
+
+  const startMs = Date.now();
+  let appliedStepCount = 0;
+  try {
+    for (const statement of statements) {
+      await input.client.command({ query: statement });
+      appliedStepCount += 1;
+    }
+  } catch (error) {
+    await insertMigrationExecutionRow({
+      ...input,
+      id: executionId,
+      checksum: checksumFile.checksum,
+      status: 'failed',
+      startedAt,
+      finishedAt: new Date(),
+      appliedStepCount,
+      totalSteps: statements.length,
+      statementHashes,
+      errorStatement: statements[appliedStepCount],
+      errorMessage: error instanceof Error ? error.message : String(error),
+      executionTimeMs: Date.now() - startMs,
+    });
+    throw new Error(
+      `Migration ${input.entry.name} failed at statement ${appliedStepCount + 1}/${statements.length}. ` +
+      'ClickHouse DDL is not transactional; partial side effects may already exist.',
+    );
+  }
+
+  await insertMigrationExecutionRow({
+    ...input,
+    id: executionId,
+    checksum: checksumFile.checksum,
+    status: 'applied',
+    startedAt,
+    finishedAt: new Date(),
+    appliedStepCount,
+    totalSteps: statements.length,
+    statementHashes,
+    executionTimeMs: Date.now() - startMs,
+  });
+
+  return {
+    name: input.entry.name,
+    state: 'applied',
+    appliedStepCount,
+    totalSteps: statements.length,
+  };
+}

--- a/packages/cli/src/utils/migration-metadata-guards.ts
+++ b/packages/cli/src/utils/migration-metadata-guards.ts
@@ -1,0 +1,23 @@
+import type { Snapshot } from '@hypequery/schema';
+import type { MigrationJournalEntry } from './migration-state.js';
+import { isRecord } from './runtime-guards.js';
+
+export function isSnapshot(value: unknown): value is Snapshot {
+  return isRecord(value) &&
+    value.version === 1 &&
+    value.dialect === 'clickhouse' &&
+    Array.isArray(value.tables) &&
+    Array.isArray(value.materializedViews) &&
+    Array.isArray(value.dependencies) &&
+    typeof value.contentHash === 'string';
+}
+
+export function isMigrationJournalEntry(value: unknown): value is MigrationJournalEntry {
+  return isRecord(value) &&
+    typeof value.name === 'string' &&
+    typeof value.timestamp === 'string' &&
+    typeof value.custom === 'boolean' &&
+    typeof value.sourceSnapshotHash === 'string' &&
+    typeof value.targetSnapshotHash === 'string' &&
+    (value.checksum === undefined || typeof value.checksum === 'string');
+}

--- a/packages/cli/src/utils/migration-remote-state.ts
+++ b/packages/cli/src/utils/migration-remote-state.ts
@@ -1,0 +1,194 @@
+import type { MigrationJournalEntry } from './migration-state.js';
+import {
+  assertValidIdentifier,
+  quoteIdentifier,
+  sqlDateTime,
+  sqlString,
+  sqlStringArray,
+} from './clickhouse-sql.js';
+import { isRecord } from './runtime-guards.js';
+
+export interface MigrationExecutionClient {
+  command(input: { query: string }): Promise<unknown>;
+  query(input: { query: string; format: 'JSONEachRow' }): Promise<{ json<T>(): Promise<T[]> }>;
+  close?(): Promise<void>;
+}
+
+export interface AppliedMigrationRecord {
+  name: string;
+  checksum: string;
+  status: 'started' | 'applied' | 'failed';
+  appliedStepCount: number;
+  totalSteps: number;
+  errorStatement?: string;
+  errorMessage?: string;
+}
+
+export interface InsertMigrationExecutionRowInput {
+  client: Pick<MigrationExecutionClient, 'command'>;
+  migrationTable: string;
+  id: string;
+  version: number;
+  entry: MigrationJournalEntry;
+  checksum: string;
+  status: 'started' | 'applied' | 'failed';
+  startedAt: Date;
+  finishedAt: Date | null;
+  appliedStepCount: number;
+  totalSteps: number;
+  statementHashes: string[];
+  errorStatement?: string;
+  errorMessage?: string;
+  executionTimeMs: number;
+  appliedUser: string;
+  cluster?: string;
+  hypequeryVersion: string;
+}
+
+interface MigrationExecutionRow {
+  name: string;
+  checksum: string;
+  status: string;
+  applied_step_count: number | string;
+  total_steps: number | string;
+  error_statement: string | null;
+  error_message: string | null;
+}
+
+interface MigrationTableExistsRow {
+  name: string;
+}
+
+export async function ensureMigrationTable(
+  client: Pick<MigrationExecutionClient, 'command'>,
+  migrationTable: string,
+) {
+  await client.command({
+    query: [
+      `CREATE TABLE IF NOT EXISTS ${quoteIdentifier(migrationTable)} (`,
+      '  id String,',
+      '  version UInt64,',
+      '  name String,',
+      '  checksum String,',
+      '  type LowCardinality(String),',
+      '  started_at DateTime64(3),',
+      '  finished_at Nullable(DateTime64(3)),',
+      '  rolled_back_at Nullable(DateTime64(3)),',
+      '  applied_step_count UInt32,',
+      '  total_steps UInt32,',
+      '  statement_hashes Array(String),',
+      '  status LowCardinality(String),',
+      '  error_statement Nullable(String),',
+      '  error_message Nullable(String),',
+      '  execution_time_ms UInt64,',
+      '  applied_user String,',
+      '  cluster Nullable(String),',
+      '  hypequery_version String',
+      ')',
+      'ENGINE = MergeTree',
+      'ORDER BY (version, name, started_at, status)',
+    ].join('\n'),
+  });
+}
+
+export async function fetchAppliedMigrations(options: {
+  client: Pick<MigrationExecutionClient, 'query'>;
+  migrationTable: string;
+}): Promise<AppliedMigrationRecord[]> {
+  const result = await options.client.query({
+    query: [
+      'SELECT name, checksum, status, applied_step_count, total_steps, error_statement, error_message',
+      `FROM ${quoteIdentifier(options.migrationTable)}`,
+      "WHERE status IN ('applied', 'failed')",
+      'ORDER BY version, started_at',
+    ].join('\n'),
+    format: 'JSONEachRow',
+  });
+  const rows = await result.json<MigrationExecutionRow>();
+
+  return rows
+    .filter(isMigrationExecutionRow)
+    .map(row => ({
+      name: row.name,
+      checksum: row.checksum,
+      status: row.status,
+      appliedStepCount: Number(row.applied_step_count),
+      totalSteps: Number(row.total_steps),
+      ...(row.error_statement ? { errorStatement: row.error_statement } : {}),
+      ...(row.error_message ? { errorMessage: row.error_message } : {}),
+    }));
+}
+
+export async function fetchAppliedMigrationsIfTableExists(options: {
+  client: Pick<MigrationExecutionClient, 'query'>;
+  migrationTable: string;
+}): Promise<AppliedMigrationRecord[]> {
+  if (!await migrationTableExists(options.client, options.migrationTable)) {
+    return [];
+  }
+
+  return fetchAppliedMigrations(options);
+}
+
+export async function migrationTableExists(
+  client: Pick<MigrationExecutionClient, 'query'>,
+  migrationTable: string,
+) {
+  assertValidIdentifier(migrationTable);
+  const result = await client.query({
+    query: [
+      'SELECT name',
+      'FROM system.tables',
+      'WHERE database = currentDatabase()',
+      `AND name = ${sqlString(migrationTable)}`,
+      'LIMIT 1',
+    ].join('\n'),
+    format: 'JSONEachRow',
+  });
+  const rows = await result.json<MigrationTableExistsRow>();
+  return rows.length > 0;
+}
+
+export async function insertMigrationExecutionRow(input: InsertMigrationExecutionRowInput) {
+  await input.client.command({
+    query: [
+      `INSERT INTO ${quoteIdentifier(input.migrationTable)}`,
+      '(',
+      '  id, version, name, checksum, type, started_at, finished_at, rolled_back_at,',
+      '  applied_step_count, total_steps, statement_hashes, status, error_statement,',
+      '  error_message, execution_time_ms, applied_user, cluster, hypequery_version',
+      ')',
+      'VALUES (',
+      [
+        sqlString(input.id),
+        String(input.version),
+        sqlString(input.entry.name),
+        sqlString(input.checksum),
+        sqlString(input.entry.custom ? 'custom' : 'generated'),
+        sqlDateTime(input.startedAt),
+        input.finishedAt ? sqlDateTime(input.finishedAt) : 'NULL',
+        'NULL',
+        String(input.appliedStepCount),
+        String(input.totalSteps),
+        sqlStringArray(input.statementHashes),
+        sqlString(input.status),
+        input.errorStatement ? sqlString(input.errorStatement) : 'NULL',
+        input.errorMessage ? sqlString(input.errorMessage) : 'NULL',
+        String(input.executionTimeMs),
+        sqlString(input.appliedUser),
+        input.cluster ? sqlString(input.cluster) : 'NULL',
+        sqlString(input.hypequeryVersion),
+      ].join(', '),
+      ')',
+    ].join('\n'),
+  });
+}
+
+function isMigrationExecutionRow(value: MigrationExecutionRow): value is MigrationExecutionRow & {
+  status: AppliedMigrationRecord['status'];
+} {
+  return isRecord(value) &&
+    typeof value.name === 'string' &&
+    typeof value.checksum === 'string' &&
+    (value.status === 'started' || value.status === 'applied' || value.status === 'failed');
+}

--- a/packages/cli/src/utils/migration-state.ts
+++ b/packages/cli/src/utils/migration-state.ts
@@ -9,7 +9,9 @@ import {
   type Snapshot,
 } from '@hypequery/schema';
 import { verifyMigrationIntegrity, writeMigrationChecksumFile } from './migration-checksums.js';
-import { isRecord } from './runtime-guards.js';
+import type { AppliedMigrationRecord } from './migration-remote-state.js';
+import { isMigrationJournalEntry, isSnapshot } from './migration-metadata-guards.js';
+import { isNotFoundError, isRecord } from './runtime-guards.js';
 
 export interface MigrationJournalEntry {
   name: string;
@@ -30,8 +32,10 @@ export interface MigrationJournal {
 export interface LocalMigrationStatus {
   name: string;
   custom: boolean;
-  state: 'pending';
+  state: 'pending' | 'applied' | 'failed';
   checksum: 'ok' | 'missing' | 'mismatch';
+  remoteChecksum?: 'ok' | 'mismatch';
+  progress?: string;
 }
 
 const META_DIR_NAME = 'meta';
@@ -173,18 +177,27 @@ export async function assertMigrationDoesNotExist(migrationsOutDir: string, migr
   throw new Error(`Migration already exists: ${path.relative(process.cwd(), migrationDir)}`);
 }
 
-export async function getLocalMigrationStatuses(migrationsOutDir: string): Promise<LocalMigrationStatus[]> {
+export async function getLocalMigrationStatuses(
+  migrationsOutDir: string,
+  appliedMigrations: AppliedMigrationRecord[] = [],
+): Promise<LocalMigrationStatus[]> {
   const journal = await readMigrationJournal(migrationsOutDir);
   const integrityResults = await verifyMigrationIntegrity(migrationsOutDir);
   const integrityByName = new Map(integrityResults.map(result => [result.migrationName, result]));
+  const appliedByName = new Map(appliedMigrations.map(result => [result.name, result]));
 
   return journal.migrations.map(entry => {
     const integrity = integrityByName.get(entry.name);
+    const applied = appliedByName.get(entry.name);
     return {
       name: entry.name,
       custom: entry.custom,
-      state: 'pending',
+      state: applied?.status === 'applied' || applied?.status === 'failed' ? applied.status : 'pending',
       checksum: !integrity || integrity.missingChecksumFile ? 'missing' : integrity.ok ? 'ok' : 'mismatch',
+      ...(applied && entry.checksum
+        ? { remoteChecksum: applied.checksum === entry.checksum ? 'ok' as const : 'mismatch' as const }
+        : {}),
+      ...(applied ? { progress: `${applied.appliedStepCount}/${applied.totalSteps}` } : {}),
     };
   });
 }
@@ -220,28 +233,4 @@ async function readJournal(journalPath: string): Promise<MigrationJournal> {
     }
     throw error;
   }
-}
-
-function isSnapshot(value: unknown): value is Snapshot {
-  return isRecord(value) &&
-    value.version === 1 &&
-    value.dialect === 'clickhouse' &&
-    Array.isArray(value.tables) &&
-    Array.isArray(value.materializedViews) &&
-    Array.isArray(value.dependencies) &&
-    typeof value.contentHash === 'string';
-}
-
-function isMigrationJournalEntry(value: unknown): value is MigrationJournalEntry {
-  return isRecord(value) &&
-    typeof value.name === 'string' &&
-    typeof value.timestamp === 'string' &&
-    typeof value.custom === 'boolean' &&
-    typeof value.sourceSnapshotHash === 'string' &&
-    typeof value.targetSnapshotHash === 'string' &&
-    (value.checksum === undefined || typeof value.checksum === 'string');
-}
-
-function isNotFoundError(error: unknown) {
-  return isRecord(error) && error.code === 'ENOENT';
 }

--- a/packages/cli/src/utils/migration-statements.ts
+++ b/packages/cli/src/utils/migration-statements.ts
@@ -1,0 +1,167 @@
+import { sha256 } from './sha256.js';
+
+const BREAKPOINT_PATTERN = /^\s*--\s*hypequery:breakpoint\s*$/i;
+
+export function splitMigrationStatements(sql: string): string[] {
+  const byBreakpoint = sql
+    .split(/\r?\n/)
+    .reduce<string[]>((parts, line) => {
+      if (BREAKPOINT_PATTERN.test(line)) {
+        parts.push('');
+        return parts;
+      }
+      parts[parts.length - 1] = `${parts[parts.length - 1]}${line}\n`;
+      return parts;
+    }, [''])
+    .map(statement => statement.trim())
+    .filter(hasExecutableSql);
+
+  if (byBreakpoint.length > 1) {
+    return byBreakpoint;
+  }
+
+  return splitSqlBySemicolon(sql);
+}
+
+export function hashStatement(statement: string) {
+  return sha256(statement.trim());
+}
+
+function splitSqlBySemicolon(sql: string) {
+  const statements: string[] = [];
+  let current = '';
+  let quote: "'" | '"' | '`' | null = null;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let index = 0; index < sql.length; index += 1) {
+    const char = sql[index];
+    const next = sql[index + 1];
+
+    if (blockComment) {
+      current += char;
+      if (char === '*' && next === '/') {
+        current += next;
+        index += 1;
+        blockComment = false;
+      }
+      continue;
+    }
+
+    if (lineComment) {
+      current += char;
+      if (char === '\n') {
+        lineComment = false;
+      }
+      continue;
+    }
+
+    if (!quote && char === '/' && next === '*') {
+      blockComment = true;
+      current += char;
+      continue;
+    }
+
+    if (!quote && char === '-' && next === '-') {
+      lineComment = true;
+      current += char;
+      continue;
+    }
+
+    if (quote) {
+      current += char;
+      if (char === '\\') {
+        current += next ?? '';
+        index += 1;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '\'' || char === '"' || char === '`') {
+      quote = char;
+      current += char;
+      continue;
+    }
+
+    if (char === ';') {
+      const statement = current.trim();
+      if (hasExecutableSql(statement)) {
+        statements.push(`${statement};`);
+      }
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  const trailing = current.trim();
+  if (hasExecutableSql(trailing)) {
+    statements.push(trailing);
+  }
+
+  return statements;
+}
+
+function hasExecutableSql(statement: string) {
+  let quote: "'" | '"' | '`' | null = null;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let index = 0; index < statement.length; index += 1) {
+    const char = statement[index];
+    const next = statement[index + 1];
+
+    if (blockComment) {
+      if (char === '*' && next === '/') {
+        index += 1;
+        blockComment = false;
+      }
+      continue;
+    }
+
+    if (lineComment) {
+      if (char === '\n') {
+        lineComment = false;
+      }
+      continue;
+    }
+
+    if (!quote && char === '-' && next === '-') {
+      lineComment = true;
+      index += 1;
+      continue;
+    }
+
+    if (!quote && char === '/' && next === '*') {
+      blockComment = true;
+      index += 1;
+      continue;
+    }
+
+    if (quote) {
+      if (char === '\\') {
+        index += 1;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '\'' || char === '"' || char === '`') {
+      return true;
+    }
+
+    if (!/\s/.test(char)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/cli/src/utils/runtime-guards.ts
+++ b/packages/cli/src/utils/runtime-guards.ts
@@ -1,3 +1,11 @@
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object';
 }
+
+export function isNodeErrorWithCode(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return isRecord(error) && error.code === code;
+}
+
+export function isNotFoundError(error: unknown): error is NodeJS.ErrnoException {
+  return isNodeErrorWithCode(error, 'ENOENT');
+}

--- a/packages/cli/src/utils/sha256.ts
+++ b/packages/cli/src/utils/sha256.ts
@@ -1,0 +1,5 @@
+import { createHash } from 'node:crypto';
+
+export function sha256(value: string | Buffer) {
+  return createHash('sha256').update(value).digest('hex');
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
+    "target": "ES2022",
+    "lib": ["ES2022"],
     "module": "ESNext",
     "moduleResolution": "bundler"
   },

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    exclude: ['src/**/*.integration.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/cli/vitest.integration.config.ts
+++ b/packages/cli/vitest.integration.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import baseConfig from './vitest.config';
+
+export default defineConfig({
+  ...baseConfig,
+  test: {
+    ...(baseConfig.test ?? {}),
+    include: ['src/**/*.integration.test.ts'],
+    exclude: [],
+    threads: false,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
## Summary

  Adds phase 6 ClickHouse migration execution support to the CLI.

  This introduces `hypequery migrate:deploy`, remote migration state tracking in ClickHouse, statement-level execution
  progress, checksum verification, and status/check support for applied remote state.

  ## Changes

  - Add `migrate:deploy` command
  - Bootstrap and write to the configured migration table
  - Apply pending migrations in journal order
  - Split migration SQL by `-- hypequery:breakpoint` and statement boundaries
  - Record started/applied/failed execution rows with step counts and statement hashes
  - Stop on first failure and record dirty state
  - Update `migrate:status` to show pending/applied/failed state and remote checksum status
  - Update `migrate:check` to validate applied remote checksums
  - Extract shared helpers for ClickHouse SQL literals/identifiers, SHA-256, migration statements, remote state, and
