### PR TITLE
feat: (datasets) Unify semantic execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           "@hypequery/datasets": patch
           "@hypequery/serve": patch
           "@hypequery/cli": patch
-          "@hypequery/mcp-server": patch
+          "@hypequery/mcp": patch
           ---
 
           Temporary canary snapshot release.
@@ -127,12 +127,13 @@ jobs:
               packages/cli/package.json \
               packages/cli/CHANGELOG.md \
               packages/mcp-server/package.json \
-              packages/mcp-server/CHANGELOG.md \
+              packages/mcp-server/CHANGELOG.md 2>/dev/null || true
+            git checkout -- \
               examples/auth-playground/package.json \
               examples/next-dashboard/package.json \
               examples/next-starter/package.json \
               examples/node-embedded/package.json \
-              examples/vite-starter/package.json
+              examples/vite-starter/package.json 2>/dev/null || true
             rm -f .changeset/canary-release.md
           }
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,57 @@ The same query can then be:
 - consumed from React with `@hypequery/react`
 - described for tools and agents
 
+If you do not need `serve`, a standalone query can execute itself:
+
+```ts
+const activeUsers = query({
+  input: z.object({ region: z.string() }),
+  query: ({ input }) =>
+    db
+      .table('users')
+      .where('status', 'eq', 'active')
+      .where('region', 'eq', input.region)
+      .execute(),
+});
+
+await activeUsers.execute({
+  input: { region: 'EMEA' },
+});
+```
+
+The same served execution API also works for semantic metrics:
+
+```ts
+import { createAPI } from '@hypequery/serve';
+import { dataset, dimension, measure } from '@hypequery/datasets';
+
+const Orders = dataset('orders', {
+  source: 'orders',
+  dimensions: {
+    region: dimension.string(),
+  },
+  measures: {
+    revenue: measure.sum('total'),
+  },
+});
+
+const revenue = Orders.metric('revenue', { measure: 'revenue' });
+
+export const api = createAPI({
+  queryBuilder,
+  metrics: { revenue },
+  datasets: { orders: Orders },
+});
+
+await api.execute('revenue', {
+  input: { dimensions: ['region'] },
+});
+
+await api.execute('dataset:orders', {
+  input: { dimensions: ['region'], measures: ['revenue'] },
+});
+```
+
 ## CLI
 
 ```bash

--- a/packages/cli/src/commands/generate-datasets.ts
+++ b/packages/cli/src/commands/generate-datasets.ts
@@ -62,16 +62,16 @@ export async function generateDatasetsCommand(options: GenerateDatasetsOptions =
     logger.header('Next steps:');
     logger.indent('1. Review and customize the generated datasets');
     logger.indent('2. Import datasets in your application code');
-    logger.indent('3. Create an executor and start querying!');
+    logger.indent('3. Create an analytics client and start querying!');
     logger.newline();
 
     logger.info('Example usage:');
     logger.indent('import { datasets } from \'./datasets/generated\';');
-    logger.indent('import { createExecutor } from \'@hypequery/datasets\';');
+    logger.indent('import { createDatasetClient } from \'@hypequery/clickhouse/datasets\';');
     logger.indent('');
     logger.indent('const rowCount = datasets.orders.metric(\'rowCount\', { measure: \'totalCount\' });');
-    logger.indent('const executor = createExecutor({ queryBuilder });');
-    logger.indent('const result = await executor.metric(rowCount);');
+    logger.indent('const analytics = createDatasetClient({ url, username, password, database });');
+    logger.indent('const result = await analytics.execute(rowCount);');
     logger.newline();
 
   } catch (error) {

--- a/packages/clickhouse/README.md
+++ b/packages/clickhouse/README.md
@@ -77,11 +77,11 @@ const analytics = createDatasetClient({
   database: process.env.CLICKHOUSE_DATABASE!,
 });
 
-await analytics.metric(revenue, {
+await analytics.execute(revenue, {
   dimensions: ['country'],
 });
 
-await analytics.dataset(Orders, {
+await analytics.execute(Orders, {
   dimensions: ['country'],
   measures: ['revenue'],
 });

--- a/packages/clickhouse/src/core/tests/public-exports.test.ts
+++ b/packages/clickhouse/src/core/tests/public-exports.test.ts
@@ -34,8 +34,8 @@ describe('Public exports', () => {
       },
     });
 
-    expect(typeof client.metric).toBe('function');
-    expect(typeof client.dataset).toBe('function');
+    expect(typeof client.execute).toBe('function');
+    expect(typeof client.toSQL).toBe('function');
   });
 
   it('renders semantic dataset plans through the ClickHouse datasets backend', async () => {
@@ -63,7 +63,7 @@ describe('Public exports', () => {
       },
     });
 
-    const result = await client.dataset(Orders, {
+    const result = await client.execute(Orders, {
       dimensions: ['country'],
       measures: ['revenue'],
     });
@@ -72,7 +72,7 @@ describe('Public exports', () => {
     expect(queries[0]).toContain('SELECT country, SUM(amount) AS revenue FROM orders');
     expect(queries[0]).toContain('GROUP BY country');
 
-    await client.dataset(Orders, {
+    await client.execute(Orders, {
       dimensions: ['country'],
       measures: ['completedRevenue'],
     });

--- a/packages/clickhouse/src/datasets.ts
+++ b/packages/clickhouse/src/datasets.ts
@@ -1,10 +1,10 @@
 import {
-  createExecutor,
+  createDatasetClient as createSemanticDatasetClient,
   type MetricFilter,
   type PlanNode,
   type SemanticBackend,
   type SemanticBackendResult,
-  type SemanticExecutor,
+  type DatasetClient,
   type SemanticExpression,
 } from '@hypequery/datasets';
 export {
@@ -55,7 +55,7 @@ import { createQueryBuilder } from './core/query-builder.js';
 import type { CreateQueryBuilderConfig } from './core/query-builder.js';
 import type { SchemaDefinition } from './core/types/builder-state.js';
 
-export type ClickHouseDatasetClient = SemanticExecutor;
+export type ClickHouseDatasetClient = DatasetClient;
 export type CreateDatasetClientConfig = CreateQueryBuilderConfig;
 
 const GRAIN_FUNCTIONS = {
@@ -286,7 +286,7 @@ export function createClickHouseSemanticBackend<Schema extends SchemaDefinition<
 export function createDatasetClient<Schema extends SchemaDefinition<Schema>>(
   config: CreateDatasetClientConfig,
 ): ClickHouseDatasetClient {
-  return createExecutor({
+  return createSemanticDatasetClient({
     backend: createClickHouseSemanticBackend<Schema>(config),
   });
 }

--- a/packages/datasets/README.md
+++ b/packages/datasets/README.md
@@ -16,7 +16,6 @@ pnpm add @hypequery/datasets
 
 ```ts
 import {
-  createExecutor,
   dataset,
   dimension,
   divide,
@@ -24,7 +23,7 @@ import {
   measure,
   nullIfZero,
 } from '@hypequery/datasets';
-import { createQueryBuilder } from '@hypequery/clickhouse';
+import { createDatasetClient } from '@hypequery/clickhouse/datasets';
 
 const Orders = dataset('orders', {
   source: 'orders',
@@ -62,23 +61,21 @@ const averageOrderValue = Orders.metric('averageOrderValue', {
     divide(revenue, nullIfZero(orderCount)),
 });
 
-const builderFactory = createQueryBuilder({
-  host: process.env.CLICKHOUSE_HOST,
+const analytics = createDatasetClient({
+  url: process.env.CLICKHOUSE_URL,
   username: process.env.CLICKHOUSE_USER,
   password: process.env.CLICKHOUSE_PASSWORD,
   database: process.env.CLICKHOUSE_DATABASE,
 });
 
-const executor = createExecutor({ queryBuilder: builderFactory });
-
-const result = await executor.metric(revenue, {
+const result = await analytics.execute(revenue, {
   dimensions: ['country'],
   filters: [eq('status', 'completed')],
   orderBy: [{ field: 'revenue', direction: 'desc' }],
   limit: 10,
 });
 
-const monthlySql = executor.toSQL(revenue.by('month'), {
+const monthlySql = analytics.toSQL(revenue.by('month'), {
   dimensions: ['country'],
 });
 ```
@@ -187,7 +184,7 @@ Use `.by(grain)` on a metric when the dataset has a `timeKey`.
 ```ts
 const monthlyRevenue = revenue.by('month');
 
-await executor.metric(monthlyRevenue, {
+await analytics.execute(monthlyRevenue, {
   dimensions: ['country'],
 });
 ```
@@ -199,7 +196,7 @@ Supported grains are `day`, `week`, `month`, `quarter`, and `year`.
 Runtime tenancy uses the dataset `tenantKey` and a runtime tenant identity.
 
 ```ts
-await executor.metric(revenue, {}, {
+await analytics.execute(revenue, {}, {
   runtime: {
     tenant: { id: 'tenant_123' },
   },
@@ -230,30 +227,28 @@ For this release, relationship-aware query execution is not shipped. Query execu
 
 ## Execution
 
-`createExecutor` accepts a query builder factory compatible with `@hypequery/clickhouse`.
+Use `createDatasetClient` from `@hypequery/clickhouse/datasets` to execute semantic targets against ClickHouse.
 
 ```ts
-const executor = createExecutor({ queryBuilder: builderFactory });
-
-const validation = executor.validate(revenue, {
+const validation = analytics.validate(revenue, {
   dimensions: ['country'],
 });
 
-const sql = executor.toSQL(revenue, {
+const sql = analytics.toSQL(revenue, {
   dimensions: ['country'],
 });
 
-const result = await executor.metric(revenue, {
+const result = await analytics.execute(revenue, {
   dimensions: ['country'],
 });
 
-const datasetResult = await executor.dataset(Orders, {
+const datasetResult = await analytics.execute(Orders, {
   dimensions: ['country'],
   measures: ['revenue'],
 });
 ```
 
-The executor validates dimensions, filters, order fields, limits, time grain requirements, tenant filtering, and derived metric plans before execution.
+The semantic client validates dimensions, filters, order fields, limits, time grain requirements, tenant filtering, and derived metric plans before execution.
 
 For ClickHouse applications, `@hypequery/clickhouse/datasets` provides a
 datasets-first client that accepts ClickHouse connection config directly:
@@ -268,7 +263,7 @@ const analytics = createDatasetClient({
   database: process.env.CLICKHOUSE_DATABASE,
 });
 
-await analytics.metric(revenue, { dimensions: ['country'] });
+await analytics.execute(revenue, { dimensions: ['country'] });
 ```
 
 ## Serve Integration

--- a/packages/datasets/src/api.type-test.ts
+++ b/packages/datasets/src/api.type-test.ts
@@ -1,6 +1,7 @@
-import { add, dataset, dimension, measure, eq, between, desc, createExecutor, SemanticExecutor } from './index.js';
+import { add, dataset, dimension, measure, eq, between, desc, createDatasetClient } from './index.js';
 import type {
   BaseMetricRef,
+  DatasetClient,
   DatasetQuery,
   DatasetQueryResult,
   DerivedMetricConfig,
@@ -82,6 +83,18 @@ type _RootExportOmitsRunDatasetQuery = Assert<
 >;
 type _RootExportOmitsValidateDatasetQuery = Assert<
   Equal<HasKey<DatasetModule, 'validateDatasetQuery'>, false>
+>;
+type _RootExportIncludesCreateDatasetClient = Assert<
+  Equal<HasKey<DatasetModule, 'createDatasetClient'>, true>
+>;
+type _RootExportOmitsCreateExecutor = Assert<
+  Equal<HasKey<DatasetModule, 'createExecutor'>, false>
+>;
+type _RootExportOmitsSemanticExecutor = Assert<
+  Equal<HasKey<DatasetModule, 'SemanticExecutor'>, false>
+>;
+type _RootExportOmitsMetricExecutor = Assert<
+  Equal<HasKey<DatasetModule, 'MetricExecutor'>, false>
 >;
 type _InternalDatasetQueryTypeCompiles = import('./internal.js').DatasetQuery;
 type _InternalExportIncludesBuildDatasetQueryBuilder = Assert<
@@ -169,15 +182,16 @@ const builderFactory: QueryBuilderFactoryLike = {
   rawQuery: async () => [],
 };
 
-const executor = createExecutor({ queryBuilder: builderFactory });
-const explicitExecutor: SemanticExecutor = executor;
+const analytics = createDatasetClient({ queryBuilder: builderFactory });
+const explicitAnalytics: DatasetClient = analytics;
 const datasetQuery: DatasetQuery = { dimensions: ['status'], measures: ['revenue'] };
 
-executor.validate(revenueMetric, { dimensions: ['status'] }, runtimeContext);
-executor.toSQL(completedRevenueMetric, { dimensions: ['status'] }, runtimeContext);
-executor.toSQL(revenueMetric, { orderBy: [desc('revenueMetric')] }, runtimeContext);
-executor.validateDataset(Orders, datasetQuery, runtimeContext);
-void executor.dataset<DatasetQueryResult['data'][number]>(Orders, datasetQuery, runtimeContext);
+analytics.validate(revenueMetric, { dimensions: ['status'] }, runtimeContext);
+analytics.toSQL(completedRevenueMetric, { dimensions: ['status'] }, runtimeContext);
+analytics.toSQL(revenueMetric, { orderBy: [desc('revenueMetric')] }, runtimeContext);
+analytics.validate(Orders, datasetQuery, runtimeContext);
+analytics.toSQL(Orders, datasetQuery, runtimeContext);
+void analytics.execute<DatasetQueryResult['data'][number]>(Orders, datasetQuery, runtimeContext);
 
 void runtimeContext;
-void explicitExecutor;
+void explicitAnalytics;

--- a/packages/datasets/src/datasets.test.ts
+++ b/packages/datasets/src/datasets.test.ts
@@ -8,7 +8,7 @@ import { eq, between, desc } from './query-helpers.js';
 import { measure } from './measure.js';
 import { createDatasetRegistry } from './registry.js';
 import { buildDatasetQueryBuilder, runDatasetQuery, validateDatasetQuery } from './dataset-query.js';
-import { createExecutor, MetricExecutor } from './executor.js';
+import { createDatasetClient, MetricQueryEngine } from './executor.js';
 import { createInMemoryBackend } from './in-memory-backend.js';
 import type { QueryBuilderFactoryLike, QueryBuilderLike } from './query-builder-protocol.js';
 
@@ -509,10 +509,10 @@ describe("DatasetRegistry", () => {
 });
 
 // =============================================================================
-// METRIC EXECUTOR TESTS
+// METRIC QUERY ENGINE TESTS
 // =============================================================================
 
-describe("MetricExecutor", () => {
+describe("MetricQueryEngine", () => {
   type BuilderColumnsInput = string[] | string;
 
   function createMockBuilderFactory(): QueryBuilderFactoryLike {
@@ -721,8 +721,8 @@ describe("MetricExecutor", () => {
 
   describe("toSQL() — base metrics", () => {
     it("generates simple aggregate SQL", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const sql = executor.toSQL(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const sql = analytics.toSQL(totalRevenue, {
         dimensions: ["country"],
       });
 
@@ -731,8 +731,8 @@ describe("MetricExecutor", () => {
     });
 
     it("injects tenant WHERE clause", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const sql = executor.toSQL(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const sql = analytics.toSQL(totalRevenue, {
         dimensions: ["country"],
       }, {
         runtime: {
@@ -744,8 +744,8 @@ describe("MetricExecutor", () => {
     });
 
     it("applies user filters", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const sql = executor.toSQL(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const sql = analytics.toSQL(totalRevenue, {
         dimensions: ["country"],
         filters: [{ field: "status", operator: "eq", value: "completed" }],
       });
@@ -754,8 +754,8 @@ describe("MetricExecutor", () => {
     });
 
     it("applies ORDER BY and LIMIT", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const sql = executor.toSQL(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const sql = analytics.toSQL(totalRevenue, {
         dimensions: ["country"],
         orderBy: [{ field: "totalRevenue", direction: "desc" }],
         limit: 100,
@@ -766,8 +766,8 @@ describe("MetricExecutor", () => {
     });
 
     it("compiles filtered measures into aggregation expressions", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const sql = executor.toSQL(completedRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const sql = analytics.toSQL(completedRevenue, {
         dimensions: ["country"],
       });
 
@@ -776,8 +776,8 @@ describe("MetricExecutor", () => {
     });
 
     it("resolves column aliases for countDistinct metrics", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const sql = executor.toSQL(uniqueCustomers, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const sql = analytics.toSQL(uniqueCustomers, {
         dimensions: ["country"],
       });
 
@@ -788,9 +788,9 @@ describe("MetricExecutor", () => {
 
   describe("toSQL() — grained metrics", () => {
     it("generates time-grained SQL with .by()", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const monthly = totalRevenue.by("month");
-      const sql = executor.toSQL(monthly);
+      const sql = analytics.toSQL(monthly);
 
       expect(sql).toContain("toStartOfMonth(created_at) AS period");
       expect(sql).toContain("GROUP BY period");
@@ -798,16 +798,16 @@ describe("MetricExecutor", () => {
     });
 
     it("supports grain via query.by", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const sql = executor.toSQL(totalRevenue, { by: "week" });
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const sql = analytics.toSQL(totalRevenue, { by: "week" });
 
       expect(sql).toContain("toStartOfWeek(created_at) AS period");
     });
 
     it("rejects conflicting query.by on grained metrics", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const monthly = totalRevenue.by("month");
-      const result = executor.validate(monthly, { by: "week" });
+      const result = analytics.validate(monthly, { by: "week" });
 
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain('already grained by "month"');
@@ -816,8 +816,8 @@ describe("MetricExecutor", () => {
 
   describe("toSQL() — derived metrics", () => {
     it("generates CTE-based SQL", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const sql = executor.toSQL(avgOrderValue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const sql = analytics.toSQL(avgOrderValue, {
         dimensions: ["country"],
       });
 
@@ -830,8 +830,8 @@ describe("MetricExecutor", () => {
     });
 
     it("does not emit GROUP BY for ungrouped derived metrics", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const sql = executor.toSQL(avgOrderValue);
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const sql = analytics.toSQL(avgOrderValue);
 
       expect(sql).toContain("WITH base AS");
       expect(sql).not.toContain("GROUP BY totalRevenue");
@@ -839,8 +839,8 @@ describe("MetricExecutor", () => {
     });
 
     it("rejects derived plans that introduce aggregate aliases into GROUP BY", () => {
-      const executor = new MetricExecutor({ builderFactory: createBrokenDerivedGroupingBuilderFactory() });
-      const result = executor.validate(avgOrderValue, {});
+      const analytics = new MetricQueryEngine({ builderFactory: createBrokenDerivedGroupingBuilderFactory() });
+      const result = analytics.validate(avgOrderValue, {});
 
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain("GROUP BY");
@@ -850,8 +850,8 @@ describe("MetricExecutor", () => {
   describe("run()", () => {
     it("executes SQL and returns MetricResult", async () => {
       const builderFactory = createMockBuilderFactory();
-      const executor = new MetricExecutor({ builderFactory });
-      const result = await executor.run(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory });
+      const result = await analytics.run(totalRevenue, {
         dimensions: ["country"],
       });
 
@@ -865,16 +865,16 @@ describe("MetricExecutor", () => {
 
     it("passes tenant context to SQL", async () => {
       const builderFactory = createMockBuilderFactory();
-      const executor = new MetricExecutor({ builderFactory });
+      const analytics = new MetricQueryEngine({ builderFactory });
 
-      await executor.run(totalRevenue, {}, {
+      await analytics.run(totalRevenue, {}, {
         runtime: {
           tenant: { id: "t1" },
         },
       });
 
       // Verify the SQL was generated (toSQL includes tenant filter)
-      const sql = executor.toSQL(totalRevenue, {}, {
+      const sql = analytics.toSQL(totalRevenue, {}, {
         runtime: {
           tenant: { id: "t1" },
         },
@@ -883,9 +883,9 @@ describe("MetricExecutor", () => {
     });
   });
 
-  describe("createExecutor()", () => {
+  describe("createDatasetClient()", () => {
     it("can execute semantic plans against an in-memory backend without a query builder", async () => {
-      const executor = createExecutor({
+      const analytics = createDatasetClient({
         backend: createInMemoryBackend({
           orders: [
             { id: "1", tenant_id: "t1", country: "US", status: "completed", amount: 100, created_at: "2026-01-02" },
@@ -896,7 +896,7 @@ describe("MetricExecutor", () => {
         }),
       });
 
-      const result = await executor.metric(avgOrderValue, {
+      const result = await analytics.execute(avgOrderValue, {
         dimensions: ["country"],
         filters: [{ field: "status", operator: "eq", value: "completed" }],
         orderBy: [{ field: "country", direction: "asc" }],
@@ -911,7 +911,7 @@ describe("MetricExecutor", () => {
         { country: "US", avgOrderValue: 100 },
       ]);
 
-      const datasetResult = await executor.dataset(Orders, {
+      const datasetResult = await analytics.execute(Orders, {
         dimensions: ["country"],
         measures: ["revenue", "orderCount"],
         filters: [{ field: "status", operator: "eq", value: "completed" }],
@@ -928,11 +928,11 @@ describe("MetricExecutor", () => {
       ]);
     });
 
-    it("executes metric queries through the semantic executor", async () => {
+    it("executes metric queries through the semantic analytics", async () => {
       const builderFactory = createMockBuilderFactory();
-      const executor = createExecutor({ queryBuilder: builderFactory });
+      const analytics = createDatasetClient({ queryBuilder: builderFactory });
 
-      const result = await executor.metric(totalRevenue, {
+      const result = await analytics.execute(totalRevenue, {
         dimensions: ["country"],
       });
 
@@ -943,11 +943,11 @@ describe("MetricExecutor", () => {
       expect(result.meta.sql).toContain("SUM(amount) AS totalRevenue");
     });
 
-    it("executes dataset queries through the semantic executor", async () => {
+    it("executes dataset queries through the semantic analytics", async () => {
       const builderFactory = createMockBuilderFactory();
-      const executor = createExecutor({ queryBuilder: builderFactory });
+      const analytics = createDatasetClient({ queryBuilder: builderFactory });
 
-      const result = await executor.dataset(Orders, {
+      const result = await analytics.execute(Orders, {
         dimensions: ["country"],
         measures: ["revenue"],
       });
@@ -961,13 +961,13 @@ describe("MetricExecutor", () => {
 
     it("generates and validates dataset queries", () => {
       const builderFactory = createMockBuilderFactory();
-      const executor = createExecutor({ queryBuilder: builderFactory });
+      const analytics = createDatasetClient({ queryBuilder: builderFactory });
 
-      const validation = executor.validateDataset(Orders, {
+      const validation = analytics.validate(Orders, {
         dimensions: ["country"],
         measures: ["revenue"],
       });
-      const sql = executor.datasetSQL(Orders, {
+      const sql = analytics.toSQL(Orders, {
         dimensions: ["country"],
         measures: ["revenue"],
       });
@@ -979,16 +979,16 @@ describe("MetricExecutor", () => {
 
   describe("validate()", () => {
     it("accepts valid queries", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const result = executor.validate(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const result = analytics.validate(totalRevenue, {
         dimensions: ["country", "status"],
       });
       expect(result.valid).toBe(true);
     });
 
     it("rejects unknown dimensions", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const result = executor.validate(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const result = analytics.validate(totalRevenue, {
         dimensions: ["nonexistent"],
       });
       expect(result.valid).toBe(false);
@@ -996,16 +996,16 @@ describe("MetricExecutor", () => {
     });
 
     it("rejects unknown filter fields", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const result = executor.validate(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const result = analytics.validate(totalRevenue, {
         filters: [{ field: "nonexistent", operator: "eq", value: "x" }],
       });
       expect(result.valid).toBe(false);
     });
 
     it("rejects incompatible filter values", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const result = executor.validate(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const result = analytics.validate(totalRevenue, {
         filters: [{ field: "amount", operator: "eq", value: "not-a-number" }],
       });
       expect(result.valid).toBe(false);
@@ -1013,8 +1013,8 @@ describe("MetricExecutor", () => {
     });
 
     it("rejects empty arrays for in/notIn filters", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const result = executor.validate(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const result = analytics.validate(totalRevenue, {
         filters: [{ field: "status", operator: "in", value: [] }],
       });
       expect(result.valid).toBe(false);
@@ -1022,8 +1022,8 @@ describe("MetricExecutor", () => {
     });
 
     it("rejects malformed between filters", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const result = executor.validate(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const result = analytics.validate(totalRevenue, {
         filters: [{ field: "amount", operator: "between", value: [1] }],
       });
       expect(result.valid).toBe(false);
@@ -1031,8 +1031,8 @@ describe("MetricExecutor", () => {
     });
 
     it("rejects like on numeric fields", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const result = executor.validate(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const result = analytics.validate(totalRevenue, {
         filters: [{ field: "amount", operator: "like", value: "%100%" }],
       });
       expect(result.valid).toBe(false);
@@ -1040,8 +1040,8 @@ describe("MetricExecutor", () => {
     });
 
     it("rejects unknown orderBy fields", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const result = executor.validate(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const result = analytics.validate(totalRevenue, {
         dimensions: ["country"],
         orderBy: [{ field: "amount", direction: "desc" }],
       });
@@ -1050,8 +1050,8 @@ describe("MetricExecutor", () => {
     });
 
     it("rejects exceeding dimension limits", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const result = executor.validate(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const result = analytics.validate(totalRevenue, {
         dimensions: ["id", "customerId", "country", "status", "amount", "createdAt"],
       });
       expect(result.valid).toBe(false);
@@ -1059,8 +1059,8 @@ describe("MetricExecutor", () => {
     });
 
     it("rejects explicit tenant filters when runtime tenancy is active", () => {
-      const executor = new MetricExecutor({ builderFactory: createMockBuilderFactory() });
-      const result = executor.validate(totalRevenue, {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const result = analytics.validate(totalRevenue, {
         filters: [{ field: "tenantId", operator: "eq", value: "t1" }],
       }, {
         runtime: {

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -1,13 +1,8 @@
 /**
- * MetricExecutor — resolves metrics to SQL and executes them.
+ * Semantic dataset client internals.
  *
- * Supports two modes:
- * 1. **Query builder** (recommended) — pass a `QueryBuilderFactoryLike` and the
- *    executor builds queries via the builder's fluent API, then calls `.execute()`.
- * 2. **Raw adapter** (deprecated) — pass a `MetricAdapter` with a `rawQuery` function
- *    and the executor generates SQL strings manually.
- *
- * The executor stays DB-agnostic via duck-typed protocol interfaces.
+ * Public callers use `createDatasetClient(...).execute(...)`. The implementation
+ * stays database-agnostic via query-builder and backend protocol interfaces.
  */
 
 import type {
@@ -156,30 +151,64 @@ function validateQuery(
   return { valid: errors.length === 0, errors };
 }
 
+function isDatasetInstance(target: unknown): target is AnyDatasetInstance {
+  return !!target && typeof target === 'object' && '__type' in target && target.__type === 'dataset';
+}
+
 // =============================================================================
-// METRIC EXECUTOR
+// DATASET CLIENT
 // =============================================================================
 
-export interface MetricExecutorOptions {
+export interface MetricQueryEngineOptions {
   /** Query builder factory for executing metrics. */
   builderFactory: QueryBuilderFactoryLike;
 }
 
-export interface SemanticExecutorOptions {
+export interface CreateDatasetClientOptions {
   /** Query builder factory for executing semantic metric and dataset queries. */
   queryBuilder?: QueryBuilderFactoryLike;
   /** Semantic backend for executing neutral semantic plans. */
   backend?: SemanticBackend;
 }
 
-export class MetricExecutor {
+export type SemanticTarget = MetricRef | GrainedMetricRef | AnyDatasetInstance;
+
+export type SemanticQuery<TTarget extends SemanticTarget> =
+  TTarget extends AnyDatasetInstance ? DatasetQuery : MetricQuery;
+
+export type SemanticResult<
+  TTarget extends SemanticTarget,
+  TRow = Record<string, unknown>,
+> = TTarget extends AnyDatasetInstance
+  ? DatasetQueryResult<TRow>
+  : MetricResult<TRow>;
+
+export interface DatasetClient {
+  execute<TRow = Record<string, unknown>, TTarget extends SemanticTarget = SemanticTarget>(
+    target: TTarget,
+    query?: SemanticQuery<TTarget>,
+    context?: ExecutionContext,
+  ): Promise<SemanticResult<TTarget, TRow>>;
+  toSQL<TTarget extends SemanticTarget>(
+    target: TTarget,
+    query?: SemanticQuery<TTarget>,
+    context?: ExecutionContext,
+  ): string;
+  validate<TTarget extends SemanticTarget>(
+    target: TTarget,
+    query?: SemanticQuery<TTarget>,
+    context?: ExecutionContext,
+  ): ValidationResult;
+}
+
+export class MetricQueryEngine {
   private builderFactory: QueryBuilderFactoryLike;
 
-  constructor(options: MetricExecutorOptions) {
+  constructor(options: MetricQueryEngineOptions) {
     this.builderFactory = options.builderFactory;
   }
 
-  getBuilderFactory(): QueryBuilderFactoryLike {
+  protected getBuilderFactory(): QueryBuilderFactoryLike {
     return this.builderFactory;
   }
 
@@ -446,20 +475,20 @@ export class MetricExecutor {
   }
 }
 
-export class SemanticExecutor extends MetricExecutor {
+export class DatasetClientImpl extends MetricQueryEngine implements DatasetClient {
   private backend?: SemanticBackend;
 
-  constructor(options: SemanticExecutorOptions) {
+  constructor(options: CreateDatasetClientOptions) {
     if (!options.queryBuilder && !options.backend) {
-      throw new Error('createExecutor requires either queryBuilder or backend.');
+      throw new Error('createDatasetClient requires either queryBuilder or backend.');
     }
     super({
       builderFactory: options.queryBuilder ?? {
         table() {
-          throw new Error('This executor was created with a semantic backend, not a query builder.');
+          throw new Error('This dataset client was created with a semantic backend, not a query builder.');
         },
         async rawQuery() {
-          throw new Error('This executor was created with a semantic backend, not a query builder.');
+          throw new Error('This dataset client was created with a semantic backend, not a query builder.');
         },
       },
     });
@@ -488,42 +517,86 @@ export class SemanticExecutor extends MetricExecutor {
   }
 
   /**
-   * Execute a metric query.
+   * Execute a semantic target.
    */
-  metric<T = Record<string, unknown>>(
-    metric: MetricRef | GrainedMetricRef,
-    query: MetricQuery = {},
+  execute<TRow = Record<string, unknown>, TTarget extends SemanticTarget = SemanticTarget>(
+    target: TTarget,
+    query: SemanticQuery<TTarget> = {} as SemanticQuery<TTarget>,
     context?: ExecutionContext,
-  ): Promise<MetricResult<T>> {
-    if (this.backend) {
-      return this.backend.execute<T>(this.planMetric(metric, query, context)) as Promise<MetricResult<T>>;
+  ): Promise<SemanticResult<TTarget, TRow>> {
+    if (isDatasetInstance(target)) {
+      return this.executeDataset<TRow>(
+        target,
+        query as DatasetQuery,
+        context,
+      ) as Promise<SemanticResult<TTarget, TRow>>;
     }
-    return this.run<T>(metric, query, context);
+
+    return this.executeMetric<TRow>(
+      target,
+      query as MetricQuery,
+      context,
+    ) as Promise<SemanticResult<TTarget, TRow>>;
   }
 
-  /**
-   * Execute a same-dataset semantic query.
-   */
-  dataset<T = Record<string, unknown>>(
-    ds: AnyDatasetInstance,
-    query: DatasetQuery = {},
+  toSQL<TTarget extends SemanticTarget>(
+    target: TTarget,
+    query: SemanticQuery<TTarget> = {} as SemanticQuery<TTarget>,
     context?: ExecutionContext,
-  ): Promise<DatasetQueryResult<T>> {
-    if (this.backend) {
-      return this.backend.execute<T>(this.planDataset(ds, query, context)) as Promise<DatasetQueryResult<T>>;
+  ): string {
+    if (isDatasetInstance(target)) {
+      return this.toDatasetSQL(target, query as DatasetQuery, context);
     }
+
+    return super.toSQL(target, query as MetricQuery, context);
+  }
+
+  validate<TTarget extends SemanticTarget>(
+    target: TTarget,
+    query: SemanticQuery<TTarget> = {} as SemanticQuery<TTarget>,
+    context?: ExecutionContext,
+  ): ValidationResult {
+    if (isDatasetInstance(target)) {
+      return validateDatasetQuery(target, query as DatasetQuery, context);
+    }
+
+    return super.validate(target, query as MetricQuery, context);
+  }
+
+  private executeMetric<TRow>(
+    metric: MetricRef | GrainedMetricRef,
+    query: MetricQuery,
+    context?: ExecutionContext,
+  ): Promise<MetricResult<TRow>> {
+    if (this.backend) {
+      return this.backend.execute<TRow>(
+        this.planMetric(metric, query, context),
+      ) as Promise<MetricResult<TRow>>;
+    }
+
+    return this.run<TRow>(metric, query, context);
+  }
+
+  private executeDataset<TRow>(
+    ds: AnyDatasetInstance,
+    query: DatasetQuery,
+    context?: ExecutionContext,
+  ): Promise<DatasetQueryResult<TRow>> {
+    if (this.backend) {
+      return this.backend.execute<TRow>(
+        this.planDataset(ds, query, context),
+      ) as Promise<DatasetQueryResult<TRow>>;
+    }
+
     return runDatasetQuery(ds, query, {
       builderFactory: context?.runtime?.builderFactory ?? this.getBuilderFactory(),
       context,
-    }) as Promise<DatasetQueryResult<T>>;
+    }) as Promise<DatasetQueryResult<TRow>>;
   }
 
-  /**
-   * Generate SQL for a dataset query without executing it.
-   */
-  datasetSQL(
+  private toDatasetSQL(
     ds: AnyDatasetInstance,
-    query: DatasetQuery = {},
+    query: DatasetQuery,
     context?: ExecutionContext,
   ): string {
     const builder = buildDatasetQueryBuilder(ds, query, {
@@ -532,21 +605,10 @@ export class SemanticExecutor extends MetricExecutor {
     });
     return builder.toSQLWithParams().sql;
   }
-
-  /**
-   * Validate a dataset query against the dataset contract.
-   */
-  validateDataset(
-    ds: AnyDatasetInstance,
-    query: DatasetQuery = {},
-    context?: ExecutionContext,
-  ): ValidationResult {
-    return validateDatasetQuery(ds, query, context);
-  }
 }
 
-export function createExecutor(options: SemanticExecutorOptions): SemanticExecutor {
-  return new SemanticExecutor(options);
+export function createDatasetClient(options: CreateDatasetClientOptions): DatasetClient {
+  return new DatasetClientImpl(options);
 }
 
 export type { DatasetQueryExecutionOptions };

--- a/packages/datasets/src/formulas.ts
+++ b/packages/datasets/src/formulas.ts
@@ -2,7 +2,7 @@
  * Formula helpers for derived metrics.
  *
  * These are symbolic — they build FormulaExpr objects that get compiled to SQL
- * by the MetricExecutor. They do not produce raw SQL strings directly.
+ * by the semantic query engine. They do not produce raw SQL strings directly.
  *
  * @example
  * ```ts

--- a/packages/datasets/src/index.ts
+++ b/packages/datasets/src/index.ts
@@ -31,9 +31,9 @@ export {
 // Registry
 export { createDatasetRegistry } from './registry.js';
 
-// Executor
-export { createExecutor, SemanticExecutor, MetricExecutor } from './executor.js';
-export type { SemanticExecutorOptions, MetricExecutorOptions } from './executor.js';
+// Dataset client
+export { createDatasetClient } from './executor.js';
+export type { DatasetClient, CreateDatasetClientOptions } from './executor.js';
 export { createInMemoryBackend } from './in-memory-backend.js';
 export type { InMemoryTable, InMemoryTables } from './in-memory-backend.js';
 export type {
@@ -97,6 +97,7 @@ export type {
   DatasetConfig,
   DatasetLimits,
   DatasetInstance,
+  AnyDatasetInstance,
   BaseMetricConfig,
   DerivedMetricConfig,
   DatasetRegistryInstance,

--- a/packages/datasets/src/internal.ts
+++ b/packages/datasets/src/internal.ts
@@ -8,9 +8,9 @@
  * DO NOT import from this file in user code!
  */
 
-// Executor - used by serve to create metric/dataset endpoints
-export { createExecutor, SemanticExecutor, MetricExecutor } from './executor.js';
-export type { SemanticExecutorOptions, MetricExecutorOptions } from './executor.js';
+// Dataset client internals - used by serve to create metric/dataset endpoints
+export { createDatasetClient, DatasetClientImpl, MetricQueryEngine } from './executor.js';
+export type { DatasetClient, CreateDatasetClientOptions, MetricQueryEngineOptions } from './executor.js';
 export { createInMemoryBackend } from './in-memory-backend.js';
 export type { InMemoryTable, InMemoryTables } from './in-memory-backend.js';
 export type {

--- a/packages/datasets/src/query-builder-protocol.ts
+++ b/packages/datasets/src/query-builder-protocol.ts
@@ -2,7 +2,7 @@
  * Duck-typed protocol interfaces for query builders.
  *
  * These interfaces define the minimal contract that a query builder must satisfy
- * to work with the MetricExecutor. The @hypequery/clickhouse `createQueryBuilder`
+ * to work with the semantic dataset client. The @hypequery/clickhouse `createQueryBuilder`
  * return value satisfies `QueryBuilderFactoryLike` structurally — no explicit
  * `implements` is needed.
  *

--- a/packages/datasets/src/registry.ts
+++ b/packages/datasets/src/registry.ts
@@ -1,7 +1,7 @@
 /**
  * DatasetRegistry — runtime registry of defined datasets.
  *
- * Used by MetricExecutor and serve() to discover datasets at startup.
+ * Used by serve() and semantic clients to discover datasets at startup.
  */
 
 import type { DatasetInstance, DatasetRegistryInstance } from './types.js';

--- a/packages/datasets/src/relationships.ts
+++ b/packages/datasets/src/relationships.ts
@@ -2,7 +2,7 @@
  * Relationship helpers for dataset definitions.
  *
  * These helpers currently define semantic model metadata only. The shipped
- * executor does not yet resolve relationship paths into joined dataset queries
+ * semantic client does not yet resolve relationship paths into joined dataset queries
  * or cross-dataset metrics.
  *
  * @example

--- a/packages/datasets/src/utils/metric-handle.ts
+++ b/packages/datasets/src/utils/metric-handle.ts
@@ -26,7 +26,7 @@ export function isMetricHandle(value: unknown): value is MetricHandle {
 export function assertMetricHandle(value: unknown): asserts value is MetricHandle {
   if (!isMetricHandle(value)) {
     throw new Error(
-      'MetricExecutor only supports MetricRef and GrainedMetricRef. ' +
+      'Metric queries only support MetricRef and GrainedMetricRef. ' +
       'dataset.query(...) is not part of the public execution API.',
     );
   }

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -24,8 +24,7 @@ pnpm add @hypequery/mcp
 Create `mcp-config.ts`:
 
 ```typescript
-import { createExecutor } from '@hypequery/datasets';
-import { createQueryBuilder } from '@hypequery/clickhouse';
+import { createDatasetClient } from '@hypequery/clickhouse/datasets';
 import { OrdersDataset, CustomersDataset } from './datasets/index.js';
 
 const revenue = OrdersDataset.metric('revenue', { measure: 'revenue' });
@@ -45,14 +44,13 @@ export const datasets = {
   },
 };
 
-// Export your executor
-const builderFactory = createQueryBuilder({
-  host: process.env.CLICKHOUSE_HOST,
+// Export the semantic runner consumed by the MCP server
+export const analytics = createDatasetClient({
+  url: process.env.CLICKHOUSE_URL,
   username: process.env.CLICKHOUSE_USER,
   password: process.env.CLICKHOUSE_PASSWORD,
+  database: process.env.CLICKHOUSE_DATABASE,
 });
-
-export const executor = createExecutor({ queryBuilder: builderFactory });
 ```
 
 ### 2. Run the MCP Server
@@ -204,15 +202,19 @@ You can also use the MCP server programmatically in your application:
 
 ```typescript
 import { createMCPServer } from '@hypequery/mcp';
-import { createExecutor } from '@hypequery/datasets';
+import { createDatasetClient } from '@hypequery/clickhouse/datasets';
 import { datasets } from './datasets/index.js';
-import { queryBuilder } from './db/index.js';
 
-const executor = createExecutor({ queryBuilder });
+const analytics = createDatasetClient({
+  url: process.env.CLICKHOUSE_URL,
+  username: process.env.CLICKHOUSE_USER,
+  password: process.env.CLICKHOUSE_PASSWORD,
+  database: process.env.CLICKHOUSE_DATABASE,
+});
 
 const server = await createMCPServer({
   datasets,
-  executor,
+  analytics,
   name: 'my-analytics-mcp',
   version: '1.0.0',
 });
@@ -250,8 +252,8 @@ The MCP server also exposes a `dataset_guide` prompt that provides natural langu
 Your config file can use environment variables for database credentials:
 
 ```typescript
-const queryBuilder = createQueryBuilder({
-  host: process.env.CLICKHOUSE_HOST || 'localhost',
+const analytics = createDatasetClient({
+  url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
   username: process.env.CLICKHOUSE_USER || 'default',
   password: process.env.CLICKHOUSE_PASSWORD,
   database: process.env.CLICKHOUSE_DATABASE || 'default',
@@ -263,7 +265,7 @@ const queryBuilder = createQueryBuilder({
 ### MCP server not connecting
 
 1. Check that the config file path is absolute, not relative
-2. Ensure the config file exports both `datasets` and `executor`
+2. Ensure the config file exports both `datasets` and `analytics`
 3. Check Claude Desktop logs for errors
 
 ### Queries failing

--- a/packages/mcp-server/TESTING.md
+++ b/packages/mcp-server/TESTING.md
@@ -33,11 +33,11 @@ cp examples/mcp-config.js ./my-mcp-config.js
 
 Edit `my-mcp-config.js` to match your ClickHouse schema:
 ```javascript
-import { dataset, dimension, measure, createExecutor } from '@hypequery/datasets';
-import { createQueryBuilder } from '@hypequery/clickhouse';
+import { dataset, dimension, measure } from '@hypequery/datasets';
+import { createDatasetClient } from '@hypequery/clickhouse/datasets';
 
-const builderFactory = createQueryBuilder({
-  host: 'localhost',
+const analytics = createDatasetClient({
+  url: 'http://localhost:8123',
   username: 'default',
   password: '',
   database: 'analytics',
@@ -62,7 +62,7 @@ export const datasets = {
     metrics: { rowCount },
   },
 };
-export const executor = createExecutor({ queryBuilder: builderFactory });
+export { analytics };
 ```
 
 ### Step 3: Test the MCP Server Standalone
@@ -299,11 +299,11 @@ If you encounter issues:
 Minimal working example:
 
 ```javascript
-import { dataset, dimension, measure, createExecutor } from '@hypequery/datasets';
-import { createQueryBuilder } from '@hypequery/clickhouse';
+import { dataset, dimension, measure } from '@hypequery/datasets';
+import { createDatasetClient } from '@hypequery/clickhouse/datasets';
 
-const builderFactory = createQueryBuilder({
-  host: 'localhost',
+const analytics = createDatasetClient({
+  url: 'http://localhost:8123',
   username: 'default',
   password: '',
   database: 'default',
@@ -329,7 +329,7 @@ export const datasets = {
     metrics: { count, sum },
   },
 };
-export const executor = createExecutor({ queryBuilder: builderFactory });
+export { analytics };
 ```
 
 This uses ClickHouse's built-in `system.numbers` table, so no setup needed!

--- a/packages/mcp-server/TEST_SUMMARY.md
+++ b/packages/mcp-server/TEST_SUMMARY.md
@@ -77,7 +77,7 @@ Comprehensive test suite for `@hypequery/mcp` with **65 passing tests** across 6
 - ✅ Server start lifecycle
 - ✅ Server stop lifecycle
 - ✅ Complete start/stop lifecycle
-- ✅ Config validation (datasets, executor)
+- ✅ Config validation (datasets, analytics)
 - ✅ Default name/version fallbacks
 - ✅ Datasets with relationships
 - ✅ Config structure support
@@ -109,7 +109,7 @@ Comprehensive test suite for `@hypequery/mcp` with **65 passing tests** across 6
 
 ### 🔄 Mocked
 - MCP SDK components (Server, StdioServerTransport)
-- MetricExecutor (query execution)
+- Semantic runner (query execution)
 - BuilderFactory
 
 ### 📝 Not Tested
@@ -154,15 +154,15 @@ it('should execute metric query with dimensions', async () => {
     meta: { sql: '...', timingMs: 60 },
   };
 
-  const executor = createMockExecutor(mockResult);
-  const result = await queryMetricTool(datasets, executor, {
+  const analytics = createMockExecutor(mockResult);
+  const result = await queryMetricTool(datasets, analytics, {
     dataset: 'orders',
     metric: 'revenue',
     dimensions: ['region'],
   });
 
   expect(data.data).toHaveLength(2);
-  expect(executor.run).toHaveBeenCalledWith(
+  expect(analytics.execute).toHaveBeenCalledWith(
     expect.anything(),
     expect.objectContaining({ dimensions: ['region'] }),
     expect.anything()

--- a/packages/mcp-server/examples/mcp-config.js
+++ b/packages/mcp-server/examples/mcp-config.js
@@ -5,16 +5,15 @@
  * Copy this file and modify it for your ClickHouse schema.
  */
 
-import { dataset, dimension, measure, createExecutor } from '@hypequery/datasets';
-import { createQueryBuilder } from '@hypequery/clickhouse';
+import { dataset, dimension, measure } from '@hypequery/datasets';
+import { createDatasetClient } from '@hypequery/clickhouse/datasets';
 
 // =============================================================================
 // ClickHouse Connection
 // =============================================================================
 
-const builderFactory = createQueryBuilder({
-  host: process.env.CLICKHOUSE_HOST || 'localhost',
-  port: process.env.CLICKHOUSE_PORT ? parseInt(process.env.CLICKHOUSE_PORT) : 8123,
+const analytics = createDatasetClient({
+  url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
   username: process.env.CLICKHOUSE_USER || 'default',
   password: process.env.CLICKHOUSE_PASSWORD || '',
   database: process.env.CLICKHOUSE_DATABASE || 'default',
@@ -54,4 +53,4 @@ export const datasets = {
   },
 };
 
-export const executor = createExecutor({ queryBuilder: builderFactory });
+export { analytics };

--- a/packages/mcp-server/examples/mcp-config.ts
+++ b/packages/mcp-server/examples/mcp-config.ts
@@ -12,16 +12,14 @@
  */
 
 import { dataset, dimension, measure } from '@hypequery/datasets';
-import { createExecutor } from '@hypequery/datasets';
-import { createQueryBuilder } from '@hypequery/clickhouse';
+import { createDatasetClient } from '@hypequery/clickhouse/datasets';
 
 // =============================================================================
 // STEP 1: Configure ClickHouse Connection
 // =============================================================================
 
-const builderFactory = createQueryBuilder({
-  host: process.env.CLICKHOUSE_HOST || 'localhost',
-  port: process.env.CLICKHOUSE_PORT ? parseInt(process.env.CLICKHOUSE_PORT) : 8123,
+const analytics = createDatasetClient({
+  url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
   username: process.env.CLICKHOUSE_USER || 'default',
   password: process.env.CLICKHOUSE_PASSWORD || '',
   database: process.env.CLICKHOUSE_DATABASE || 'default',
@@ -72,7 +70,7 @@ export const CustomersDataset = dataset('customers', {
 });
 
 // =============================================================================
-// STEP 3: Export Datasets and Executor for MCP Server
+// STEP 3: Export Datasets and Semantic Runner for MCP Server
 // =============================================================================
 
 /**
@@ -95,10 +93,10 @@ export const datasets = {
 };
 
 /**
- * Create and export the metric executor
+ * Export the semantic runner consumed by the MCP server
  * This handles query execution against ClickHouse
  */
-export const executor = createExecutor({ queryBuilder: builderFactory });
+export { analytics };
 
 // =============================================================================
 // STEP 4: Claude Desktop Configuration

--- a/packages/mcp-server/examples/system-numbers-config.js
+++ b/packages/mcp-server/examples/system-numbers-config.js
@@ -8,12 +8,12 @@
  *   node dist/bin.js --config examples/system-numbers-config.js
  */
 
-import { dataset, dimension, measure, createExecutor } from '@hypequery/datasets';
-import { createQueryBuilder } from '@hypequery/clickhouse';
+import { dataset, dimension, measure } from '@hypequery/datasets';
+import { createDatasetClient } from '@hypequery/clickhouse/datasets';
 
 // Connect to local ClickHouse (defaults)
-const builderFactory = createQueryBuilder({
-  host: process.env.CLICKHOUSE_HOST || 'localhost',
+const analytics = createDatasetClient({
+  url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
   username: process.env.CLICKHOUSE_USER || 'default',
   password: process.env.CLICKHOUSE_PASSWORD || '',
   database: 'default',
@@ -46,7 +46,7 @@ export const datasets = {
   },
 };
 
-export const executor = createExecutor({ queryBuilder: builderFactory });
+export { analytics };
 
 /**
  * Test queries to try with Claude:

--- a/packages/mcp-server/src/bin.ts
+++ b/packages/mcp-server/src/bin.ts
@@ -4,7 +4,7 @@
  * MCP Server CLI
  *
  * This is a standalone executable that starts the MCP server.
- * Users can configure it by creating a config file that exports datasets and executor.
+ * Users can configure it by creating a config file that exports datasets and analytics.
  *
  * Usage:
  *   npx hypequery-mcp --config ./mcp-config.js
@@ -38,10 +38,10 @@ async function main() {
     console.error('');
     console.error('Usage: hypequery-mcp --config ./mcp-config.js');
     console.error('');
-    console.error('The config file should export { datasets, executor }:');
+    console.error('The config file should export { datasets, analytics }:');
     console.error('');
     console.error('  export const datasets = { ... };');
-    console.error('  export const executor = createExecutor({ queryBuilder });');
+    console.error('  export const analytics = createDatasetClient({ ... });');
     process.exit(1);
   }
 
@@ -51,20 +51,20 @@ async function main() {
     // Dynamic import of the config file
     const configModule = await import(pathToFileURL(configPath).href);
 
-    const { datasets, executor } = configModule;
+    const { datasets, analytics } = configModule;
 
     if (!datasets) {
       throw new Error('Config file must export "datasets"');
     }
 
-    if (!executor) {
-      throw new Error('Config file must export "executor"');
+    if (!analytics) {
+      throw new Error('Config file must export "analytics"');
     }
 
     // Create and start the MCP server
     await createMCPServer({
       datasets,
-      executor,
+      analytics,
       name: 'hypequery-mcp-server',
       version: '0.1.0',
     });

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HypequeryMCPServer } from './server.js';
-import type { SemanticExecutor } from '@hypequery/datasets';
+import type { DatasetClient } from '@hypequery/datasets';
 
 // Mock the MCP SDK
 vi.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
@@ -20,11 +20,8 @@ vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
 }));
 
 describe('HypequeryMCPServer', () => {
-  const mockExecutor: SemanticExecutor = {
-    metric: vi.fn(),
-    dataset: vi.fn(),
-    run: vi.fn(),
-    getBuilderFactory: vi.fn().mockReturnValue({}),
+  const mockAnalytics: DatasetClient = {
+    execute: vi.fn(),
   } as any;
 
   const mockDatasets = {
@@ -46,7 +43,7 @@ describe('HypequeryMCPServer', () => {
   it('should create server instance with default config', () => {
     const server = new HypequeryMCPServer({
       datasets: mockDatasets,
-      executor: mockExecutor,
+      analytics: mockAnalytics,
     });
 
     expect(server).toBeInstanceOf(HypequeryMCPServer);
@@ -55,7 +52,7 @@ describe('HypequeryMCPServer', () => {
   it('should create server instance with custom name and version', () => {
     const server = new HypequeryMCPServer({
       datasets: mockDatasets,
-      executor: mockExecutor,
+      analytics: mockAnalytics,
       name: 'custom-mcp-server',
       version: '1.0.0',
     });
@@ -66,7 +63,7 @@ describe('HypequeryMCPServer', () => {
   it('should accept empty datasets', () => {
     const server = new HypequeryMCPServer({
       datasets: {},
-      executor: mockExecutor,
+      analytics: mockAnalytics,
     });
 
     expect(server).toBeInstanceOf(HypequeryMCPServer);
@@ -81,7 +78,7 @@ describe('HypequeryMCPServer', () => {
 
     const server = new HypequeryMCPServer({
       datasets,
-      executor: mockExecutor,
+      analytics: mockAnalytics,
     });
 
     expect(server).toBeInstanceOf(HypequeryMCPServer);
@@ -90,7 +87,7 @@ describe('HypequeryMCPServer', () => {
   it('should start server successfully', async () => {
     const server = new HypequeryMCPServer({
       datasets: mockDatasets,
-      executor: mockExecutor,
+      analytics: mockAnalytics,
     });
 
     // Mock console.error to verify logging
@@ -106,7 +103,7 @@ describe('HypequeryMCPServer', () => {
   it('should stop server successfully', async () => {
     const server = new HypequeryMCPServer({
       datasets: mockDatasets,
-      executor: mockExecutor,
+      analytics: mockAnalytics,
     });
 
     await expect(server.stop()).resolves.toBeUndefined();
@@ -115,7 +112,7 @@ describe('HypequeryMCPServer', () => {
   it('should handle server lifecycle', async () => {
     const server = new HypequeryMCPServer({
       datasets: mockDatasets,
-      executor: mockExecutor,
+      analytics: mockAnalytics,
     });
 
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -130,28 +127,25 @@ describe('HypequeryMCPServer', () => {
 });
 
 describe('HypequeryMCPServer config validation', () => {
-  const mockExecutor: SemanticExecutor = {
-    metric: vi.fn(),
-    dataset: vi.fn(),
-    run: vi.fn(),
-    getBuilderFactory: vi.fn().mockReturnValue({}),
+  const mockAnalytics: DatasetClient = {
+    execute: vi.fn(),
   } as any;
 
   it('should accept undefined datasets', () => {
     // Server doesn't validate config, it accepts whatever is passed
     const server = new HypequeryMCPServer({
       datasets: undefined as any,
-      executor: mockExecutor,
+      analytics: mockAnalytics,
     });
 
     expect(server).toBeInstanceOf(HypequeryMCPServer);
   });
 
-  it('should accept undefined executor', () => {
+  it('should accept undefined analytics', () => {
     // Server doesn't validate config, it accepts whatever is passed
     const server = new HypequeryMCPServer({
       datasets: {},
-      executor: undefined as any,
+      analytics: undefined as any,
     });
 
     expect(server).toBeInstanceOf(HypequeryMCPServer);
@@ -160,7 +154,7 @@ describe('HypequeryMCPServer config validation', () => {
   it('should use default name when not provided', () => {
     const server = new HypequeryMCPServer({
       datasets: {},
-      executor: mockExecutor,
+      analytics: mockAnalytics,
     });
 
     expect(server).toBeInstanceOf(HypequeryMCPServer);
@@ -169,7 +163,7 @@ describe('HypequeryMCPServer config validation', () => {
   it('should use default version when not provided', () => {
     const server = new HypequeryMCPServer({
       datasets: {},
-      executor: mockExecutor,
+      analytics: mockAnalytics,
     });
 
     expect(server).toBeInstanceOf(HypequeryMCPServer);
@@ -177,11 +171,8 @@ describe('HypequeryMCPServer config validation', () => {
 });
 
 describe('HypequeryMCPServer with complex datasets', () => {
-  const mockExecutor: SemanticExecutor = {
-    metric: vi.fn(),
-    dataset: vi.fn(),
-    run: vi.fn(),
-    getBuilderFactory: vi.fn().mockReturnValue({}),
+  const mockAnalytics: DatasetClient = {
+    execute: vi.fn(),
   } as any;
 
   it('should handle dataset with relationships', () => {
@@ -204,7 +195,7 @@ describe('HypequeryMCPServer with complex datasets', () => {
 
     const server = new HypequeryMCPServer({
       datasets,
-      executor: mockExecutor,
+      analytics: mockAnalytics,
     });
 
     expect(server).toBeInstanceOf(HypequeryMCPServer);
@@ -226,7 +217,7 @@ describe('HypequeryMCPServer with complex datasets', () => {
 
     const server = new HypequeryMCPServer({
       datasets,
-      executor: mockExecutor,
+      analytics: mockAnalytics,
     });
 
     expect(server).toBeInstanceOf(HypequeryMCPServer);
@@ -256,7 +247,7 @@ describe('HypequeryMCPServer with complex datasets', () => {
 
     const server = new HypequeryMCPServer({
       datasets,
-      executor: mockExecutor,
+      analytics: mockAnalytics,
     });
 
     expect(server).toBeInstanceOf(HypequeryMCPServer);

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -13,7 +13,7 @@ import {
   ListPromptsRequestSchema,
   GetPromptRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import type { SemanticExecutor } from '@hypequery/datasets';
+import type { DatasetClient } from '@hypequery/datasets';
 import { listDatasetsTool } from './tools/list-datasets.js';
 import { getDatasetSchemaTool } from './tools/introspect.js';
 import { queryMetricTool } from './tools/query-metric.js';
@@ -28,9 +28,9 @@ export interface MCPServerConfig {
   datasets: DatasetRegistry;
 
   /**
-   * Semantic executor for running metric and dataset queries
+   * Semantic analytics for running metric and dataset queries
    */
-  executor: SemanticExecutor;
+  analytics: DatasetClient;
 
   /**
    * Server name (shown in MCP client)
@@ -231,14 +231,14 @@ export class HypequeryMCPServer {
           case 'query_metric':
             return await queryMetricTool(
               this.config.datasets,
-              this.config.executor,
+              this.config.analytics,
               args
             );
 
           case 'query_dataset':
             return await queryDatasetTool(
               this.config.datasets,
-              this.config.executor,
+              this.config.analytics,
               args
             );
 

--- a/packages/mcp-server/src/tools/query-dataset.test.ts
+++ b/packages/mcp-server/src/tools/query-dataset.test.ts
@@ -4,29 +4,26 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { queryDatasetTool } from './query-dataset.js';
-import type { SemanticExecutor } from '@hypequery/datasets';
+import type { DatasetClient } from '@hypequery/datasets';
 
 describe('queryDatasetTool', () => {
-  const createMockExecutor = (mockResult: any): SemanticExecutor => ({
-    metric: vi.fn(),
-    dataset: vi.fn().mockResolvedValue(mockResult),
-    run: vi.fn(),
-    getBuilderFactory: vi.fn().mockReturnValue({}),
+  const createMockAnalytics = (mockResult: any): DatasetClient => ({
+    execute: vi.fn().mockResolvedValue(mockResult),
   } as any);
 
   it('should throw error when dataset parameter is missing', async () => {
-    const executor = createMockExecutor({});
+    const analytics = createMockAnalytics({});
 
     await expect(
-      queryDatasetTool({}, executor, { dimensions: ['region'] })
+      queryDatasetTool({}, analytics, { dimensions: ['region'] })
     ).rejects.toThrow('dataset parameter is required');
   });
 
   it('should throw error when dataset is not found', async () => {
-    const executor = createMockExecutor({});
+    const analytics = createMockAnalytics({});
 
     await expect(
-      queryDatasetTool({}, executor, { dataset: 'nonexistent', dimensions: ['region'] })
+      queryDatasetTool({}, analytics, { dataset: 'nonexistent', dimensions: ['region'] })
     ).rejects.toThrow('Dataset not found: nonexistent');
   });
 
@@ -34,10 +31,10 @@ describe('queryDatasetTool', () => {
     const datasets = {
       orders: {},
     };
-    const executor = createMockExecutor({});
+    const analytics = createMockAnalytics({});
 
     await expect(
-      queryDatasetTool(datasets, executor, { dataset: 'orders' })
+      queryDatasetTool(datasets, analytics, { dataset: 'orders' })
     ).rejects.toThrow('At least one dimension or metric must be specified');
   });
 
@@ -57,8 +54,8 @@ describe('queryDatasetTool', () => {
       orders: {},
     };
 
-    const executor = createMockExecutor(mockResult);
-    const result = await queryDatasetTool(datasets, executor, {
+    const analytics = createMockAnalytics(mockResult);
+    const result = await queryDatasetTool(datasets, analytics, {
       dataset: 'orders',
       dimensions: ['region'],
     });
@@ -67,7 +64,7 @@ describe('queryDatasetTool', () => {
     expect(data.data).toHaveLength(2);
     expect(data.meta.rowCount).toBe(2);
 
-    expect(executor.dataset).toHaveBeenCalledWith(
+    expect(analytics.execute).toHaveBeenCalledWith(
       {},
       {
         dimensions: ['region'],
@@ -93,8 +90,8 @@ describe('queryDatasetTool', () => {
       orders: {},
     };
 
-    const executor = createMockExecutor(mockResult);
-    const result = await queryDatasetTool(datasets, executor, {
+    const analytics = createMockAnalytics(mockResult);
+    const result = await queryDatasetTool(datasets, analytics, {
       dataset: 'orders',
       metrics: ['revenue', 'count'],
     });
@@ -102,7 +99,7 @@ describe('queryDatasetTool', () => {
     const data = JSON.parse(result.content[0].text);
     expect(data.data).toEqual([{ revenue: 1000, count: 50 }]);
 
-    expect(executor.dataset).toHaveBeenCalledWith(
+    expect(analytics.execute).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         measures: ['revenue', 'count'],
@@ -125,8 +122,8 @@ describe('queryDatasetTool', () => {
       orders: {},
     };
 
-    const executor = createMockExecutor(mockResult);
-    const result = await queryDatasetTool(datasets, executor, {
+    const analytics = createMockAnalytics(mockResult);
+    const result = await queryDatasetTool(datasets, analytics, {
       dataset: 'orders',
       dimensions: ['region'],
       metrics: ['revenue'],
@@ -135,7 +132,7 @@ describe('queryDatasetTool', () => {
     const data = JSON.parse(result.content[0].text);
     expect(data.data).toHaveLength(2);
 
-    expect(executor.dataset).toHaveBeenCalledWith(
+    expect(analytics.execute).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         dimensions: ['region'],
@@ -155,20 +152,20 @@ describe('queryDatasetTool', () => {
       orders: {},
     };
 
-    const executor = createMockExecutor(mockResult);
+    const analytics = createMockAnalytics(mockResult);
     const filters = [
       { field: 'status', operator: 'eq', value: 'completed' },
       { field: 'amount', operator: 'gte', value: 100 },
     ];
 
-    await queryDatasetTool(datasets, executor, {
+    await queryDatasetTool(datasets, analytics, {
       dataset: 'orders',
       dimensions: ['region'],
       metrics: ['revenue'],
       filters,
     });
 
-    expect(executor.dataset).toHaveBeenCalledWith(
+    expect(analytics.execute).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         filters,
@@ -190,15 +187,15 @@ describe('queryDatasetTool', () => {
       orders: {},
     };
 
-    const executor = createMockExecutor(mockResult);
-    await queryDatasetTool(datasets, executor, {
+    const analytics = createMockAnalytics(mockResult);
+    await queryDatasetTool(datasets, analytics, {
       dataset: 'orders',
       dimensions: ['week'],
       metrics: ['revenue'],
       grain: 'week',
     });
 
-    expect(executor.dataset).toHaveBeenCalledWith(
+    expect(analytics.execute).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         by: 'week',
@@ -221,13 +218,13 @@ describe('queryDatasetTool', () => {
       orders: {},
     };
 
-    const executor = createMockExecutor(mockResult);
+    const analytics = createMockAnalytics(mockResult);
     const orderBy = [
       { field: 'revenue', direction: 'desc' },
       { field: 'region', direction: 'asc' },
     ];
 
-    await queryDatasetTool(datasets, executor, {
+    await queryDatasetTool(datasets, analytics, {
       dataset: 'orders',
       dimensions: ['region'],
       metrics: ['revenue'],
@@ -235,7 +232,7 @@ describe('queryDatasetTool', () => {
       limit: 5,
     });
 
-    expect(executor.dataset).toHaveBeenCalledWith(
+    expect(analytics.execute).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         orderBy,
@@ -262,8 +259,8 @@ describe('queryDatasetTool', () => {
       orders: {},
     };
 
-    const executor = createMockExecutor(mockResult);
-    const result = await queryDatasetTool(datasets, executor, {
+    const analytics = createMockAnalytics(mockResult);
+    const result = await queryDatasetTool(datasets, analytics, {
       dataset: 'orders',
       dimensions: ['region', 'category'],
       metrics: ['revenue', 'count'],
@@ -291,8 +288,8 @@ describe('queryDatasetTool', () => {
       orders: {},
     };
 
-    const executor = createMockExecutor(mockResult);
-    const result = await queryDatasetTool(datasets, executor, {
+    const analytics = createMockAnalytics(mockResult);
+    const result = await queryDatasetTool(datasets, analytics, {
       dataset: 'orders',
       dimensions: ['region'],
     });
@@ -312,15 +309,15 @@ describe('queryDatasetTool', () => {
       orders: {},
     };
 
-    const executor = createMockExecutor(mockResult);
-    await queryDatasetTool(datasets, executor, {
+    const analytics = createMockAnalytics(mockResult);
+    await queryDatasetTool(datasets, analytics, {
       dataset: 'orders',
       dimensions: ['region'],
       filters: [],
       orderBy: [],
     });
 
-    expect(executor.dataset).toHaveBeenCalledWith(
+    expect(analytics.execute).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         filters: [],

--- a/packages/mcp-server/src/tools/query-dataset.ts
+++ b/packages/mcp-server/src/tools/query-dataset.ts
@@ -4,12 +4,12 @@
  * Executes an ad-hoc dataset query with custom dimensions and metrics.
  */
 
-import type { SemanticExecutor, DatasetQuery } from '@hypequery/datasets';
+import type { DatasetClient, DatasetQuery } from '@hypequery/datasets';
 import type { DatasetRegistry, QueryDatasetArgs, MCPToolResponse, QueryResultResponse, MAX_QUERY_LIMIT } from '../types.js';
 
 export async function queryDatasetTool(
   datasets: DatasetRegistry,
-  executor: SemanticExecutor,
+  analytics: DatasetClient,
   args: unknown
 ): Promise<MCPToolResponse> {
   // Parse and validate args
@@ -48,7 +48,7 @@ export async function queryDatasetTool(
     query.limit = Math.min(limit, MAX_LIMIT);
   }
 
-  const result = await executor.dataset(dataset as any, query, {
+  const result = await analytics.execute(dataset as any, query, {
     runtime: {
       tenant: undefined,
     },

--- a/packages/mcp-server/src/tools/query-metric.test.ts
+++ b/packages/mcp-server/src/tools/query-metric.test.ts
@@ -4,37 +4,34 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { queryMetricTool } from './query-metric.js';
-import type { SemanticExecutor } from '@hypequery/datasets';
+import type { DatasetClient } from '@hypequery/datasets';
 
 describe('queryMetricTool', () => {
-  const createMockExecutor = (mockResult: any): SemanticExecutor => ({
-    metric: vi.fn().mockResolvedValue(mockResult),
-    dataset: vi.fn(),
-    run: vi.fn(),
-    getBuilderFactory: vi.fn().mockReturnValue({}),
+  const createMockAnalytics = (mockResult: any): DatasetClient => ({
+    execute: vi.fn().mockResolvedValue(mockResult),
   } as any);
 
   it('should throw error when dataset parameter is missing', async () => {
-    const executor = createMockExecutor({});
+    const analytics = createMockAnalytics({});
 
     await expect(
-      queryMetricTool({}, executor, { metric: 'revenue' })
+      queryMetricTool({}, analytics, { metric: 'revenue' })
     ).rejects.toThrow('dataset parameter is required');
   });
 
   it('should throw error when metric parameter is missing', async () => {
-    const executor = createMockExecutor({});
+    const analytics = createMockAnalytics({});
 
     await expect(
-      queryMetricTool({}, executor, { dataset: 'orders' })
+      queryMetricTool({}, analytics, { dataset: 'orders' })
     ).rejects.toThrow('metric parameter is required');
   });
 
   it('should throw error when dataset is not found', async () => {
-    const executor = createMockExecutor({});
+    const analytics = createMockAnalytics({});
 
     await expect(
-      queryMetricTool({}, executor, { dataset: 'nonexistent', metric: 'revenue' })
+      queryMetricTool({}, analytics, { dataset: 'nonexistent', metric: 'revenue' })
     ).rejects.toThrow('Dataset not found: nonexistent');
   });
 
@@ -46,10 +43,10 @@ describe('queryMetricTool', () => {
         },
       },
     };
-    const executor = createMockExecutor({});
+    const analytics = createMockAnalytics({});
 
     await expect(
-      queryMetricTool(datasets, executor, { dataset: 'orders', metric: 'nonexistent' })
+      queryMetricTool(datasets, analytics, { dataset: 'orders', metric: 'nonexistent' })
     ).rejects.toThrow('Metric not found: nonexistent in dataset orders');
   });
 
@@ -68,8 +65,8 @@ describe('queryMetricTool', () => {
       },
     };
 
-    const executor = createMockExecutor(mockResult);
-    const result = await queryMetricTool(datasets, executor, {
+    const analytics = createMockAnalytics(mockResult);
+    const result = await queryMetricTool(datasets, analytics, {
       dataset: 'orders',
       metric: 'revenue',
     });
@@ -81,7 +78,7 @@ describe('queryMetricTool', () => {
     expect(data.meta.timingMs).toBe(45);
     expect(data.meta.rowCount).toBe(1);
 
-    expect(executor.metric).toHaveBeenCalledWith(
+    expect(analytics.execute).toHaveBeenCalledWith(
       { type: 'sum' },
       {
         dimensions: [],
@@ -90,7 +87,6 @@ describe('queryMetricTool', () => {
       },
       {
         runtime: {
-          builderFactory: {},
           tenant: undefined,
         },
       }
@@ -117,8 +113,8 @@ describe('queryMetricTool', () => {
       },
     };
 
-    const executor = createMockExecutor(mockResult);
-    const result = await queryMetricTool(datasets, executor, {
+    const analytics = createMockAnalytics(mockResult);
+    const result = await queryMetricTool(datasets, analytics, {
       dataset: 'orders',
       metric: 'revenue',
       dimensions: ['region'],
@@ -128,7 +124,7 @@ describe('queryMetricTool', () => {
     expect(data.data).toHaveLength(2);
     expect(data.meta.rowCount).toBe(2);
 
-    expect(executor.metric).toHaveBeenCalledWith(
+    expect(analytics.execute).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         dimensions: ['region'],
@@ -149,19 +145,19 @@ describe('queryMetricTool', () => {
       },
     };
 
-    const executor = createMockExecutor(mockResult);
+    const analytics = createMockAnalytics(mockResult);
     const filters = [
       { field: 'status', operator: 'eq', value: 'completed' },
       { field: 'amount', operator: 'gt', value: 100 },
     ];
 
-    await queryMetricTool(datasets, executor, {
+    await queryMetricTool(datasets, analytics, {
       dataset: 'orders',
       metric: 'revenue',
       filters,
     });
 
-    expect(executor.metric).toHaveBeenCalledWith(
+    expect(analytics.execute).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         filters,
@@ -185,14 +181,14 @@ describe('queryMetricTool', () => {
       },
     };
 
-    const executor = createMockExecutor(mockResult);
-    await queryMetricTool(datasets, executor, {
+    const analytics = createMockAnalytics(mockResult);
+    await queryMetricTool(datasets, analytics, {
       dataset: 'orders',
       metric: 'revenue',
       grain: 'month',
     });
 
-    expect(executor.metric).toHaveBeenCalledWith(
+    expect(analytics.execute).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         by: 'month',
@@ -218,10 +214,10 @@ describe('queryMetricTool', () => {
       },
     };
 
-    const executor = createMockExecutor(mockResult);
+    const analytics = createMockAnalytics(mockResult);
     const orderBy = [{ field: 'revenue', direction: 'desc' }];
 
-    await queryMetricTool(datasets, executor, {
+    await queryMetricTool(datasets, analytics, {
       dataset: 'orders',
       metric: 'revenue',
       dimensions: ['region'],
@@ -229,7 +225,7 @@ describe('queryMetricTool', () => {
       limit: 10,
     });
 
-    expect(executor.metric).toHaveBeenCalledWith(
+    expect(analytics.execute).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         orderBy,
@@ -250,13 +246,13 @@ describe('queryMetricTool', () => {
       },
     };
 
-    const executor = createMockExecutor(mockResult);
-    await queryMetricTool(datasets, executor, {
+    const analytics = createMockAnalytics(mockResult);
+    await queryMetricTool(datasets, analytics, {
       dataset: 'orders',
       metric: 'revenue',
     });
 
-    expect(executor.metric).toHaveBeenCalledWith(
+    expect(analytics.execute).toHaveBeenCalledWith(
       { type: 'sum' },
       expect.anything(),
       expect.anything()
@@ -272,13 +268,13 @@ describe('queryMetricTool', () => {
       },
     };
 
-    const executor = createMockExecutor(mockResult);
-    await queryMetricTool(datasets, executor, {
+    const analytics = createMockAnalytics(mockResult);
+    await queryMetricTool(datasets, analytics, {
       dataset: 'orders',
       metric: 'totalRevenue',
     });
 
-    expect(executor.metric).toHaveBeenCalledWith(
+    expect(analytics.execute).toHaveBeenCalledWith(
       { type: 'sum' },
       expect.anything(),
       expect.anything()
@@ -300,8 +296,8 @@ describe('queryMetricTool', () => {
       },
     };
 
-    const executor = createMockExecutor(mockResult);
-    const result = await queryMetricTool(datasets, executor, {
+    const analytics = createMockAnalytics(mockResult);
+    const result = await queryMetricTool(datasets, analytics, {
       dataset: 'orders',
       metric: 'revenue',
     });

--- a/packages/mcp-server/src/tools/query-metric.ts
+++ b/packages/mcp-server/src/tools/query-metric.ts
@@ -4,12 +4,12 @@
  * Executes a metric query with optional dimensions, filters, grain, and sorting.
  */
 
-import type { SemanticExecutor, MetricQuery } from '@hypequery/datasets';
+import type { DatasetClient, MetricQuery } from '@hypequery/datasets';
 import type { DatasetRegistry, QueryMetricArgs, MCPToolResponse, QueryResultResponse, MAX_QUERY_LIMIT } from '../types.js';
 
 export async function queryMetricTool(
   datasets: DatasetRegistry,
-  executor: SemanticExecutor,
+  analytics: DatasetClient,
   args: unknown
 ): Promise<MCPToolResponse> {
   // Parse and validate args
@@ -55,9 +55,8 @@ export async function queryMetricTool(
   }
 
   // Execute the query
-  const result = await executor.metric(metric, query, {
+  const result = await analytics.execute(metric, query, {
     runtime: {
-      builderFactory: executor.getBuilderFactory(),
       tenant: undefined,
     },
   });

--- a/packages/serve/DATASETS_AND_METRICS_SPEC.md
+++ b/packages/serve/DATASETS_AND_METRICS_SPEC.md
@@ -15,7 +15,7 @@ When these packages are ready for public docs, the first docs pass should focus 
   - derived metrics
   - `.by(grain)`
   - runtime tenancy shape
-  - `MetricExecutor`
+  - semantic execution engine
   - intentional root exports only; serve-only helpers should stay under `@hypequery/datasets/internal`
 - `@hypequery/serve`
   - generated metric endpoints
@@ -90,7 +90,7 @@ Key departures from the previous spec:
 │  │                      │   │   └─ dataset.metric(...)   │   │
 │  └──────────────────────┘   └────────────────────────────┘   │
 │                                                               │
-│  MetricExecutor / dataset-query helpers ──→ QueryBuilder      │
+│  Semantic execution engine / dataset-query helpers ──→ QueryBuilder      │
 │  ServeHandler ──→ transports (serve, node, fetch)             │
 └──────────────────────────────────────────────────────────────┘
 ```
@@ -303,7 +303,7 @@ const marginPercent = Orders.metric("marginPercent", {
 
 **Execution model for derived metrics:**
 
-The executor wraps the base aggregations in a CTE and computes derived formulas in an outer SELECT:
+The semantic engine wraps the base aggregations in a CTE and computes derived formulas in an outer SELECT:
 
 ```sql
 WITH base AS (
@@ -400,8 +400,18 @@ Only `.by(grain)` is implemented in the current pre-release surface. Rolling win
 Metrics define canonical values. Consumers can narrow them at query time by specifying dimensions and filters:
 
 ```ts
-// Server-side (in-process)
-const result = await executor.run(totalRevenue, {
+// Served API (in-process)
+const result = await api.execute("totalRevenue", {
+  input: {
+    dimensions: ["country", "status"],
+    filters: [{ field: "status", operator: "eq", value: "completed" }],
+    orderBy: [{ field: "totalRevenue", direction: "desc" }],
+    limit: 100,
+  },
+});
+
+// Standalone semantic client
+const standaloneResult = await analytics.execute(totalRevenue, {
   dimensions: ["country", "status"],
   filters: [{ field: "status", operator: "eq", value: "completed" }],
   orderBy: [{ field: "totalRevenue", direction: "desc" }],
@@ -601,7 +611,7 @@ External behavior depends on configuration:
 | Default | `{ data: [...] }` — meta excluded |
 | `X-Include-Meta: true` header | `{ data: [...], meta: { ... } }` |
 | `envelope: true` in serve config | Always includes meta |
-| In-process `executor.run()` | Always returns full `MetricResult` |
+| Standalone `analytics.execute(metric, query)` | Always returns full `MetricResult` |
 
 ---
 
@@ -609,7 +619,7 @@ External behavior depends on configuration:
 
 ### 4.1 Key Decision: Delegate to QueryBuilder
 
-The semantic layer does **not** generate SQL strings directly as its source of truth. `MetricExecutor` and the shared dataset-query helpers compose the existing `@hypequery/clickhouse` QueryBuilder programmatically. This gives us parameterized queries, dialect handling, CTE support, caching, and logging for free.
+The semantic layer does **not** generate SQL strings directly as its source of truth. The semantic execution engine and the shared dataset-query helpers compose the existing `@hypequery/clickhouse` QueryBuilder programmatically. This gives us parameterized queries, dialect handling, CTE support, caching, and logging for free.
 
 The QueryBuilder exposes everything we need:
 - `.table(name)` — start from a physical table
@@ -624,12 +634,12 @@ The QueryBuilder exposes everything we need:
 - `.toSQL()` / `.toSQLWithParams()` — SQL output without executing
 - `.execute()` — execute with logging, caching, and parameterization
 
-The QueryBuilder is heavily generic-typed for user-facing fluent chains. The semantic execution layer works with the duck-typed builder protocol internally — type safety lives at the dataset/metric definition and contract boundary, not inside the executor.
+The QueryBuilder is heavily generic-typed for user-facing fluent chains. The semantic execution layer works with the duck-typed builder protocol internally — type safety lives at the dataset/metric definition and contract boundary, not inside the semantic engine.
 
-### 4.2 MetricExecutor
+### 4.2 Semantic Execution Engine
 
 ```ts
-class MetricExecutor {
+class DatasetClient {
   private qb: ReturnType<typeof createQueryBuilder<any>>;
 
   constructor(options: {
@@ -677,9 +687,9 @@ runDatasetQuery(dataset, query, options)
 
 These helpers are for package integration, primarily serve-backed dataset endpoints. They should not be documented as the user-facing datasets API unless we deliberately promote them later.
 
-### 4.3 How MetricExecutor Builds Queries
+### 4.3 How Semantic Execution Builds Queries
 
-The executor translates metric definitions into QueryBuilder calls. Here's the
+The semantic engine translates metric definitions into QueryBuilder calls. Here's the
 mapping for each case:
 
 **Base metrics — `.table().select().sum().where().groupBy().execute()`**
@@ -731,7 +741,7 @@ LIMIT 100
 
 ```ts
 // Metric: avgOrderValue = divide(totalRevenue, orderCount)
-// The executor collects all base metrics, builds a CTE, then wraps with formula.
+// The semantic engine collects all base metrics, builds a CTE, then wraps with formula.
 
 const baseBuilder = this.qb
   .table("orders")
@@ -848,7 +858,7 @@ GROUP BY customers.country
 
 ### 4.5 Aggregation Mapping
 
-The executor maps metric aggregation specs to QueryBuilder methods:
+The semantic engine maps metric aggregation specs to QueryBuilder methods:
 
 ```ts
 function applyAggregation(builder, spec, alias) {
@@ -984,7 +994,7 @@ const Orders = dataset("orders", {
 });
 ```
 
-The executor validates these before generating SQL. Violations return a `400` with a clear error message.
+The semantic engine validates these before generating SQL. Violations return a `400` with a clear error message.
 
 ### 5.7 Schema Compatibility
 
@@ -1036,7 +1046,7 @@ Current v1 checks include:
 
 - `Dataset.metric()` method
 - Aggregation helpers: `sum`, `count`, `countDistinct`, `avg`, `min`, `max`
-- `MetricExecutor` — SQL generation + execution for base metrics
+- Semantic execution engine — SQL generation + execution for base metrics
 - `MetricRef` type with `.contract()` method
 - Tenant auto-injection in generated SQL
 - Tests: SQL generation, parameterization, tenant injection, contract generation

--- a/packages/serve/README.md
+++ b/packages/serve/README.md
@@ -49,6 +49,41 @@ Now you can:
 - consume it from `@hypequery/react`
 - describe it for tools and agents
 
+The same `api.execute(...)` call works for configured metrics and datasets:
+
+```ts
+import { createAPI } from '@hypequery/serve';
+import { createQueryBuilder } from '@hypequery/clickhouse';
+import { dataset, dimension, measure } from '@hypequery/datasets';
+
+const Orders = dataset('orders', {
+  source: 'orders',
+  dimensions: {
+    country: dimension.string(),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+  },
+});
+
+const revenue = Orders.metric('revenue', { measure: 'revenue' });
+const queryBuilder = createQueryBuilder({ url, username, password, database });
+
+const api = createAPI({
+  queryBuilder,
+  metrics: { revenue },
+  datasets: { orders: Orders },
+});
+
+await api.execute('revenue', {
+  input: { dimensions: ['country'] },
+});
+
+await api.execute('dataset:orders', {
+  input: { dimensions: ['country'], measures: ['revenue'] },
+});
+```
+
 ## Main Ideas
 
 ### `query({ ... })`
@@ -59,7 +94,27 @@ Defines a typed contract:
 - optional input schema
 - query implementation
 
-### `serve({ queries })`
+Standalone queries can execute without creating a served API:
+
+```ts
+const topCustomers = query({
+  input: z.object({ limit: z.number().int().positive() }),
+  query: async ({ input }) =>
+    db
+      .table('orders')
+      .select(['customer_id'])
+      .sum('total', 'revenue')
+      .groupBy('customer_id')
+      .limit(input.limit)
+      .execute(),
+});
+
+await topCustomers.execute({
+  input: { limit: 10 },
+});
+```
+
+### `serve({ queries, metrics, datasets })`
 
 Builds a runtime around those contracts:
 

--- a/packages/serve/src/semantic/datasets/index.ts
+++ b/packages/serve/src/semantic/datasets/index.ts
@@ -36,9 +36,6 @@ export {
   filter,
   order,
   createDatasetRegistry,
-  createExecutor,
-  SemanticExecutor,
-  MetricExecutor,
 } from '@hypequery/datasets';
 
 export type {
@@ -70,8 +67,6 @@ export type {
   MetricResult,
   DatasetQueryResult,
   MetricHandle,
-  SemanticExecutorOptions,
-  MetricExecutorOptions,
   ExecutionContext,
   SemanticExecutionRuntime,
   SemanticTenantRuntime,

--- a/packages/serve/src/semantic/datasets/metric-endpoint.ts
+++ b/packages/serve/src/semantic/datasets/metric-endpoint.ts
@@ -3,7 +3,7 @@
  *
  * The generated endpoint is a POST handler that:
  * - Validates dimensions/filters against the metric's contract
- * - Calls MetricExecutor.run() with the parsed query + tenant context
+ * - Calls DatasetClient.execute() with the parsed query + tenant context
  * - Returns { data } or { data, meta } based on headers
  */
 
@@ -18,8 +18,7 @@ import type {
   ServeMiddleware,
   TenantConfigOverride,
 } from '../../types.js';
-import type { MetricContract, MetricHandle } from '@hypequery/datasets';
-import { MetricExecutor } from '@hypequery/datasets';
+import type { DatasetClient, MetricContract, MetricHandle, QueryBuilderFactoryLike } from '@hypequery/datasets';
 import { ServeHttpError } from '../../errors.js';
 import {
   resolveSemanticExecutionRuntime,
@@ -113,7 +112,8 @@ function resolveMetricEntry<TAuth extends AuthContext>(
 export function createMetricEndpoint<TAuth extends AuthContext>(
   name: string,
   entry: MetricEntry<TAuth>,
-  executor: MetricExecutor,
+  analytics: DatasetClient,
+  defaultBuilderFactory: QueryBuilderFactoryLike,
 ): ServeEndpoint<typeof metricQueryInputSchema, typeof metricResultSchema, any, TAuth, any> {
   const resolved = resolveMetricEntry(entry);
   const metricRef = resolved.metric;
@@ -142,10 +142,10 @@ export function createMetricEndpoint<TAuth extends AuthContext>(
     const runtime = resolveSemanticExecutionRuntime(semanticContext);
     const runtimeBuilderFactory = resolveSemanticQueryBuilder(
       semanticContext,
-      executor.getBuilderFactory(),
+      defaultBuilderFactory,
     );
     const tenantHandledByBuilder = resolveSemanticTenantHandledByBuilder(semanticContext)
-      || (ctx.tenantId != null && runtimeBuilderFactory !== executor.getBuilderFactory());
+      || (ctx.tenantId != null && runtimeBuilderFactory !== defaultBuilderFactory);
 
     // Build the metric query
     const query = {
@@ -172,7 +172,7 @@ export function createMetricEndpoint<TAuth extends AuthContext>(
           },
         }
       : undefined;
-    const validation = executor.validate(metricRef, query, validationContext);
+    const validation = analytics.validate(metricRef, query, validationContext);
     if (!validation.valid) {
       throw new ServeHttpError(
         400,
@@ -182,7 +182,7 @@ export function createMetricEndpoint<TAuth extends AuthContext>(
     }
 
     // Execute with tenant context
-    const result = await executor.run(metricRef, query, {
+    const result = await analytics.execute(metricRef, query, {
       runtime: {
         ...runtime,
         builderFactory: runtimeBuilderFactory,

--- a/packages/serve/src/semantic/datasets/serve-integration.test.ts
+++ b/packages/serve/src/semantic/datasets/serve-integration.test.ts
@@ -6,10 +6,10 @@ import {
   measure,
   divide,
   nullIfZero,
-  MetricExecutor,
   type QueryBuilderLike,
   type QueryBuilderFactoryLike,
 } from '@hypequery/datasets';
+import { MetricQueryEngine } from '@hypequery/datasets/internal';
 import type { ServeRequest } from '../../types.js';
 import type { ServeQueryEvent } from '../../query-logger.js';
 
@@ -459,7 +459,7 @@ describe("Serve integration — metrics", () => {
       expect(semanticBody(response).error.message).toContain('does not allow operator "like"');
     });
 
-    it("passes dimensions and filters to the executor", async () => {
+    it("passes dimensions and filters to the semantic client", async () => {
       const factory = createMockBuilderFactory();
       const api = createAPI({
         metrics: { totalRevenue },
@@ -659,9 +659,9 @@ describe("Serve integration — metrics", () => {
       expect(semanticBody(response).meta.sql).toBeDefined();
     });
 
-    it("matches MetricExecutor.toSQL() for base metrics", async () => {
+    it("matches MetricQueryEngine.toSQL() for base metrics", async () => {
       const factory = createMockBuilderFactory();
-      const executor = new MetricExecutor({ builderFactory: factory });
+      const engine = new MetricQueryEngine({ builderFactory: factory });
       const api = createAPI({
         metrics: { totalRevenue },
         queryBuilder: factory,
@@ -686,12 +686,12 @@ describe("Serve integration — metrics", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(semanticBody(response).meta.sql).toBe(executor.toSQL(totalRevenue, query));
+      expect(semanticBody(response).meta.sql).toBe(engine.toSQL(totalRevenue, query));
     });
 
-    it("matches MetricExecutor.toSQL() for derived metrics", async () => {
+    it("matches MetricQueryEngine.toSQL() for derived metrics", async () => {
       const factory = createMockBuilderFactory();
-      const executor = new MetricExecutor({ builderFactory: factory });
+      const engine = new MetricQueryEngine({ builderFactory: factory });
       const api = createAPI({
         metrics: { avgOrderValue },
         queryBuilder: factory,
@@ -713,7 +713,7 @@ describe("Serve integration — metrics", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(semanticBody(response).meta.sql).toBe(executor.toSQL(avgOrderValue, query));
+      expect(semanticBody(response).meta.sql).toBe(engine.toSQL(avgOrderValue, query));
     });
   });
 

--- a/packages/serve/src/semantic/datasets/utils/dataset-entry.ts
+++ b/packages/serve/src/semantic/datasets/utils/dataset-entry.ts
@@ -3,12 +3,12 @@ import type {
   AuthStrategy,
   TenantConfigOverride,
 } from '../../../types.js';
-import type { DatasetInstance } from '@hypequery/datasets';
+import type { AnyDatasetInstance } from '@hypequery/datasets';
 
 export type DatasetEntry<TAuth extends AuthContext = AuthContext> =
-  | DatasetInstance
+  | AnyDatasetInstance
   | {
-      dataset: DatasetInstance;
+      dataset: AnyDatasetInstance;
       auth?: AuthStrategy<TAuth> | null;
       tenant?: TenantConfigOverride<TAuth>;
       cache?: number | null;
@@ -17,11 +17,11 @@ export type DatasetEntry<TAuth extends AuthContext = AuthContext> =
       maxLimit?: number;
     };
 
-type DatasetEntryOptions<TAuth extends AuthContext> = Exclude<DatasetEntry<TAuth>, DatasetInstance>;
+type DatasetEntryOptions<TAuth extends AuthContext> = Exclude<DatasetEntry<TAuth>, AnyDatasetInstance>;
 
 function isDatasetInstance<TAuth extends AuthContext>(
   entry: DatasetEntry<TAuth>,
-): entry is DatasetInstance {
+): entry is AnyDatasetInstance {
   return !!entry && typeof entry === 'object' && '__type' in entry && entry.__type === 'dataset';
 }
 
@@ -34,7 +34,7 @@ function isDatasetEntryOptions<TAuth extends AuthContext>(
 export function resolveDatasetEntry<TAuth extends AuthContext>(
   entry: DatasetEntry<TAuth>,
 ): {
-  dataset: DatasetInstance;
+  dataset: AnyDatasetInstance;
   auth?: AuthStrategy<TAuth> | null;
   tenant?: TenantConfigOverride<TAuth>;
   cache?: number | null;

--- a/packages/serve/src/semantic/datasets/utils/dataset-query-metadata.ts
+++ b/packages/serve/src/semantic/datasets/utils/dataset-query-metadata.ts
@@ -1,7 +1,7 @@
-import type { DatasetInstance } from '@hypequery/datasets';
+import type { AnyDatasetInstance } from '@hypequery/datasets';
 
 export function buildDatasetQueryDescription(
-  ds: DatasetInstance,
+  ds: AnyDatasetInstance,
   maxLimit: number,
 ): string {
   const dimensionNames = Object.keys(ds.dimensions);

--- a/packages/serve/src/serve.ts
+++ b/packages/serve/src/serve.ts
@@ -9,9 +9,12 @@ import type {
   ServeConfig,
   ServeContextFactory,
   ServeEndpointMap,
+  ServeSemanticEndpointMap,
   ServeQueriesMap,
   ServeRequest,
   StandaloneQueryDefinition,
+  MetricsConfig,
+  DatasetsConfig,
 } from "./types.js";
 import type { ZodTypeAny } from "zod";
 import { defineServe } from "./server/define-serve.js";
@@ -147,7 +150,16 @@ export const query = createQueryFactory();
 export function serve<
   TContext extends Record<string, unknown> = Record<string, unknown>,
   TAuth extends AuthContext = AuthContext,
-  TQueries extends ServeQueriesMap<TContext, TAuth> = ServeQueriesMap<TContext, TAuth>
->(config: ServeConfig<TContext, TAuth, TQueries>): ServeBuilder<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth> {
-  return defineServe<TContext, TAuth, TQueries>(config);
+  TQueries extends ServeQueriesMap<TContext, TAuth> = Record<never, never>,
+  TMetrics extends MetricsConfig<TAuth> = Record<never, never>,
+  TDatasets extends DatasetsConfig<TAuth> = Record<never, never>
+>(
+  config: ServeConfig<TContext, TAuth, TQueries, TMetrics, TDatasets>
+): ServeBuilder<
+  ServeEndpointMap<TQueries, TContext, TAuth>
+    & ServeSemanticEndpointMap<TMetrics, TDatasets, TContext, TAuth>,
+  TContext,
+  TAuth
+> {
+  return defineServe<TContext, TAuth, TQueries, TMetrics, TDatasets>(config);
 }

--- a/packages/serve/src/server/create-api.ts
+++ b/packages/serve/src/server/create-api.ts
@@ -10,6 +10,9 @@ import type {
   ServeMiddleware,
   ServeQueriesMap,
   ServeConfig,
+  MetricsConfig,
+  DatasetsConfig,
+  ServeSemanticEndpointMap,
 } from "../types.js";
 import { createEndpoint } from "../endpoint.js";
 import { ServeRouter, applyBasePath, normalizeRoutePath } from "../router.js";
@@ -19,7 +22,7 @@ import { createServeHandler } from "../pipeline.js";
 import { createDocsEndpoint, createOpenApiEndpoint } from "../pipeline.js";
 import { createExecuteQuery } from "./execute-query.js";
 import { createAPImethods } from "./api-builder.js";
-import { createExecutor } from "@hypequery/datasets";
+import { createDatasetClient } from "@hypequery/datasets";
 import { createMetricEndpoint, createDatasetEndpoint } from "../semantic/datasets/index.js";
 import { attachSemanticQueryBuilder } from "../semantic/query-builder-context.js";
 
@@ -68,10 +71,17 @@ const assertSemanticKeyAvailable = (
 export const createAPI = <
   TContext extends Record<string, unknown> = Record<string, unknown>,
   TAuth extends AuthContext = AuthContext,
-  TQueries extends ServeQueriesMap<TContext, TAuth> = ServeQueriesMap<TContext, TAuth>
+  TQueries extends ServeQueriesMap<TContext, TAuth> = Record<never, never>,
+  TMetrics extends MetricsConfig<TAuth> = Record<never, never>,
+  TDatasets extends DatasetsConfig<TAuth> = Record<never, never>
 >(
-  config: ServeConfig<TContext, TAuth, TQueries>
-): HypeQueryAPI<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth> => {
+  config: ServeConfig<TContext, TAuth, TQueries, TMetrics, TDatasets>
+): HypeQueryAPI<
+  ServeEndpointMap<TQueries, TContext, TAuth>
+    & ServeSemanticEndpointMap<TMetrics, TDatasets, TContext, TAuth>,
+  TContext,
+  TAuth
+> => {
   const basePath = config.basePath ?? "/api/analytics";
   const router = new ServeRouter(basePath);
   const globalMiddlewares: ServeMiddleware<any, any, TContext, TAuth>[] = [
@@ -163,11 +173,11 @@ export const createAPI = <
       );
     }
 
-    const executor = createExecutor({ queryBuilder: builderFactory });
+    const analytics = createDatasetClient({ queryBuilder: builderFactory });
 
     for (const [name, entry] of Object.entries(metricsEntries)) {
       assertSemanticKeyAvailable(queryEntries as Record<string, unknown>, name, "metric");
-      const metricEndpoint = createMetricEndpoint(name, entry, executor);
+      const metricEndpoint = createMetricEndpoint(name, entry, analytics, builderFactory);
       const metricsPath = config.semanticPaths?.metrics ?? '/metrics';
       const routePath = normalizeRoutePath(`${metricsPath}/${name}`);
 
@@ -236,7 +246,7 @@ export const createAPI = <
   );
 
   const api = createAPImethods<TQueries, TContext, TAuth>(
-    queryEntries,
+    queryEntries as ServeEndpointMap<TQueries, TContext, TAuth>,
     queryLogger,
     router,
     authStrategies,
@@ -244,7 +254,12 @@ export const createAPI = <
     executeQuery,
     handler,
     basePath,
-  );
+  ) as HypeQueryAPI<
+    ServeEndpointMap<TQueries, TContext, TAuth>
+      & ServeSemanticEndpointMap<TMetrics, TDatasets, TContext, TAuth>,
+    TContext,
+    TAuth
+  >;
 
   if (openapiConfig.enabled) {
     const openapiEndpoint = createOpenApiEndpoint(

--- a/packages/serve/src/server/define-serve.ts
+++ b/packages/serve/src/server/define-serve.ts
@@ -3,8 +3,11 @@ import type {
   ServeBuilder,
   ServeConfig,
   ServeEndpointMap,
+  ServeSemanticEndpointMap,
   ServeQueriesMap,
   StartServerOptions,
+  MetricsConfig,
+  DatasetsConfig,
 } from "../types.js";
 import { createAPI } from "./create-api.js";
 
@@ -30,11 +33,18 @@ import { createAPI } from "./create-api.js";
 export const defineServe = <
   TContext extends Record<string, unknown> = Record<string, unknown>,
   TAuth extends AuthContext = AuthContext,
-  TQueries extends ServeQueriesMap<TContext, TAuth> = ServeQueriesMap<TContext, TAuth>
+  TQueries extends ServeQueriesMap<TContext, TAuth> = Record<never, never>,
+  TMetrics extends MetricsConfig<TAuth> = Record<never, never>,
+  TDatasets extends DatasetsConfig<TAuth> = Record<never, never>
 >(
-  config: ServeConfig<TContext, TAuth, TQueries>
-): ServeBuilder<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth> => {
-  const api = createAPI<TContext, TAuth, TQueries>(config);
+  config: ServeConfig<TContext, TAuth, TQueries, TMetrics, TDatasets>
+): ServeBuilder<
+  ServeEndpointMap<TQueries, TContext, TAuth>
+    & ServeSemanticEndpointMap<TMetrics, TDatasets, TContext, TAuth>,
+  TContext,
+  TAuth
+> => {
+  const api = createAPI<TContext, TAuth, TQueries, TMetrics, TDatasets>(config);
 
   const loadNodeAdapter = async () => {
     if (typeof require !== "undefined") {
@@ -44,7 +54,12 @@ export const defineServe = <
   };
 
   // Extend the API with backwards-compatible ServeBuilder methods
-  const builder = api as unknown as ServeBuilder<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth>;
+  const builder = api as unknown as ServeBuilder<
+    ServeEndpointMap<TQueries, TContext, TAuth>
+      & ServeSemanticEndpointMap<TMetrics, TDatasets, TContext, TAuth>,
+    TContext,
+    TAuth
+  >;
   const routeConfig: Record<string, { method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "OPTIONS" }> = {};
 
   for (const [key, endpoint] of Object.entries(api.queries)) {

--- a/packages/serve/src/server/init-serve.ts
+++ b/packages/serve/src/server/init-serve.ts
@@ -5,6 +5,8 @@ import type {
   ServeInitializer,
   ServeQueriesMap,
   ServeConfig,
+  MetricsConfig,
+  DatasetsConfig,
 } from "../types.js";
 import { createProcedureBuilder } from "../builder.js";
 import { defineServe } from "./define-serve.js";
@@ -22,7 +24,9 @@ type ServeInitializerOptions<
   ServeConfig<
     InferInitializerContext<TFactory, TAuth>,
     TAuth,
-    ServeQueriesMap<InferInitializerContext<TFactory, TAuth>, TAuth>
+    ServeQueriesMap<InferInitializerContext<TFactory, TAuth>, TAuth>,
+    Record<never, never>,
+    Record<never, never>
   >,
   "queries" | "context"
 > & { context: TFactory };
@@ -30,8 +34,10 @@ type ServeInitializerOptions<
 type ServeInitializerDefinition<
   TContext extends Record<string, unknown>,
   TAuth extends AuthContext,
-  TQueries extends ServeQueriesMap<TContext, TAuth>
-> = Omit<ServeConfig<TContext, TAuth, TQueries>, "context">;
+  TQueries extends ServeQueriesMap<TContext, TAuth>,
+  TMetrics extends MetricsConfig<TAuth>,
+  TDatasets extends DatasetsConfig<TAuth>
+> = Omit<ServeConfig<TContext, TAuth, TQueries, TMetrics, TDatasets>, "context">;
 
 export const initServe = <
   TFactory extends ServeContextFactory<any, TAuth>,
@@ -43,11 +49,18 @@ export const initServe = <
   type TContext = InferInitializerContext<TFactory, TAuth>;
   const { context, ...staticOptions } = options;
   const procedure = createProcedureBuilder<TContext, TAuth>();
-  const define = <TQueries extends ServeQueriesMap<TContext, TAuth>>(
-    config: ServeInitializerDefinition<TContext, TAuth, TQueries>
+  const define = <
+    TQueries extends ServeQueriesMap<TContext, TAuth>,
+    TMetrics extends MetricsConfig<TAuth> = Record<never, never>,
+    TDatasets extends DatasetsConfig<TAuth> = Record<never, never>
+  >(
+    config: ServeInitializerDefinition<TContext, TAuth, TQueries, TMetrics, TDatasets>
   ) => {
-    return defineServe<TContext, TAuth, TQueries>({
-      ...staticOptions,
+    return defineServe<TContext, TAuth, TQueries, TMetrics, TDatasets>({
+      ...(staticOptions as Omit<
+        ServeConfig<TContext, TAuth, TQueries, TMetrics, TDatasets>,
+        "queries" | "context"
+      >),
       ...config,
       context: (context ?? {}) as ServeContextFactory<TContext, TAuth>,
     });

--- a/packages/serve/src/type-tests/semantic.test-d.ts
+++ b/packages/serve/src/type-tests/semantic.test-d.ts
@@ -1,4 +1,6 @@
 import { dataset, dimension, measure, divide, nullIfZero, belongsTo } from '../semantic/index.js';
+import { createAPI } from '../index.js';
+import type { QueryBuilderFactoryLike } from '@hypequery/datasets';
 
 const Customers = dataset('customers', {
   source: 'customers',
@@ -41,3 +43,27 @@ const monthlyRevenue = totalRevenue.by('month');
 
 monthlyRevenue.contract();
 avgOrderValue.contract();
+
+const queryBuilder: QueryBuilderFactoryLike = {
+  table: (() => {
+    throw new Error('type-only query builder');
+  }) as QueryBuilderFactoryLike['table'],
+  rawQuery: async () => [],
+};
+
+const semanticApi = createAPI({
+  metrics: { totalRevenue },
+  datasets: { orders: Orders },
+  queryBuilder,
+});
+
+void semanticApi.execute('totalRevenue', {
+  input: { dimensions: ['status'] },
+});
+
+void semanticApi.execute('dataset:orders', {
+  input: { dimensions: ['status'], measures: ['revenue'] },
+});
+
+// @ts-expect-error only configured semantic keys are executable
+void semanticApi.execute('dataset:customers', { input: {} });

--- a/packages/serve/src/types.ts
+++ b/packages/serve/src/types.ts
@@ -1,4 +1,4 @@
-import type { ZodTypeAny } from "zod";
+import type { ZodType, ZodTypeAny } from "zod";
 import type { ServeQueryLogger, ServeQueryEventCallback, ServeQueryEvent } from "./query-logger.js";
 import type { QueryBuilderFactoryLike } from "@hypequery/datasets";
 
@@ -550,13 +550,56 @@ export type MetricsConfig<TAuth extends AuthContext = AuthContext> =
 // Dataset serve config types
 // ---------------------------------------------------------------------------
 
-import type { DatasetInstance, MetricHandle } from "@hypequery/datasets";
+import type {
+  DatasetInstance,
+  DatasetQuery,
+  DatasetQueryResult,
+  MetricHandle,
+  MetricQuery,
+  MetricResult,
+} from "@hypequery/datasets";
 import type { DatasetEntry } from "./semantic/datasets/dataset-endpoint.js";
 export type { DatasetEntry } from "./semantic/datasets/dataset-endpoint.js";
 
 /** Map of dataset names to entries. */
 export type DatasetsConfig<TAuth extends AuthContext = AuthContext> =
   Record<string, DatasetEntry<TAuth>>;
+
+export type SemanticMetricEndpointMap<
+  TMetrics extends MetricsConfig<TAuth>,
+  TContext extends Record<string, unknown>,
+  TAuth extends AuthContext,
+> = {
+  [TKey in keyof TMetrics & string]: ServeEndpoint<
+    ZodType<MetricQuery>,
+    ZodType<MetricResult>,
+    TContext,
+    TAuth,
+    MetricResult
+  >;
+};
+
+export type SemanticDatasetEndpointMap<
+  TDatasets extends DatasetsConfig<TAuth>,
+  TContext extends Record<string, unknown>,
+  TAuth extends AuthContext,
+> = {
+  [TKey in keyof TDatasets & string as `dataset:${TKey}`]: ServeEndpoint<
+    ZodType<DatasetQuery>,
+    ZodType<DatasetQueryResult>,
+    TContext,
+    TAuth,
+    DatasetQueryResult
+  >;
+};
+
+export type ServeSemanticEndpointMap<
+  TMetrics extends MetricsConfig<TAuth>,
+  TDatasets extends DatasetsConfig<TAuth>,
+  TContext extends Record<string, unknown>,
+  TAuth extends AuthContext,
+> = SemanticMetricEndpointMap<TMetrics, TContext, TAuth>
+  & SemanticDatasetEndpointMap<TDatasets, TContext, TAuth>;
 
 // ---------------------------------------------------------------------------
 // ServeConfig
@@ -565,7 +608,9 @@ export type DatasetsConfig<TAuth extends AuthContext = AuthContext> =
 export interface ServeConfig<
   TContext extends Record<string, unknown> = Record<string, unknown>,
   TAuth extends AuthContext = AuthContext,
-  TQueries extends ServeQueriesMap<TContext, TAuth> = ServeQueriesMap<TContext, TAuth>
+  TQueries extends ServeQueriesMap<TContext, TAuth> = Record<never, never>,
+  TMetrics extends MetricsConfig<TAuth> = Record<never, never>,
+  TDatasets extends DatasetsConfig<TAuth> = Record<never, never>
 > {
   queries?: TQueries;
   /**
@@ -587,7 +632,7 @@ export interface ServeConfig<
    * });
    * ```
    */
-  metrics?: MetricsConfig<TAuth>;
+  metrics?: TMetrics;
   /**
    * Semantic dataset endpoints — auto-generated POST endpoints for each dataset.
    * Each dataset gets a `POST /api/analytics/datasets/:name/query` endpoint
@@ -607,7 +652,7 @@ export interface ServeConfig<
    * });
    * ```
    */
-  datasets?: DatasetsConfig<TAuth>;
+  datasets?: TDatasets;
   /**
    * Query builder instance for metric/dataset execution.
    * Required when `metrics` or `datasets` are provided.
@@ -956,12 +1001,30 @@ export interface ServeInitializer<
   readonly procedure: QueryProcedureBuilder<TContext, TAuth>;
   readonly query: QueryFactory<TContext, TAuth>;
   queries<TQueries extends ServeQueriesMap<TContext, TAuth>>(queries: TQueries): TQueries;
-  serve<TQueries extends ServeQueriesMap<TContext, TAuth>>(
-    config: Omit<ServeConfig<TContext, TAuth, TQueries>, "context">
-  ): ServeBuilder<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth>;
-  define<TQueries extends ServeQueriesMap<TContext, TAuth>>(
-    config: Omit<ServeConfig<TContext, TAuth, TQueries>, "context">
-  ): ServeBuilder<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth>;
+  serve<
+    TQueries extends ServeQueriesMap<TContext, TAuth>,
+    TMetrics extends MetricsConfig<TAuth> = Record<never, never>,
+    TDatasets extends DatasetsConfig<TAuth> = Record<never, never>
+  >(
+    config: Omit<ServeConfig<TContext, TAuth, TQueries, TMetrics, TDatasets>, "context">
+  ): ServeBuilder<
+    ServeEndpointMap<TQueries, TContext, TAuth>
+      & ServeSemanticEndpointMap<TMetrics, TDatasets, TContext, TAuth>,
+    TContext,
+    TAuth
+  >;
+  define<
+    TQueries extends ServeQueriesMap<TContext, TAuth>,
+    TMetrics extends MetricsConfig<TAuth> = Record<never, never>,
+    TDatasets extends DatasetsConfig<TAuth> = Record<never, never>
+  >(
+    config: Omit<ServeConfig<TContext, TAuth, TQueries, TMetrics, TDatasets>, "context">
+  ): ServeBuilder<
+    ServeEndpointMap<TQueries, TContext, TAuth>
+      & ServeSemanticEndpointMap<TMetrics, TDatasets, TContext, TAuth>,
+    TContext,
+    TAuth
+  >;
 }
 
 export type QueryFactory<

--- a/plans/datasets-package-dx-options.md
+++ b/plans/datasets-package-dx-options.md
@@ -125,7 +125,7 @@ const executor = createExecutor({
   }),
 });
 
-await executor.dataset(Orders, {
+await executor.execute(Orders, {
   dimensions: ['country'],
   measures: ['revenue'],
 });
@@ -236,11 +236,11 @@ import { createExecutor } from '@hypequery/datasets';
 
 const executor = createExecutor({ queryBuilder });
 
-await executor.metric(revenue, {
+await executor.execute(revenue, {
   dimensions: ['country'],
 });
 
-await executor.dataset(Orders, {
+await executor.execute(Orders, {
   dimensions: ['country'],
   measures: ['revenue'],
 });
@@ -253,7 +253,7 @@ import { createDatasetClient } from '@hypequery/clickhouse/datasets';
 
 const analytics = createDatasetClient(clickhouseConfig);
 
-await analytics.metric(revenue, {
+await analytics.execute(revenue, {
   dimensions: ['country'],
 });
 ```
@@ -330,13 +330,13 @@ const analytics = createDatasetClient({
   database: process.env.CLICKHOUSE_DATABASE!,
 });
 
-const result = await analytics.metric(revenue, {
+const result = await analytics.execute(revenue, {
   dimensions: ['country'],
   filters: [eq('status', 'completed')],
   orderBy: [desc('revenue')],
 });
 
-const datasetResult = await analytics.dataset(Orders, {
+const datasetResult = await analytics.execute(Orders, {
   dimensions: ['country'],
   measures: ['revenue', 'orderCount'],
 });
@@ -610,8 +610,8 @@ Good for generic `@hypequery/datasets`:
 
 ```ts
 const executor = createExecutor({ queryBuilder });
-await executor.metric(revenue, query);
-await executor.dataset(Orders, query);
+await executor.execute(revenue, query);
+await executor.execute(Orders, query);
 ```
 
 Pros:
@@ -703,8 +703,8 @@ Usage:
 ```ts
 const executor = createExecutor({ queryBuilder });
 
-await executor.metric(revenue, query);
-await executor.dataset(Orders, query);
+await executor.execute(revenue, query);
+await executor.execute(Orders, query);
 ```
 
 ### `@hypequery/clickhouse/datasets`
@@ -725,8 +725,8 @@ Usage:
 ```ts
 const analytics = createDatasetClient(clickhouseConfig);
 
-await analytics.metric(revenue, query);
-await analytics.dataset(Orders, query);
+await analytics.execute(revenue, query);
+await analytics.execute(Orders, query);
 ```
 
 ## Migration Notes From Current Pre-Release API
@@ -752,7 +752,7 @@ import { createQueryBuilder } from '@hypequery/clickhouse';
 const queryBuilder = createQueryBuilder(config);
 const executor = createExecutor({ queryBuilder });
 
-await executor.metric(revenue, query);
+await executor.execute(revenue, query);
 ```
 
 Best ClickHouse replacement:
@@ -767,7 +767,7 @@ import {
 
 const analytics = createDatasetClient(config);
 
-await analytics.metric(revenue, query);
+await analytics.execute(revenue, query);
 ```
 
 ## Open Questions
@@ -782,7 +782,7 @@ await analytics.metric(revenue, query);
 
 3. Should the client method be `dataset(...)` or `query(...)`?
 
-   Recommendation: use `dataset(ds, query)` for symmetry with `metric(metric, query)`. Consider adding `queryDataset` only if user testing shows `dataset(...)` reads oddly.
+   Recommendation: use `execute(target, query)` for both metric refs and dataset instances so semantic execution matches `api.execute(...)`.
 
 4. Should the ClickHouse datasets subpath be documented as the default path?
 

--- a/scripts/smoke-semantic-consumer.sh
+++ b/scripts/smoke-semantic-consumer.sh
@@ -36,6 +36,12 @@ TSC="$ROOT_DIR/packages/datasets/node_modules/typescript/bin/tsc"
     exit 1
   fi
 
+  if "$TSC" --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --skipLibCheck --noEmit invalid-root-executor.ts >/tmp/hq-invalid-executor.log 2>&1; then
+    cat /tmp/hq-invalid-executor.log
+    echo 'Expected root executor import to fail, but it compiled.'
+    exit 1
+  fi
+
   if "$TSC" --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --skipLibCheck --noEmit invalid-deep-import.ts >/tmp/hq-invalid-deep.log 2>&1; then
     cat /tmp/hq-invalid-deep.log
     echo 'Expected deep serve import to fail, but it compiled.'

--- a/scripts/utils/write-semantic-consumer-fixtures.mjs
+++ b/scripts/utils/write-semantic-consumer-fixtures.mjs
@@ -20,8 +20,8 @@ const files = {
   "include": ["valid-*.ts"]
 }
 `,
-  'valid-root-imports.ts': `import { dataset, dimension, measure, MetricExecutor } from '@hypequery/datasets';
-import type { MetricQuery } from '@hypequery/datasets';
+  'valid-root-imports.ts': `import { createDatasetClient, dataset, dimension, measure } from '@hypequery/datasets';
+import type { DatasetClient, MetricQuery } from '@hypequery/datasets';
 import {
   checkDatasetsAgainstSchema,
   column,
@@ -64,10 +64,21 @@ const ordersTable = defineTable('orders', {
 const snapshot = serializeSchemaToSnapshot(defineSchema({ tables: [ordersTable] }));
 const compatibility = checkDatasetsAgainstSchema({ snapshot, datasets: [Orders] });
 const api = createAPI({});
+const analytics = createDatasetClient({
+  queryBuilder: {
+    table() {
+      throw new Error('not executed');
+    },
+    async rawQuery() {
+      return [];
+    },
+  },
+});
+const explicitAnalytics: DatasetClient = analytics;
 
 void revenue;
 void query;
-void MetricExecutor;
+void explicitAnalytics;
 void compatibility;
 void api;
 `,
@@ -82,6 +93,12 @@ void query;
   'invalid-root-dataset-query.ts': `import { runDatasetQuery } from '@hypequery/datasets';
 
 void runDatasetQuery;
+`,
+  'invalid-root-executor.ts': `import { createExecutor, MetricExecutor, SemanticExecutor } from '@hypequery/datasets';
+
+void createExecutor;
+void MetricExecutor;
+void SemanticExecutor;
 `,
   'invalid-deep-import.ts': `import { createAPI } from '@hypequery/serve/dist/server/create-api.js';
 


### PR DESCRIPTION
## Summary

  - Unified semantic execution around execute(...) for both metrics and datasets.
  - Replaced the public executor API with createDatasetClient(...) and DatasetClient.
  - Updated serve so api.execute(...) works for normal queries, configured metrics, and configured datasets.
  - Updated docs, examples, MCP config, and type tests to use the new API shape.

  ## API Shape

  // Serve
  await api.execute('revenue', { input: { dimensions: ['country'] } });
  await api.execute('dataset:orders', { input: { dimensions: ['country'], measures: ['revenue'] } });

  // Standalone query
  await query.execute();

  // Standalone semantic metrics/datasets
  const analytics = createDatasetClient(...);

  await analytics.execute(revenue, { dimensions: ['country'] });
  await analytics.execute(Orders, { dimensions: ['country'], measures: ['revenue'] });

  ## Cleanup

  - Removed public createExecutor, SemanticExecutor, and MetricExecutor exports.
  - Added DatasetClient, CreateDatasetClientOptions, and semantic target/query/result helper types.
  - Kept metric execution internals behind MetricQueryEngine.
  - Removed public getBuilderFactory() from the dataset client surface.
  - Renamed MCP config from executor to analytics.
  - Cleaned stale docs/comments referring to executor-based metric execution.
