### PR TITLE
task:cli datasets init dx

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -35,6 +35,7 @@ function addTypeGenerationOptions(command: Command) {
   return command
     .description('Regenerate types from ClickHouse')
     .option('-o, --output <path>', 'Output file (default: analytics/schema.ts)')
+    .option('--path <path>', 'Analytics directory (derives <path>/schema.ts)')
     .option('--tables <names>', 'Only generate for specific tables (comma-separated)')
     .option('--database <type>', 'Database driver to use (default: auto-detect)');
 }
@@ -44,6 +45,10 @@ program
   .command('init')
   .description('Initialize a new hypequery project')
   .option('--path <path>', 'Output directory (default: analytics/)')
+  .option('--style <style>', 'Scaffold style: queries or datasets')
+  .option('--all-tables', 'Generate datasets for all discovered tables when using --style datasets')
+  .option('--tables <names>', 'Generate datasets for specific tables when using --style datasets (comma-separated)')
+  .option('--exclude-tables <names>', 'Exclude tables from dataset generation when using --style datasets (comma-separated)')
   .option('--no-example', 'Skip example query generation')
   .option('--no-interactive', 'Non-interactive mode (use env vars)')
   .option('--force', 'Overwrite existing files')
@@ -64,6 +69,7 @@ program
   .option('--redis-url <url>', 'Redis connection URL')
   .option('--open', 'Open browser automatically')
   .option('--cors', 'Enable CORS')
+  .option('--path <path>', 'Analytics directory (loads <path>/api.ts or <path>/queries.ts)')
   .option('-q, --quiet', 'Suppress startup messages')
   .action(runCommand(async (file: string | undefined, options: DevOptions) => {
     await devCommand(file, options);
@@ -84,7 +90,9 @@ program
   .command('generate:datasets')
   .description('Generate dataset definitions from ClickHouse schema')
   .option('-o, --output <path>', 'Output file (default: src/datasets/generated.ts)')
+  .option('--path <path>', 'Analytics directory (derives <path>/datasets.ts)')
   .option('--tables <names>', 'Only generate for specific tables (comma-separated)')
+  .option('--exclude-tables <names>', 'Exclude specific tables (comma-separated)')
   .action(runCommand(async (options: GenerateDatasetsOptions) => {
     await generateDatasetsCommand(options);
   }));

--- a/packages/cli/src/commands/dev.test.ts
+++ b/packages/cli/src/commands/dev.test.ts
@@ -92,7 +92,7 @@ describe('dev command', () => {
     it('should start dev server successfully', async () => {
       await devCommand(undefined, { watch: false });
 
-      expect(findFiles.findQueriesFile).toHaveBeenCalledWith(undefined);
+      expect(findFiles.findQueriesFile).toHaveBeenCalledWith();
       expect(loadApi.loadApiModule).toHaveBeenCalledWith('/app/queries.ts');
       expect(mockServeDev).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -111,6 +111,26 @@ describe('dev command', () => {
       await devCommand('/custom/queries.ts', { watch: false });
 
       expect(findFiles.findQueriesFile).toHaveBeenCalledWith('/custom/queries.ts');
+    });
+
+    it('should load api file from path option', async () => {
+      vi.mocked(findFiles.findApiFileForPath).mockResolvedValue('/app/custom/api.ts');
+
+      await devCommand(undefined, { watch: false, path: 'custom' });
+
+      expect(findFiles.findApiFileForPath).toHaveBeenCalledWith('custom');
+      expect(findFiles.findQueriesFile).not.toHaveBeenCalled();
+      expect(loadApi.loadApiModule).toHaveBeenCalledWith('/app/custom/api.ts');
+    });
+
+    it('should let positional file win over path option', async () => {
+      vi.mocked(findFiles.findQueriesFile).mockResolvedValue('/app/manual.ts');
+
+      await devCommand('manual.ts', { watch: false, path: 'custom' });
+
+      expect(findFiles.findQueriesFile).toHaveBeenCalledWith('manual.ts');
+      expect(findFiles.findApiFileForPath).not.toHaveBeenCalled();
+      expect(loadApi.loadApiModule).toHaveBeenCalledWith('/app/manual.ts');
     });
 
     it('should display table count when available', async () => {
@@ -194,9 +214,9 @@ describe('dev command', () => {
         expect((error as ProcessExitError).code).toBe(1);
       }
 
-      expect(logger.error).toHaveBeenCalledWith('Could not find queries file');
+      expect(logger.error).toHaveBeenCalledWith('Could not find hypequery API file');
       expect(logger.info).toHaveBeenCalledWith('Expected one of:');
-      expect(logger.indent).toHaveBeenCalledWith('• analytics/queries.ts');
+      expect(logger.indent).toHaveBeenCalledWith('• analytics/api.ts');
       expect(exitHandler.exitMock).toHaveBeenCalledWith(1);
     });
 

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -2,7 +2,7 @@ import { watch } from 'node:fs';
 import path from 'node:path';
 import ora from 'ora';
 import { logger } from '../utils/logger.js';
-import { findQueriesFile } from '../utils/find-files.js';
+import { findApiFileForPath, findQueriesFile } from '../utils/find-files.js';
 import { getTableCount } from '../utils/detect-database.js';
 import { loadApiModule } from '../utils/load-api.js';
 
@@ -10,17 +10,21 @@ import { loadApiModule } from '../utils/load-api.js';
  * Display error when queries file cannot be found
  */
 function displayQueriesFileNotFoundError(commandName: string): void {
-  logger.error('Could not find queries file');
+  logger.error('Could not find hypequery API file');
   logger.newline();
   logger.info('Expected one of:');
+  logger.indent('• hypequery.ts');
+  logger.indent('• analytics/api.ts');
+  logger.indent('• src/analytics/api.ts');
+  logger.indent('• api.ts');
+  logger.indent('• src/api.ts');
   logger.indent('• analytics/queries.ts');
   logger.indent('• src/analytics/queries.ts');
-  logger.indent('• hypequery.ts');
   logger.newline();
   logger.info("Did you run 'hypequery init'?");
   logger.newline();
   logger.info('Or specify the file explicitly:');
-  logger.indent(`hypequery ${commandName} ./path/to/queries.ts`);
+  logger.indent(`hypequery ${commandName} ./path/to/api.ts`);
   logger.newline();
 }
 
@@ -33,11 +37,16 @@ export interface DevOptions {
   redisUrl?: string;
   open?: boolean;
   cors?: boolean;
+  path?: string;
 }
 
 export async function devCommand(file?: string, options: DevOptions = {}) {
   // Step 1: Find queries file
-  const queriesFile = await findQueriesFile(file);
+  const queriesFile = file
+    ? await findQueriesFile(file)
+    : options.path
+      ? await findApiFileForPath(options.path)
+      : await findQueriesFile();
 
   if (!queriesFile) {
     displayQueriesFileNotFoundError('dev');

--- a/packages/cli/src/commands/generate-datasets.test.ts
+++ b/packages/cli/src/commands/generate-datasets.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as detectDb from '../utils/detect-database.js';
+import { mockProcessExit } from '../test-utils.js';
+
+const mockLogger = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  reload: vi.fn(),
+  header: vi.fn(),
+  newline: vi.fn(),
+  indent: vi.fn(),
+  box: vi.fn(),
+  table: vi.fn(),
+  raw: vi.fn(),
+}));
+const mockGenerateDatasets = vi.hoisted(() => vi.fn());
+
+vi.mock('../utils/detect-database.js');
+vi.mock('../utils/logger.js', () => ({
+  logger: mockLogger,
+}));
+vi.mock('../generators/dataset-generator.js', () => ({
+  generateDatasets: mockGenerateDatasets,
+}));
+vi.mock('ora', () => ({
+  default: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  })),
+}));
+
+let generateDatasetsCommand: typeof import('./generate-datasets.js')['generateDatasetsCommand'];
+
+describe('generate datasets command', () => {
+  let exitHandler: ReturnType<typeof mockProcessExit>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ generateDatasetsCommand } = await import('./generate-datasets.js'));
+    exitHandler = mockProcessExit();
+    vi.clearAllMocks();
+    vi.mocked(detectDb.getTableCount).mockResolvedValue(10);
+    mockGenerateDatasets.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    exitHandler.restore();
+  });
+
+  it('derives datasets output from path when provided', async () => {
+    await generateDatasetsCommand({ path: 'custom' });
+
+    expect(mockGenerateDatasets).toHaveBeenCalledWith(
+      expect.objectContaining({ outputPath: expect.stringContaining('custom/datasets.ts') }),
+    );
+  });
+
+  it('prefers output over path', async () => {
+    await generateDatasetsCommand({ output: 'explicit.ts', path: 'custom' });
+
+    expect(mockGenerateDatasets).toHaveBeenCalledWith(
+      expect.objectContaining({ outputPath: expect.stringContaining('explicit.ts') }),
+    );
+  });
+
+  it('passes include and exclude table filters', async () => {
+    await generateDatasetsCommand({
+      path: 'custom',
+      tables: 'orders, customers',
+      excludeTables: 'orders_archive',
+    });
+
+    expect(mockGenerateDatasets).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeTables: ['orders', 'customers'],
+        excludeTables: ['orders_archive'],
+      }),
+    );
+  });
+});

--- a/packages/cli/src/commands/generate-datasets.ts
+++ b/packages/cli/src/commands/generate-datasets.ts
@@ -13,7 +13,18 @@ import { generateDatasets } from '../generators/dataset-generator.js';
 
 export interface GenerateDatasetsOptions {
   output?: string;
+  path?: string;
   tables?: string;
+  excludeTables?: string;
+}
+
+function parseTableList(value: string | undefined): string[] | undefined {
+  const parsed = value
+    ?.split(',')
+    .map((table) => table.trim())
+    .filter(Boolean);
+
+  return parsed && parsed.length > 0 ? parsed : undefined;
 }
 
 export async function generateDatasetsCommand(options: GenerateDatasetsOptions = {}) {
@@ -22,17 +33,15 @@ export async function generateDatasetsCommand(options: GenerateDatasetsOptions =
 
   if (options.output) {
     outputPath = path.resolve(process.cwd(), options.output);
+  } else if (options.path) {
+    outputPath = path.resolve(process.cwd(), options.path, 'datasets.ts');
   } else {
     // Default to src/datasets/generated.ts
     outputPath = path.join(process.cwd(), 'src', 'datasets', 'generated.ts');
   }
 
-  const parsedTables = options.tables
-    ? options.tables
-        .split(',')
-        .map((table) => table.trim())
-        .filter(Boolean)
-    : undefined;
+  const parsedTables = parseTableList(options.tables);
+  const excludedTables = parseTableList(options.excludeTables);
 
   logger.newline();
   logger.header('hypequery generate datasets');
@@ -52,6 +61,7 @@ export async function generateDatasetsCommand(options: GenerateDatasetsOptions =
     await generateDatasets({
       outputPath,
       includeTables: parsedTables,
+      excludeTables: excludedTables,
     });
 
     datasetSpinner.succeed(`Generated dataset definitions for ${parsedTables?.length || tableCount} tables`);

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -94,6 +94,14 @@ describe('generate command', () => {
       expect(logger.success).toHaveBeenCalledWith(expect.stringContaining('custom/schema.ts'));
     });
 
+    it('derives schema output from path when provided', async () => {
+      await generateCommand({ path: 'custom' });
+
+      expect(mockGenerateTypes).toHaveBeenCalledWith(
+        expect.objectContaining({ outputPath: expect.stringContaining('custom/schema.ts') })
+      );
+    });
+
     it('uses existing schema file when found', async () => {
       vi.mocked(findFiles.findSchemaFile).mockResolvedValue('/app/src/schema.ts');
 
@@ -249,6 +257,14 @@ describe('generate command', () => {
 
       expect(mockGenerateTypes).toHaveBeenCalledWith(
         expect.objectContaining({ outputPath: expect.stringContaining('custom.ts') })
+      );
+    });
+
+    it('prefers output over path', async () => {
+      await generateCommand({ output: 'explicit.ts', path: 'custom' });
+
+      expect(mockGenerateTypes).toHaveBeenCalledWith(
+        expect.objectContaining({ outputPath: expect.stringContaining('explicit.ts') })
       );
     });
   });

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -7,6 +7,7 @@ import { getTypeGenerator } from '../generators/index.js';
 
 export interface GenerateOptions {
   output?: string;
+  path?: string;
   tables?: string;
   database?: DatabaseType;
   commandName?: string;
@@ -18,6 +19,8 @@ export async function generateCommand(options: GenerateOptions = {}) {
 
   if (options.output) {
     outputPath = path.resolve(process.cwd(), options.output);
+  } else if (options.path) {
+    outputPath = path.resolve(process.cwd(), options.path, 'schema.ts');
   } else {
     // Try to find existing schema file
     const existingSchema = await findSchemaFile();

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -32,6 +32,10 @@ const mockGetTypeGenerator = vi.fn(() => mockGenerateTypes);
 vi.mock('../generators/index.js', () => ({
   getTypeGenerator: mockGetTypeGenerator,
 }));
+const mockGenerateDatasets = vi.fn().mockResolvedValue(undefined);
+vi.mock('../generators/dataset-generator.js', () => ({
+  generateDatasets: mockGenerateDatasets,
+}));
 
 // Import after mocks
 let initCommand: any;
@@ -352,6 +356,178 @@ describe('init command - graceful failure handling', () => {
       await initCommand({});
 
       expect(installScaffoldDependencies).toHaveBeenCalled();
+    });
+  });
+
+  describe('Style scaffolds', () => {
+    it('prompts for style in interactive mode and defaults to query files', async () => {
+      vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue(null);
+      vi.mocked(prompts.promptOutputDirectory).mockResolvedValue('analytics');
+      vi.mocked(prompts.promptInitStyle).mockResolvedValue('queries');
+
+      await initCommand({});
+
+      expect(prompts.promptOutputDirectory).toHaveBeenCalled();
+      expect(prompts.promptInitStyle).toHaveBeenCalled();
+      expect(writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('analytics/queries.ts'),
+        expect.stringContaining('initServe'),
+      );
+    });
+
+    it('creates datasets scaffold under a custom path without generating all tables by default', async () => {
+      process.env.CLICKHOUSE_URL = 'http://test:8123';
+      delete process.env.CLICKHOUSE_HOST;
+      process.env.CLICKHOUSE_DATABASE = 'test_db';
+      process.env.CLICKHOUSE_USERNAME = 'test_user';
+      process.env.CLICKHOUSE_PASSWORD = 'test_pass';
+
+      vi.mocked(detectDb.validateConnection).mockResolvedValue(true);
+      vi.mocked(detectDb.getTableCount).mockResolvedValue(10);
+
+      await initCommand({
+        noInteractive: true,
+        force: true,
+        style: 'datasets',
+        path: 'custom',
+      });
+
+      expect(mockGenerateTypes).toHaveBeenCalledWith(
+        expect.objectContaining({ outputPath: expect.stringContaining('custom/schema.ts') }),
+      );
+      expect(mockGenerateDatasets).not.toHaveBeenCalled();
+      expect(writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('custom/datasets.ts'),
+        expect.stringContaining('exampleEvents'),
+      );
+      expect(writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('custom/client.ts'),
+        expect.any(String),
+      );
+      expect(writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('custom/api.ts'),
+        expect.stringContaining('createAPI'),
+      );
+      expect(writeFile).not.toHaveBeenCalledWith(
+        expect.stringContaining('custom/queries.ts'),
+        expect.any(String),
+      );
+      expect(installScaffoldDependencies).toHaveBeenCalledWith('datasets');
+    });
+
+    it('generates selected datasets from explicit tables in non-interactive mode', async () => {
+      process.env.CLICKHOUSE_URL = 'http://test:8123';
+      delete process.env.CLICKHOUSE_HOST;
+      process.env.CLICKHOUSE_DATABASE = 'test_db';
+      process.env.CLICKHOUSE_USERNAME = 'test_user';
+      process.env.CLICKHOUSE_PASSWORD = 'test_pass';
+
+      vi.mocked(detectDb.validateConnection).mockResolvedValue(true);
+      vi.mocked(detectDb.getTableCount).mockResolvedValue(10);
+
+      await initCommand({
+        noInteractive: true,
+        force: true,
+        style: 'datasets',
+        path: 'custom',
+        tables: 'orders, customers',
+        excludeTables: 'customers_archive',
+      });
+
+      expect(mockGenerateDatasets).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outputPath: expect.stringContaining('custom/datasets.ts'),
+          includeTables: ['orders', 'customers'],
+          excludeTables: ['customers_archive'],
+        }),
+      );
+    });
+
+    it('generates all datasets only when allTables is explicit', async () => {
+      process.env.CLICKHOUSE_URL = 'http://test:8123';
+      delete process.env.CLICKHOUSE_HOST;
+      process.env.CLICKHOUSE_DATABASE = 'test_db';
+      process.env.CLICKHOUSE_USERNAME = 'test_user';
+      process.env.CLICKHOUSE_PASSWORD = 'test_pass';
+
+      vi.mocked(detectDb.validateConnection).mockResolvedValue(true);
+      vi.mocked(detectDb.getTableCount).mockResolvedValue(10);
+
+      await initCommand({
+        noInteractive: true,
+        force: true,
+        style: 'datasets',
+        path: 'custom',
+        allTables: true,
+      });
+
+      expect(mockGenerateDatasets).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outputPath: expect.stringContaining('custom/datasets.ts'),
+          includeTables: undefined,
+        }),
+      );
+    });
+
+    it('prompts for dataset tables in interactive datasets mode', async () => {
+      vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue({
+        host: 'http://localhost:8123',
+        database: 'default',
+        username: 'default',
+        password: 'correct',
+      });
+      vi.mocked(detectDb.validateConnection).mockResolvedValue(true);
+      vi.mocked(detectDb.getTableCount).mockResolvedValue(3);
+      vi.mocked(detectDb.getTables).mockResolvedValue(['orders', 'customers', 'events']);
+      vi.mocked(prompts.promptOutputDirectory).mockResolvedValue('analytics');
+      vi.mocked(prompts.promptGenerateExample).mockResolvedValue(true);
+      vi.mocked(prompts.promptTableSelection).mockResolvedValue('orders');
+      vi.mocked(prompts.promptInitStyle).mockResolvedValue('datasets');
+      vi.mocked(prompts.promptDatasetTableSelection).mockResolvedValue(['orders', 'customers']);
+
+      await initCommand({});
+
+      expect(prompts.promptDatasetTableSelection).toHaveBeenCalledWith(
+        ['orders', 'customers', 'events'],
+        ['orders'],
+      );
+      expect(mockGenerateDatasets).toHaveBeenCalledWith(
+        expect.objectContaining({
+          includeTables: ['orders', 'customers'],
+        }),
+      );
+    });
+
+    it('creates query scaffold under a custom path', async () => {
+      process.env.CLICKHOUSE_URL = 'http://test:8123';
+      delete process.env.CLICKHOUSE_HOST;
+      process.env.CLICKHOUSE_DATABASE = 'test_db';
+      process.env.CLICKHOUSE_USERNAME = 'test_user';
+      process.env.CLICKHOUSE_PASSWORD = 'test_pass';
+
+      vi.mocked(detectDb.validateConnection).mockResolvedValue(true);
+      vi.mocked(detectDb.getTableCount).mockResolvedValue(10);
+
+      await initCommand({
+        noInteractive: true,
+        force: true,
+        style: 'queries',
+        path: 'custom',
+      });
+
+      expect(writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('custom/client.ts'),
+        expect.any(String),
+      );
+      expect(writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('custom/queries.ts'),
+        expect.stringContaining('initServe'),
+      );
+      expect(writeFile).not.toHaveBeenCalledWith(
+        expect.stringContaining('custom/api.ts'),
+        expect.any(String),
+      );
+      expect(installScaffoldDependencies).toHaveBeenCalledWith('queries');
     });
   });
 });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -5,11 +5,14 @@ import { logger } from '../utils/logger.js';
 import {
   promptClickHouseConnection,
   promptOutputDirectory,
+  promptInitStyle,
   promptGenerateExample,
   promptTableSelection,
+  promptDatasetTableSelection,
   confirmOverwrite,
   promptRetry,
   promptContinueWithoutDb,
+  type InitStyle,
 } from '../utils/prompts.js';
 import {
   validateConnection,
@@ -20,16 +23,36 @@ import { hasEnvFile, hasGitignore } from '../utils/find-files.js';
 import { generateEnvTemplate, appendToEnv } from '../templates/env.js';
 import { generateClientTemplate } from '../templates/client.js';
 import { generateQueriesTemplate } from '../templates/queries.js';
+import { generateApiTemplate } from '../templates/api.js';
+import { generateDatasetsPlaceholderTemplate } from '../templates/datasets.js';
 import { appendToGitignore } from '../templates/gitignore.js';
 import { getTypeGenerator } from '../generators/index.js';
+import { generateDatasets } from '../generators/dataset-generator.js';
 import { installScaffoldDependencies } from '../utils/dependency-installer.js';
 
 export interface InitOptions {
   path?: string;
+  style?: InitStyle;
+  allTables?: boolean;
+  tables?: string;
+  excludeTables?: string;
   noExample?: boolean;
   noInteractive?: boolean;
   force?: boolean;
   skipConnection?: boolean;
+}
+
+function normalizeInitStyle(style: InitOptions['style']): InitStyle {
+  return style === 'datasets' ? 'datasets' : 'queries';
+}
+
+function parseTableList(value: string | undefined): string[] | undefined {
+  const parsed = value
+    ?.split(',')
+    .map((table) => table.trim())
+    .filter(Boolean);
+
+  return parsed && parsed.length > 0 ? parsed : undefined;
 }
 
 type ConnectionConfig = {
@@ -106,7 +129,6 @@ export async function initCommand(options: InitOptions = {}) {
   // Step 2: Get connection details
   let connectionConfig = await resolveConnectionConfig(options);
   let hasValidConnection = false;
-  let tableCount = 0;
 
   // Handle user skipping connection details
   if (!connectionConfig) {
@@ -116,9 +138,8 @@ export async function initCommand(options: InitOptions = {}) {
     logger.info('Skipping database connection test (requested).');
     logger.newline();
   } else {
-    const { hasValidConnection: valid, tableCount: count } = await testConnection(connectionConfig);
+    const { hasValidConnection: valid } = await testConnection(connectionConfig);
     hasValidConnection = valid;
-    tableCount = count;
 
     if (!hasValidConnection) {
       if (noInteractive) {
@@ -154,11 +175,23 @@ export async function initCommand(options: InitOptions = {}) {
 
   const resolvedOutputDir = path.resolve(process.cwd(), outputDir);
 
+  let style = normalizeInitStyle(options.style);
+  if (!options.style && !noInteractive) {
+    style = await promptInitStyle();
+  }
+
   // Step 5: Check for existing files
   const filesToCreate = [
     path.join(resolvedOutputDir, 'client.ts'),
     path.join(resolvedOutputDir, 'schema.ts'),
-    path.join(resolvedOutputDir, 'queries.ts'),
+    ...(style === 'datasets'
+      ? [
+          path.join(resolvedOutputDir, 'datasets.ts'),
+          path.join(resolvedOutputDir, 'api.ts'),
+        ]
+      : [
+          path.join(resolvedOutputDir, 'queries.ts'),
+        ]),
   ];
 
   const existingFiles: string[] = [];
@@ -185,15 +218,33 @@ export async function initCommand(options: InitOptions = {}) {
   // Step 6: Ask about example query (only if we have a valid connection)
   let generateExample = !options.noExample && hasValidConnection;
   let selectedTable: string | null = null;
+  let discoveredTables: string[] | null = null;
 
   if (generateExample && !noInteractive && hasValidConnection) {
     generateExample = await promptGenerateExample();
 
     if (generateExample) {
-      const tables = await getTables('clickhouse');
-      selectedTable = await promptTableSelection(tables);
+      discoveredTables = await getTables('clickhouse');
+      selectedTable = await promptTableSelection(discoveredTables);
       generateExample = selectedTable !== null;
     }
+  }
+
+  let datasetTables = parseTableList(options.tables);
+  const excludedDatasetTables = parseTableList(options.excludeTables);
+
+  if (
+    style === 'datasets' &&
+    hasValidConnection &&
+    !options.allTables &&
+    !datasetTables &&
+    !noInteractive
+  ) {
+    discoveredTables ??= await getTables('clickhouse');
+    datasetTables = await promptDatasetTableSelection(
+      discoveredTables,
+      selectedTable ? [selectedTable] : [],
+    );
   }
 
   logger.newline();
@@ -265,19 +316,53 @@ export interface IntrospectedSchema {
   await writeFile(clientPath, generateClientTemplate());
   logger.success(`Created ClickHouse client (${path.relative(process.cwd(), clientPath)})`);
 
-  // Step 11: Create queries.ts
-  const queriesPath = path.join(resolvedOutputDir, 'queries.ts');
-  await writeFile(
-    queriesPath,
-    generateQueriesTemplate({
-      hasExample: generateExample,
-      tableName: selectedTable || undefined,
-    })
-  );
-  logger.success(`Created queries file (${path.relative(process.cwd(), queriesPath)})`);
+  // Step 11: Create API entrypoint
+  let apiPath: string;
+  let generatedAnyDatasets = false;
+  let generatedSelectedDataset = false;
+  if (style === 'datasets') {
+    const datasetsPath = path.join(resolvedOutputDir, 'datasets.ts');
+    const shouldGenerateDatasets = hasValidConnection && (
+      options.allTables === true ||
+      (datasetTables !== undefined && datasetTables.length > 0)
+    );
 
-  if (generateExample && selectedTable) {
-    logger.success(`Created example query using '${selectedTable}' table`);
+    if (shouldGenerateDatasets) {
+      await generateDatasets({
+        outputPath: datasetsPath,
+        includeTables: options.allTables ? undefined : datasetTables,
+        excludeTables: excludedDatasetTables,
+      });
+      generatedAnyDatasets = true;
+      generatedSelectedDataset = selectedTable !== null && (
+        options.allTables === true ||
+        datasetTables?.includes(selectedTable) === true
+      );
+    } else {
+      await writeFile(datasetsPath, generateDatasetsPlaceholderTemplate());
+      if (hasValidConnection) {
+        logger.info('Skipped dataset generation. Run `hypequery generate:datasets --path ' + outputDir + ' --tables table1,table2` when ready.');
+      }
+    }
+    logger.success(`Created datasets file (${path.relative(process.cwd(), datasetsPath)})`);
+
+    apiPath = path.join(resolvedOutputDir, 'api.ts');
+    await writeFile(apiPath, generateApiTemplate());
+    logger.success(`Created API file (${path.relative(process.cwd(), apiPath)})`);
+  } else {
+    apiPath = path.join(resolvedOutputDir, 'queries.ts');
+    await writeFile(
+      apiPath,
+      generateQueriesTemplate({
+        hasExample: generateExample,
+        tableName: selectedTable || undefined,
+      })
+    );
+    logger.success(`Created queries file (${path.relative(process.cwd(), apiPath)})`);
+  }
+
+  if (generateExample && selectedTable && (style === 'queries' || generatedSelectedDataset)) {
+    logger.success(`Created example ${style === 'datasets' ? 'dataset' : 'query'} using '${selectedTable}' table`);
   }
 
   // Step 12: Update .gitignore
@@ -297,25 +382,39 @@ export interface IntrospectedSchema {
   }
 
   // Step 13: Ensure required hypequery packages are installed
-  await installScaffoldDependencies();
+  await installScaffoldDependencies(style);
 
   // Step 14: Success message
   logger.newline();
   logger.header('Setup complete!');
 
   if (hasValidConnection) {
-    logger.info('Try your first query:');
-    logger.newline();
-    logger.indent(`import { api } from './${path.relative(process.cwd(), queriesPath).replace(/\.ts$/, '.js')}'`);
-    const exampleQueryKey = generateExample && selectedTable
-      ? `${selectedTable.replace(/_([a-z])/g, (_, l) => l.toUpperCase())}Query`
-      : 'exampleMetric';
-    logger.indent(`const result = await api.execute('${exampleQueryKey}')`);
-    logger.newline();
+    if (style === 'datasets' && !generatedAnyDatasets) {
+      logger.info('Next:');
+      logger.indent(`hypequery generate:datasets --path ${outputDir} --tables table1,table2`);
+      logger.newline();
+    } else if (style === 'datasets' && !generatedSelectedDataset) {
+      logger.info('Next:');
+      logger.indent('npx hypequery dev          Start development server');
+      logger.newline();
+    } else {
+      logger.info('Try your first query:');
+      logger.newline();
+      logger.indent(`import { api } from './${path.relative(process.cwd(), apiPath).replace(/\.ts$/, '.js')}'`);
+      const exampleQueryKey = generateExample && selectedTable
+        ? `${selectedTable.replace(/_([a-z])/g, (_, l) => l.toUpperCase())}Query`
+        : 'exampleMetric';
+      if (style === 'datasets' && selectedTable) {
+        logger.indent(`const result = await api.execute('dataset:${selectedTable}', { input: {} })`);
+      } else {
+        logger.indent(`const result = await api.execute('${exampleQueryKey}')`);
+      }
+      logger.newline();
 
-    logger.info('Next:');
-    logger.indent('npx hypequery dev          Start development server');
-    logger.newline();
+      logger.info('Next:');
+      logger.indent('npx hypequery dev          Start development server');
+      logger.newline();
+    }
   } else {
     logger.info('Next steps:');
     logger.newline();

--- a/packages/cli/src/templates/api.ts
+++ b/packages/cli/src/templates/api.ts
@@ -1,0 +1,18 @@
+/**
+ * Generate api.ts file for the semantic datasets API.
+ */
+export function generateApiTemplate(): string {
+  return `import { createAPI } from '@hypequery/serve';
+import type { InferApiType } from '@hypequery/serve';
+import { db } from './client.js';
+import { datasets } from './datasets.js';
+
+export const api = createAPI({
+  queryBuilder: db,
+  datasets,
+});
+
+export type ApiDefinition = InferApiType<typeof api>;
+`;
+}
+

--- a/packages/cli/src/templates/datasets.ts
+++ b/packages/cli/src/templates/datasets.ts
@@ -1,0 +1,24 @@
+/**
+ * Generate placeholder datasets.ts file for no-connection init.
+ */
+export function generateDatasetsPlaceholderTemplate(): string {
+  return `import { dataset, dimension, measure } from '@hypequery/datasets';
+
+const exampleEvents = dataset('example_events', {
+  source: 'example_events',
+  timeKey: 'created_at',
+  dimensions: {
+    id: dimension.string(),
+    createdAt: dimension.timestamp({ column: 'created_at' }),
+  },
+  measures: {
+    eventCount: measure.count('id', { label: 'Event Count' }),
+  },
+});
+
+export const datasets = {
+  exampleEvents,
+};
+`;
+}
+

--- a/packages/cli/src/templates/scaffold-node-next.test.ts
+++ b/packages/cli/src/templates/scaffold-node-next.test.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { generateClientTemplate } from './client.js';
 import { generateQueriesTemplate } from './queries.js';
+import { generateApiTemplate } from './api.js';
+import { generateDatasetsPlaceholderTemplate } from './datasets.js';
 
 const tempDirs: string[] = [];
 
@@ -29,7 +31,7 @@ describe('generated scaffold NodeNext compatibility', () => {
     await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })));
   });
 
-  it('passes tsc --noEmit with NodeNext imports and local module shims', async () => {
+  it('passes query scaffold tsc --noEmit with NodeNext imports and local module shims', async () => {
     const projectDir = await mkdtemp(path.join(os.tmpdir(), 'hypequery-cli-scaffold-'));
     tempDirs.push(projectDir);
 
@@ -114,6 +116,92 @@ export type InferQueryResult<TApi, TName extends string> = unknown;
 `);
     await writeFile(path.join(analyticsDir, 'client.ts'), generateClientTemplate());
     await writeFile(path.join(analyticsDir, 'queries.ts'), generateQueriesTemplate({ hasExample: false }));
+
+    const result = await runTypeCheck(projectDir);
+    expect(result.code, result.stderr).toBe(0);
+  });
+
+  it('passes datasets scaffold tsc --noEmit with NodeNext imports and local module shims', async () => {
+    const projectDir = await mkdtemp(path.join(os.tmpdir(), 'hypequery-cli-scaffold-'));
+    tempDirs.push(projectDir);
+
+    const analyticsDir = path.join(projectDir, 'analytics');
+    await mkdir(path.join(projectDir, 'node_modules/@hypequery/clickhouse'), { recursive: true });
+    await mkdir(path.join(projectDir, 'node_modules/@hypequery/serve'), { recursive: true });
+    await mkdir(path.join(projectDir, 'node_modules/@hypequery/datasets'), { recursive: true });
+    await mkdir(analyticsDir, { recursive: true });
+
+    await writeFile(path.join(projectDir, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022',
+        module: 'NodeNext',
+        moduleResolution: 'NodeNext',
+        strict: true,
+        noEmit: true,
+        skipLibCheck: true,
+      },
+      include: ['analytics/**/*.ts'],
+    }, null, 2));
+
+    await writeFile(path.join(projectDir, 'analytics', 'globals.d.ts'), `declare const process: {
+  env: Record<string, string | undefined>;
+};
+`);
+
+    await writeFile(path.join(projectDir, 'node_modules/@hypequery/clickhouse/package.json'), JSON.stringify({
+      name: '@hypequery/clickhouse',
+      type: 'module',
+      exports: {
+        '.': './index.d.ts',
+      },
+    }, null, 2));
+    await writeFile(path.join(projectDir, 'node_modules/@hypequery/clickhouse/index.d.ts'), `export declare function createQueryBuilder<TSchema>(config: unknown): {
+  table(name: string): unknown;
+  rawQuery?(sql: string, params?: unknown[]): Promise<unknown[]>;
+};
+`);
+
+    await writeFile(path.join(projectDir, 'node_modules/@hypequery/serve/package.json'), JSON.stringify({
+      name: '@hypequery/serve',
+      type: 'module',
+      exports: {
+        '.': './index.d.ts',
+      },
+    }, null, 2));
+    await writeFile(path.join(projectDir, 'node_modules/@hypequery/serve/index.d.ts'), `export declare function createAPI(config: {
+  queryBuilder: unknown;
+  datasets: Record<string, unknown>;
+}): {
+  execute(name: string, options?: unknown): Promise<unknown>;
+};
+export type InferApiType<T> = T;
+`);
+
+    await writeFile(path.join(projectDir, 'node_modules/@hypequery/datasets/package.json'), JSON.stringify({
+      name: '@hypequery/datasets',
+      type: 'module',
+      exports: {
+        '.': './index.d.ts',
+      },
+    }, null, 2));
+    await writeFile(path.join(projectDir, 'node_modules/@hypequery/datasets/index.d.ts'), `type DatasetDefinition = {
+  metric(name: string, config: unknown): unknown;
+};
+export declare function dataset(name: string, config: unknown): DatasetDefinition;
+export declare const dimension: {
+  string(config?: unknown): unknown;
+  timestamp(config?: unknown): unknown;
+};
+export declare const measure: {
+  count(field: string, config?: unknown): unknown;
+};
+`);
+
+    await writeFile(path.join(analyticsDir, 'schema.ts'), `export interface IntrospectedSchema {}
+`);
+    await writeFile(path.join(analyticsDir, 'client.ts'), generateClientTemplate());
+    await writeFile(path.join(analyticsDir, 'datasets.ts'), generateDatasetsPlaceholderTemplate());
+    await writeFile(path.join(analyticsDir, 'api.ts'), generateApiTemplate());
 
     const result = await runTypeCheck(projectDir);
     expect(result.code, result.stderr).toBe(0);

--- a/packages/cli/src/utils/dependency-installer.test.ts
+++ b/packages/cli/src/utils/dependency-installer.test.ts
@@ -55,10 +55,28 @@ describe('dependency installer', () => {
     ]);
   });
 
+  it('includes datasets package for datasets scaffold style', () => {
+    expect(resolveScaffoldPackages('1.1.1', 'datasets')).toEqual([
+      '@hypequery/clickhouse',
+      '@hypequery/serve',
+      'zod@^3.23.8',
+      '@hypequery/datasets',
+    ]);
+  });
+
   it('pins sibling packages to the same canary version', () => {
     expect(resolveScaffoldPackages('0.0.0-canary-20260506195711')).toEqual([
       '@hypequery/clickhouse@0.0.0-canary-20260506195711',
       '@hypequery/serve@0.0.0-canary-20260506195711',
+      'zod@^3.23.8',
+    ]);
+  });
+
+  it('pins datasets to the same canary version when needed', () => {
+    expect(resolveScaffoldPackages('0.0.0-canary-20260506195711', 'datasets')).toEqual([
+      '@hypequery/clickhouse@0.0.0-canary-20260506195711',
+      '@hypequery/serve@0.0.0-canary-20260506195711',
+      '@hypequery/datasets@0.0.0-canary-20260506195711',
       'zod@^3.23.8',
     ]);
   });

--- a/packages/cli/src/utils/dependency-installer.ts
+++ b/packages/cli/src/utils/dependency-installer.ts
@@ -7,6 +7,7 @@ import { logger } from './logger.js';
 
 const ZOD_SCAFFOLD_VERSION = '^3.23.8';
 const STABLE_SCAFFOLD_PACKAGES = ['@hypequery/clickhouse', '@hypequery/serve', `zod@${ZOD_SCAFFOLD_VERSION}`] as const;
+type ScaffoldStyle = 'queries' | 'datasets';
 const CLI_PACKAGE_PATH = fileURLToPath(new URL('../../package.json', import.meta.url));
 
 type PackageManager = 'pnpm' | 'yarn' | 'npm' | 'bun';
@@ -96,16 +97,22 @@ function formatManualCommand(manager: PackageManager, packages: string[]) {
   return `${MANUAL_COMMANDS[manager]} ${packages.join(' ')}`;
 }
 
-export function resolveScaffoldPackages(cliVersion: string | undefined): string[] {
+export function resolveScaffoldPackages(cliVersion: string | undefined, style: ScaffoldStyle = 'queries'): string[] {
+  const includeDatasets = style === 'datasets';
+
   if (cliVersion?.includes('canary')) {
     return [
       `@hypequery/clickhouse@${cliVersion}`,
       `@hypequery/serve@${cliVersion}`,
+      ...(includeDatasets ? [`@hypequery/datasets@${cliVersion}`] : []),
       `zod@${ZOD_SCAFFOLD_VERSION}`,
     ];
   }
 
-  return [...STABLE_SCAFFOLD_PACKAGES];
+  return [
+    ...STABLE_SCAFFOLD_PACKAGES,
+    ...(includeDatasets ? ['@hypequery/datasets'] : []),
+  ];
 }
 
 function shouldInstallPackage(pkgJson: PackageJson, specifier: string): boolean {
@@ -128,7 +135,7 @@ function shouldInstallPackage(pkgJson: PackageJson, specifier: string): boolean 
   return existingVersion !== desiredVersion;
 }
 
-export async function installScaffoldDependencies() {
+export async function installScaffoldDependencies(style: ScaffoldStyle = 'queries') {
   if (process.env.HYPEQUERY_SKIP_INSTALL === '1') {
     return;
   }
@@ -138,11 +145,12 @@ export async function installScaffoldDependencies() {
     readCliPackageJson(),
   ]);
   if (!pkgJson) {
-    logger.warn('package.json not found. Install @hypequery/clickhouse, @hypequery/serve, and zod manually.');
+    const extra = style === 'datasets' ? ', @hypequery/datasets' : '';
+    logger.warn(`package.json not found. Install @hypequery/clickhouse, @hypequery/serve${extra}, and zod manually.`);
     return;
   }
 
-  const requestedPackages = resolveScaffoldPackages(cliPkgJson?.version);
+  const requestedPackages = resolveScaffoldPackages(cliPkgJson?.version, style);
   const missing = requestedPackages.filter(pkg => shouldInstallPackage(pkgJson, pkg));
   if (missing.length === 0) {
     return;

--- a/packages/cli/src/utils/find-files.test.ts
+++ b/packages/cli/src/utils/find-files.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { access } from 'node:fs/promises';
 import {
   findQueriesFile,
+  findApiFileForPath,
   findSchemaFile,
+  findDatasetsFile,
   findClientFile,
   hasEnvFile,
   hasGitignore,
@@ -51,21 +53,25 @@ describe('find-files', () => {
       expect(access).toHaveBeenCalledWith('/test/project/hypequery.ts');
     });
 
-    it('should try analytics/queries.ts if hypequery.ts not found', async () => {
+    it('should prefer analytics/api.ts after hypequery.ts', async () => {
       vi.mocked(access)
         .mockRejectedValueOnce(new Error('ENOENT')) // hypequery.ts
-        .mockResolvedValueOnce(undefined); // analytics/queries.ts
+        .mockResolvedValueOnce(undefined); // analytics/api.ts
 
       const result = await findQueriesFile();
 
-      expect(result).toBe('/test/project/analytics/queries.ts');
+      expect(result).toBe('/test/project/analytics/api.ts');
       expect(access).toHaveBeenCalledWith('/test/project/hypequery.ts');
-      expect(access).toHaveBeenCalledWith('/test/project/analytics/queries.ts');
+      expect(access).toHaveBeenCalledWith('/test/project/analytics/api.ts');
     });
 
     it('should try all default paths in order', async () => {
       vi.mocked(access)
         .mockRejectedValueOnce(new Error('ENOENT')) // hypequery.ts
+        .mockRejectedValueOnce(new Error('ENOENT')) // analytics/api.ts
+        .mockRejectedValueOnce(new Error('ENOENT')) // src/analytics/api.ts
+        .mockRejectedValueOnce(new Error('ENOENT')) // api.ts
+        .mockRejectedValueOnce(new Error('ENOENT')) // src/api.ts
         .mockRejectedValueOnce(new Error('ENOENT')) // analytics/queries.ts
         .mockRejectedValueOnce(new Error('ENOENT')) // src/analytics/queries.ts
         .mockResolvedValueOnce(undefined); // queries.ts
@@ -73,7 +79,7 @@ describe('find-files', () => {
       const result = await findQueriesFile();
 
       expect(result).toBe('/test/project/queries.ts');
-      expect(access).toHaveBeenCalledTimes(4);
+      expect(access).toHaveBeenCalledTimes(8);
     });
 
     it('should return null if no default paths exist', async () => {
@@ -85,7 +91,35 @@ describe('find-files', () => {
     });
   });
 
+  describe('findApiFileForPath', () => {
+    it('should prefer api.ts before queries.ts in a provided directory', async () => {
+      vi.mocked(access).mockResolvedValue(undefined);
+
+      const result = await findApiFileForPath('custom');
+
+      expect(result).toBe('/test/project/custom/api.ts');
+      expect(access).toHaveBeenCalledWith('/test/project/custom/api.ts');
+    });
+
+    it('should fall back to queries.ts in a provided directory', async () => {
+      vi.mocked(access)
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockResolvedValueOnce(undefined);
+
+      const result = await findApiFileForPath('custom');
+
+      expect(result).toBe('/test/project/custom/queries.ts');
+    });
+  });
+
   describe('findSchemaFile', () => {
+    it('should derive schema.ts from a provided directory', async () => {
+      const result = await findSchemaFile('custom');
+
+      expect(result).toBe('/test/project/custom/schema.ts');
+      expect(access).not.toHaveBeenCalled();
+    });
+
     it('should find analytics/schema.ts first', async () => {
       vi.mocked(access).mockResolvedValue(undefined);
 
@@ -110,6 +144,23 @@ describe('find-files', () => {
       const result = await findSchemaFile();
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('findDatasetsFile', () => {
+    it('should derive datasets.ts from a provided directory', async () => {
+      const result = await findDatasetsFile('custom');
+
+      expect(result).toBe('/test/project/custom/datasets.ts');
+      expect(access).not.toHaveBeenCalled();
+    });
+
+    it('should find analytics/datasets.ts first', async () => {
+      vi.mocked(access).mockResolvedValue(undefined);
+
+      const result = await findDatasetsFile();
+
+      expect(result).toBe('/test/project/analytics/datasets.ts');
     });
   });
 

--- a/packages/cli/src/utils/find-files.ts
+++ b/packages/cli/src/utils/find-files.ts
@@ -21,8 +21,12 @@ async function findFile(candidates: string[]): Promise<string | null> {
 /**
  * Common query file locations to check
  */
-const DEFAULT_QUERY_PATHS = [
+const DEFAULT_API_PATHS = [
   'hypequery.ts',
+  'analytics/api.ts',
+  'src/analytics/api.ts',
+  'api.ts',
+  'src/api.ts',
   'analytics/queries.ts',
   'src/analytics/queries.ts',
   'queries.ts',
@@ -45,18 +49,43 @@ export async function findQueriesFile(customPath?: string): Promise<string | nul
   }
 
   // Check default locations
-  return findFile(DEFAULT_QUERY_PATHS);
+  return findFile(DEFAULT_API_PATHS);
+}
+
+export async function findApiFileForPath(directory: string): Promise<string | null> {
+  return findFile([
+    path.join(directory, 'api.ts'),
+    path.join(directory, 'queries.ts'),
+  ]);
 }
 
 /**
  * Find the schema file (generated types)
  */
-export async function findSchemaFile(): Promise<string | null> {
+export async function findSchemaFile(directory?: string): Promise<string | null> {
+  if (directory) {
+    return path.resolve(process.cwd(), directory, 'schema.ts');
+  }
+
   return findFile([
     'analytics/schema.ts',
     'src/analytics/schema.ts',
     'schema.ts',
     'src/schema.ts',
+  ]);
+}
+
+export async function findDatasetsFile(directory?: string): Promise<string | null> {
+  if (directory) {
+    return path.resolve(process.cwd(), directory, 'datasets.ts');
+  }
+
+  return findFile([
+    'analytics/datasets.ts',
+    'src/analytics/datasets.ts',
+    'datasets.ts',
+    'src/datasets.ts',
+    'src/datasets/generated.ts',
   ]);
 }
 

--- a/packages/cli/src/utils/load-api.test.ts
+++ b/packages/cli/src/utils/load-api.test.ts
@@ -49,7 +49,7 @@ describe('load-api', () => {
     vi.mocked(access).mockResolvedValue(undefined);
     testGlobal.__hypequeryCliImportOverride = async (moduleUrl) => {
       if (moduleUrl.includes('hypequery-cli-') || moduleUrl.includes('.hypequery/tmp/')) {
-        return { api: { handler: () => {} } };
+        return { api: { handler: () => undefined } };
       }
 
       return import(/* @vite-ignore */ moduleUrl);

--- a/packages/cli/src/utils/load-api.ts
+++ b/packages/cli/src/utils/load-api.ts
@@ -39,23 +39,32 @@ export async function loadApiModule(modulePath: string) {
 
     throw new Error(
       `Invalid API module: ${relativePath}\n\n` +
-      `The module must export a 'defineServe' result as 'api'.\n\n` +
+      `The module must export a hypequery API as 'api'.\n\n` +
       (availableExports.length > 0
         ? `Found exports: ${availableExports.join(', ')}\n\n`
         : `No exports found in the module.\n\n`) +
       `Expected format:\n\n` +
       `  import { initServe } from '@hypequery/serve';\n` +
       `  \n` +
-      `  const { define, queries, query } = initServe({\n` +
+      `  const { query, serve } = initServe({\n` +
       `    context: () => ({ db }),\n` +
       `  });\n` +
       `  \n` +
-      `  export const api = define({\n` +
-      `    queries: queries({\n` +
-      `      myQuery: query.query(async ({ ctx }) => {\n` +
-      `        // ...\n` +
-      `      }),\n` +
-      `    }),\n` +
+      `  const myQuery = query({\n` +
+      `    query: async ({ ctx }) => ctx.db.table('events').select('*').limit(10).execute(),\n` +
+      `  });\n` +
+      `  \n` +
+      `  export const api = serve({\n` +
+      `    queries: { myQuery },\n` +
+      `  });\n\n` +
+      `Or the datasets semantic API:\n\n` +
+      `  import { createAPI } from '@hypequery/serve';\n` +
+      `  import { db } from './client.js';\n` +
+      `  import { datasets } from './datasets.js';\n` +
+      `  \n` +
+      `  export const api = createAPI({\n` +
+      `    queryBuilder: db,\n` +
+      `    datasets,\n` +
       `  });\n`
     );
   }

--- a/packages/cli/src/utils/prompts.test.ts
+++ b/packages/cli/src/utils/prompts.test.ts
@@ -3,8 +3,10 @@ import prompts from 'prompts';
 import {
   promptClickHouseConnection,
   promptOutputDirectory,
+  promptInitStyle,
   promptGenerateExample,
   promptTableSelection,
+  promptDatasetTableSelection,
   confirmOverwrite,
   promptRetry,
   promptContinueWithoutDb,
@@ -162,6 +164,37 @@ describe('prompts', () => {
     });
   });
 
+  describe('promptInitStyle', () => {
+    it('should return selected style', async () => {
+      vi.mocked(prompts).mockResolvedValue({ style: 'datasets' });
+
+      const result = await promptInitStyle();
+
+      expect(result).toBe('datasets');
+    });
+
+    it('should default to query style when user cancels', async () => {
+      vi.mocked(prompts).mockResolvedValue({});
+
+      const result = await promptInitStyle();
+
+      expect(result).toBe('queries');
+    });
+
+    it('should default the prompt selection to query-builder routes', async () => {
+      vi.mocked(prompts).mockResolvedValue({ style: 'queries' });
+
+      await promptInitStyle();
+
+      expect(prompts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'style',
+          initial: 0,
+        }),
+      );
+    });
+  });
+
   describe('promptGenerateExample', () => {
     it('should return true when user confirms', async () => {
       vi.mocked(prompts).mockResolvedValue({ generate: true });
@@ -260,6 +293,60 @@ describe('prompts', () => {
           ]),
         })
       );
+    });
+  });
+
+  describe('promptDatasetTableSelection', () => {
+    it('should return selected dataset tables', async () => {
+      vi.mocked(prompts).mockResolvedValue({ tables: ['orders', 'customers'] });
+
+      const result = await promptDatasetTableSelection(['orders', 'customers', 'events']);
+
+      expect(result).toEqual(['orders', 'customers']);
+    });
+
+    it('should return an empty list if no tables provided', async () => {
+      const result = await promptDatasetTableSelection([]);
+
+      expect(result).toEqual([]);
+      expect(prompts).not.toHaveBeenCalled();
+    });
+
+    it('should preselect default tables', async () => {
+      vi.mocked(prompts).mockResolvedValue({ tables: ['orders'] });
+
+      await promptDatasetTableSelection(['orders', 'customers'], ['orders']);
+
+      expect(prompts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'multiselect',
+          choices: expect.arrayContaining([
+            expect.objectContaining({
+              title: 'orders',
+              selected: true,
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('should default to no tables when user cancels', async () => {
+      vi.mocked(prompts).mockResolvedValue({});
+
+      const result = await promptDatasetTableSelection(['orders']);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should warn and show the first 20 tables for large databases', async () => {
+      const tables = Array.from({ length: 25 }, (_, i) => `table_${i}`);
+      vi.mocked(prompts).mockResolvedValue({ tables: ['table_0'] });
+
+      await promptDatasetTableSelection(tables);
+
+      expect(logger.warn).toHaveBeenCalledWith('Showing first 20 of 25 tables');
+      const call = vi.mocked(prompts).mock.calls[0][0] as any;
+      expect(call.choices).toHaveLength(20);
     });
   });
 

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -84,6 +84,23 @@ export async function promptOutputDirectory(): Promise<string> {
   return response.directory;
 }
 
+export type InitStyle = 'queries' | 'datasets';
+
+export async function promptInitStyle(): Promise<InitStyle> {
+  const response = await prompts({
+    type: 'select',
+    name: 'style',
+    message: 'Choose your dev API style',
+    choices: [
+      { title: 'Query builder routes', value: 'queries' },
+      { title: 'Datasets semantic API', value: 'datasets' },
+    ],
+    initial: 0,
+  });
+
+  return response.style ?? 'queries';
+}
+
 /**
  * Prompt for example query generation
  */
@@ -127,6 +144,41 @@ export async function promptTableSelection(tables: string[]): Promise<string | n
   });
 
   return response.table;
+}
+
+/**
+ * Prompt for dataset table selection.
+ */
+export async function promptDatasetTableSelection(
+  tables: string[],
+  defaultTables: string[] = [],
+): Promise<string[]> {
+  if (tables.length === 0) {
+    return [];
+  }
+
+  // Warn if showing truncated list
+  if (tables.length > 20) {
+    logger.warn(`Showing first 20 of ${tables.length} tables`);
+    logger.indent('Use --tables or --all-tables for more control in larger databases');
+    logger.newline();
+  }
+
+  const defaults = new Set(defaultTables);
+  const response = await prompts({
+    type: 'multiselect',
+    name: 'tables',
+    message: 'Which tables should we scaffold as datasets?',
+    choices: tables.slice(0, 20).map(table => ({
+      title: table,
+      value: table,
+      selected: defaults.has(table),
+    })),
+    min: 0,
+    instructions: false,
+  });
+
+  return response.tables ?? [];
 }
 
 /**

--- a/packages/datasets/README.md
+++ b/packages/datasets/README.md
@@ -4,12 +4,26 @@ Type-safe semantic analytics definitions for Hypequery.
 
 Use this package to define datasets, dimensions, measures, metrics, derived metrics, and runtime validation rules in TypeScript. `@hypequery/datasets` owns semantic meaning and planning; `@hypequery/clickhouse` owns query construction and execution; `@hypequery/serve` owns HTTP/runtime delivery.
 
+`@hypequery/datasets` is the semantic layer. It is useful when you want analytics concepts in TypeScript rather than in YAML, raw SQL strings, or a separate BI server:
+
+- datasets map physical tables or views to typed business fields
+- dimensions and measures define the allowed query surface
+- metrics name reusable business calculations
+- derived metrics compose same-dataset metrics with symbolic formula helpers
+- runtime validation rejects invalid dimensions, filters, ordering, limits, tenant filters, and derived metric plans before SQL is executed
+
 ## Install
 
 ```bash
 npm install @hypequery/datasets
 # or
 pnpm add @hypequery/datasets
+```
+
+For ClickHouse execution, also install the ClickHouse backend package:
+
+```bash
+npm install @hypequery/clickhouse
 ```
 
 ## Quick Start
@@ -76,6 +90,12 @@ const result = await analytics.execute(revenue, {
   filters: [eq('status', 'completed')],
   orderBy: [{ field: 'revenue', direction: 'desc' }],
   limit: 10,
+});
+
+const datasetResult = await analytics.execute(Orders, {
+  dimensions: ['country', 'status'],
+  measures: ['revenue', 'orderCount'],
+  filters: [eq('status', 'completed')],
 });
 
 const monthlySql = analytics.toSQL(revenue.by('month'), {
@@ -180,6 +200,27 @@ const averageOrderValue = Orders.metric('averageOrderValue', {
 
 Cross-dataset derived metrics and derived-from-derived metrics are intentionally rejected in the current public surface.
 
+### Metric Queries vs Dataset Queries
+
+Metrics and datasets support two related access patterns:
+
+- Metric queries execute one named metric at a time. They are best for reusable product metrics such as `revenue`, `averageOrderValue`, or `monthlyRevenue`, while still allowing valid dimensions, filters, order fields, limits, and time grains.
+- Dataset queries execute an ad-hoc selection of dimensions and measures from one dataset. They are best when callers need Cube-style flexibility within the same dataset, such as grouping by `country` and `status` while selecting both `revenue` and `orderCount`.
+
+```ts
+await analytics.execute(revenue, {
+  dimensions: ['country'],
+  filters: [eq('status', 'completed')],
+});
+
+await analytics.execute(Orders, {
+  dimensions: ['country', 'status'],
+  measures: ['revenue', 'orderCount'],
+});
+```
+
+Both paths use the same dataset definition and validation rules. Metric queries provide named, reusable business contracts; dataset queries provide same-dataset exploration.
+
 ### Time Grains
 
 Use `.by(grain)` on a metric when the dataset has a `timeKey`.
@@ -277,11 +318,28 @@ await analytics.execute(revenue, { dimensions: ['country'] });
 
 The `SemanticBackend` interface enables support for other databases. Future packages like `@hypequery/duckdb` or `@hypequery/postgres` would follow the same pattern.
 
+## Integration Surfaces
+
+Dataset definitions can be reused in several places:
+
+- direct execution with `createDatasetClient(...)`
+- SQL inspection with `analytics.toSQL(...)`
+- runtime validation with `analytics.validate(...)`
+- HTTP metric and dataset endpoints through `@hypequery/serve`
+- agent-facing tools through `@hypequery/mcp`
+- schema compatibility checks through `@hypequery/schema`
+
 ## Serve Integration
 
 `@hypequery/serve` can expose metric and dataset endpoints from dataset definitions. Dataset endpoint planning uses `@hypequery/datasets/internal` as a package-integration boundary.
 
 Do not import `@hypequery/datasets/internal` in application code unless you are integrating Hypequery packages. It is intentionally not the public user-facing API.
+
+Metric endpoints expose named metrics. Dataset endpoints expose same-dataset ad-hoc dimensions and measures. Both surfaces are generated from dataset contracts, so invalid fields are rejected before execution.
+
+## Agent Integration
+
+`@hypequery/mcp` exposes dataset contracts, metric queries, and dataset queries over Model Context Protocol. This package does not run an MCP server directly; it provides the semantic definitions and execution client that the MCP package consumes.
 
 ## Schema Compatibility
 
@@ -302,13 +360,20 @@ if (!report.valid) {
 
 The checker validates source tables/views, dimension columns, measure fields, tenant/time keys, filtered measure fields, numeric measure types, and relationship join columns. Complex SQL expressions are reported with explicit limitation warnings.
 
-## What Is Not Public API
+## Current Scope And Limits
 
-- `dataset.query(...)`
-- Root exports for dataset endpoint execution helpers
-- Deep imports from package internals
-- Automatic relationship JOIN execution
-- Cross-dataset derived metrics
+The current semantic execution surface is intentionally scoped:
+
+- `dataset.query(...)` is not public API
+- Root exports for dataset endpoint execution helpers are not public API
+- Deep imports from package internals are not application API
+- Automatic relationship JOIN execution is not shipped
+- Cross-dataset derived metrics are rejected
+- Derived-from-derived metrics are rejected
+- Pre-aggregations or materialized rollups are not implemented
+- BI tool protocol compatibility is not implemented
+
+Relationship metadata is available for documentation, agents, and compatibility checks, but query execution is same-dataset only.
 
 ## License
 

--- a/plans/cli-datasets-init-readme-draft.md
+++ b/plans/cli-datasets-init-readme-draft.md
@@ -1,0 +1,161 @@
+# CLI Datasets Init README Draft
+
+Draft copy for the `@hypequery/cli` README when the datasets scaffold is released.
+
+## `hypequery init`
+
+`hypequery init` scaffolds a Hypequery analytics directory. By default it keeps the existing query-builder route setup.
+
+```bash
+npx hypequery init
+```
+
+Default query-builder scaffold:
+
+```text
+analytics/client.ts
+analytics/schema.ts
+analytics/queries.ts
+.env
+.gitignore
+```
+
+Interactive setup asks for:
+
+- ClickHouse connection details
+- output directory, such as `analytics/`, `src/analytics/`, or a custom path
+- scaffold style: query-builder routes or datasets semantic API
+- optional example query table when a ClickHouse connection is available
+
+If the ClickHouse connection is skipped or unavailable, `init` still creates placeholder files so the project can be filled in later.
+
+## Datasets Scaffold
+
+Use the datasets style to scaffold the semantic API entrypoint:
+
+```bash
+npx hypequery init --style datasets
+```
+
+Datasets scaffold:
+
+```text
+analytics/client.ts
+analytics/schema.ts
+analytics/datasets.ts
+analytics/api.ts
+.env
+.gitignore
+```
+
+`init --style datasets` does not generate every ClickHouse table by default. In interactive mode, it prompts for the tables to scaffold as datasets. In non-interactive mode, it writes a placeholder `datasets.ts` unless table generation is explicitly requested.
+
+Generate selected datasets during init:
+
+```bash
+npx hypequery init --style datasets --tables orders,customers
+```
+
+Generate all discovered tables during init:
+
+```bash
+npx hypequery init --style datasets --all-tables
+```
+
+Exclude tables from generation:
+
+```bash
+npx hypequery init --style datasets --all-tables --exclude-tables raw_events,audit_log
+```
+
+When no ClickHouse connection is available, datasets init creates:
+
+```text
+analytics/schema.ts     # placeholder schema
+analytics/datasets.ts   # placeholder exampleEvents dataset
+analytics/api.ts        # createAPI entrypoint
+```
+
+After configuring `.env`, regenerate schema types and datasets:
+
+```bash
+npx hypequery generate --path analytics
+npx hypequery generate:datasets --path analytics --tables orders,customers
+```
+
+## `hypequery generate`
+
+`hypequery generate` regenerates TypeScript schema types from ClickHouse. It does not generate semantic dataset definitions.
+
+```bash
+npx hypequery generate
+```
+
+Options:
+
+- `--output <path>`: explicit schema output file
+- `--path <path>`: analytics directory, writes `<path>/schema.ts`
+- `--tables <names>`: comma-separated table list
+- `--database <type>`: currently `clickhouse`
+
+Examples:
+
+```bash
+npx hypequery generate --path analytics
+npx hypequery generate --tables orders,customers
+npx hypequery generate --output analytics/schema.ts
+```
+
+## `hypequery generate:datasets`
+
+`hypequery generate:datasets` generates semantic dataset definitions from ClickHouse schema introspection.
+
+```bash
+npx hypequery generate:datasets --path analytics --tables orders,customers
+```
+
+Options:
+
+- `--output <path>`: explicit datasets output file
+- `--path <path>`: analytics directory, writes `<path>/datasets.ts`
+- `--tables <names>`: comma-separated table list
+- `--exclude-tables <names>`: comma-separated exclusion list
+
+Examples:
+
+```bash
+npx hypequery generate:datasets --path analytics --tables orders,customers
+npx hypequery generate:datasets --path analytics --exclude-tables raw_events,audit_log
+```
+
+## `hypequery dev`
+
+`hypequery dev` can load either scaffold style.
+
+Default discovery checks API-style files first, then query files:
+
+```text
+hypequery.ts
+analytics/api.ts
+src/analytics/api.ts
+api.ts
+src/api.ts
+analytics/queries.ts
+src/analytics/queries.ts
+queries.ts
+src/queries.ts
+```
+
+Load a specific analytics directory:
+
+```bash
+npx hypequery dev --path analytics
+```
+
+This checks:
+
+```text
+analytics/api.ts
+analytics/queries.ts
+```
+


### PR DESCRIPTION
  ## Summary

  Improves the CLI datasets scaffold DX so `hypequery init --style datasets` is explicit and conservative by default.

  ## Changes

  - Add datasets scaffold support to `hypequery init`
  - Add `--style datasets` with generated `datasets.ts` and `api.ts`
  - Keep plain `hypequery init` on the existing query-builder scaffold
  - Prompt interactive users to choose which tables to scaffold as datasets
  - Avoid generating all ClickHouse tables by default
  - Add explicit dataset generation flags:
    - `--tables orders,customers`
    - `--all-tables`
    - `--exclude-tables raw_events,audit_log`
  - Add `--path` support for `generate`, `generate:datasets`, and `dev`
  - Add `generate:datasets --exclude-tables`
  - Add draft README copy for release docs

  ## Behavior

  `hypequery init` still creates the existing query-builder setup by default.

  `hypequery init --style datasets` creates:

  - `analytics/client.ts`
  - `analytics/schema.ts`
  - `analytics/datasets.ts`
  - `analytics/api.ts`

  Dataset definitions are generated only when users select tables interactively or pass explicit flags. Non-
  interactive datasets init without table flags writes a placeholder `datasets.ts`.