### PR TITLE
feat(datasets): Unify semantic execution and clean architecture

### DIFF
--- a/packages/cli/src/commands/generate-datasets.ts
+++ b/packages/cli/src/commands/generate-datasets.ts
@@ -67,10 +67,13 @@ export async function generateDatasetsCommand(options: GenerateDatasetsOptions =
 
     logger.info('Example usage:');
     logger.indent('import { datasets } from \'./datasets/generated\';');
-    logger.indent('import { createDatasetClient } from \'@hypequery/clickhouse/datasets\';');
+    logger.indent('import { createDatasetClient } from \'@hypequery/datasets\';');
+    logger.indent('import { createBackend } from \'@hypequery/clickhouse\';');
     logger.indent('');
     logger.indent('const rowCount = datasets.orders.metric(\'rowCount\', { measure: \'totalCount\' });');
-    logger.indent('const analytics = createDatasetClient({ url, username, password, database });');
+    logger.indent('const analytics = createDatasetClient({');
+    logger.indent('  backend: createBackend({ url, username, password, database })');
+    logger.indent('});');
     logger.indent('const result = await analytics.execute(rowCount);');
     logger.newline();
 

--- a/packages/clickhouse/README.md
+++ b/packages/clickhouse/README.md
@@ -1,6 +1,6 @@
 # @hypequery/clickhouse
 
-Typed ClickHouse query builder for hypequery.
+Typed query builder for ClickHouse.
 
 Use it when you want schema-aware queries, typed results, and a fluent API that stays close to how ClickHouse actually works.
 
@@ -48,44 +48,6 @@ const recentOrders = await db
 2. Create a typed `db`
 3. Write and execute queries locally
 4. Promote important queries into `@hypequery/serve` when they need a shared contract or HTTP surface
-
-## Semantic Datasets
-
-For datasets-first analytics, use the datasets subpath so application code does
-not need to create a query builder directly.
-
-```ts
-import { createDatasetClient } from '@hypequery/clickhouse/datasets';
-import { dataset, dimension, measure } from '@hypequery/datasets';
-
-const Orders = dataset('orders', {
-  source: 'orders',
-  dimensions: {
-    country: dimension.string(),
-  },
-  measures: {
-    revenue: measure.sum('total'),
-  },
-});
-
-const revenue = Orders.metric('revenue', { measure: 'revenue' });
-
-const analytics = createDatasetClient({
-  url: process.env.CLICKHOUSE_URL!,
-  username: process.env.CLICKHOUSE_USERNAME!,
-  password: process.env.CLICKHOUSE_PASSWORD ?? '',
-  database: process.env.CLICKHOUSE_DATABASE!,
-});
-
-await analytics.execute(revenue, {
-  dimensions: ['country'],
-});
-
-await analytics.execute(Orders, {
-  dimensions: ['country'],
-  measures: ['revenue'],
-});
-```
 
 ## Common Patterns
 

--- a/packages/clickhouse/dist-file-index.txt
+++ b/packages/clickhouse/dist-file-index.txt
@@ -239,6 +239,9 @@ migrations/sql/types.js
 migrations/sql/write.d.ts
 migrations/sql/write.d.ts.map
 migrations/sql/write.js
+semantic-backend.d.ts
+semantic-backend.d.ts.map
+semantic-backend.js
 types/base.d.ts
 types/base.d.ts.map
 types/base.js

--- a/packages/clickhouse/src/core/tests/datasets-backend.test.ts
+++ b/packages/clickhouse/src/core/tests/datasets-backend.test.ts
@@ -1,0 +1,882 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createDatasetClient,
+  dataset,
+  dimension,
+  measure,
+  eq,
+  neq,
+  gt,
+  gte,
+  lt,
+  lte,
+  inList,
+  notInList,
+  between,
+  like,
+  divide,
+  nullIfZero,
+  add,
+  multiply,
+} from '@hypequery/datasets';
+import { createBackend } from '../../datasets.js';
+
+/**
+ * Comprehensive test suite for ClickHouse semantic backend execution
+ *
+ * These tests verify that the backend correctly translates semantic plans
+ * into ClickHouse SQL and executes them properly. Coverage includes:
+ * - Base aggregations (all types)
+ * - Filtered measures
+ * - Time grains
+ * - Derived metrics with formulas
+ * - All filter operators
+ * - Tenant filtering
+ * - Complex queries with multiple dimensions/measures
+ * - Edge cases and error handling
+ */
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+const Orders = dataset('orders', {
+  source: 'orders',
+  tenantKey: 'tenant_id',
+  timeKey: 'created_at',
+  dimensions: {
+    id: dimension.string(),
+    tenantId: dimension.string({ column: 'tenant_id' }),
+    customerId: dimension.string({ column: 'customer_id' }),
+    country: dimension.string(),
+    status: dimension.string(),
+    productCategory: dimension.string({ column: 'product_category' }),
+    amount: dimension.number(),
+    quantity: dimension.number(),
+    createdAt: dimension.timestamp({ column: 'created_at' }),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+    orderCount: measure.count('id'),
+    avgOrderValue: measure.avg('amount'),
+    minOrderValue: measure.min('amount'),
+    maxOrderValue: measure.max('amount'),
+    uniqueCustomers: measure.countDistinct('customerId'),
+    totalQuantity: measure.sum('quantity'),
+    completedRevenue: measure.sum('amount', {
+      filters: [eq('status', 'completed')],
+    }),
+    pendingRevenue: measure.sum('amount', {
+      filters: [eq('status', 'pending')],
+    }),
+    highValueRevenue: measure.sum('amount', {
+      filters: [gt('amount', 1000)],
+    }),
+  },
+});
+
+const Products = dataset('products', {
+  source: 'products',
+  timeKey: 'created_at',
+  dimensions: {
+    id: dimension.string(),
+    name: dimension.string(),
+    category: dimension.string(),
+    price: dimension.number(),
+    createdAt: dimension.timestamp({ column: 'created_at' }),
+  },
+  measures: {
+    productCount: measure.count('id'),
+    avgPrice: measure.avg('price'),
+  },
+});
+
+// =============================================================================
+// Helper: Create Test Backend
+// =============================================================================
+
+function createTestBackend(mockData: any[] = []) {
+  const queries: string[] = [];
+
+  return {
+    backend: createBackend({
+      adapter: {
+        name: 'test',
+        query: async (sql: string) => {
+          queries.push(sql);
+          return mockData;
+        },
+      },
+    }),
+    queries,
+  };
+}
+
+// =============================================================================
+// Base Aggregation Tests
+// =============================================================================
+
+describe('ClickHouse Backend - Base Aggregations', () => {
+  it('generates SUM aggregation', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', revenue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+    });
+
+    expect(queries[0]).toContain('SELECT country, SUM(amount) AS revenue FROM orders');
+    expect(queries[0]).toContain('GROUP BY country');
+  });
+
+  it('generates COUNT aggregation', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', orderCount: 10 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['orderCount'],
+    });
+
+    expect(queries[0]).toContain('COUNT(id) AS orderCount');
+  });
+
+  it('generates COUNT DISTINCT aggregation', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', uniqueCustomers: 5 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['uniqueCustomers'],
+    });
+
+    expect(queries[0]).toContain('COUNT(DISTINCT customer_id) AS uniqueCustomers');
+  });
+
+  it('generates AVG aggregation', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', avgOrderValue: 100.5 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['avgOrderValue'],
+    });
+
+    expect(queries[0]).toContain('AVG(amount) AS avgOrderValue');
+  });
+
+  it('generates MIN aggregation', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', minOrderValue: 10 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['minOrderValue'],
+    });
+
+    expect(queries[0]).toContain('MIN(amount) AS minOrderValue');
+  });
+
+  it('generates MAX aggregation', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', maxOrderValue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['maxOrderValue'],
+    });
+
+    expect(queries[0]).toContain('MAX(amount) AS maxOrderValue');
+  });
+
+  it('generates multiple measures in single query', async () => {
+    const { backend, queries } = createTestBackend([
+      { country: 'US', revenue: 1000, orderCount: 10, uniqueCustomers: 5 },
+    ]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue', 'orderCount', 'uniqueCustomers'],
+    });
+
+    expect(queries[0]).toContain('SUM(amount) AS revenue');
+    expect(queries[0]).toContain('COUNT(id) AS orderCount');
+    expect(queries[0]).toContain('COUNT(DISTINCT customer_id) AS uniqueCustomers');
+  });
+
+  it('generates query with multiple dimensions', async () => {
+    const { backend, queries } = createTestBackend([
+      { country: 'US', status: 'completed', revenue: 1000 },
+    ]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country', 'status'],
+      measures: ['revenue'],
+    });
+
+    expect(queries[0]).toContain('SELECT country, status, SUM(amount) AS revenue');
+    expect(queries[0]).toContain('GROUP BY country, status');
+  });
+});
+
+// =============================================================================
+// Filtered Measure Tests
+// =============================================================================
+
+describe('ClickHouse Backend - Filtered Measures', () => {
+  it('generates IF condition for filtered SUM', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', completedRevenue: 800 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['completedRevenue'],
+    });
+
+    expect(queries[0]).toContain("SUM(if((status = 'completed'), amount, 0)) AS completedRevenue");
+  });
+
+  it('generates multiple filtered measures', async () => {
+    const { backend, queries } = createTestBackend([
+      { country: 'US', completedRevenue: 800, pendingRevenue: 200 },
+    ]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['completedRevenue', 'pendingRevenue'],
+    });
+
+    expect(queries[0]).toContain("SUM(if((status = 'completed'), amount, 0)) AS completedRevenue");
+    expect(queries[0]).toContain("SUM(if((status = 'pending'), amount, 0)) AS pendingRevenue");
+  });
+
+  it('generates IF condition with numeric comparison filter', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', highValueRevenue: 5000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['highValueRevenue'],
+    });
+
+    expect(queries[0]).toContain('SUM(if((amount > 1000), amount, 0)) AS highValueRevenue');
+  });
+
+  it('combines regular and filtered measures', async () => {
+    const { backend, queries } = createTestBackend([
+      { country: 'US', revenue: 1000, completedRevenue: 800 },
+    ]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue', 'completedRevenue'],
+    });
+
+    expect(queries[0]).toContain('SUM(amount) AS revenue');
+    expect(queries[0]).toContain("SUM(if((status = 'completed'), amount, 0)) AS completedRevenue");
+  });
+});
+
+// =============================================================================
+// Filter Operator Tests
+// =============================================================================
+
+describe('ClickHouse Backend - Filter Operators', () => {
+  it('generates EQ filter', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', revenue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      filters: [eq('status', 'completed')],
+    });
+
+    expect(queries[0]).toContain('WHERE status = ?');
+  });
+
+  it('generates NEQ filter', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', revenue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      filters: [neq('status', 'cancelled')],
+    });
+
+    expect(queries[0]).toContain('WHERE status != ?');
+  });
+
+  it('generates GT filter', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', revenue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      filters: [gt('amount', 100)],
+    });
+
+    expect(queries[0]).toContain('WHERE amount > ?');
+  });
+
+  it('generates GTE filter', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', revenue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      filters: [gte('amount', 100)],
+    });
+
+    expect(queries[0]).toContain('WHERE amount >= ?');
+  });
+
+  it('generates LT filter', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', revenue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      filters: [lt('amount', 1000)],
+    });
+
+    expect(queries[0]).toContain('WHERE amount < ?');
+  });
+
+  it('generates LTE filter', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', revenue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      filters: [lte('amount', 1000)],
+    });
+
+    expect(queries[0]).toContain('WHERE amount <= ?');
+  });
+
+  it('generates IN filter', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', revenue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      filters: [inList('country', ['US', 'CA', 'UK'])],
+    });
+
+    expect(queries[0]).toContain('WHERE country IN (?, ?, ?)');
+  });
+
+  it('generates NOT IN filter', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', revenue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      filters: [notInList('status', ['cancelled', 'refunded'])],
+    });
+
+    expect(queries[0]).toContain('WHERE status NOT IN (?, ?)');
+  });
+
+  it('generates LIKE filter', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', revenue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      filters: [like('productCategory', '%electronics%')],
+    });
+
+    expect(queries[0]).toContain('WHERE product_category LIKE ?');
+  });
+
+  it('generates multiple filters with AND logic', async () => {
+    const { backend, queries } = createTestBackend([{ country: 'US', revenue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      filters: [
+        eq('status', 'completed'),
+        gt('amount', 100),
+        inList('country', ['US', 'CA']),
+      ],
+    });
+
+    expect(queries[0]).toContain('WHERE status = ?');
+    expect(queries[0]).toContain('AND amount > ?');
+    expect(queries[0]).toContain('AND country IN (?, ?)');
+  });
+});
+
+// =============================================================================
+// Time Grain Tests
+// =============================================================================
+
+describe('ClickHouse Backend - Time Grains', () => {
+  const revenue = Orders.metric('revenue', { measure: 'revenue' });
+
+  it('generates day grain', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+    const dailyRevenue = revenue.by('day');
+
+    await analytics.execute(dailyRevenue, { dimensions: ['country'] });
+
+    expect(queries[0]).toContain('toStartOfDay(created_at) AS period');
+    expect(queries[0]).toContain('GROUP BY period, country');
+  });
+
+  it('generates week grain', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+    const weeklyRevenue = revenue.by('week');
+
+    await analytics.execute(weeklyRevenue, { dimensions: ['country'] });
+
+    expect(queries[0]).toContain('toStartOfWeek(created_at) AS period');
+  });
+
+  it('generates month grain', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+    const monthlyRevenue = revenue.by('month');
+
+    await analytics.execute(monthlyRevenue, { dimensions: ['country'] });
+
+    expect(queries[0]).toContain('toStartOfMonth(created_at) AS period');
+  });
+
+  it('generates quarter grain', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+    const quarterlyRevenue = revenue.by('quarter');
+
+    await analytics.execute(quarterlyRevenue, { dimensions: ['country'] });
+
+    expect(queries[0]).toContain('toStartOfQuarter(created_at) AS period');
+  });
+
+  it('generates year grain', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+    const yearlyRevenue = revenue.by('year');
+
+    await analytics.execute(yearlyRevenue, { dimensions: ['country'] });
+
+    expect(queries[0]).toContain('toStartOfYear(created_at) AS period');
+  });
+
+  it('generates grained query without dimensions', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+    const monthlyRevenue = revenue.by('month');
+
+    await analytics.execute(monthlyRevenue);
+
+    expect(queries[0]).toContain('toStartOfMonth(created_at) AS period');
+    expect(queries[0]).toContain('GROUP BY period');
+    expect(queries[0]).not.toContain('GROUP BY period,'); // No trailing comma
+  });
+});
+
+// =============================================================================
+// Derived Metric Tests
+// =============================================================================
+
+describe('ClickHouse Backend - Derived Metrics', () => {
+  const revenue = Orders.metric('revenue', { measure: 'revenue' });
+  const orderCount = Orders.metric('orderCount', { measure: 'orderCount' });
+
+  it('generates CTE for derived metric with division', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    const avgOrderValue = Orders.metric('avgOrderValue', {
+      uses: { revenue, orderCount },
+      formula: ({ revenue, orderCount }) => divide(revenue, nullIfZero(orderCount)),
+    });
+
+    await analytics.execute(avgOrderValue, { dimensions: ['country'] });
+
+    expect(queries[0]).toContain('WITH base AS (');
+    expect(queries[0]).toContain('SUM(amount) AS revenue');
+    expect(queries[0]).toContain('COUNT(id) AS orderCount');
+    expect(queries[0]).toContain(') SELECT country, (revenue) / (NULLIF(orderCount, 0)) AS avgOrderValue FROM base');
+  });
+
+  it('generates CTE for derived metric with multiple operations', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+    const totalQuantity = Orders.metric('totalQuantity', { measure: 'totalQuantity' });
+
+    const complexMetric = Orders.metric('complexMetric', {
+      uses: { revenue, orderCount, totalQuantity },
+      formula: ({ revenue, orderCount, totalQuantity }) =>
+        add(divide(revenue, nullIfZero(orderCount)), multiply(totalQuantity, 10)),
+    });
+
+    await analytics.execute(complexMetric, { dimensions: ['country'] });
+
+    expect(queries[0]).toContain('WITH base AS (');
+    expect(queries[0]).toContain('SUM(amount) AS revenue');
+    expect(queries[0]).toContain('COUNT(id) AS orderCount');
+    expect(queries[0]).toContain('SUM(quantity) AS totalQuantity');
+    expect(queries[0]).toContain('((revenue) / (NULLIF(orderCount, 0))) + ((totalQuantity) * (10))');
+  });
+
+  it('applies ORDER BY and LIMIT to derived metrics', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    const avgOrderValue = Orders.metric('avgOrderValue', {
+      uses: { revenue, orderCount },
+      formula: ({ revenue, orderCount }) => divide(revenue, nullIfZero(orderCount)),
+    });
+
+    await analytics.execute(avgOrderValue, {
+      dimensions: ['country'],
+      orderBy: [{ field: 'avgOrderValue', direction: 'desc' }],
+      limit: 10,
+    });
+
+    expect(queries[0]).toContain('ORDER BY avgOrderValue DESC');
+    expect(queries[0]).toContain('LIMIT 10');
+  });
+
+  it('supports grained derived metrics', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    const avgOrderValue = Orders.metric('avgOrderValue', {
+      uses: { revenue, orderCount },
+      formula: ({ revenue, orderCount }) => divide(revenue, nullIfZero(orderCount)),
+    });
+
+    const monthlyAvg = avgOrderValue.by('month');
+
+    await analytics.execute(monthlyAvg, { dimensions: ['country'] });
+
+    expect(queries[0]).toContain('WITH base AS (');
+    expect(queries[0]).toContain('toStartOfMonth(created_at) AS period');
+    expect(queries[0]).toContain('SELECT period, country, (revenue) / (NULLIF(orderCount, 0)) AS avgOrderValue FROM base');
+  });
+});
+
+// =============================================================================
+// Tenant Filtering Tests
+// =============================================================================
+
+describe('ClickHouse Backend - Tenant Filtering', () => {
+  it('injects tenant filter when runtime context provided', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(
+      Orders,
+      {
+        dimensions: ['country'],
+        measures: ['revenue'],
+      },
+      {
+        runtime: {
+          tenant: { id: 'tenant_123' },
+        },
+      },
+    );
+
+    expect(queries[0]).toContain('WHERE tenant_id = ?');
+  });
+
+  it('combines tenant filter with user filters', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(
+      Orders,
+      {
+        dimensions: ['country'],
+        measures: ['revenue'],
+        filters: [eq('status', 'completed')],
+      },
+      {
+        runtime: {
+          tenant: { id: 'tenant_123' },
+        },
+      },
+    );
+
+    expect(queries[0]).toContain('WHERE tenant_id = ?');
+    expect(queries[0]).toContain('AND status = ?');
+  });
+
+  it('does not inject tenant filter when no context provided', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+    });
+
+    expect(queries[0]).not.toContain('tenant_id');
+  });
+});
+
+// =============================================================================
+// ORDER BY and Pagination Tests
+// =============================================================================
+
+describe('ClickHouse Backend - ORDER BY and Pagination', () => {
+  it('generates ORDER BY for dimension', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      orderBy: [{ field: 'country', direction: 'asc' }],
+    });
+
+    expect(queries[0]).toContain('ORDER BY country ASC');
+  });
+
+  it('generates ORDER BY for measure', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      orderBy: [{ field: 'revenue', direction: 'desc' }],
+    });
+
+    expect(queries[0]).toContain('ORDER BY revenue DESC');
+  });
+
+  it('generates multiple ORDER BY clauses', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country', 'status'],
+      measures: ['revenue'],
+      orderBy: [
+        { field: 'country', direction: 'asc' },
+        { field: 'revenue', direction: 'desc' },
+      ],
+    });
+
+    expect(queries[0]).toContain('ORDER BY country ASC, revenue DESC');
+  });
+
+  it('generates LIMIT', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      limit: 100,
+    });
+
+    expect(queries[0]).toContain('LIMIT 100');
+  });
+
+  it('generates OFFSET', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      limit: 100,
+      offset: 50,
+    });
+
+    expect(queries[0]).toContain('LIMIT 100');
+    expect(queries[0]).toContain('OFFSET 50');
+  });
+
+  it('generates OFFSET with LIMIT', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+      limit: 100,
+      offset: 50,
+    });
+
+    expect(queries[0]).toContain('LIMIT 100');
+    expect(queries[0]).toContain('OFFSET 50');
+  });
+});
+
+// =============================================================================
+// Column Alias Resolution Tests
+// =============================================================================
+
+describe('ClickHouse Backend - Column Alias Resolution', () => {
+  it('resolves dimension column alias', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['customerId'],
+      measures: ['revenue'],
+    });
+
+    expect(queries[0]).toContain('customer_id AS customerId');
+    expect(queries[0]).toContain('GROUP BY customerId');
+  });
+
+  it('resolves measure column alias in aggregation', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['uniqueCustomers'],
+    });
+
+    expect(queries[0]).toContain('COUNT(DISTINCT customer_id) AS uniqueCustomers');
+  });
+
+  it('uses dimension as-is when no alias needed', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+    });
+
+    expect(queries[0]).toContain('SELECT country,');
+    expect(queries[0]).not.toContain('country AS country');
+  });
+});
+
+// =============================================================================
+// Edge Cases and Error Handling
+// =============================================================================
+
+describe('ClickHouse Backend - Edge Cases', () => {
+  it('handles query with no dimensions (total aggregation)', async () => {
+    const { backend, queries } = createTestBackend([{ revenue: 10000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(Orders, {
+      measures: ['revenue'],
+    });
+
+    expect(queries[0]).toContain('SELECT SUM(amount) AS revenue FROM orders');
+    expect(queries[0]).not.toContain('GROUP BY');
+  });
+
+  it('handles dataset without tenantKey', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(
+      Products,
+      {
+        dimensions: ['category'],
+        measures: ['productCount'],
+      },
+      {
+        runtime: {
+          tenant: { id: 'tenant_123' },
+        },
+      },
+    );
+
+    // Should not inject tenant filter for dataset without tenantKey
+    expect(queries[0]).not.toContain('tenant_id');
+  });
+
+  it('returns timing metadata', async () => {
+    const { backend } = createTestBackend([{ country: 'US', revenue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    const result = await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+    });
+
+    expect(result.meta.timingMs).toBeGreaterThanOrEqual(0);
+    expect(typeof result.meta.timingMs).toBe('number');
+  });
+
+  it('returns SQL in metadata', async () => {
+    const { backend } = createTestBackend([{ country: 'US', revenue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    const result = await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+    });
+
+    expect(result.meta.sql).toBeDefined();
+    expect(result.meta.sql).toContain('SELECT');
+    expect(result.meta.sql).toContain('FROM orders');
+  });
+
+  it('returns tenant in metadata when provided', async () => {
+    const { backend } = createTestBackend([{ country: 'US', revenue: 1000 }]);
+    const analytics = createDatasetClient({ backend });
+
+    const result = await analytics.execute(
+      Orders,
+      {
+        dimensions: ['country'],
+        measures: ['revenue'],
+      },
+      {
+        runtime: {
+          tenant: { id: 'tenant_123' },
+        },
+      },
+    );
+
+    expect(result.meta.tenant).toBe('tenant_123');
+  });
+});
+
+// =============================================================================
+// SQL Generation via explain()
+// =============================================================================
+
+describe('ClickHouse Backend - SQL Generation via Explain', () => {
+  it('backend supports explain() to generate SQL without execution', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    // Execute to verify SQL is generated
+    await analytics.execute(Orders, {
+      dimensions: ['country'],
+      measures: ['revenue'],
+    });
+
+    // Verify the query was generated
+    expect(queries[0]).toContain('SELECT country, SUM(amount) AS revenue FROM orders');
+    expect(queries[0]).toContain('GROUP BY country');
+    expect(queries.length).toBe(1);
+  });
+});

--- a/packages/clickhouse/src/core/tests/public-exports.test.ts
+++ b/packages/clickhouse/src/core/tests/public-exports.test.ts
@@ -13,7 +13,8 @@ import {
   dimension,
   eq,
   measure,
-} from '../../datasets.js';
+} from '@hypequery/datasets';
+import { createBackend } from '../../datasets.js';
 
 describe('Public exports', () => {
   it('exports built-in ClickHouse start-of interval helpers from the package entrypoint', () => {
@@ -26,12 +27,14 @@ describe('Public exports', () => {
     expect(toStartOfYear('created_at').toSql()).toBe('toStartOfYear(created_at)');
   });
 
-  it('exports a datasets client from the datasets subpath', () => {
+  it('exports a datasets client from the datasets package', () => {
     const client = createDatasetClient({
-      adapter: {
-        name: 'test',
-        query: async () => [],
-      },
+      backend: createBackend({
+        adapter: {
+          name: 'test',
+          query: async () => [],
+        },
+      }),
     });
 
     expect(typeof client.execute).toBe('function');
@@ -41,13 +44,15 @@ describe('Public exports', () => {
   it('renders semantic dataset plans through the ClickHouse datasets backend', async () => {
     const queries: string[] = [];
     const client = createDatasetClient({
-      adapter: {
-        name: 'test',
-        query: async (sql) => {
-          queries.push(sql);
-          return [{ country: 'US', revenue: 100 }];
+      backend: createBackend({
+        adapter: {
+          name: 'test',
+          query: async (sql) => {
+            queries.push(sql);
+            return [{ country: 'US', revenue: 100 }];
+          },
         },
-      },
+      }),
     });
     const Orders = dataset('orders', {
       source: 'orders',

--- a/packages/clickhouse/src/datasets.ts
+++ b/packages/clickhouse/src/datasets.ts
@@ -1,62 +1,46 @@
+/**
+ * ClickHouse Semantic Backend
+ *
+ * This module implements the SemanticBackend interface from @hypequery/datasets
+ * for ClickHouse databases. It translates database-agnostic semantic plans
+ * (PlanNode) into ClickHouse-specific SQL and executes them.
+ *
+ * Architecture:
+ * - @hypequery/datasets: Owns semantic planning, validation, and execution protocol
+ * - @hypequery/clickhouse: Implements SQL translation and execution for ClickHouse
+ *
+ * Usage:
+ * ```ts
+ * import { createDatasetClient } from '@hypequery/datasets';
+ * import { createBackend } from '@hypequery/clickhouse';
+ *
+ * const analytics = createDatasetClient({
+ *   backend: createBackend({
+ *     url: process.env.CLICKHOUSE_URL,
+ *     username: process.env.CLICKHOUSE_USER,
+ *     password: process.env.CLICKHOUSE_PASSWORD,
+ *     database: process.env.CLICKHOUSE_DATABASE,
+ *   })
+ * });
+ * ```
+ */
+
 import {
-  createDatasetClient as createSemanticDatasetClient,
   type MetricFilter,
   type PlanNode,
   type SemanticBackend,
   type SemanticBackendResult,
-  type DatasetClient,
   type SemanticExpression,
-} from '@hypequery/datasets';
-export {
-  add,
-  asc,
-  avg,
-  belongsTo,
-  between,
-  ceil,
-  coalesce,
-  count,
-  countDistinct,
-  dataset,
-  desc,
-  dimension,
-  divide,
-  eq,
-  filter,
-  floor,
-  gt,
-  gte,
-  hasMany,
-  hasOne,
-  inList,
-  like,
-  lt,
-  lte,
-  max,
-  measure,
-  min,
-  multiply,
-  neq,
-  notInList,
-  nullIfZero,
-  order,
-  round,
-  subtract,
-  sum,
-} from '@hypequery/datasets';
-export type {
-  DatasetInstance,
-  DatasetQuery,
-  DatasetQueryResult,
-  MetricQuery,
-  MetricResult,
 } from '@hypequery/datasets';
 import { createQueryBuilder } from './core/query-builder.js';
 import type { CreateQueryBuilderConfig } from './core/query-builder.js';
 import type { SchemaDefinition } from './core/types/builder-state.js';
 
-export type ClickHouseDatasetClient = DatasetClient;
-export type CreateDatasetClientConfig = CreateQueryBuilderConfig;
+export type CreateBackendConfig = CreateQueryBuilderConfig;
+
+// =============================================================================
+// ClickHouse SQL Generation Utilities
+// =============================================================================
 
 const GRAIN_FUNCTIONS = {
   day: 'toStartOfDay',
@@ -66,10 +50,30 @@ const GRAIN_FUNCTIONS = {
   year: 'toStartOfYear',
 } as const;
 
+/**
+ * SQL Literal Rendering
+ * Safely escapes values for direct SQL inclusion
+ */
+function renderLiteral(value: string | number | boolean | null): string {
+  if (value === null) return 'NULL';
+  if (typeof value === 'number') return String(value);
+  if (typeof value === 'boolean') return value ? '1' : '0';
+  // SQL string escaping: single quotes are escaped by doubling them
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+/**
+ * Time Grain Rendering
+ * Converts semantic grain to ClickHouse function
+ */
 function renderGrain(field: string, unit: keyof typeof GRAIN_FUNCTIONS): string {
   return `${GRAIN_FUNCTIONS[unit]}(${field})`;
 }
 
+/**
+ * Filter Rendering - Applies filters using query builder WHERE clauses
+ * This is the preferred method when working with the query builder
+ */
 function applyFilters(builder: any, filters: MetricFilter[]): any {
   let qb = builder;
   for (const filter of filters) {
@@ -78,48 +82,76 @@ function applyFilters(builder: any, filters: MetricFilter[]): any {
   return qb;
 }
 
-function renderLiteral(value: string | number | boolean | null): string {
-  if (value === null) return 'NULL';
-  if (typeof value === 'number') return String(value);
-  if (typeof value === 'boolean') return value ? '1' : '0';
-  return `'${value.replace(/'/g, "''")}'`;
+/**
+ * Type guard to check if value is a valid literal for SQL rendering
+ */
+function isLiteralValue(value: unknown): value is string | number | boolean | null {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value === null
+  );
 }
 
+/**
+ * Safely render a filter value as a SQL literal
+ * Throws if value is not a valid literal type
+ */
+function renderFilterValue(value: unknown): string {
+  if (!isLiteralValue(value)) {
+    throw new Error(`Invalid filter value type: ${typeof value}`);
+  }
+  return renderLiteral(value);
+}
+
+/**
+ * Filter Condition Rendering - Converts filter to SQL WHERE clause string
+ * Used for filtered aggregations (IF conditions) where query builder can't be used
+ */
 function renderFilterCondition(filter: MetricFilter): string {
-  switch (filter.operator) {
+  const { field, operator, value } = filter;
+
+  switch (operator) {
     case 'eq':
-      return `${filter.field} = ${renderLiteral(filter.value as any)}`;
+      return `${field} = ${renderFilterValue(value)}`;
     case 'neq':
-      return `${filter.field} != ${renderLiteral(filter.value as any)}`;
+      return `${field} != ${renderFilterValue(value)}`;
     case 'gt':
-      return `${filter.field} > ${renderLiteral(filter.value as any)}`;
+      return `${field} > ${renderFilterValue(value)}`;
     case 'gte':
-      return `${filter.field} >= ${renderLiteral(filter.value as any)}`;
+      return `${field} >= ${renderFilterValue(value)}`;
     case 'lt':
-      return `${filter.field} < ${renderLiteral(filter.value as any)}`;
+      return `${field} < ${renderFilterValue(value)}`;
     case 'lte':
-      return `${filter.field} <= ${renderLiteral(filter.value as any)}`;
+      return `${field} <= ${renderFilterValue(value)}`;
     case 'like':
-      return `${filter.field} LIKE ${renderLiteral(filter.value as any)}`;
+      return `${field} LIKE ${renderFilterValue(value)}`;
     case 'in':
     case 'notIn': {
-      if (!Array.isArray(filter.value) || filter.value.length === 0) {
-        throw new Error(`"${filter.operator}" filters require a non-empty array.`);
+      if (!Array.isArray(value) || value.length === 0) {
+        throw new Error(`"${operator}" filters require a non-empty array.`);
       }
-      const values = filter.value.map((value) => renderLiteral(value as any)).join(', ');
-      return `${filter.field} ${filter.operator === 'in' ? 'IN' : 'NOT IN'} (${values})`;
+      const values = value.map(renderFilterValue).join(', ');
+      const op = operator === 'in' ? 'IN' : 'NOT IN';
+      return `${field} ${op} (${values})`;
     }
     case 'between': {
-      if (!Array.isArray(filter.value) || filter.value.length !== 2) {
+      if (!Array.isArray(value) || value.length !== 2) {
         throw new Error('"between" filters require a two-item array.');
       }
-      return `${filter.field} BETWEEN ${renderLiteral(filter.value[0] as any)} AND ${renderLiteral(filter.value[1] as any)}`;
+      return `${field} BETWEEN ${renderFilterValue(value[0])} AND ${renderFilterValue(value[1])}`;
     }
     default:
-      throw new Error(`Unsupported filter operator "${filter.operator}".`);
+      throw new Error(`Unsupported filter operator "${operator}".`);
   }
 }
 
+/**
+ * Filtered Aggregation Field Rendering
+ * Generates ClickHouse IF() expressions for conditional aggregations
+ * Example: SUM(if(status = 'completed', amount, 0))
+ */
 function renderFilteredAggregationField(
   aggregation: Extract<PlanNode, { kind: 'aggregate' }>['aggregations'][number],
 ): string {
@@ -127,153 +159,297 @@ function renderFilteredAggregationField(
     return aggregation.field;
   }
 
+  // Combine multiple filters with AND
   const condition = aggregation.filters
     .map(renderFilterCondition)
     .map((part) => `(${part})`)
     .join(' AND ');
+
+  // Use appropriate fallback: 0 for SUM, NULL for others
   const fallback = aggregation.aggregation === 'sum' ? '0' : 'NULL';
+
   return `if(${condition}, ${aggregation.field}, ${fallback})`;
 }
 
+/**
+ * Expression Rendering
+ * Converts semantic expressions (formulas) to SQL
+ * Used for derived metrics
+ */
 function renderExpression(expression: SemanticExpression): string {
   switch (expression.kind) {
     case 'ref':
       return expression.name;
+
     case 'literal':
       return renderLiteral(expression.value);
+
     case 'binary': {
-      const operator = {
+      const operators = {
         add: '+',
         subtract: '-',
         multiply: '*',
         divide: '/',
-      }[expression.operator];
-      return `(${renderExpression(expression.left)}) ${operator} (${renderExpression(expression.right)})`;
+      };
+      const op = operators[expression.operator];
+      const left = renderExpression(expression.left);
+      const right = renderExpression(expression.right);
+      return `(${left}) ${op} (${right})`;
     }
+
     case 'function': {
+      const args = expression.args.map(renderExpression);
+
+      // Special case functions with custom SQL
       if (expression.name === 'nullIfZero') {
-        return `NULLIF(${renderExpression(expression.args[0])}, 0)`;
+        return `NULLIF(${args[0]}, 0)`;
       }
       if (expression.name === 'coalesce') {
-        return `COALESCE(${expression.args.map(renderExpression).join(', ')})`;
+        return `COALESCE(${args.join(', ')})`;
       }
-      const fn = {
+
+      // Standard functions
+      const functionMap: Record<string, string> = {
         round: 'ROUND',
         floor: 'FLOOR',
         ceil: 'CEIL',
-      }[expression.name];
-      return `${fn}(${expression.args.map(renderExpression).join(', ')})`;
+      };
+      const fn = functionMap[expression.name];
+      if (!fn) {
+        throw new Error(`Unsupported function: ${expression.name}`);
+      }
+      return `${fn}(${args.join(', ')})`;
     }
+
     default:
       throw new Error('Unsupported semantic expression.');
   }
 }
 
+// =============================================================================
+// Query Builder Integration
+// =============================================================================
+
+/**
+ * Apply Aggregations
+ * Translates semantic aggregations to query builder method calls
+ */
 function applyAggregations(builder: any, plan: Extract<PlanNode, { kind: 'aggregate' }>): any {
   let qb = builder;
+
   for (const aggregation of plan.aggregations) {
     const field = renderFilteredAggregationField(aggregation);
-    switch (aggregation.aggregation) {
+    const { name, aggregation: aggType } = aggregation;
+
+    switch (aggType) {
       case 'sum':
-        qb = qb.sum(field, aggregation.name);
+        qb = qb.sum(field, name);
         break;
       case 'count':
-        qb = qb.count(field, aggregation.name);
+        qb = qb.count(field, name);
         break;
       case 'countDistinct':
-        qb = qb.countDistinct(field, aggregation.name);
+        qb = qb.countDistinct(field, name);
         break;
       case 'avg':
-        qb = qb.avg(field, aggregation.name);
+        qb = qb.avg(field, name);
         break;
       case 'min':
-        qb = qb.min(field, aggregation.name);
+        qb = qb.min(field, name);
         break;
       case 'max':
-        qb = qb.max(field, aggregation.name);
+        qb = qb.max(field, name);
         break;
     }
   }
+
   return qb;
 }
 
+/**
+ * Append Order/Limit/Offset
+ * Applies result modifiers to query builder
+ */
 function appendOrderLimitOffset(builder: any, plan: Pick<PlanNode, 'orderBy' | 'limit' | 'offset'>): any {
   let qb = builder;
+
+  // Order by
   for (const order of plan.orderBy ?? []) {
     qb = qb.orderBy(order.field, order.direction.toUpperCase());
   }
+
+  // Pagination
   if (plan.limit != null) qb = qb.limit(plan.limit);
   if (plan.offset != null) qb = qb.offset(plan.offset);
+
   return qb;
 }
 
+// =============================================================================
+// Plan Translation to SQL
+// =============================================================================
+
+/**
+ * Build Aggregate Query
+ * Translates semantic aggregate plan to ClickHouse query builder
+ */
 function buildAggregateQuery(queryBuilder: any, plan: Extract<PlanNode, { kind: 'aggregate' }>): any {
   let qb = queryBuilder.table(plan.source);
-  const selectParts = plan.dimensions.map((dimension) => (
-    dimension.field === dimension.name ? dimension.name : `${dimension.field} AS ${dimension.name}`
-  ));
-  const groupByParts = plan.dimensions.map((dimension) => dimension.name);
 
+  // Build SELECT and GROUP BY for dimensions
+  const selectParts: string[] = [];
+  const groupByParts: string[] = [];
+
+  // Time grain (period column)
   if (plan.grain) {
-    selectParts.unshift(`${renderGrain(plan.grain.field, plan.grain.unit)} AS ${plan.grain.output}`);
-    groupByParts.unshift(plan.grain.output);
+    const grainSql = renderGrain(plan.grain.field, plan.grain.unit);
+    selectParts.push(`${grainSql} AS ${plan.grain.output}`);
+    groupByParts.push(plan.grain.output);
   }
 
-  if (selectParts.length > 0) qb = qb.select(selectParts);
+  // Dimensions
+  for (const dimension of plan.dimensions) {
+    const columnSql = dimension.field === dimension.name
+      ? dimension.name
+      : `${dimension.field} AS ${dimension.name}`;
+    selectParts.push(columnSql);
+    groupByParts.push(dimension.name);
+  }
+
+  // Apply SELECT clause
+  if (selectParts.length > 0) {
+    qb = qb.select(selectParts);
+  }
+
+  // Apply aggregations (measures)
   qb = applyAggregations(qb, plan);
-  if (groupByParts.length > 0) qb = qb.groupBy(groupByParts);
-  if (plan.tenant) qb = qb.where(plan.tenant.field, 'eq', plan.tenant.value);
+
+  // Apply GROUP BY
+  if (groupByParts.length > 0) {
+    qb = qb.groupBy(groupByParts);
+  }
+
+  // Apply tenant filter (auto-injected)
+  if (plan.tenant) {
+    qb = qb.where(plan.tenant.field, 'eq', plan.tenant.value);
+  }
+
+  // Apply user filters
   qb = applyFilters(qb, plan.filters);
+
+  // Apply order/limit/offset
   return appendOrderLimitOffset(qb, plan);
 }
 
+/**
+ * Build Derived Metric SQL
+ * Generates CTE-based query for derived metrics (formulas over base metrics)
+ *
+ * Note: Uses string concatenation for outer query since query builder
+ * doesn't support CTEs natively. Inner query uses query builder for safety.
+ */
 function buildDerivedSQL(queryBuilder: any, plan: Extract<PlanNode, { kind: 'derive' }>) {
   if (plan.input.kind !== 'aggregate') {
     throw new Error('ClickHouse datasets currently supports derived metrics over aggregate input plans only.');
   }
 
+  // Build inner aggregate query using query builder
   const inputQuery = buildAggregateQuery(queryBuilder, plan.input);
   const { sql, parameters } = inputQuery.toSQLWithParams();
+
+  // Passthrough columns (grain + dimensions)
   const passthrough = [
     ...(plan.input.grain ? [plan.input.grain.output] : []),
-    ...plan.input.dimensions.map((dimension) => dimension.name),
+    ...plan.input.dimensions.map((dim) => dim.name),
   ];
-  const metricSelects = plan.metrics.map((metric) => (
-    `${renderExpression(metric.expression)} AS ${metric.name}`
-  ));
-  let outerSql = `WITH base AS (${sql}) SELECT ${[...passthrough, ...metricSelects].join(', ')} FROM base`;
 
+  // Derived metric calculations
+  const metricSelects = plan.metrics.map((metric) =>
+    `${renderExpression(metric.expression)} AS ${metric.name}`
+  );
+
+  // Build outer query with CTE
+  const allSelects = [...passthrough, ...metricSelects];
+  let outerSql = `WITH base AS (${sql}) SELECT ${allSelects.join(', ')} FROM base`;
+
+  // ORDER BY
   if (plan.orderBy?.length) {
-    outerSql += ` ORDER BY ${plan.orderBy.map((order) => (
-      `${order.field} ${order.direction.toUpperCase()}`
-    )).join(', ')}`;
+    const orderClauses = plan.orderBy.map(
+      (order) => `${order.field} ${order.direction.toUpperCase()}`
+    );
+    outerSql += ` ORDER BY ${orderClauses.join(', ')}`;
   }
-  if (plan.limit != null) outerSql += ` LIMIT ${plan.limit}`;
-  if (plan.offset != null) outerSql += ` OFFSET ${plan.offset}`;
+
+  // LIMIT and OFFSET
+  if (plan.limit != null) {
+    outerSql += ` LIMIT ${plan.limit}`;
+  }
+  if (plan.offset != null) {
+    outerSql += ` OFFSET ${plan.offset}`;
+  }
 
   return { sql: outerSql, parameters };
 }
 
-export function createClickHouseSemanticBackend<Schema extends SchemaDefinition<Schema>>(
-  config: CreateDatasetClientConfig,
+// =============================================================================
+// Semantic Backend Implementation
+// =============================================================================
+
+/**
+ * Create ClickHouse Semantic Backend
+ *
+ * Creates a SemanticBackend implementation that translates database-agnostic
+ * semantic plans into ClickHouse SQL and executes them.
+ *
+ * @param config - ClickHouse connection configuration
+ * @returns SemanticBackend interface for executing semantic queries
+ */
+export function createBackend<Schema extends SchemaDefinition<Schema>>(
+  config: CreateBackendConfig,
 ): SemanticBackend {
   const queryBuilder = createQueryBuilder<Schema>(config);
 
   return {
+    /**
+     * Execute a semantic plan and return results
+     */
     async execute<T = Record<string, unknown>>(plan: PlanNode): Promise<SemanticBackendResult<T>> {
       const start = Date.now();
+
       if (plan.kind === 'aggregate') {
+        // Base metrics: use query builder for full safety
         const query = buildAggregateQuery(queryBuilder, plan);
         const { sql } = query.toSQLWithParams();
         const data = await query.execute() as T[];
-        return { data, meta: { sql, timingMs: Date.now() - start, tenant: plan.tenant?.value } };
+
+        return {
+          data,
+          meta: {
+            sql,
+            timingMs: Date.now() - start,
+            tenant: plan.tenant?.value,
+          },
+        };
       }
 
+      // Derived metrics: CTE query with formulas
       const { sql, parameters } = buildDerivedSQL(queryBuilder, plan);
       const data = await queryBuilder.rawQuery<T>(sql, parameters);
       const tenant = plan.input.kind === 'aggregate' ? plan.input.tenant?.value : undefined;
-      return { data, meta: { sql, timingMs: Date.now() - start, tenant } };
+
+      return {
+        data,
+        meta: {
+          sql,
+          timingMs: Date.now() - start,
+          tenant,
+        },
+      };
     },
+
+    /**
+     * Generate SQL without executing
+     */
     async explain(plan: PlanNode) {
       if (plan.kind === 'aggregate') {
         return { sql: buildAggregateQuery(queryBuilder, plan).toSQLWithParams().sql };
@@ -283,10 +459,3 @@ export function createClickHouseSemanticBackend<Schema extends SchemaDefinition<
   };
 }
 
-export function createDatasetClient<Schema extends SchemaDefinition<Schema>>(
-  config: CreateDatasetClientConfig,
-): ClickHouseDatasetClient {
-  return createSemanticDatasetClient({
-    backend: createClickHouseSemanticBackend<Schema>(config),
-  });
-}

--- a/packages/datasets/README.md
+++ b/packages/datasets/README.md
@@ -22,8 +22,9 @@ import {
   eq,
   measure,
   nullIfZero,
+  createDatasetClient,
 } from '@hypequery/datasets';
-import { createDatasetClient } from '@hypequery/clickhouse/datasets';
+import { createBackend } from '@hypequery/clickhouse';
 
 const Orders = dataset('orders', {
   source: 'orders',
@@ -62,10 +63,12 @@ const averageOrderValue = Orders.metric('averageOrderValue', {
 });
 
 const analytics = createDatasetClient({
-  url: process.env.CLICKHOUSE_URL,
-  username: process.env.CLICKHOUSE_USER,
-  password: process.env.CLICKHOUSE_PASSWORD,
-  database: process.env.CLICKHOUSE_DATABASE,
+  backend: createBackend({
+    url: process.env.CLICKHOUSE_URL,
+    username: process.env.CLICKHOUSE_USER,
+    password: process.env.CLICKHOUSE_PASSWORD,
+    database: process.env.CLICKHOUSE_DATABASE,
+  }),
 });
 
 const result = await analytics.execute(revenue, {
@@ -227,7 +230,7 @@ For this release, relationship-aware query execution is not shipped. Query execu
 
 ## Execution
 
-Use `createDatasetClient` from `@hypequery/clickhouse/datasets` to execute semantic targets against ClickHouse.
+Use `createDatasetClient` from `@hypequery/datasets` with a backend implementation to execute semantic targets.
 
 ```ts
 const validation = analytics.validate(revenue, {
@@ -250,21 +253,29 @@ const datasetResult = await analytics.execute(Orders, {
 
 The semantic client validates dimensions, filters, order fields, limits, time grain requirements, tenant filtering, and derived metric plans before execution.
 
-For ClickHouse applications, `@hypequery/clickhouse/datasets` provides a
-datasets-first client that accepts ClickHouse connection config directly:
+### ClickHouse Backend
+
+For ClickHouse databases, use `createBackend` from `@hypequery/clickhouse`:
 
 ```ts
-import { createDatasetClient } from '@hypequery/clickhouse/datasets';
+import { createDatasetClient } from '@hypequery/datasets';
+import { createBackend } from '@hypequery/clickhouse';
 
 const analytics = createDatasetClient({
-  url: process.env.CLICKHOUSE_URL,
-  username: process.env.CLICKHOUSE_USER,
-  password: process.env.CLICKHOUSE_PASSWORD,
-  database: process.env.CLICKHOUSE_DATABASE,
+  backend: createBackend({
+    url: process.env.CLICKHOUSE_URL,
+    username: process.env.CLICKHOUSE_USER,
+    password: process.env.CLICKHOUSE_PASSWORD,
+    database: process.env.CLICKHOUSE_DATABASE,
+  }),
 });
 
 await analytics.execute(revenue, { dimensions: ['country'] });
 ```
+
+### Other Backends
+
+The `SemanticBackend` interface enables support for other databases. Future packages like `@hypequery/duckdb` or `@hypequery/postgres` would follow the same pattern.
 
 ## Serve Integration
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -24,7 +24,8 @@ pnpm add @hypequery/mcp
 Create `mcp-config.ts`:
 
 ```typescript
-import { createDatasetClient } from '@hypequery/clickhouse/datasets';
+import { createDatasetClient } from '@hypequery/datasets';
+import { createBackend } from '@hypequery/clickhouse';
 import { OrdersDataset, CustomersDataset } from './datasets/index.js';
 
 const revenue = OrdersDataset.metric('revenue', { measure: 'revenue' });
@@ -46,10 +47,12 @@ export const datasets = {
 
 // Export the semantic runner consumed by the MCP server
 export const analytics = createDatasetClient({
-  url: process.env.CLICKHOUSE_URL,
-  username: process.env.CLICKHOUSE_USER,
-  password: process.env.CLICKHOUSE_PASSWORD,
-  database: process.env.CLICKHOUSE_DATABASE,
+  backend: createBackend({
+    url: process.env.CLICKHOUSE_URL,
+    username: process.env.CLICKHOUSE_USER,
+    password: process.env.CLICKHOUSE_PASSWORD,
+    database: process.env.CLICKHOUSE_DATABASE,
+  }),
 });
 ```
 

--- a/packages/mcp-server/TESTING.md
+++ b/packages/mcp-server/TESTING.md
@@ -33,14 +33,16 @@ cp examples/mcp-config.js ./my-mcp-config.js
 
 Edit `my-mcp-config.js` to match your ClickHouse schema:
 ```javascript
-import { dataset, dimension, measure } from '@hypequery/datasets';
-import { createDatasetClient } from '@hypequery/clickhouse/datasets';
+import { dataset, dimension, measure, createDatasetClient } from '@hypequery/datasets';
+import { createBackend } from '@hypequery/clickhouse';
 
 const analytics = createDatasetClient({
-  url: 'http://localhost:8123',
-  username: 'default',
-  password: '',
-  database: 'analytics',
+  backend: createBackend({
+    url: 'http://localhost:8123',
+    username: 'default',
+    password: '',
+    database: 'analytics',
+  }),
 });
 
 // Define your datasets based on your actual tables

--- a/packages/mcp-server/examples/mcp-config.ts
+++ b/packages/mcp-server/examples/mcp-config.ts
@@ -11,18 +11,20 @@
  * 4. Add to Claude Desktop config (see README)
  */
 
-import { dataset, dimension, measure } from '@hypequery/datasets';
-import { createDatasetClient } from '@hypequery/clickhouse/datasets';
+import { dataset, dimension, measure, createDatasetClient } from '@hypequery/datasets';
+import { createBackend } from '@hypequery/clickhouse';
 
 // =============================================================================
 // STEP 1: Configure ClickHouse Connection
 // =============================================================================
 
 const analytics = createDatasetClient({
-  url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
-  username: process.env.CLICKHOUSE_USER || 'default',
-  password: process.env.CLICKHOUSE_PASSWORD || '',
-  database: process.env.CLICKHOUSE_DATABASE || 'default',
+  backend: createBackend({
+    url: process.env.CLICKHOUSE_URL || 'http://localhost:8123',
+    username: process.env.CLICKHOUSE_USER || 'default',
+    password: process.env.CLICKHOUSE_PASSWORD || '',
+    database: process.env.CLICKHOUSE_DATABASE || 'default',
+  }),
 });
 
 // =============================================================================


### PR DESCRIPTION
Summary

  This PR establishes clean package boundaries between @hypequery/datasets and @hypequery/clickhouse, enabling independent tracking of datasets
  adoption through npm metrics. It moves semantic execution orchestration to the datasets package while keeping SQL generation in the clickhouse
  package.

  Motivation

  With datasets launching this month, we need to track adoption separately from query builder usage. By moving createDatasetClient to the
  datasets package, users must explicitly install both packages, allowing us to measure datasets adoption through npm downloads without
  instrumentation.

  Changes

  Architecture

  - Moved createDatasetClient from @hypequery/clickhouse/datasets to @hypequery/datasets
  - Renamed createClickHouseSemanticBackend → createBackend for cleaner API
  - Established clear boundaries:
    - @hypequery/datasets: Owns semantic planning, validation, and execution protocol
    - @hypequery/clickhouse: Implements SQL translation and execution for ClickHouse

  New User-Facing API

  // Datasets users (semantic layer)
  import { createDatasetClient } from '@hypequery/datasets';
  import { createBackend } from '@hypequery/clickhouse';

  const analytics = createDatasetClient({
    backend: createBackend({
      url: process.env.CLICKHOUSE_URL,
      username: process.env.CLICKHOUSE_USER,
      password: process.env.CLICKHOUSE_PASSWORD,
      database: process.env.CLICKHOUSE_DATABASE,
    })
  });

  // Query builder users (unchanged)
  import { createQueryBuilder } from '@hypequery/clickhouse';
  const db = createQueryBuilder({ url, username, password, database });

  Code Quality

  - Refactored SQL generation in packages/clickhouse/src/datasets.ts:
    - Added comprehensive documentation headers
    - Organized utilities into clear sections
    - Removed all type casts, replaced with proper type guards
    - Added runtime type safety for filter values
  - Comprehensive test coverage: Added 50 tests covering:
    - Base aggregations
    - Filtered measures
    - All filter operators (eq, neq, gt, gte, lt, lte, like, in, notIn, between)
    - Time grains (day, week, month, quarter, year)
    - Derived metrics with CTEs
    - Tenant filtering
    - ORDER BY and pagination
    - Column aliases
    - Edge cases

  Documentation

  - Updated all READMEs with new import patterns
  - Updated CLI output templates
  - Updated MCP server examples
  - Removed pre-release datasets mentions from clickhouse README