### PR TITLE
feat: (migrations) dev push command

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,6 +7,7 @@ import { migrationCheckCommand, type MigrationCheckOptions } from './commands/mi
 import { migrationDeployCommand, type MigrationDeployOptions } from './commands/migration-deploy.js';
 import { migrationStatusCommand, type MigrationStatusOptions } from './commands/migration-status.js';
 import { pullCommand, type PullOptions } from './commands/pull.js';
+import { pushCommand, type PushOptions } from './commands/push.js';
 
 const program = new Command();
 
@@ -105,6 +106,14 @@ program
   }));
 
 program
+  .command('push')
+  .description('Apply schema changes directly to ClickHouse for development')
+  .option('-c, --config <path>', 'Config file (default: hypequery.config.ts)')
+  .action(runCommand(async (options: PushOptions) => {
+    await pushCommand(options);
+  }));
+
+program
   .command('migrate:deploy')
   .description('Apply pending ClickHouse migrations')
   .option('-c, --config <path>', 'Config file (default: hypequery.config.ts)')
@@ -157,6 +166,7 @@ program.on('--help', () => {
   console.log('  hypequery generate:types --output analytics/schema.ts');
   console.log('  hypequery generate:migration add_orders_table');
   console.log('  hypequery pull');
+  console.log('  hypequery push');
   console.log('  hypequery migrate:deploy');
   console.log('  hypequery migrate:status');
   console.log('  hypequery migrate:check');

--- a/packages/cli/src/commands/generate-migration.test.ts
+++ b/packages/cli/src/commands/generate-migration.test.ts
@@ -1,16 +1,16 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  column,
-  defineSchema,
-  defineTable,
-  serializeSchemaToSnapshot,
-  snapshotToStableJson,
-  type ClickHouseSchemaAst,
-} from '@hypequery/schema';
-import { mockProcessExit, ProcessExitError } from '../test-utils.js';
+  eventsMigrationSchema,
+  eventsMigrationSchemaWithNameColumn,
+  migrationConfigFixture,
+  mockConfigAndSchemaLoader,
+  mockProcessExit,
+  ProcessExitError,
+  writeLatestSnapshotFixture,
+} from '../test-utils.js';
 
 type LoadModule = typeof import('../utils/load-api.js')['loadModule'];
 
@@ -73,7 +73,7 @@ describe('generate:migration command', () => {
   });
 
   it('generates migration artifacts from a schema diff', async () => {
-    mockConfigAndSchema(eventsSchema());
+    mockConfigAndSchemaLoader(loadModule, eventsMigrationSchema());
 
     const { generateMigrationCommand } = await import('./generate-migration.js');
     await generateMigrationCommand('add_events', { timestamp: '20260525120000' });
@@ -109,7 +109,7 @@ describe('generate:migration command', () => {
   });
 
   it('creates custom SQL migrations without advancing the latest snapshot', async () => {
-    mockConfigAndSchema(eventsSchema());
+    mockConfigAndSchemaLoader(loadModule, eventsMigrationSchema());
 
     const { generateMigrationCommand } = await import('./generate-migration.js');
     await generateMigrationCommand('backfill_events', {
@@ -144,9 +144,9 @@ describe('generate:migration command', () => {
   });
 
   it('does not write migration files when the schema matches the latest snapshot', async () => {
-    const schema = eventsSchema();
-    mockConfigAndSchema(schema);
-    await writeLatestSnapshotFixture(schema);
+    const schema = eventsMigrationSchema();
+    mockConfigAndSchemaLoader(loadModule, schema);
+    await writeLatestSnapshotFixture(tempDir, schema);
 
     const { generateMigrationCommand } = await import('./generate-migration.js');
     await generateMigrationCommand('noop', { timestamp: '20260525121000' });
@@ -158,8 +158,8 @@ describe('generate:migration command', () => {
   });
 
   it('diffs against the latest saved snapshot for incremental migrations', async () => {
-    await writeLatestSnapshotFixture(eventsSchema());
-    mockConfigAndSchema(eventsSchemaWithNameColumn());
+    await writeLatestSnapshotFixture(tempDir, eventsMigrationSchema());
+    mockConfigAndSchemaLoader(loadModule, eventsMigrationSchemaWithNameColumn());
 
     const { generateMigrationCommand } = await import('./generate-migration.js');
     await generateMigrationCommand('add_event_name', { timestamp: '20260525121500' });
@@ -181,7 +181,7 @@ describe('generate:migration command', () => {
   it('exits when the schema module does not export a schema', async () => {
     loadModule.mockImplementation(async (modulePath) => {
       if (modulePath === 'hypequery.config.ts') {
-        return { default: configFixture() };
+        return { default: migrationConfigFixture() };
       }
 
       return { notSchema: true };
@@ -195,72 +195,3 @@ describe('generate:migration command', () => {
     expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Invalid schema module'));
   });
 });
-
-function mockConfigAndSchema(schema: ClickHouseSchemaAst) {
-  loadModule.mockImplementation(async (modulePath) => {
-    if (modulePath === 'hypequery.config.ts') {
-      return { default: configFixture() };
-    }
-
-    return { default: schema };
-  });
-}
-
-function configFixture() {
-  return {
-    dialect: 'clickhouse',
-    schema: './schema.ts',
-    migrations: { out: './migrations' },
-    dbCredentials: {
-      host: 'localhost',
-      username: 'default',
-      database: 'analytics',
-    },
-  };
-}
-
-async function writeLatestSnapshotFixture(schema: ClickHouseSchemaAst) {
-  const snapshot = serializeSchemaToSnapshot(schema);
-  const metaDir = path.join(tempDir, 'migrations', 'meta');
-  await mkdir(metaDir, { recursive: true });
-  await writeFile(
-    path.join(metaDir, 'latest_snapshot.json'),
-    `${snapshotToStableJson(snapshot)}\n`,
-    'utf8',
-  );
-}
-
-function eventsSchema() {
-  return defineSchema({
-    tables: [
-      defineTable('events', {
-        columns: {
-          id: column.UUID(),
-          created_at: column.DateTime(),
-        },
-        engine: {
-          type: 'MergeTree',
-          orderBy: ['created_at'],
-        },
-      }),
-    ],
-  });
-}
-
-function eventsSchemaWithNameColumn() {
-  return defineSchema({
-    tables: [
-      defineTable('events', {
-        columns: {
-          id: column.UUID(),
-          created_at: column.DateTime(),
-          name: column.String(),
-        },
-        engine: {
-          type: 'MergeTree',
-          orderBy: ['created_at'],
-        },
-      }),
-    ],
-  });
-}

--- a/packages/cli/src/commands/push.test.ts
+++ b/packages/cli/src/commands/push.test.ts
@@ -1,0 +1,133 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  emptyMigrationSchema,
+  eventsMigrationSchema,
+  mockConfigAndSchemaLoader,
+  mockProcessExit,
+  ProcessExitError,
+  writeLatestSnapshotFixture,
+} from '../test-utils.js';
+
+type LoadModule = typeof import('../utils/load-api.js')['loadModule'];
+
+vi.mock('../utils/load-api.js', () => ({
+  loadModule: vi.fn(),
+}));
+
+const mockClient = vi.hoisted(() => ({
+  command: vi.fn(),
+  close: vi.fn(),
+}));
+
+vi.mock('../utils/clickhouse-migration-introspection.js', () => ({
+  createMigrationClickHouseClient: vi.fn(() => mockClient),
+}));
+
+const mockLogger = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  reload: vi.fn(),
+  header: vi.fn(),
+  newline: vi.fn(),
+  indent: vi.fn(),
+  box: vi.fn(),
+  table: vi.fn(),
+  raw: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: mockLogger,
+}));
+
+const mockSpinner = vi.hoisted(() => ({
+  start: vi.fn().mockReturnThis(),
+  succeed: vi.fn().mockReturnThis(),
+  fail: vi.fn().mockReturnThis(),
+  stop: vi.fn().mockReturnThis(),
+}));
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => mockSpinner),
+}));
+
+let tempDir: string;
+let previousCwd: string;
+let loadModule: ReturnType<typeof vi.mocked<LoadModule>>;
+
+describe('push command', () => {
+  let exitHandler: ReturnType<typeof mockProcessExit>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockClient.command.mockResolvedValue(undefined);
+    mockClient.close.mockResolvedValue(undefined);
+
+    previousCwd = process.cwd();
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'hypequery-push-'));
+    process.chdir(tempDir);
+    exitHandler = mockProcessExit();
+
+    ({ loadModule } = await import('../utils/load-api.js'));
+  });
+
+  afterEach(async () => {
+    exitHandler.restore();
+    process.chdir(previousCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('applies schema diff directly and advances the latest snapshot', async () => {
+    await writeLatestSnapshotFixture(tempDir, emptyMigrationSchema());
+    mockConfigAndSchemaLoader(loadModule, eventsMigrationSchema());
+    const { pushCommand } = await import('./push.js');
+
+    await pushCommand();
+
+    expect(mockClient.command).toHaveBeenCalledWith(expect.objectContaining({
+      query: expect.stringContaining('CREATE TABLE `events`'),
+    }));
+    const latestSnapshot = JSON.parse(
+      await readFile(path.join(tempDir, 'migrations', 'meta', 'latest_snapshot.json'), 'utf8'),
+    );
+    expect(latestSnapshot.tables).toEqual([
+      expect.objectContaining({ name: 'events' }),
+    ]);
+    await expect(
+      readFile(path.join(tempDir, 'migrations', 'meta', 'migrations.json'), 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('development-only'));
+    expect(mockLogger.success).toHaveBeenCalledWith(expect.stringContaining('Pushed schema changes'));
+  });
+
+  it('does not apply or write when there are no schema changes', async () => {
+    await writeLatestSnapshotFixture(tempDir, eventsMigrationSchema());
+    mockConfigAndSchemaLoader(loadModule, eventsMigrationSchema());
+    const { pushCommand } = await import('./push.js');
+
+    await pushCommand();
+
+    expect(mockClient.command).not.toHaveBeenCalled();
+    expect(mockLogger.info).toHaveBeenCalledWith('Nothing to push.');
+  });
+
+  it('does not advance the latest snapshot when direct apply fails', async () => {
+    await writeLatestSnapshotFixture(tempDir, emptyMigrationSchema());
+    mockConfigAndSchemaLoader(loadModule, eventsMigrationSchema());
+    mockClient.command.mockRejectedValue(new Error('boom'));
+    const { pushCommand } = await import('./push.js');
+
+    await expect(pushCommand()).rejects.toBeInstanceOf(ProcessExitError);
+
+    const latestSnapshot = JSON.parse(
+      await readFile(path.join(tempDir, 'migrations', 'meta', 'latest_snapshot.json'), 'utf8'),
+    );
+    expect(latestSnapshot.tables).toEqual([]);
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Push failed at statement'));
+  });
+});

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -1,0 +1,81 @@
+import path from 'node:path';
+import ora from 'ora';
+import {
+  createMigrationPlan,
+  diffSnapshots,
+  renderMigrationArtifacts,
+  serializeSchemaToSnapshot,
+} from '@hypequery/schema';
+import { createMigrationClickHouseClient } from '../utils/clickhouse-migration-introspection.js';
+import { loadHypequeryConfig } from '../utils/load-hypequery-config.js';
+import { logger } from '../utils/logger.js';
+import { applyMigrationSqlDirectly } from '../utils/migration-direct-apply.js';
+import { createMigrationTimestamp } from '../utils/migration-names.js';
+import { loadMigrationSchema } from '../utils/migration-schema.js';
+import {
+  readLatestMigrationSnapshot,
+  writeLatestMigrationSnapshot,
+} from '../utils/migration-state.js';
+
+export interface PushOptions {
+  config?: string;
+}
+
+export async function pushCommand(options: PushOptions = {}) {
+  logger.newline();
+  logger.header('hypequery push');
+
+  try {
+    const config = await loadHypequeryConfig(options.config);
+    const migrationsOutDir = path.resolve(process.cwd(), config.migrations.out);
+
+    logger.warn('Push is a development-only workflow. Do not use it for CI or production databases.');
+    logger.warn('Push applies schema changes directly and does not write migration files or remote migration history.');
+
+    const loadSpinner = ora('Loading schema state...').start();
+    const previousSnapshot = await readLatestMigrationSnapshot(migrationsOutDir);
+    const schema = await loadMigrationSchema(config.schema);
+    const nextSnapshot = serializeSchemaToSnapshot(schema);
+    loadSpinner.succeed('Loaded schema state');
+
+    const planSpinner = ora('Planning direct schema push...').start();
+    const plan = createMigrationPlan(diffSnapshots(previousSnapshot, nextSnapshot));
+
+    if (plan.operations.length === 0) {
+      planSpinner.succeed('No schema changes detected');
+      logger.info('Nothing to push.');
+      logger.newline();
+      return;
+    }
+
+    const artifacts = renderMigrationArtifacts(plan, {
+      name: 'push',
+      timestamp: createMigrationTimestamp(),
+      cluster: config.cluster?.name,
+    });
+    planSpinner.succeed(`Planned ${plan.operations.length} operations`);
+
+    if (artifacts.meta.unsafe || plan.requiredConfirmations.length > 0) {
+      logger.warn('Direct push includes operations that require careful review.');
+    }
+
+    const applySpinner = ora('Applying schema changes directly...').start();
+    const client = createMigrationClickHouseClient(config.dbCredentials);
+    try {
+      const result = await applyMigrationSqlDirectly(client, artifacts.upSql);
+      await writeLatestMigrationSnapshot(migrationsOutDir, nextSnapshot);
+      applySpinner.succeed(`Applied ${result.appliedStepCount}/${result.totalSteps} statements`);
+    } finally {
+      await client.close();
+    }
+
+    logger.success('Pushed schema changes and updated latest migration snapshot.');
+    logger.info('No migration file was written. Generate a migration for shared or production workflows.');
+    logger.newline();
+  } catch (error) {
+    logger.newline();
+    logger.error(error instanceof Error ? error.message : String(error));
+    logger.newline();
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/test-utils.ts
+++ b/packages/cli/src/test-utils.ts
@@ -1,5 +1,13 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import {
+  column,
+  defineSchema,
+  defineTable,
+  serializeSchemaToSnapshot,
+  snapshotToStableJson,
+  type ClickHouseSchemaAst,
+} from '@hypequery/schema';
 import { vi } from 'vitest';
 import type { Mock } from 'vitest';
 
@@ -148,4 +156,81 @@ export async function createMigrationFilesFixture(rootDir: string, name: string)
   await writeFile(path.join(migrationDir, 'meta.json'), '{}\n', 'utf8');
   await writeFile(path.join(migrationDir, 'plan.json'), '{}\n', 'utf8');
   return migrationDir;
+}
+
+export function migrationConfigFixture() {
+  return {
+    dialect: 'clickhouse',
+    schema: './schema.ts',
+    migrations: { out: './migrations' },
+    dbCredentials: {
+      host: 'localhost',
+      username: 'default',
+      database: 'analytics',
+    },
+  };
+}
+
+export function mockConfigAndSchemaLoader(
+  loadModule: Mock,
+  schema: ClickHouseSchemaAst,
+  config = migrationConfigFixture(),
+) {
+  loadModule.mockImplementation(async (modulePath) => {
+    if (modulePath === 'hypequery.config.ts') {
+      return { default: config };
+    }
+
+    return { default: schema };
+  });
+}
+
+export async function writeLatestSnapshotFixture(rootDir: string, schema: ClickHouseSchemaAst) {
+  const snapshot = serializeSchemaToSnapshot(schema);
+  const metaDir = path.join(rootDir, 'migrations', 'meta');
+  await mkdir(metaDir, { recursive: true });
+  await writeFile(
+    path.join(metaDir, 'latest_snapshot.json'),
+    `${snapshotToStableJson(snapshot)}\n`,
+    'utf8',
+  );
+}
+
+export function emptyMigrationSchema() {
+  return defineSchema({ tables: [] });
+}
+
+export function eventsMigrationSchema() {
+  return defineSchema({
+    tables: [
+      defineTable('events', {
+        columns: {
+          id: column.UUID(),
+          created_at: column.DateTime(),
+        },
+        engine: {
+          type: 'MergeTree',
+          orderBy: ['created_at'],
+        },
+      }),
+    ],
+  });
+}
+
+export function eventsMigrationSchemaWithNameColumn() {
+  return defineSchema({
+    tables: [
+      defineTable('events', {
+        columns: {
+          id: column.UUID(),
+          created_at: column.DateTime(),
+          name: column.String(),
+        },
+        engine: {
+          type: 'MergeTree',
+          orderBy: ['created_at'],
+        },
+      }),
+    ],
+  });
 }

--- a/packages/cli/src/utils/migration-direct-apply.test.ts
+++ b/packages/cli/src/utils/migration-direct-apply.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { applyMigrationSqlDirectly } from './migration-direct-apply.js';
+
+describe('migration direct apply', () => {
+  it('applies split SQL statements in order', async () => {
+    const client = {
+      command: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(applyMigrationSqlDirectly(client, [
+      'SELECT 1;',
+      '-- hypequery:breakpoint',
+      'SELECT 2;',
+    ].join('\n'))).resolves.toEqual({
+      appliedStepCount: 2,
+      totalSteps: 2,
+    });
+
+    expect(client.command).toHaveBeenNthCalledWith(1, { query: 'SELECT 1;' });
+    expect(client.command).toHaveBeenNthCalledWith(2, { query: 'SELECT 2;' });
+  });
+
+  it('reports the failing statement index', async () => {
+    const client = {
+      command: vi.fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('boom')),
+    };
+
+    await expect(applyMigrationSqlDirectly(client, 'SELECT 1;\nSELECT 2;'))
+      .rejects
+      .toThrow('Push failed at statement 2/2');
+  });
+
+  it('rejects empty SQL', async () => {
+    const client = {
+      command: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(applyMigrationSqlDirectly(client, '-- comment only\n'))
+      .rejects
+      .toThrow('no executable SQL');
+    expect(client.command).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/utils/migration-direct-apply.ts
+++ b/packages/cli/src/utils/migration-direct-apply.ts
@@ -1,0 +1,37 @@
+import { splitMigrationStatements } from './migration-statements.js';
+import type { MigrationExecutionClient } from './migration-remote-state.js';
+
+export interface ApplyMigrationSqlDirectlyResult {
+  appliedStepCount: number;
+  totalSteps: number;
+}
+
+export async function applyMigrationSqlDirectly(
+  client: Pick<MigrationExecutionClient, 'command'>,
+  sql: string,
+): Promise<ApplyMigrationSqlDirectlyResult> {
+  const statements = splitMigrationStatements(sql);
+  if (statements.length === 0) {
+    throw new Error('Push produced no executable SQL statements.');
+  }
+
+  let appliedStepCount = 0;
+
+  try {
+    for (const statement of statements) {
+      await client.command({ query: statement });
+      appliedStepCount += 1;
+    }
+  } catch (error) {
+    throw new Error(
+      `Push failed at statement ${appliedStepCount + 1}/${statements.length}. ` +
+      'ClickHouse DDL is not transactional; partial side effects may already exist. ' +
+      `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  return {
+    appliedStepCount,
+    totalSteps: statements.length,
+  };
+}

--- a/packages/cli/src/utils/migration-execution.integration.test.ts
+++ b/packages/cli/src/utils/migration-execution.integration.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { applyPendingMigrations } from './migration-execution.js';
 import { fetchAppliedMigrations } from './migration-remote-state.js';
 import { createMigrationClickHouseClient } from './clickhouse-migration-introspection.js';
@@ -102,12 +102,12 @@ testSuite('migration execution integration', () => {
       ].join('\n'),
     });
 
-    await expect(applyPendingMigrations({
+    await suppressExpectedClickHouseFailure(() => expect(applyPendingMigrations({
       migrationsOutDir,
       migrationTable,
       credentials: clickhouseCredentials(),
       appliedUser: 'integration-test',
-    })).rejects.toThrow('failed at statement 2/2');
+    })).rejects.toThrow('failed at statement 2/2'));
 
     const applied = await fetchAppliedMigrations({ client, migrationTable });
     expect(applied).toEqual(expect.arrayContaining([
@@ -163,4 +163,21 @@ function clickhouseCredentials(): ClickHouseMigrationDbCredentials {
 
 function ignoreCleanupError(error: unknown) {
   void error;
+}
+
+async function suppressExpectedClickHouseFailure(assertion: () => Promise<unknown>) {
+  const originalError = console.error.bind(console);
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    const message = args.map(String).join(' ');
+    if (message.includes('DUPLICATE_COLUMN') || message.includes('Cannot add column')) {
+      return;
+    }
+    originalError(...args);
+  });
+
+  try {
+    await assertion();
+  } finally {
+    errorSpy.mockRestore();
+  }
 }


### PR DESCRIPTION
## Summary

  Adds the Phase 7 migrations `push` workflow for development-only direct schema application.

  `hypequery push` computes the diff between the latest saved migration snapshot and the current TypeScript schema,
  renders SQL, applies it directly to ClickHouse, and advances `migrations/meta/latest_snapshot.json` only after
  successful execution.

  ## Changes

  - Add `hypequery push`
  - Add direct SQL apply helper for rendered migration SQL
  - Warn clearly that `push` is dev-only and does not write migration files or remote migration history
  - Preserve the previous snapshot if direct apply fails
  - Reject empty/comment-only SQL before applying
  - Reuse shared migration test fixtures across push and generate-migration tests
  - Register `push` in CLI help output