### PR TITLE
feat: (mcp | datasets) query validation and mcp scoping

### DIFF
--- a/packages/clickhouse/dist-file-index.txt
+++ b/packages/clickhouse/dist-file-index.txt
@@ -140,6 +140,9 @@ core/utils/streaming-helpers.js
 core/utils/tuple-filter-validation.d.ts
 core/utils/tuple-filter-validation.d.ts.map
 core/utils/tuple-filter-validation.js
+core/utils/type-inference.d.ts
+core/utils/type-inference.d.ts.map
+core/utils/type-inference.js
 core/utils.d.ts
 core/utils.d.ts.map
 core/utils.js

--- a/packages/clickhouse/src/core/tests/datasets-backend.test.ts
+++ b/packages/clickhouse/src/core/tests/datasets-backend.test.ts
@@ -42,7 +42,6 @@ import { createBackend } from '../../datasets.js';
 
 const Orders = dataset('orders', {
   source: 'orders',
-  tenantKey: 'tenant_id',
   timeKey: 'created_at',
   dimensions: {
     id: dimension.string(),
@@ -72,6 +71,25 @@ const Orders = dataset('orders', {
     highValueRevenue: measure.sum('amount', {
       filters: [gt('amount', 1000)],
     }),
+  },
+});
+
+const TenantOrders = dataset('tenantOrders', {
+  source: 'orders',
+  tenantKey: 'tenant_id',
+  timeKey: 'created_at',
+  dimensions: {
+    id: dimension.string(),
+    tenantId: dimension.string({ column: 'tenant_id' }),
+    customerId: dimension.string({ column: 'customer_id' }),
+    country: dimension.string(),
+    status: dimension.string(),
+    amount: dimension.number(),
+    createdAt: dimension.timestamp({ column: 'created_at' }),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+    orderCount: measure.count('id'),
   },
 });
 
@@ -588,7 +606,7 @@ describe('ClickHouse Backend - Tenant Filtering', () => {
     const analytics = createDatasetClient({ backend });
 
     await analytics.execute(
-      Orders,
+      TenantOrders,
       {
         dimensions: ['country'],
         measures: ['revenue'],
@@ -608,7 +626,7 @@ describe('ClickHouse Backend - Tenant Filtering', () => {
     const analytics = createDatasetClient({ backend });
 
     await analytics.execute(
-      Orders,
+      TenantOrders,
       {
         dimensions: ['country'],
         measures: ['revenue'],
@@ -625,16 +643,14 @@ describe('ClickHouse Backend - Tenant Filtering', () => {
     expect(queries[0]).toContain('AND status = ?');
   });
 
-  it('does not inject tenant filter when no context provided', async () => {
-    const { backend, queries } = createTestBackend([]);
+  it('rejects tenant-keyed datasets when no tenant context is provided', async () => {
+    const { backend } = createTestBackend([]);
     const analytics = createDatasetClient({ backend });
 
-    await analytics.execute(Orders, {
+    expect(() => analytics.execute(TenantOrders, {
       dimensions: ['country'],
       measures: ['revenue'],
-    });
-
-    expect(queries[0]).not.toContain('tenant_id');
+    })).toThrow('requires runtime tenant scoping');
   });
 });
 
@@ -843,7 +859,7 @@ describe('ClickHouse Backend - Edge Cases', () => {
     const analytics = createDatasetClient({ backend });
 
     const result = await analytics.execute(
-      Orders,
+      TenantOrders,
       {
         dimensions: ['country'],
         measures: ['revenue'],

--- a/packages/clickhouse/src/datasets.ts
+++ b/packages/clickhouse/src/datasets.ts
@@ -331,7 +331,7 @@ function buildAggregateQuery(queryBuilder: any, plan: Extract<PlanNode, { kind: 
 
   // Apply tenant filter (auto-injected)
   if (plan.tenant) {
-    qb = qb.where(plan.tenant.field, 'eq', plan.tenant.value);
+    qb = qb.where(plan.tenant.field, plan.tenant.operator, plan.tenant.value);
   }
 
   // Apply user filters
@@ -427,7 +427,7 @@ export function createBackend<Schema extends SchemaDefinition<Schema>>(
           meta: {
             sql,
             timingMs: Date.now() - start,
-            tenant: plan.tenant?.value,
+            tenant: plan.tenant?.operator === 'eq' ? plan.tenant.value : undefined,
           },
         };
       }
@@ -435,7 +435,9 @@ export function createBackend<Schema extends SchemaDefinition<Schema>>(
       // Derived metrics: CTE query with formulas
       const { sql, parameters } = buildDerivedSQL(queryBuilder, plan);
       const data = await queryBuilder.rawQuery<T>(sql, parameters);
-      const tenant = plan.input.kind === 'aggregate' ? plan.input.tenant?.value : undefined;
+      const tenant = plan.input.kind === 'aggregate' && plan.input.tenant?.operator === 'eq'
+        ? plan.input.tenant.value
+        : undefined;
 
       return {
         data,
@@ -458,4 +460,3 @@ export function createBackend<Schema extends SchemaDefinition<Schema>>(
     },
   };
 }
-

--- a/packages/datasets/README.md
+++ b/packages/datasets/README.md
@@ -78,7 +78,7 @@ const result = await analytics.execute(revenue, {
   limit: 10,
 }, {
   runtime: {
-    tenant: { id: 'tenant_123' },
+    tenant: 'tenant_123',
   },
 });
 
@@ -86,7 +86,7 @@ const monthlySql = analytics.toSQL(revenue.by('month'), {
   dimensions: ['country'],
 }, {
   runtime: {
-    tenant: { id: 'tenant_123' },
+    tenant: 'tenant_123',
   },
 });
 ```
@@ -114,7 +114,7 @@ const Orders = dataset('orders', {
 
 `source` is the physical table or view name. The first `dataset()` argument is the logical dataset name. `tenantKey` and `timeKey` are physical column names used for runtime tenant isolation and time graining.
 
-If `tenantKey` is set, queries against the dataset require runtime tenant context. This is fail-closed: Hypequery will reject metric and dataset queries that do not include `runtime.tenant.id`.
+If `tenantKey` is set, queries against the dataset require runtime tenant context. This is fail-closed: Hypequery will reject metric and dataset queries that do not include a tenant runtime value or an explicitly enabled cross-tenant scope.
 
 ### Dimensions
 
@@ -201,7 +201,7 @@ await analytics.execute(monthlyRevenue, {
   dimensions: ['country'],
 }, {
   runtime: {
-    tenant: { id: 'tenant_123' },
+    tenant: 'tenant_123',
   },
 });
 ```
@@ -229,12 +229,12 @@ const revenue = Orders.metric('revenue', { measure: 'revenue' });
 
 await analytics.execute(revenue, {}, {
   runtime: {
-    tenant: { id: 'tenant_123' },
+    tenant: 'tenant_123',
   },
 });
 ```
 
-Here `tenantKey` is the physical column and `tenant.id` is the trusted runtime value. Together they produce a tenant predicate equivalent to:
+Here `tenantKey` is the physical column and `runtime.tenant` is the trusted runtime value. Together they produce a tenant predicate equivalent to:
 
 ```sql
 WHERE tenant_id = 'tenant_123'
@@ -247,6 +247,22 @@ await analytics.execute(revenue);
 // Error: Dataset "orders" requires runtime tenant scoping.
 ```
 
+You can also provide a trusted set of tenants for admin dashboards that are scoped to multiple accounts:
+
+```ts
+await analytics.execute(revenue, {}, {
+  runtime: {
+    tenant: { in: ['tenant_123', 'tenant_456'] },
+  },
+});
+```
+
+This produces a tenant predicate equivalent to:
+
+```sql
+WHERE tenant_id IN ('tenant_123', 'tenant_456')
+```
+
 When runtime tenancy is active, explicit filters on the tenant field are rejected. This prevents duplicate or conflicting tenant predicates:
 
 ```ts
@@ -254,13 +270,25 @@ await analytics.execute(revenue, {
   filters: [eq('tenantId', 'tenant_123')],
 }, {
   runtime: {
-    tenant: { id: 'tenant_123' },
+    tenant: 'tenant_123',
   },
 });
 // Error: Cannot filter on tenant field "tenantId" when runtime tenancy enforcement is active.
 ```
 
 The runtime integration should provide tenant identity from trusted server/session state. Do not accept tenant ids from end-user query input. In `@hypequery/serve`, regular hand-written queries can use Serve tenant auto-injection, but semantic dataset and metric endpoints pass tenant identity to `@hypequery/datasets`, and datasets injects the filter from `tenantKey`.
+
+For jobs, admin tools, or reporting surfaces that intentionally query across tenants, use `runtime.tenant: { scope: 'all' }`:
+
+```ts
+await analytics.execute(revenue, {}, {
+  runtime: {
+    tenant: { scope: 'all' },
+  },
+});
+```
+
+`scope: 'all'` omits the tenant predicate for every `tenantKey` dataset touched by the semantic query. Use this only in trusted contexts like background jobs or admin dashboards, not in request-facing clients or MCP servers.
 
 ### Relationships
 
@@ -291,7 +319,7 @@ const validation = analytics.validate(revenue, {
   dimensions: ['country'],
 }, {
   runtime: {
-    tenant: { id: 'tenant_123' },
+    tenant: 'tenant_123',
   },
 });
 
@@ -299,7 +327,7 @@ const sql = analytics.toSQL(revenue, {
   dimensions: ['country'],
 }, {
   runtime: {
-    tenant: { id: 'tenant_123' },
+    tenant: 'tenant_123',
   },
 });
 
@@ -307,7 +335,7 @@ const result = await analytics.execute(revenue, {
   dimensions: ['country'],
 }, {
   runtime: {
-    tenant: { id: 'tenant_123' },
+    tenant: 'tenant_123',
   },
 });
 
@@ -316,7 +344,7 @@ const datasetResult = await analytics.execute(Orders, {
   measures: ['revenue'],
 }, {
   runtime: {
-    tenant: { id: 'tenant_123' },
+    tenant: 'tenant_123',
   },
 });
 ```
@@ -342,7 +370,7 @@ const analytics = createDatasetClient({
 
 await analytics.execute(revenue, { dimensions: ['country'] }, {
   runtime: {
-    tenant: { id: 'tenant_123' },
+    tenant: 'tenant_123',
   },
 });
 ```

--- a/packages/datasets/README.md
+++ b/packages/datasets/README.md
@@ -76,10 +76,18 @@ const result = await analytics.execute(revenue, {
   filters: [eq('status', 'completed')],
   orderBy: [{ field: 'revenue', direction: 'desc' }],
   limit: 10,
+}, {
+  runtime: {
+    tenant: { id: 'tenant_123' },
+  },
 });
 
 const monthlySql = analytics.toSQL(revenue.by('month'), {
   dimensions: ['country'],
+}, {
+  runtime: {
+    tenant: { id: 'tenant_123' },
+  },
 });
 ```
 
@@ -105,6 +113,8 @@ const Orders = dataset('orders', {
 ```
 
 `source` is the physical table or view name. The first `dataset()` argument is the logical dataset name. `tenantKey` and `timeKey` are physical column names used for runtime tenant isolation and time graining.
+
+If `tenantKey` is set, queries against the dataset require runtime tenant context. This is fail-closed: Hypequery will reject metric and dataset queries that do not include `runtime.tenant.id`.
 
 ### Dimensions
 
@@ -189,6 +199,10 @@ const monthlyRevenue = revenue.by('month');
 
 await analytics.execute(monthlyRevenue, {
   dimensions: ['country'],
+}, {
+  runtime: {
+    tenant: { id: 'tenant_123' },
+  },
 });
 ```
 
@@ -199,6 +213,20 @@ Supported grains are `day`, `week`, `month`, `quarter`, and `year`.
 Runtime tenancy uses the dataset `tenantKey` and a runtime tenant identity.
 
 ```ts
+const Orders = dataset('orders', {
+  source: 'orders',
+  tenantKey: 'tenant_id',
+  dimensions: {
+    tenantId: dimension.string({ column: 'tenant_id' }),
+    country: dimension.string(),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+  },
+});
+
+const revenue = Orders.metric('revenue', { measure: 'revenue' });
+
 await analytics.execute(revenue, {}, {
   runtime: {
     tenant: { id: 'tenant_123' },
@@ -206,7 +234,33 @@ await analytics.execute(revenue, {}, {
 });
 ```
 
-When runtime tenancy is active, explicit filters on the tenant field are rejected. This prevents duplicate or conflicting tenant predicates.
+Here `tenantKey` is the physical column and `tenant.id` is the trusted runtime value. Together they produce a tenant predicate equivalent to:
+
+```sql
+WHERE tenant_id = 'tenant_123'
+```
+
+If a dataset has `tenantKey`, runtime tenant context is required:
+
+```ts
+await analytics.execute(revenue);
+// Error: Dataset "orders" requires runtime tenant scoping.
+```
+
+When runtime tenancy is active, explicit filters on the tenant field are rejected. This prevents duplicate or conflicting tenant predicates:
+
+```ts
+await analytics.execute(revenue, {
+  filters: [eq('tenantId', 'tenant_123')],
+}, {
+  runtime: {
+    tenant: { id: 'tenant_123' },
+  },
+});
+// Error: Cannot filter on tenant field "tenantId" when runtime tenancy enforcement is active.
+```
+
+The runtime integration should provide tenant identity from trusted server/session state. Do not accept tenant ids from end-user query input. In `@hypequery/serve`, regular hand-written queries can use Serve tenant auto-injection, but semantic dataset and metric endpoints pass tenant identity to `@hypequery/datasets`, and datasets injects the filter from `tenantKey`.
 
 ### Relationships
 
@@ -235,19 +289,35 @@ Use `createDatasetClient` from `@hypequery/datasets` with a backend implementati
 ```ts
 const validation = analytics.validate(revenue, {
   dimensions: ['country'],
+}, {
+  runtime: {
+    tenant: { id: 'tenant_123' },
+  },
 });
 
 const sql = analytics.toSQL(revenue, {
   dimensions: ['country'],
+}, {
+  runtime: {
+    tenant: { id: 'tenant_123' },
+  },
 });
 
 const result = await analytics.execute(revenue, {
   dimensions: ['country'],
+}, {
+  runtime: {
+    tenant: { id: 'tenant_123' },
+  },
 });
 
 const datasetResult = await analytics.execute(Orders, {
   dimensions: ['country'],
   measures: ['revenue'],
+}, {
+  runtime: {
+    tenant: { id: 'tenant_123' },
+  },
 });
 ```
 
@@ -270,7 +340,11 @@ const analytics = createDatasetClient({
   }),
 });
 
-await analytics.execute(revenue, { dimensions: ['country'] });
+await analytics.execute(revenue, { dimensions: ['country'] }, {
+  runtime: {
+    tenant: { id: 'tenant_123' },
+  },
+});
 ```
 
 ### Other Backends

--- a/packages/datasets/src/api.type-test.ts
+++ b/packages/datasets/src/api.type-test.ts
@@ -70,7 +70,7 @@ type _MeasureFilterType = Assert<
   Equal<MeasureOptions['filters'], MetricFilter[] | undefined>
 >;
 type _TenantRuntimeShape = Assert<
-  Equal<keyof NonNullable<NonNullable<ExecutionContext['runtime']>['tenant']>, 'id'>
+  Equal<NonNullable<NonNullable<ExecutionContext['runtime']>['tenant']>, string | { id: string } | { in: string[] } | { scope: 'all' }>
 >;
 type _DatasetHasNoQueryMethod = Assert<
   Equal<HasKey<typeof Orders, 'query'>, false>
@@ -156,9 +156,25 @@ Orders.metric('invalidDerivedFromDerivedMetric', {
 
 const runtimeContext: ExecutionContext = {
   runtime: {
-    tenant: {
-      id: 'tenant-1',
-    },
+    tenant: 'tenant-1',
+  },
+};
+
+const legacyTenantRuntimeContext: ExecutionContext = {
+  runtime: {
+    tenant: { id: 'tenant-1' },
+  },
+};
+
+const tenantSetRuntimeContext: ExecutionContext = {
+  runtime: {
+    tenant: { in: ['tenant-1', 'tenant-2'] },
+  },
+};
+
+const crossTenantRuntimeContext: ExecutionContext = {
+  runtime: {
+    tenant: { scope: 'all' },
   },
 };
 

--- a/packages/datasets/src/dataset-query.ts
+++ b/packages/datasets/src/dataset-query.ts
@@ -30,7 +30,6 @@ function toResultMeta(
 export interface DatasetQueryExecutionOptions {
   builderFactory: QueryBuilderFactoryLike;
   context?: ExecutionContext;
-  tenantHandledByBuilder?: boolean;
 }
 
 export function validateDatasetQuery(
@@ -69,7 +68,7 @@ export function buildDatasetQueryBuilder(
 
   const tenantColumn = resolveTenantFilterColumn(ds, options.context);
   const tenantId = options.context?.runtime?.tenant?.id;
-  if (tenantId && tenantColumn && !options.tenantHandledByBuilder) {
+  if (tenantId && tenantColumn) {
     qb = qb.where(tenantColumn, 'eq', tenantId);
   }
 

--- a/packages/datasets/src/dataset-query.ts
+++ b/packages/datasets/src/dataset-query.ts
@@ -14,6 +14,10 @@ import {
 } from './query-planner.js';
 import { type ValidationResult } from './validation.js';
 import { validateDatasetQueryInput } from './utils/dataset-query-validation.js';
+import {
+  getRuntimeTenantId,
+  getRuntimeTenantPredicate,
+} from './utils/tenant-runtime.js';
 
 function toResultMeta(
   qb: QueryBuilderLike,
@@ -23,7 +27,7 @@ function toResultMeta(
   return {
     sql: qb.toSQLWithParams().sql,
     timingMs,
-    tenant: context?.runtime?.tenant?.id,
+    tenant: getRuntimeTenantId(context),
   };
 }
 
@@ -67,9 +71,9 @@ export function buildDatasetQueryBuilder(
   }
 
   const tenantColumn = resolveTenantFilterColumn(ds, options.context);
-  const tenantId = options.context?.runtime?.tenant?.id;
-  if (tenantId && tenantColumn) {
-    qb = qb.where(tenantColumn, 'eq', tenantId);
+  const tenantPredicate = getRuntimeTenantPredicate(options.context);
+  if (tenantPredicate && tenantColumn) {
+    qb = qb.where(tenantColumn, tenantPredicate.operator, tenantPredicate.value);
   }
 
   for (const filter of query.filters ?? []) {

--- a/packages/datasets/src/dataset.ts
+++ b/packages/datasets/src/dataset.ts
@@ -73,7 +73,7 @@ export function dataset<
 
   function metric<TName extends string>(
     metricName: TName,
-    metricConfig: BaseMetricConfig<TDimensions, TMeasures>,
+    metricConfig: BaseMetricConfig<TMeasures>,
   ): BaseMetricRef<TDatasetName, TName>;
   function metric<TName extends string>(
     metricName: TName,
@@ -81,7 +81,7 @@ export function dataset<
   ): DerivedMetricRef<TDatasetName, TName>;
   function metric<TName extends string>(
     metricName: TName,
-    metricConfig: BaseMetricConfig<TDimensions, TMeasures> | DerivedMetricConfig<TDatasetName>,
+    metricConfig: BaseMetricConfig<TMeasures> | DerivedMetricConfig<TDatasetName>,
   ): BaseMetricRef<TDatasetName, TName> | DerivedMetricRef<TDatasetName, TName> {
     if (isDerivedMetricConfig(metricConfig)) {
       validateDerivedMetric(ds, metricName, metricConfig);

--- a/packages/datasets/src/datasets.test.ts
+++ b/packages/datasets/src/datasets.test.ts
@@ -61,6 +61,12 @@ const Orders = dataset("orders", {
   },
 });
 
+const TENANT_CONTEXT = {
+  runtime: {
+    tenant: { id: "tenant-1" },
+  },
+} as const;
+
 // =============================================================================
 // DATASET + FIELD TESTS
 // =============================================================================
@@ -357,6 +363,15 @@ describe("dataset query helpers", () => {
     ]);
   });
 
+  it("rejects tenant-keyed dataset queries without runtime tenant scoping", () => {
+    const validation = validateDatasetQuery(Orders, {
+      measures: ['revenue'],
+    });
+
+    expect(validation.valid).toBe(false);
+    expect(validation.errors[0]).toContain('Dataset "orders" requires runtime tenant scoping.');
+  });
+
   it("builds dataset query SQL through the shared datasets planner", () => {
     const builder = buildDatasetQueryBuilder(Orders, {
       dimensions: ['status'],
@@ -387,6 +402,7 @@ describe("dataset query helpers", () => {
       measures: ['revenue'],
     }, {
       builderFactory: createDatasetQueryBuilderFactory([{ revenue: 42 }]),
+      context: TENANT_CONTEXT,
     });
 
     expect(result.data).toEqual([{ revenue: 42 }]);
@@ -724,7 +740,7 @@ describe("MetricQueryEngine", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const sql = analytics.toSQL(totalRevenue, {
         dimensions: ["country"],
-      });
+      }, TENANT_CONTEXT);
 
       expect(sql).toContain("SELECT country, SUM(amount) AS totalRevenue FROM orders");
       expect(sql).toContain("GROUP BY country");
@@ -748,7 +764,7 @@ describe("MetricQueryEngine", () => {
       const sql = analytics.toSQL(totalRevenue, {
         dimensions: ["country"],
         filters: [{ field: "status", operator: "eq", value: "completed" }],
-      });
+      }, TENANT_CONTEXT);
 
       expect(sql).toContain("status = ?");
     });
@@ -759,7 +775,7 @@ describe("MetricQueryEngine", () => {
         dimensions: ["country"],
         orderBy: [{ field: "totalRevenue", direction: "desc" }],
         limit: 100,
-      });
+      }, TENANT_CONTEXT);
 
       expect(sql).toContain("ORDER BY totalRevenue DESC");
       expect(sql).toContain("LIMIT 100");
@@ -769,7 +785,7 @@ describe("MetricQueryEngine", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const sql = analytics.toSQL(completedRevenue, {
         dimensions: ["country"],
-      });
+      }, TENANT_CONTEXT);
 
       expect(sql).toContain("SUM(if((status = 'completed'), amount, 0)) AS completedRevenue");
       expect(sql).toContain("GROUP BY country");
@@ -779,7 +795,7 @@ describe("MetricQueryEngine", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const sql = analytics.toSQL(uniqueCustomers, {
         dimensions: ["country"],
-      });
+      }, TENANT_CONTEXT);
 
       expect(sql).toContain("COUNT(DISTINCT customer_id) AS uniqueCustomers");
       expect(sql).not.toContain("COUNT(DISTINCT customerId)");
@@ -790,7 +806,7 @@ describe("MetricQueryEngine", () => {
     it("generates time-grained SQL with .by()", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const monthly = totalRevenue.by("month");
-      const sql = analytics.toSQL(monthly);
+      const sql = analytics.toSQL(monthly, {}, TENANT_CONTEXT);
 
       expect(sql).toContain("toStartOfMonth(created_at) AS period");
       expect(sql).toContain("GROUP BY period");
@@ -799,7 +815,7 @@ describe("MetricQueryEngine", () => {
 
     it("supports grain via query.by", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
-      const sql = analytics.toSQL(totalRevenue, { by: "week" });
+      const sql = analytics.toSQL(totalRevenue, { by: "week" }, TENANT_CONTEXT);
 
       expect(sql).toContain("toStartOfWeek(created_at) AS period");
     });
@@ -807,7 +823,7 @@ describe("MetricQueryEngine", () => {
     it("rejects conflicting query.by on grained metrics", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const monthly = totalRevenue.by("month");
-      const result = analytics.validate(monthly, { by: "week" });
+      const result = analytics.validate(monthly, { by: "week" }, TENANT_CONTEXT);
 
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain('already grained by "month"');
@@ -819,7 +835,7 @@ describe("MetricQueryEngine", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const sql = analytics.toSQL(avgOrderValue, {
         dimensions: ["country"],
-      });
+      }, TENANT_CONTEXT);
 
       expect(sql).toContain("WITH base AS");
       expect(sql).toContain("SUM(amount) AS totalRevenue");
@@ -831,7 +847,7 @@ describe("MetricQueryEngine", () => {
 
     it("does not emit GROUP BY for ungrouped derived metrics", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
-      const sql = analytics.toSQL(avgOrderValue);
+      const sql = analytics.toSQL(avgOrderValue, {}, TENANT_CONTEXT);
 
       expect(sql).toContain("WITH base AS");
       expect(sql).not.toContain("GROUP BY totalRevenue");
@@ -840,7 +856,7 @@ describe("MetricQueryEngine", () => {
 
     it("rejects derived plans that introduce aggregate aliases into GROUP BY", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createBrokenDerivedGroupingBuilderFactory() });
-      const result = analytics.validate(avgOrderValue, {});
+      const result = analytics.validate(avgOrderValue, {}, TENANT_CONTEXT);
 
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain("GROUP BY");
@@ -853,7 +869,7 @@ describe("MetricQueryEngine", () => {
       const analytics = new MetricQueryEngine({ builderFactory });
       const result = await analytics.run(totalRevenue, {
         dimensions: ["country"],
-      });
+      }, TENANT_CONTEXT);
 
       expect(result.data).toEqual([
         { country: "US", totalRevenue: 5000 },
@@ -934,7 +950,7 @@ describe("MetricQueryEngine", () => {
 
       const result = await analytics.execute(totalRevenue, {
         dimensions: ["country"],
-      });
+      }, TENANT_CONTEXT);
 
       expect(result.data).toEqual([
         { country: "US", totalRevenue: 5000 },
@@ -950,7 +966,7 @@ describe("MetricQueryEngine", () => {
       const result = await analytics.execute(Orders, {
         dimensions: ["country"],
         measures: ["revenue"],
-      });
+      }, TENANT_CONTEXT);
 
       expect(result.data).toEqual([
         { country: "US", totalRevenue: 5000 },
@@ -966,11 +982,11 @@ describe("MetricQueryEngine", () => {
       const validation = analytics.validate(Orders, {
         dimensions: ["country"],
         measures: ["revenue"],
-      });
+      }, TENANT_CONTEXT);
       const sql = analytics.toSQL(Orders, {
         dimensions: ["country"],
         measures: ["revenue"],
-      });
+      }, TENANT_CONTEXT);
 
       expect(validation.valid).toBe(true);
       expect(sql).toContain("GROUP BY country");
@@ -978,11 +994,21 @@ describe("MetricQueryEngine", () => {
   });
 
   describe("validate()", () => {
+    it("rejects tenant-keyed metric queries without runtime tenant scoping", () => {
+      const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
+      const result = analytics.validate(totalRevenue, {
+        dimensions: ["country"],
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('Dataset "orders" requires runtime tenant scoping.');
+    });
+
     it("accepts valid queries", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const result = analytics.validate(totalRevenue, {
         dimensions: ["country", "status"],
-      });
+      }, TENANT_CONTEXT);
       expect(result.valid).toBe(true);
     });
 
@@ -990,7 +1016,7 @@ describe("MetricQueryEngine", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const result = analytics.validate(totalRevenue, {
         dimensions: ["nonexistent"],
-      });
+      }, TENANT_CONTEXT);
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain("Unknown dimension");
     });
@@ -999,7 +1025,7 @@ describe("MetricQueryEngine", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const result = analytics.validate(totalRevenue, {
         filters: [{ field: "nonexistent", operator: "eq", value: "x" }],
-      });
+      }, TENANT_CONTEXT);
       expect(result.valid).toBe(false);
     });
 
@@ -1007,7 +1033,7 @@ describe("MetricQueryEngine", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const result = analytics.validate(totalRevenue, {
         filters: [{ field: "amount", operator: "eq", value: "not-a-number" }],
-      });
+      }, TENANT_CONTEXT);
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain('expects a number value');
     });
@@ -1016,7 +1042,7 @@ describe("MetricQueryEngine", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const result = analytics.validate(totalRevenue, {
         filters: [{ field: "status", operator: "in", value: [] }],
-      });
+      }, TENANT_CONTEXT);
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain('expects a non-empty array');
     });
@@ -1025,7 +1051,7 @@ describe("MetricQueryEngine", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const result = analytics.validate(totalRevenue, {
         filters: [{ field: "amount", operator: "between", value: [1] }],
-      });
+      }, TENANT_CONTEXT);
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain('"between" expects a two-item array');
     });
@@ -1034,7 +1060,7 @@ describe("MetricQueryEngine", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const result = analytics.validate(totalRevenue, {
         filters: [{ field: "amount", operator: "like", value: "%100%" }],
-      });
+      }, TENANT_CONTEXT);
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain('"like" is only supported');
     });
@@ -1044,7 +1070,7 @@ describe("MetricQueryEngine", () => {
       const result = analytics.validate(totalRevenue, {
         dimensions: ["country"],
         orderBy: [{ field: "amount", direction: "desc" }],
-      });
+      }, TENANT_CONTEXT);
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain("Unknown orderBy field");
     });
@@ -1053,7 +1079,7 @@ describe("MetricQueryEngine", () => {
       const analytics = new MetricQueryEngine({ builderFactory: createMockBuilderFactory() });
       const result = analytics.validate(totalRevenue, {
         dimensions: ["id", "customerId", "country", "status", "amount", "createdAt"],
-      });
+      }, TENANT_CONTEXT);
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain("Too many dimensions");
     });
@@ -1226,7 +1252,7 @@ describe("dataset SQL generation matrix", () => {
         "maxAmount",
         "taxedRevenue",
       ],
-    });
+    }, TENANT_CONTEXT);
 
     expect(sql).toContain("SELECT country_code AS country, upper(country_code) AS countryUpper");
     expect(sql).toContain("SUM(amount) AS revenue");
@@ -1280,7 +1306,7 @@ describe("dataset SQL generation matrix", () => {
         between("createdAt", "2026-01-01", "2026-01-31"),
         like("status", "complete%"),
       ],
-    });
+    }, TENANT_CONTEXT);
 
     expect(sql).toContain("status != ?");
     expect(sql).toContain("amount > ?");

--- a/packages/datasets/src/datasets.test.ts
+++ b/packages/datasets/src/datasets.test.ts
@@ -351,9 +351,7 @@ describe("dataset query helpers", () => {
       filters: [eq('tenantId', 'tenant-123')],
     }, {
       runtime: {
-        tenant: {
-          id: 'tenant-123',
-        },
+        tenant: 'tenant-123',
       },
     });
 
@@ -370,6 +368,50 @@ describe("dataset query helpers", () => {
 
     expect(validation.valid).toBe(false);
     expect(validation.errors[0]).toContain('Dataset "orders" requires runtime tenant scoping.');
+  });
+
+  it("accepts shorthand runtime tenant strings", () => {
+    const validation = validateDatasetQuery(Orders, {
+      measures: ['revenue'],
+    }, {
+      runtime: {
+        tenant: 'tenant-123',
+      },
+    });
+
+    expect(validation.valid).toBe(true);
+  });
+
+  it("builds tenant set queries with an IN predicate", () => {
+    const builder = buildDatasetQueryBuilder(Orders, {
+      dimensions: ['status'],
+      measures: ['revenue'],
+    }, {
+      builderFactory: createDatasetQueryBuilderFactory(),
+      context: {
+        runtime: {
+          tenant: { in: ['tenant-1', 'tenant-2'] },
+        },
+      },
+    });
+
+    expect(builder.toSQLWithParams().sql).toContain("tenant_id in ?");
+  });
+
+  it("allows cross-tenant scope and omits tenant predicates", () => {
+    const builder = buildDatasetQueryBuilder(Orders, {
+      dimensions: ['status'],
+      measures: ['revenue'],
+    }, {
+      builderFactory: createDatasetQueryBuilderFactory(),
+      context: {
+        runtime: {
+          tenant: { scope: 'all' },
+        },
+      },
+    });
+
+    expect(builder.toSQLWithParams().sql).not.toContain("tenant_id");
   });
 
   it("builds dataset query SQL through the shared datasets planner", () => {
@@ -885,21 +927,66 @@ describe("MetricQueryEngine", () => {
 
       await analytics.run(totalRevenue, {}, {
         runtime: {
-          tenant: { id: "t1" },
+          tenant: "t1",
         },
       });
 
       // Verify the SQL was generated (toSQL includes tenant filter)
       const sql = analytics.toSQL(totalRevenue, {}, {
         runtime: {
-          tenant: { id: "t1" },
+          tenant: "t1",
         },
       });
       expect(sql).toContain("tenant_id");
     });
+
+    it("executes cross-tenant metrics and omits tenant predicates", async () => {
+      const analytics = new MetricQueryEngine({
+        builderFactory: createMockBuilderFactory(),
+      });
+
+      const result = await analytics.run(totalRevenue, {}, {
+        runtime: {
+          tenant: { scope: "all" },
+        },
+      });
+
+      expect(result.meta.tenant).toBeUndefined();
+      expect(analytics.toSQL(totalRevenue, {}, {
+        runtime: {
+          tenant: { scope: "all" },
+        },
+      })).not.toContain("tenant_id");
+    });
   });
 
   describe("createDatasetClient()", () => {
+    it("executes all-tenant dataset queries across tenants", async () => {
+      const analytics = createDatasetClient({
+        backend: createInMemoryBackend({
+          orders: [
+            { id: "1", tenant_id: "t1", country: "US", amount: 100 },
+            { id: "2", tenant_id: "t2", country: "DE", amount: 75 },
+          ],
+        }),
+      });
+
+      const result = await analytics.execute(Orders, {
+        dimensions: ["country"],
+        measures: ["revenue"],
+        orderBy: [{ field: "country", direction: "asc" }],
+      }, {
+        runtime: {
+          tenant: { scope: "all" },
+        },
+      });
+
+      expect(result.data).toEqual([
+        { country: "DE", revenue: 75 },
+        { country: "US", revenue: 100 },
+      ]);
+    });
+
     it("can execute semantic plans against an in-memory backend without a query builder", async () => {
       const analytics = createDatasetClient({
         backend: createInMemoryBackend({

--- a/packages/datasets/src/datasets.test.ts
+++ b/packages/datasets/src/datasets.test.ts
@@ -4,7 +4,7 @@ import { dimension } from './field.js';
 import { belongsTo, hasMany, hasOne } from './relationships.js';
 import { sum, count, countDistinct, avg, min, max } from './aggregations.js';
 import { divide, multiply, subtract, add, nullIfZero, coalesce, round, floor, ceil } from './formulas.js';
-import { eq, between, desc } from './query-helpers.js';
+import { eq, neq, gt, gte, lt, lte, inList, notInList, between, like, desc } from './query-helpers.js';
 import { measure } from './measure.js';
 import { createDatasetRegistry } from './registry.js';
 import { buildDatasetQueryBuilder, runDatasetQuery, validateDatasetQuery } from './dataset-query.js';
@@ -1071,5 +1071,244 @@ describe("MetricQueryEngine", () => {
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain('Cannot filter on tenant field "tenantId"');
     });
+  });
+});
+
+describe("dataset SQL generation matrix", () => {
+  type BuilderColumnsInput = string[] | string;
+
+  const MatrixOrders = dataset("matrixOrders", {
+    source: "orders",
+    tenantKey: "tenant_id",
+    timeKey: "created_at",
+    dimensions: {
+      id: dimension.string(),
+      tenantId: dimension.string({ column: "tenant_id" }),
+      country: dimension.string({ column: "country_code" }),
+      status: dimension.string(),
+      amount: dimension.number(),
+      customerId: dimension.string({ column: "customer_id" }),
+      createdAt: dimension.timestamp({ column: "created_at" }),
+      countryUpper: dimension.string({ sql: "upper(country_code)" }),
+    },
+    measures: {
+      revenue: measure.sum("amount"),
+      orderCount: measure.count("id"),
+      uniqueCustomers: measure.countDistinct("customerId"),
+      averageAmount: measure.avg("amount"),
+      minAmount: measure.min("amount"),
+      maxAmount: measure.max("amount"),
+      taxedRevenue: measure.sum("amount", { sql: "amount * 1.2" }),
+      completedRevenue: measure.sum("amount", {
+        filters: [eq("status", "completed"), gt("amount", 10)],
+      }),
+    },
+    limits: {
+      maxResultSize: 500,
+    },
+  });
+
+  function createSqlBuilderFactory(): QueryBuilderFactoryLike {
+    const operatorSql: Record<string, string> = {
+      eq: "=",
+      neq: "!=",
+      gt: ">",
+      gte: ">=",
+      lt: "<",
+      lte: "<=",
+      in: "IN",
+      notIn: "NOT IN",
+      between: "BETWEEN",
+      like: "LIKE",
+    };
+
+    function createBuilder(source: string): QueryBuilderLike {
+      const state = {
+        select: [] as string[],
+        where: [] as string[],
+        groupBy: [] as string[],
+        orderBy: [] as string[],
+        limit: undefined as number | undefined,
+        offset: undefined as number | undefined,
+      };
+
+      const renderWhere = (column: string, operator: string) => {
+        if (operator === "between") {
+          return `${column} BETWEEN ? AND ?`;
+        }
+        if (operator === "in" || operator === "notIn") {
+          return `${column} ${operatorSql[operator]} (?)`;
+        }
+        return `${column} ${operatorSql[operator] ?? operator} ?`;
+      };
+
+      const buildSql = () => [
+        `SELECT ${state.select.join(", ")} FROM ${source}`,
+        state.where.length > 0 ? `WHERE ${state.where.join(" AND ")}` : "",
+        state.groupBy.length > 0 ? `GROUP BY ${state.groupBy.join(", ")}` : "",
+        state.orderBy.length > 0 ? `ORDER BY ${state.orderBy.join(", ")}` : "",
+        state.limit != null ? `LIMIT ${state.limit}` : "",
+        state.offset != null ? `OFFSET ${state.offset}` : "",
+      ].filter(Boolean).join(" ");
+
+      const builder: QueryBuilderLike = {
+        select: (args: BuilderColumnsInput) => {
+          state.select.push(...(Array.isArray(args) ? args : [args]));
+          return builder;
+        },
+        sum: (column: string, alias?: string) => {
+          state.select.push(`SUM(${column}) AS ${alias ?? `${column}_sum`}`);
+          return builder;
+        },
+        count: (column: string, alias?: string) => {
+          state.select.push(`COUNT(${column}) AS ${alias ?? `${column}_count`}`);
+          return builder;
+        },
+        countDistinct: (column: string, alias?: string) => {
+          state.select.push(`COUNT(DISTINCT ${column}) AS ${alias ?? `${column}_countDistinct`}`);
+          return builder;
+        },
+        avg: (column: string, alias?: string) => {
+          state.select.push(`AVG(${column}) AS ${alias ?? `${column}_avg`}`);
+          return builder;
+        },
+        min: (column: string, alias?: string) => {
+          state.select.push(`MIN(${column}) AS ${alias ?? `${column}_min`}`);
+          return builder;
+        },
+        max: (column: string, alias?: string) => {
+          state.select.push(`MAX(${column}) AS ${alias ?? `${column}_max`}`);
+          return builder;
+        },
+        where: (column: string, operator: string, _value: unknown) => {
+          state.where.push(renderWhere(column, operator));
+          return builder;
+        },
+        groupBy: (args: BuilderColumnsInput) => {
+          state.groupBy.push(...(Array.isArray(args) ? args : [args]));
+          return builder;
+        },
+        orderBy: (column: string, direction?: string) => {
+          state.orderBy.push(`${column} ${direction ?? "ASC"}`);
+          return builder;
+        },
+        limit: (count: number) => {
+          state.limit = count;
+          return builder;
+        },
+        offset: (count: number) => {
+          state.offset = count;
+          return builder;
+        },
+        toSQLWithParams: () => ({ sql: buildSql(), parameters: [] }),
+        execute: vi.fn().mockResolvedValue([]),
+      };
+
+      return builder;
+    }
+
+    return {
+      table: createBuilder,
+      rawQuery: vi.fn().mockResolvedValue([]),
+    };
+  }
+
+  it("generates all dataset aggregation types with aliases and custom SQL expressions", () => {
+    const analytics = createDatasetClient({ queryBuilder: createSqlBuilderFactory() });
+    const sql = analytics.toSQL(MatrixOrders, {
+      dimensions: ["country", "countryUpper"],
+      measures: [
+        "revenue",
+        "orderCount",
+        "uniqueCustomers",
+        "averageAmount",
+        "minAmount",
+        "maxAmount",
+        "taxedRevenue",
+      ],
+    });
+
+    expect(sql).toContain("SELECT country_code AS country, upper(country_code) AS countryUpper");
+    expect(sql).toContain("SUM(amount) AS revenue");
+    expect(sql).toContain("COUNT(id) AS orderCount");
+    expect(sql).toContain("COUNT(DISTINCT customer_id) AS uniqueCustomers");
+    expect(sql).toContain("AVG(amount) AS averageAmount");
+    expect(sql).toContain("MIN(amount) AS minAmount");
+    expect(sql).toContain("MAX(amount) AS maxAmount");
+    expect(sql).toContain("SUM(amount * 1.2) AS taxedRevenue");
+    expect(sql).toContain("GROUP BY country, countryUpper");
+  });
+
+  it("generates filtered measures, tenant scoping, time grain, ordering, limit, and offset together", () => {
+    const analytics = createDatasetClient({ queryBuilder: createSqlBuilderFactory() });
+    const sql = analytics.toSQL(MatrixOrders, {
+      dimensions: ["status"],
+      measures: ["completedRevenue"],
+      by: "month",
+      filters: [eq("country", "US")],
+      orderBy: [desc("completedRevenue")],
+      limit: 50,
+      offset: 10,
+    }, {
+      runtime: {
+        tenant: { id: "tenant-1" },
+      },
+    });
+
+    expect(sql).toContain("toStartOfMonth(created_at) AS period");
+    expect(sql).toContain("status");
+    expect(sql).toContain("SUM(if((status = 'completed') AND (amount > 10), amount, 0)) AS completedRevenue");
+    expect(sql).toContain("WHERE tenant_id = ? AND country_code = ?");
+    expect(sql).toContain("GROUP BY period, status");
+    expect(sql).toContain("ORDER BY completedRevenue DESC");
+    expect(sql).toContain("LIMIT 50 OFFSET 10");
+  });
+
+  it("forwards every dataset filter operator through resolved fields", () => {
+    const analytics = createDatasetClient({ queryBuilder: createSqlBuilderFactory() });
+    const sql = analytics.toSQL(MatrixOrders, {
+      dimensions: ["status"],
+      measures: ["revenue"],
+      filters: [
+        neq("status", "cancelled"),
+        gt("amount", 10),
+        gte("amount", 20),
+        lt("amount", 100),
+        lte("amount", 200),
+        inList("country", ["US", "DE"]),
+        notInList("status", ["fraud"]),
+        between("createdAt", "2026-01-01", "2026-01-31"),
+        like("status", "complete%"),
+      ],
+    });
+
+    expect(sql).toContain("status != ?");
+    expect(sql).toContain("amount > ?");
+    expect(sql).toContain("amount >= ?");
+    expect(sql).toContain("amount < ?");
+    expect(sql).toContain("amount <= ?");
+    expect(sql).toContain("country_code IN (?)");
+    expect(sql).toContain("status NOT IN (?)");
+    expect(sql).toContain("created_at BETWEEN ? AND ?");
+    expect(sql).toContain("status LIKE ?");
+  });
+
+  it("validates pagination and dataset max result limits before SQL generation", () => {
+    const analytics = createDatasetClient({ queryBuilder: createSqlBuilderFactory() });
+
+    expect(analytics.validate(MatrixOrders, {
+      measures: ["revenue"],
+      limit: -1,
+    }).errors).toContain("Invalid limit: expected a non-negative integer.");
+
+    expect(analytics.validate(MatrixOrders, {
+      measures: ["revenue"],
+      offset: 1.5,
+    }).errors).toContain("Invalid offset: expected a non-negative integer.");
+
+    expect(analytics.validate(MatrixOrders, {
+      measures: ["revenue"],
+      limit: 501,
+    }).errors).toContain("Too many results requested: 501 (max 500)");
   });
 });

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -76,6 +76,12 @@ function validateQuery(
     ...(grain ? ['period'] : []),
   ]);
 
+  if (ds.tenantKey && !context?.runtime?.tenant?.id) {
+    errors.push(
+      `Dataset "${ds.name}" requires runtime tenant scoping.`,
+    );
+  }
+
   if (metric.__type === 'grained_metric_ref' && query.by && query.by !== metric.grain) {
     errors.push(
       `Metric "${ref.name}" is already grained by "${metric.grain}" and cannot be queried with by="${query.by}".`,

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -56,6 +56,11 @@ import {
   buildDatasetPlan,
   buildMetricPlan,
 } from './semantic-planner.js';
+import {
+  getRuntimeTenantId,
+  getRuntimeTenantPredicate,
+  validateTenantRuntime,
+} from './utils/tenant-runtime.js';
 
 function validateQuery(
   metric: MetricHandle,
@@ -76,10 +81,9 @@ function validateQuery(
     ...(grain ? ['period'] : []),
   ]);
 
-  if (ds.tenantKey && !context?.runtime?.tenant?.id) {
-    errors.push(
-      `Dataset "${ds.name}" requires runtime tenant scoping.`,
-    );
+  const tenantRuntimeError = validateTenantRuntime(ds, context);
+  if (tenantRuntimeError) {
+    errors.push(tenantRuntimeError);
   }
 
   if (metric.__type === 'grained_metric_ref' && query.by && query.by !== metric.grain) {
@@ -327,7 +331,7 @@ export class MetricQueryEngine {
       const { sql, params } = this.buildDerivedSQLViaBuilder(ref, spec, query, grain, context);
       const data = await activeBuilderFactory.rawQuery<T>(sql, params);
       const timingMs = Date.now() - start;
-      return { data, meta: { sql, timingMs, tenant: context?.runtime?.tenant?.id } };
+      return { data, meta: { sql, timingMs, tenant: getRuntimeTenantId(context) } };
     }
 
     // Base metrics: fully use the builder's execute()
@@ -335,7 +339,7 @@ export class MetricQueryEngine {
     const { sql } = builder.toSQLWithParams();
     const data = await builder.execute<T>();
     const timingMs = Date.now() - start;
-    return { data, meta: { sql, timingMs, tenant: context?.runtime?.tenant?.id } };
+    return { data, meta: { sql, timingMs, tenant: getRuntimeTenantId(context) } };
   }
 
   private buildBaseQuery(
@@ -368,9 +372,9 @@ export class MetricQueryEngine {
 
     // Tenant auto-injection
     const tenantColumn = resolveTenantFilterColumn(ds, context);
-    const tenantId = context?.runtime?.tenant?.id;
-    if (tenantId && tenantColumn) {
-      qb = qb.where(tenantColumn, 'eq', tenantId);
+    const tenantPredicate = getRuntimeTenantPredicate(context);
+    if (tenantPredicate && tenantColumn) {
+      qb = qb.where(tenantColumn, tenantPredicate.operator, tenantPredicate.value);
     }
 
     // User filters
@@ -431,9 +435,9 @@ export class MetricQueryEngine {
 
     // Filters on CTE
     const tenantColumn = resolveTenantFilterColumn(ds, context);
-    const tenantId = context?.runtime?.tenant?.id;
-    if (tenantId && tenantColumn) {
-      cteBuilder = cteBuilder.where(tenantColumn, 'eq', tenantId);
+    const tenantPredicate = getRuntimeTenantPredicate(context);
+    if (tenantPredicate && tenantColumn) {
+      cteBuilder = cteBuilder.where(tenantColumn, tenantPredicate.operator, tenantPredicate.value);
     }
     for (const filter of query.filters ?? []) {
       if (isTenantScopedFilter(ds, filter, context)) {
@@ -586,6 +590,10 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
     context?: ExecutionContext,
   ): Promise<MetricResult<TRow>> {
     if (this.backend) {
+      const validation = validateQuery(metric, query, context);
+      if (!validation.valid) {
+        throw new Error(`Invalid metric query: ${validation.errors.join('; ')}`);
+      }
       return this.backend.execute<TRow>(
         this.planMetric(metric, query, context),
       ) as Promise<MetricResult<TRow>>;
@@ -600,11 +608,19 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
     context?: ExecutionContext,
   ): Promise<DatasetQueryResult<TRow>> {
     if (this.backend) {
+      const validation = this.validate(ds, query, context);
+      if (!validation.valid) {
+        throw new Error(`Invalid dataset query: ${validation.errors.join('; ')}`);
+      }
       return this.backend.execute<TRow>(
         this.planDataset(ds, query, context),
       ) as Promise<DatasetQueryResult<TRow>>;
     }
 
+    const validation = this.validate(ds, query, context);
+    if (!validation.valid) {
+      throw new Error(`Invalid dataset query: ${validation.errors.join('; ')}`);
+    }
     return runDatasetQuery(ds, query, {
       builderFactory: context?.runtime?.builderFactory ?? this.getBuilderFactory(),
       context,

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -135,6 +135,14 @@ function validateQuery(
     errors.push(`Cannot use "by" grain — dataset "${ds.name}" has no timeKey.`);
   }
 
+  if (query.limit != null && (!Number.isInteger(query.limit) || query.limit < 0)) {
+    errors.push(`Invalid limit: expected a non-negative integer.`);
+  }
+
+  if (query.offset != null && (!Number.isInteger(query.offset) || query.offset < 0)) {
+    errors.push(`Invalid offset: expected a non-negative integer.`);
+  }
+
   // Validate limits
   if (ds.limits) {
     if (ds.limits.maxDimensions && (query.dimensions?.length ?? 0) > ds.limits.maxDimensions) {
@@ -145,6 +153,9 @@ function validateQuery(
     }
     if (ds.limits.maxFilters && (query.filters?.length ?? 0) > ds.limits.maxFilters) {
       errors.push(`Too many filters (${query.filters?.length}). Max: ${ds.limits.maxFilters}`);
+    }
+    if (ds.limits.maxResultSize && query.limit != null && query.limit > ds.limits.maxResultSize) {
+      errors.push(`Too many results requested (${query.limit}). Max: ${ds.limits.maxResultSize}`);
     }
   }
 

--- a/packages/datasets/src/in-memory-backend.ts
+++ b/packages/datasets/src/in-memory-backend.ts
@@ -54,9 +54,15 @@ function applyFilters(rows: InMemoryTable, filters: MetricFilter[]): InMemoryTab
   return rows.filter((row) => filters.every((filter) => compareFilter(valueForField(row, filter.field), filter)));
 }
 
-function applyTenant(rows: InMemoryTable, tenant?: { field: string; value: string }): InMemoryTable {
+function applyTenant(
+  rows: InMemoryTable,
+  tenant?: Extract<PlanNode, { kind: 'aggregate' }>['tenant'],
+): InMemoryTable {
   if (!tenant) {
     return rows;
+  }
+  if (tenant.operator === 'in') {
+    return rows.filter((row) => tenant.value.includes(String(row[tenant.field])));
   }
   return rows.filter((row) => row[tenant.field] === tenant.value);
 }

--- a/packages/datasets/src/query-planner.ts
+++ b/packages/datasets/src/query-planner.ts
@@ -9,6 +9,7 @@ import type {
 import type { QueryBuilderLike } from "./query-builder-protocol.js";
 import { GRAIN_FUNCTIONS } from "./constants.js";
 import { applyFilteredAggregationExpression } from './utils/filtered-aggregation-sql.js';
+import { getRuntimeTenantPredicate } from './utils/tenant-runtime.js';
 
 type DatasetShape = AnyDatasetInstance;
 
@@ -154,7 +155,7 @@ export function resolveTenantFilterColumn(
   ds: DatasetShape,
   context?: ExecutionContext,
 ): string | undefined {
-  if (!context?.runtime?.tenant?.id) {
+  if (!getRuntimeTenantPredicate(context)) {
     return undefined;
   }
 

--- a/packages/datasets/src/semantic-plan.ts
+++ b/packages/datasets/src/semantic-plan.ts
@@ -56,7 +56,7 @@ export type PlanNode =
     orderBy?: MetricOrderBy[];
     limit?: number;
     offset?: number;
-    tenant?: { field: string; value: string };
+    tenant?: { field: string; operator: 'eq'; value: string } | { field: string; operator: 'in'; value: string[] };
   }
   | {
     kind: 'derive';

--- a/packages/datasets/src/semantic-planner.ts
+++ b/packages/datasets/src/semantic-planner.ts
@@ -18,6 +18,7 @@ import {
   type MetricHandle,
 } from './utils/metric-handle.js';
 import { validateDatasetQuery } from './dataset-query.js';
+import { getRuntimeTenantPredicate } from './utils/tenant-runtime.js';
 
 function resolveField(ds: AnyDatasetInstance, field: string): string {
   const dimension = ds.dimensions[field];
@@ -77,11 +78,11 @@ function aggregationForMeasure(
 }
 
 function tenantForContext(ds: AnyDatasetInstance, context?: ExecutionContext) {
-  const tenantId = context?.runtime?.tenant?.id;
-  if (!tenantId || !ds.tenantKey) {
+  const tenantPredicate = getRuntimeTenantPredicate(context);
+  if (!tenantPredicate || !ds.tenantKey) {
     return undefined;
   }
-  return { field: ds.tenantKey, value: tenantId };
+  return { field: ds.tenantKey, ...tenantPredicate };
 }
 
 function grainForQuery(ds: AnyDatasetInstance, unit: MetricQuery['by'] | undefined) {

--- a/packages/datasets/src/types.ts
+++ b/packages/datasets/src/types.ts
@@ -226,7 +226,6 @@ export interface DatasetLimits {
 }
 
 export interface BaseMetricConfig<
-  TDimensions extends Record<string, DimensionDefinition> = Record<string, DimensionDefinition>,
   TMeasures extends Record<string, MeasureDefinition> = Record<string, MeasureDefinition>,
 > {
   measure: keyof TMeasures & string;
@@ -274,7 +273,7 @@ export interface DatasetInstance<
   limits?: DatasetLimits;
   metric<TName extends string>(
     metricName: TName,
-    metricConfig: BaseMetricConfig<TDimensions, TMeasures>,
+    metricConfig: BaseMetricConfig<TMeasures>,
   ): BaseMetricRef<TDatasetName, TName>;
   metric<TName extends string>(
     metricName: TName,

--- a/packages/datasets/src/types.ts
+++ b/packages/datasets/src/types.ts
@@ -195,9 +195,11 @@ export interface DatasetQueryResult<T = Record<string, unknown>> {
   meta?: MetricResultMeta;
 }
 
-export interface SemanticTenantRuntime {
-  id: string;
-}
+export type SemanticTenantRuntime =
+  | string
+  | { id: string }
+  | { in: string[] }
+  | { scope: 'all' };
 
 export interface SemanticExecutionRuntime {
   builderFactory?: QueryBuilderFactoryLike;

--- a/packages/datasets/src/utils/dataset-metric-ref.ts
+++ b/packages/datasets/src/utils/dataset-metric-ref.ts
@@ -20,11 +20,10 @@ type AnyMeasures = Record<string, MeasureDefinition>;
 type AnyRelationships = Record<string, RelationshipDefinition>;
 
 export function isDerivedMetricConfig<
-  TDimensions extends Record<string, DimensionDefinition>,
   TMeasures extends Record<string, MeasureDefinition>,
   TDatasetName extends string,
 >(
-  config: BaseMetricConfig<TDimensions, TMeasures> | DerivedMetricConfig<TDatasetName>,
+  config: BaseMetricConfig<TMeasures> | DerivedMetricConfig<TDatasetName>,
 ): config is DerivedMetricConfig<TDatasetName> {
   return 'uses' in config && 'formula' in config;
 }

--- a/packages/datasets/src/utils/dataset-query-validation.ts
+++ b/packages/datasets/src/utils/dataset-query-validation.ts
@@ -22,6 +22,12 @@ export function validateDatasetQueryInput(
     ...(query.by ? ['period'] : []),
   ]);
 
+  if (ds.tenantKey && !context?.runtime?.tenant?.id) {
+    errors.push(
+      `Dataset "${ds.name}" requires runtime tenant scoping.`,
+    );
+  }
+
   if (selectedDimensions.length === 0 && selectedMeasures.length === 0) {
     errors.push(`Dataset "${ds.name}" query must select at least one dimension or measure.`);
   }

--- a/packages/datasets/src/utils/dataset-query-validation.ts
+++ b/packages/datasets/src/utils/dataset-query-validation.ts
@@ -4,6 +4,10 @@ import type {
   ExecutionContext,
 } from '../types.js';
 import { validateFilterValue, type ValidationResult } from '../validation.js';
+import {
+  getRuntimeTenantPredicate,
+  validateTenantRuntime,
+} from './tenant-runtime.js';
 
 export function validateDatasetQueryInput(
   ds: AnyDatasetInstance,
@@ -22,10 +26,9 @@ export function validateDatasetQueryInput(
     ...(query.by ? ['period'] : []),
   ]);
 
-  if (ds.tenantKey && !context?.runtime?.tenant?.id) {
-    errors.push(
-      `Dataset "${ds.name}" requires runtime tenant scoping.`,
-    );
+  const tenantRuntimeError = validateTenantRuntime(ds, context);
+  if (tenantRuntimeError) {
+    errors.push(tenantRuntimeError);
   }
 
   if (selectedDimensions.length === 0 && selectedMeasures.length === 0) {
@@ -66,7 +69,7 @@ export function validateDatasetQueryInput(
       const resolvedColumn = resolvedDimension?.sql
         ? undefined
         : resolvedDimension?.column ?? resolvedField;
-      if (context?.runtime?.tenant?.id && ds.tenantKey && resolvedColumn === ds.tenantKey) {
+      if (getRuntimeTenantPredicate(context) && ds.tenantKey && resolvedColumn === ds.tenantKey) {
         errors.push(
           `Cannot filter on tenant field "${filter.field}" when runtime tenancy enforcement is active.`,
         );

--- a/packages/datasets/src/utils/dataset-query-validation.ts
+++ b/packages/datasets/src/utils/dataset-query-validation.ts
@@ -90,6 +90,14 @@ export function validateDatasetQueryInput(
     errors.push(`Cannot use "by" grain — dataset "${ds.name}" has no timeKey.`);
   }
 
+  if (query.limit != null && (!Number.isInteger(query.limit) || query.limit < 0)) {
+    errors.push(`Invalid limit: expected a non-negative integer.`);
+  }
+
+  if (query.offset != null && (!Number.isInteger(query.offset) || query.offset < 0)) {
+    errors.push(`Invalid offset: expected a non-negative integer.`);
+  }
+
   if (ds.limits?.maxDimensions && query.dimensions && query.dimensions.length > ds.limits.maxDimensions) {
     errors.push(`Too many dimensions: ${query.dimensions.length} (max ${ds.limits.maxDimensions})`);
   }
@@ -100,6 +108,10 @@ export function validateDatasetQueryInput(
 
   if (ds.limits?.maxFilters && query.filters && query.filters.length > ds.limits.maxFilters) {
     errors.push(`Too many filters: ${query.filters.length} (max ${ds.limits.maxFilters})`);
+  }
+
+  if (ds.limits?.maxResultSize && query.limit != null && query.limit > ds.limits.maxResultSize) {
+    errors.push(`Too many results requested: ${query.limit} (max ${ds.limits.maxResultSize})`);
   }
 
   return { valid: errors.length === 0, errors };

--- a/packages/datasets/src/utils/metric-handle.ts
+++ b/packages/datasets/src/utils/metric-handle.ts
@@ -8,6 +8,7 @@ import type {
   TimeGrain,
 } from '../types.js';
 import { resolveDimensionExpression, resolveFilterField, resolveTenantFilterColumn } from '../query-planner.js';
+import { getRuntimeTenantPredicate } from './tenant-runtime.js';
 type DatasetShape = AnyDatasetInstance;
 
 function isMetricHandleType(value: unknown): value is 'metric_ref' | 'grained_metric_ref' {
@@ -44,7 +45,7 @@ export function getTenantRuntimeColumn(
   ds: DatasetShape,
   context?: ExecutionContext,
 ): string | undefined {
-  if (!context?.runtime?.tenant?.id) {
+  if (!getRuntimeTenantPredicate(context)) {
     return undefined;
   }
 

--- a/packages/datasets/src/utils/tenant-runtime.ts
+++ b/packages/datasets/src/utils/tenant-runtime.ts
@@ -1,0 +1,54 @@
+import type {
+  AnyDatasetInstance,
+  ExecutionContext,
+} from '../types.js';
+
+export type TenantPredicate =
+  | { operator: 'eq'; value: string }
+  | { operator: 'in'; value: string[] };
+
+export function getRuntimeTenantPredicate(
+  context?: ExecutionContext,
+): TenantPredicate | undefined {
+  const tenant = context?.runtime?.tenant;
+  if (!tenant) {
+    return undefined;
+  }
+  if (typeof tenant === 'string') {
+    return { operator: 'eq', value: tenant };
+  }
+  if ('id' in tenant) {
+    return { operator: 'eq', value: tenant.id };
+  }
+  if ('in' in tenant && tenant.in.length > 0) {
+    return { operator: 'in', value: tenant.in };
+  }
+  return undefined;
+}
+
+export function getRuntimeTenantId(context?: ExecutionContext): string | undefined {
+  const predicate = getRuntimeTenantPredicate(context);
+  return predicate?.operator === 'eq' ? predicate.value : undefined;
+}
+
+export function isCrossTenantRuntime(context?: ExecutionContext): boolean {
+  const tenant = context?.runtime?.tenant;
+  return !!tenant && typeof tenant === 'object' && 'scope' in tenant && tenant.scope === 'all';
+}
+
+export function hasTenantRuntime(context?: ExecutionContext): boolean {
+  return !!getRuntimeTenantPredicate(context) || isCrossTenantRuntime(context);
+}
+
+export function validateTenantRuntime(
+  ds: AnyDatasetInstance,
+  context?: ExecutionContext,
+): string | undefined {
+  if (!ds.tenantKey) {
+    return undefined;
+  }
+  if (!hasTenantRuntime(context)) {
+    return `Dataset "${ds.name}" requires runtime tenant scoping.`;
+  }
+  return undefined;
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -17,6 +17,7 @@ export type {
   DatasetRegistry,
   QueryMetricArgs,
   QueryDatasetArgs,
+  QueryToolOptions,
   GetDatasetSchemaArgs,
   MCPToolResponse,
   DatasetSchema,

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -4,12 +4,17 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HypequeryMCPServer } from './server.js';
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { DatasetClient } from '@hypequery/datasets';
+
+const requestHandlers = vi.hoisted(() => new Map<unknown, (request: any) => unknown>());
 
 // Mock the MCP SDK
 vi.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
   Server: vi.fn().mockImplementation(() => ({
-    setRequestHandler: vi.fn(),
+    setRequestHandler: vi.fn((schema, handler) => {
+      requestHandlers.set(schema, handler);
+    }),
     connect: vi.fn(),
     close: vi.fn(),
   })),
@@ -38,6 +43,7 @@ describe('HypequeryMCPServer', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    requestHandlers.clear();
   });
 
   it('should create server instance with default config', () => {
@@ -69,6 +75,19 @@ describe('HypequeryMCPServer', () => {
     expect(server).toBeInstanceOf(HypequeryMCPServer);
   });
 
+  it('should require server tenantId for tenant-scoped datasets', () => {
+    expect(() => new HypequeryMCPServer({
+      datasets: {
+        orders: {
+          tenantKey: 'tenant_id',
+          dimensions: {},
+          metrics: {},
+        },
+      },
+      analytics: mockAnalytics,
+    })).toThrow('tenantId is required for tenant-scoped datasets: orders');
+  });
+
   it('should accept multiple datasets', () => {
     const datasets = {
       orders: { dimensions: {}, metrics: {} },
@@ -79,6 +98,7 @@ describe('HypequeryMCPServer', () => {
     const server = new HypequeryMCPServer({
       datasets,
       analytics: mockAnalytics,
+      tenantId: 'company-1',
     });
 
     expect(server).toBeInstanceOf(HypequeryMCPServer);
@@ -123,6 +143,56 @@ describe('HypequeryMCPServer', () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith('Hypequery MCP Server started');
 
     consoleErrorSpy.mockRestore();
+  });
+
+  it('should forward server tenantId through query_dataset tool calls', async () => {
+    const analytics: DatasetClient = {
+      execute: vi.fn().mockResolvedValue({
+        data: [{ region: 'US', revenue: 100 }],
+        meta: { sql: 'SELECT region, SUM(amount) AS revenue FROM orders', timingMs: 12 },
+      }),
+    } as any;
+    const orders = {
+      tenantKey: 'tenant_id',
+      dimensions: {},
+      metrics: {},
+    };
+
+    new HypequeryMCPServer({
+      datasets: { orders },
+      analytics,
+      tenantId: 'tenant-123',
+    });
+
+    const handler = requestHandlers.get(CallToolRequestSchema);
+    expect(handler).toBeDefined();
+
+    const result = await handler?.({
+      params: {
+        name: 'query_dataset',
+        arguments: {
+          dataset: 'orders',
+          metrics: ['revenue'],
+          dimensions: ['region'],
+        },
+      },
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      content: expect.any(Array),
+    }));
+    expect(analytics.execute).toHaveBeenCalledWith(
+      orders,
+      expect.objectContaining({
+        dimensions: ['region'],
+        measures: ['revenue'],
+      }),
+      {
+        runtime: {
+          tenant: { id: 'tenant-123' },
+        },
+      },
+    );
   });
 });
 
@@ -196,6 +266,7 @@ describe('HypequeryMCPServer with complex datasets', () => {
     const server = new HypequeryMCPServer({
       datasets,
       analytics: mockAnalytics,
+      tenantId: 'company-1',
     });
 
     expect(server).toBeInstanceOf(HypequeryMCPServer);
@@ -218,6 +289,7 @@ describe('HypequeryMCPServer with complex datasets', () => {
     const server = new HypequeryMCPServer({
       datasets,
       analytics: mockAnalytics,
+      tenantId: 'company-1',
     });
 
     expect(server).toBeInstanceOf(HypequeryMCPServer);

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -41,6 +41,36 @@ export interface MCPServerConfig {
    * Server version
    */
   version?: string;
+
+  /**
+   * Trusted tenant id used to scope tenant-keyed datasets.
+   */
+  tenantId?: string;
+}
+
+function getTenantKey(dataset: Record<string, unknown>): string | undefined {
+  const config = dataset.config;
+  const configTenantKey = config && typeof config === 'object' && 'tenantKey' in config
+    ? (config as { tenantKey?: unknown }).tenantKey
+    : undefined;
+  const tenantKey = dataset.tenantKey ?? configTenantKey;
+  return typeof tenantKey === 'string' && tenantKey.length > 0 ? tenantKey : undefined;
+}
+
+function validateTenantConfig(config: MCPServerConfig) {
+  if (config.tenantId) {
+    return;
+  }
+
+  const tenantScopedDatasets = Object.entries(config.datasets ?? {})
+    .filter(([, ds]) => getTenantKey(ds))
+    .map(([name]) => name);
+
+  if (tenantScopedDatasets.length > 0) {
+    throw new Error(
+      `MCP server tenantId is required for tenant-scoped datasets: ${tenantScopedDatasets.join(', ')}`,
+    );
+  }
 }
 
 export class HypequeryMCPServer {
@@ -48,6 +78,7 @@ export class HypequeryMCPServer {
   private config: MCPServerConfig;
 
   constructor(config: MCPServerConfig) {
+    validateTenantConfig(config);
     this.config = config;
 
     this.server = new Server(
@@ -152,10 +183,6 @@ export class HypequeryMCPServer {
                 type: 'number',
                 description: 'Number of rows to skip before returning results (optional)',
               },
-              tenant: {
-                type: 'string',
-                description: 'Tenant id used to scope the query when the dataset has tenant isolation (optional)',
-              },
             },
             required: ['dataset', 'metric'],
           },
@@ -221,10 +248,6 @@ export class HypequeryMCPServer {
                 type: 'number',
                 description: 'Number of rows to skip before returning results (optional)',
               },
-              tenant: {
-                type: 'string',
-                description: 'Tenant id used to scope the query when the dataset has tenant isolation (optional)',
-              },
             },
             required: ['dataset'],
           },
@@ -248,14 +271,16 @@ export class HypequeryMCPServer {
             return await queryMetricTool(
               this.config.datasets,
               this.config.analytics,
-              args
+              args,
+              { tenantId: this.config.tenantId },
             );
 
           case 'query_dataset':
             return await queryDatasetTool(
               this.config.datasets,
               this.config.analytics,
-              args
+              args,
+              { tenantId: this.config.tenantId },
             );
 
           default:

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -48,11 +48,13 @@ export interface MCPServerConfig {
   tenantId?: string;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object';
+}
+
 function getTenantKey(dataset: Record<string, unknown>): string | undefined {
   const config = dataset.config;
-  const configTenantKey = config && typeof config === 'object' && 'tenantKey' in config
-    ? (config as { tenantKey?: unknown }).tenantKey
-    : undefined;
+  const configTenantKey = isRecord(config) ? config.tenantKey : undefined;
   const tenantKey = dataset.tenantKey ?? configTenantKey;
   return typeof tenantKey === 'string' && tenantKey.length > 0 ? tenantKey : undefined;
 }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -148,6 +148,14 @@ export class HypequeryMCPServer {
                 type: 'number',
                 description: 'Maximum number of rows to return (optional)',
               },
+              offset: {
+                type: 'number',
+                description: 'Number of rows to skip before returning results (optional)',
+              },
+              tenant: {
+                type: 'string',
+                description: 'Tenant id used to scope the query when the dataset has tenant isolation (optional)',
+              },
             },
             required: ['dataset', 'metric'],
           },
@@ -208,6 +216,14 @@ export class HypequeryMCPServer {
               limit: {
                 type: 'number',
                 description: 'Maximum number of rows to return (optional)',
+              },
+              offset: {
+                type: 'number',
+                description: 'Number of rows to skip before returning results (optional)',
+              },
+              tenant: {
+                type: 'string',
+                description: 'Tenant id used to scope the query when the dataset has tenant isolation (optional)',
               },
             },
             required: ['dataset'],

--- a/packages/mcp-server/src/tools/args.ts
+++ b/packages/mcp-server/src/tools/args.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { MetricFilter } from '@hypequery/datasets';
 import { MAX_QUERY_LIMIT } from '../types.js';
 
 const filterSchema = z.object({
@@ -46,4 +47,14 @@ export function parseToolArgs<T>(schema: z.ZodType<T>, toolName: string, args: u
     throw new Error(`Invalid ${toolName} arguments: ${formatZodError(result.error)}`);
   }
   return result.data;
+}
+
+export function toMetricFilters(
+  filters: Array<{ field: string; operator: MetricFilter['operator']; value?: unknown }> = [],
+): MetricFilter[] {
+  return filters.map(filter => ({
+    field: filter.field,
+    operator: filter.operator,
+    value: filter.value,
+  }));
 }

--- a/packages/mcp-server/src/tools/args.ts
+++ b/packages/mcp-server/src/tools/args.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+import { MAX_QUERY_LIMIT } from '../types.js';
+
+const filterSchema = z.object({
+  field: z.string().min(1),
+  operator: z.enum(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'in', 'notIn', 'between', 'like']),
+  value: z.any().refine(value => value !== undefined, 'Required'),
+}).strict();
+
+const orderBySchema = z.object({
+  field: z.string().min(1),
+  direction: z.enum(['asc', 'desc']),
+}).strict();
+
+const baseQuerySchema = z.object({
+  dimensions: z.array(z.string().min(1)).optional(),
+  filters: z.array(filterSchema).optional(),
+  grain: z.enum(['day', 'week', 'month', 'quarter', 'year']).optional(),
+  orderBy: z.array(orderBySchema).optional(),
+  limit: z.number().int().nonnegative().max(MAX_QUERY_LIMIT).optional(),
+  offset: z.number().int().nonnegative().optional(),
+  tenant: z.string().min(1).optional(),
+  tenantId: z.string().min(1).optional(),
+}).strict();
+
+export const queryMetricArgsSchema = baseQuerySchema.extend({
+  dataset: z.string().min(1).optional(),
+  metric: z.string().min(1).optional(),
+});
+
+export const queryDatasetArgsSchema = baseQuerySchema.extend({
+  dataset: z.string().min(1).optional(),
+  metrics: z.array(z.string().min(1)).optional(),
+});
+
+function formatZodError(error: z.ZodError): string {
+  return error.issues
+    .map(issue => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : 'arguments';
+      return `${path}: ${issue.message}`;
+    })
+    .join('; ');
+}
+
+export function parseToolArgs<T>(schema: z.ZodType<T>, toolName: string, args: unknown): T {
+  const result = schema.safeParse(args);
+  if (!result.success) {
+    throw new Error(`Invalid ${toolName} arguments: ${formatZodError(result.error)}`);
+  }
+  return result.data;
+}
+
+export function resolveTenantId(args: { tenant?: string; tenantId?: string }): string | undefined {
+  if (args.tenant && args.tenantId && args.tenant !== args.tenantId) {
+    throw new Error('tenant and tenantId must match when both are provided');
+  }
+  return args.tenant ?? args.tenantId;
+}

--- a/packages/mcp-server/src/tools/args.ts
+++ b/packages/mcp-server/src/tools/args.ts
@@ -19,8 +19,6 @@ const baseQuerySchema = z.object({
   orderBy: z.array(orderBySchema).optional(),
   limit: z.number().int().nonnegative().max(MAX_QUERY_LIMIT).optional(),
   offset: z.number().int().nonnegative().optional(),
-  tenant: z.string().min(1).optional(),
-  tenantId: z.string().min(1).optional(),
 }).strict();
 
 export const queryMetricArgsSchema = baseQuerySchema.extend({
@@ -48,11 +46,4 @@ export function parseToolArgs<T>(schema: z.ZodType<T>, toolName: string, args: u
     throw new Error(`Invalid ${toolName} arguments: ${formatZodError(result.error)}`);
   }
   return result.data;
-}
-
-export function resolveTenantId(args: { tenant?: string; tenantId?: string }): string | undefined {
-  if (args.tenant && args.tenantId && args.tenant !== args.tenantId) {
-    throw new Error('tenant and tenantId must match when both are provided');
-  }
-  return args.tenant ?? args.tenantId;
 }

--- a/packages/mcp-server/src/tools/query-dataset.ts
+++ b/packages/mcp-server/src/tools/query-dataset.ts
@@ -5,8 +5,8 @@
  */
 
 import type { DatasetClient, DatasetQuery } from '@hypequery/datasets';
-import type { DatasetRegistry, MCPToolResponse, QueryResultResponse, MAX_QUERY_LIMIT, QueryToolOptions } from '../types.js';
-import { parseToolArgs, queryDatasetArgsSchema } from './args.js';
+import type { DatasetRegistry, MCPToolResponse, QueryResultResponse, QueryToolOptions } from '../types.js';
+import { parseToolArgs, queryDatasetArgsSchema, toMetricFilters } from './args.js';
 
 export async function queryDatasetTool(
   datasets: DatasetRegistry,
@@ -35,7 +35,7 @@ export async function queryDatasetTool(
   const query: DatasetQuery = {
     dimensions: dimensions || [],
     measures: metrics || [],
-    filters: (filters || []) as DatasetQuery['filters'],
+    filters: toMetricFilters(filters),
     orderBy: orderBy || [],
   };
 
@@ -43,10 +43,8 @@ export async function queryDatasetTool(
     query.by = grain;
   }
 
-  // Apply limit with maximum cap
-  const MAX_LIMIT: typeof MAX_QUERY_LIMIT = 10000;
   if (limit !== undefined) {
-    query.limit = Math.min(limit, MAX_LIMIT);
+    query.limit = limit;
   }
   if (offset !== undefined) {
     query.offset = offset;

--- a/packages/mcp-server/src/tools/query-dataset.ts
+++ b/packages/mcp-server/src/tools/query-dataset.ts
@@ -5,16 +5,17 @@
  */
 
 import type { DatasetClient, DatasetQuery } from '@hypequery/datasets';
-import type { DatasetRegistry, QueryDatasetArgs, MCPToolResponse, QueryResultResponse, MAX_QUERY_LIMIT } from '../types.js';
+import type { DatasetRegistry, MCPToolResponse, QueryResultResponse, MAX_QUERY_LIMIT } from '../types.js';
+import { parseToolArgs, queryDatasetArgsSchema, resolveTenantId } from './args.js';
 
 export async function queryDatasetTool(
   datasets: DatasetRegistry,
   analytics: DatasetClient,
   args: unknown
 ): Promise<MCPToolResponse> {
-  // Parse and validate args
-  const validatedArgs = args as QueryDatasetArgs;
-  const { dataset: datasetName, dimensions, metrics, filters, grain, orderBy, limit } = validatedArgs;
+  const validatedArgs = parseToolArgs(queryDatasetArgsSchema, 'query_dataset', args);
+  const { dataset: datasetName, dimensions, metrics, filters, grain, orderBy, limit, offset } = validatedArgs;
+  const tenantId = resolveTenantId(validatedArgs);
 
   if (!datasetName) {
     throw new Error('dataset parameter is required');
@@ -34,7 +35,7 @@ export async function queryDatasetTool(
   const query: DatasetQuery = {
     dimensions: dimensions || [],
     measures: metrics || [],
-    filters: filters || [],
+    filters: (filters || []) as DatasetQuery['filters'],
     orderBy: orderBy || [],
   };
 
@@ -47,10 +48,13 @@ export async function queryDatasetTool(
   if (limit !== undefined) {
     query.limit = Math.min(limit, MAX_LIMIT);
   }
+  if (offset !== undefined) {
+    query.offset = offset;
+  }
 
   const result = await analytics.execute(dataset as any, query, {
     runtime: {
-      tenant: undefined,
+      tenant: tenantId ? { id: tenantId } : undefined,
     },
   });
 

--- a/packages/mcp-server/src/tools/query-dataset.ts
+++ b/packages/mcp-server/src/tools/query-dataset.ts
@@ -5,17 +5,17 @@
  */
 
 import type { DatasetClient, DatasetQuery } from '@hypequery/datasets';
-import type { DatasetRegistry, MCPToolResponse, QueryResultResponse, MAX_QUERY_LIMIT } from '../types.js';
-import { parseToolArgs, queryDatasetArgsSchema, resolveTenantId } from './args.js';
+import type { DatasetRegistry, MCPToolResponse, QueryResultResponse, MAX_QUERY_LIMIT, QueryToolOptions } from '../types.js';
+import { parseToolArgs, queryDatasetArgsSchema } from './args.js';
 
 export async function queryDatasetTool(
   datasets: DatasetRegistry,
   analytics: DatasetClient,
-  args: unknown
+  args: unknown,
+  options: QueryToolOptions = {},
 ): Promise<MCPToolResponse> {
   const validatedArgs = parseToolArgs(queryDatasetArgsSchema, 'query_dataset', args);
   const { dataset: datasetName, dimensions, metrics, filters, grain, orderBy, limit, offset } = validatedArgs;
-  const tenantId = resolveTenantId(validatedArgs);
 
   if (!datasetName) {
     throw new Error('dataset parameter is required');
@@ -54,7 +54,7 @@ export async function queryDatasetTool(
 
   const result = await analytics.execute(dataset as any, query, {
     runtime: {
-      tenant: tenantId ? { id: tenantId } : undefined,
+      tenant: options.tenantId ? { id: options.tenantId } : undefined,
     },
   });
 

--- a/packages/mcp-server/src/tools/query-metric.ts
+++ b/packages/mcp-server/src/tools/query-metric.ts
@@ -5,17 +5,17 @@
  */
 
 import type { DatasetClient, MetricQuery } from '@hypequery/datasets';
-import type { DatasetRegistry, MCPToolResponse, QueryResultResponse, MAX_QUERY_LIMIT } from '../types.js';
-import { parseToolArgs, queryMetricArgsSchema, resolveTenantId } from './args.js';
+import type { DatasetRegistry, MCPToolResponse, QueryResultResponse, MAX_QUERY_LIMIT, QueryToolOptions } from '../types.js';
+import { parseToolArgs, queryMetricArgsSchema } from './args.js';
 
 export async function queryMetricTool(
   datasets: DatasetRegistry,
   analytics: DatasetClient,
-  args: unknown
+  args: unknown,
+  options: QueryToolOptions = {},
 ): Promise<MCPToolResponse> {
   const validatedArgs = parseToolArgs(queryMetricArgsSchema, 'query_metric', args);
   const { dataset: datasetName, metric: metricName, dimensions, filters, grain, orderBy, limit, offset } = validatedArgs;
-  const tenantId = resolveTenantId(validatedArgs);
 
   if (!datasetName) {
     throw new Error('dataset parameter is required');
@@ -61,7 +61,7 @@ export async function queryMetricTool(
   // Execute the query
   const result = await analytics.execute(metric, query, {
     runtime: {
-      tenant: tenantId ? { id: tenantId } : undefined,
+      tenant: options.tenantId ? { id: options.tenantId } : undefined,
     },
   });
 

--- a/packages/mcp-server/src/tools/query-metric.ts
+++ b/packages/mcp-server/src/tools/query-metric.ts
@@ -5,16 +5,17 @@
  */
 
 import type { DatasetClient, MetricQuery } from '@hypequery/datasets';
-import type { DatasetRegistry, QueryMetricArgs, MCPToolResponse, QueryResultResponse, MAX_QUERY_LIMIT } from '../types.js';
+import type { DatasetRegistry, MCPToolResponse, QueryResultResponse, MAX_QUERY_LIMIT } from '../types.js';
+import { parseToolArgs, queryMetricArgsSchema, resolveTenantId } from './args.js';
 
 export async function queryMetricTool(
   datasets: DatasetRegistry,
   analytics: DatasetClient,
   args: unknown
 ): Promise<MCPToolResponse> {
-  // Parse and validate args
-  const validatedArgs = args as QueryMetricArgs;
-  const { dataset: datasetName, metric: metricName, dimensions, filters, grain, orderBy, limit } = validatedArgs;
+  const validatedArgs = parseToolArgs(queryMetricArgsSchema, 'query_metric', args);
+  const { dataset: datasetName, metric: metricName, dimensions, filters, grain, orderBy, limit, offset } = validatedArgs;
+  const tenantId = resolveTenantId(validatedArgs);
 
   if (!datasetName) {
     throw new Error('dataset parameter is required');
@@ -40,7 +41,7 @@ export async function queryMetricTool(
   // Build the query with proper types
   const query: MetricQuery = {
     dimensions: dimensions || [],
-    filters: filters || [],
+    filters: (filters || []) as MetricQuery['filters'],
     orderBy: orderBy || [],
   };
 
@@ -53,11 +54,14 @@ export async function queryMetricTool(
   if (limit !== undefined) {
     query.limit = Math.min(limit, MAX_LIMIT);
   }
+  if (offset !== undefined) {
+    query.offset = offset;
+  }
 
   // Execute the query
   const result = await analytics.execute(metric, query, {
     runtime: {
-      tenant: undefined,
+      tenant: tenantId ? { id: tenantId } : undefined,
     },
   });
 

--- a/packages/mcp-server/src/tools/query-metric.ts
+++ b/packages/mcp-server/src/tools/query-metric.ts
@@ -5,8 +5,8 @@
  */
 
 import type { DatasetClient, MetricQuery } from '@hypequery/datasets';
-import type { DatasetRegistry, MCPToolResponse, QueryResultResponse, MAX_QUERY_LIMIT, QueryToolOptions } from '../types.js';
-import { parseToolArgs, queryMetricArgsSchema } from './args.js';
+import type { DatasetRegistry, MCPToolResponse, QueryResultResponse, QueryToolOptions } from '../types.js';
+import { parseToolArgs, queryMetricArgsSchema, toMetricFilters } from './args.js';
 
 export async function queryMetricTool(
   datasets: DatasetRegistry,
@@ -41,7 +41,7 @@ export async function queryMetricTool(
   // Build the query with proper types
   const query: MetricQuery = {
     dimensions: dimensions || [],
-    filters: (filters || []) as MetricQuery['filters'],
+    filters: toMetricFilters(filters),
     orderBy: orderBy || [],
   };
 
@@ -49,10 +49,8 @@ export async function queryMetricTool(
     query.by = grain;
   }
 
-  // Apply limit with maximum cap
-  const MAX_LIMIT: typeof MAX_QUERY_LIMIT = 10000;
   if (limit !== undefined) {
-    query.limit = Math.min(limit, MAX_LIMIT);
+    query.limit = limit;
   }
   if (offset !== undefined) {
     query.offset = offset;

--- a/packages/mcp-server/src/tools/query-sql.integration.test.ts
+++ b/packages/mcp-server/src/tools/query-sql.integration.test.ts
@@ -141,7 +141,8 @@ describe('MCP query tools SQL integration', () => {
       orderBy: [desc('completedRevenue')],
       limit: 25,
       offset: 5,
-      tenant: 'tenant-1',
+    }, {
+      tenantId: 'tenant-1',
     });
 
     const response = parseToolResponse(result);
@@ -153,7 +154,7 @@ describe('MCP query tools SQL integration', () => {
     expect(response.meta.rowCount).toBe(1);
   });
 
-  it('returns metric SQL with tenant scoping from tenantId alias', async () => {
+  it('returns metric SQL with server-provided tenant scoping', async () => {
     const analytics = createDatasetClient({
       queryBuilder: createSqlBuilderFactory([{ country: 'US', totalRevenue: 100 }]),
     });
@@ -165,6 +166,7 @@ describe('MCP query tools SQL integration', () => {
       dataset: 'orders',
       metric: 'totalRevenue',
       dimensions: ['country'],
+    }, {
       tenantId: 'tenant-1',
     });
 
@@ -183,8 +185,26 @@ describe('MCP query tools SQL integration', () => {
       dataset: 'orders',
       metrics: ['revenue'],
       filters: [eq('tenantId', 'tenant-1')],
-      tenant: 'tenant-1',
+    }, {
+      tenantId: 'tenant-1',
     })).rejects.toThrow('Cannot filter on tenant field "tenantId"');
+  });
+
+  it('rejects tenant-keyed MCP queries without tenant scoping', async () => {
+    const analytics = createDatasetClient({ queryBuilder: createSqlBuilderFactory() });
+    const registry = {
+      orders: Object.assign(Orders, { totalRevenue }) as any,
+    };
+
+    await expect(queryDatasetTool(registry, analytics, {
+      dataset: 'orders',
+      metrics: ['revenue'],
+    })).rejects.toThrow('requires runtime tenant scoping');
+
+    await expect(queryMetricTool(registry, analytics, {
+      dataset: 'orders',
+      metric: 'totalRevenue',
+    })).rejects.toThrow('requires runtime tenant scoping');
   });
 
   it('rejects malformed MCP query arguments before execution', async () => {
@@ -200,5 +220,11 @@ describe('MCP query tools SQL integration', () => {
       metric: 'totalRevenue',
       limit: -1,
     })).rejects.toThrow('Invalid query_metric arguments');
+
+    await expect(queryDatasetTool({ orders: Orders as any }, analytics, {
+      dataset: 'orders',
+      metrics: ['revenue'],
+      tenantId: 'tenant-1',
+    })).rejects.toThrow('Invalid query_dataset arguments');
   });
 });

--- a/packages/mcp-server/src/tools/query-sql.integration.test.ts
+++ b/packages/mcp-server/src/tools/query-sql.integration.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createDatasetClient,
+  dataset,
+  dimension,
+  measure,
+  eq,
+  desc,
+  type QueryBuilderFactoryLike,
+  type QueryBuilderLike,
+} from '@hypequery/datasets';
+import { queryDatasetTool } from './query-dataset.js';
+import { queryMetricTool } from './query-metric.js';
+
+type BuilderColumnsInput = string[] | string;
+
+const Orders = dataset('orders', {
+  source: 'orders',
+  tenantKey: 'tenant_id',
+  timeKey: 'created_at',
+  dimensions: {
+    id: dimension.string(),
+    tenantId: dimension.string({ column: 'tenant_id' }),
+    country: dimension.string({ column: 'country_code' }),
+    status: dimension.string(),
+    amount: dimension.number(),
+    createdAt: dimension.timestamp({ column: 'created_at' }),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+    orderCount: measure.count('id'),
+    completedRevenue: measure.sum('amount', {
+      filters: [eq('status', 'completed')],
+    }),
+  },
+});
+
+const totalRevenue = Orders.metric('totalRevenue', { measure: 'revenue' });
+
+function createSqlBuilderFactory(mockData: Record<string, unknown>[] = []): QueryBuilderFactoryLike {
+  function createBuilder(source: string): QueryBuilderLike {
+    const state = {
+      select: [] as string[],
+      where: [] as string[],
+      groupBy: [] as string[],
+      orderBy: [] as string[],
+      limit: undefined as number | undefined,
+      offset: undefined as number | undefined,
+    };
+
+    const buildSql = () => [
+      `SELECT ${state.select.join(', ')} FROM ${source}`,
+      state.where.length > 0 ? `WHERE ${state.where.join(' AND ')}` : '',
+      state.groupBy.length > 0 ? `GROUP BY ${state.groupBy.join(', ')}` : '',
+      state.orderBy.length > 0 ? `ORDER BY ${state.orderBy.join(', ')}` : '',
+      state.limit != null ? `LIMIT ${state.limit}` : '',
+      state.offset != null ? `OFFSET ${state.offset}` : '',
+    ].filter(Boolean).join(' ');
+
+    const builder: QueryBuilderLike = {
+      select: (args: BuilderColumnsInput) => {
+        state.select.push(...(Array.isArray(args) ? args : [args]));
+        return builder;
+      },
+      sum: (column: string, alias?: string) => {
+        state.select.push(`SUM(${column}) AS ${alias ?? `${column}_sum`}`);
+        return builder;
+      },
+      count: (column: string, alias?: string) => {
+        state.select.push(`COUNT(${column}) AS ${alias ?? `${column}_count`}`);
+        return builder;
+      },
+      countDistinct: (column: string, alias?: string) => {
+        state.select.push(`COUNT(DISTINCT ${column}) AS ${alias ?? `${column}_countDistinct`}`);
+        return builder;
+      },
+      avg: (column: string, alias?: string) => {
+        state.select.push(`AVG(${column}) AS ${alias ?? `${column}_avg`}`);
+        return builder;
+      },
+      min: (column: string, alias?: string) => {
+        state.select.push(`MIN(${column}) AS ${alias ?? `${column}_min`}`);
+        return builder;
+      },
+      max: (column: string, alias?: string) => {
+        state.select.push(`MAX(${column}) AS ${alias ?? `${column}_max`}`);
+        return builder;
+      },
+      where: (column: string, operator: string, _value: unknown) => {
+        state.where.push(`${column} ${operator === 'eq' ? '=' : operator} ?`);
+        return builder;
+      },
+      groupBy: (args: BuilderColumnsInput) => {
+        state.groupBy.push(...(Array.isArray(args) ? args : [args]));
+        return builder;
+      },
+      orderBy: (column: string, direction?: string) => {
+        state.orderBy.push(`${column} ${direction ?? 'ASC'}`);
+        return builder;
+      },
+      limit: (count: number) => {
+        state.limit = count;
+        return builder;
+      },
+      offset: (count: number) => {
+        state.offset = count;
+        return builder;
+      },
+      toSQLWithParams: () => ({ sql: buildSql(), parameters: [] }),
+      execute: vi.fn().mockResolvedValue(mockData),
+    };
+
+    return builder;
+  }
+
+  return {
+    table: createBuilder,
+    rawQuery: vi.fn().mockResolvedValue(mockData),
+  };
+}
+
+function parseToolResponse(result: Awaited<ReturnType<typeof queryDatasetTool>>) {
+  return JSON.parse(result.content[0].text) as {
+    data: Record<string, unknown>[];
+    meta: { sql?: string; rowCount: number; timingMs?: number };
+  };
+}
+
+describe('MCP query tools SQL integration', () => {
+  it('returns dataset SQL with tenant scoping, grain, filtered measures, limit, and offset', async () => {
+    const analytics = createDatasetClient({
+      queryBuilder: createSqlBuilderFactory([{ period: '2026-01-01', country: 'US', completedRevenue: 100 }]),
+    });
+
+    const result = await queryDatasetTool({ orders: Orders as any }, analytics, {
+      dataset: 'orders',
+      dimensions: ['country'],
+      metrics: ['completedRevenue'],
+      grain: 'month',
+      filters: [eq('status', 'completed')],
+      orderBy: [desc('completedRevenue')],
+      limit: 25,
+      offset: 5,
+      tenant: 'tenant-1',
+    });
+
+    const response = parseToolResponse(result);
+    expect(response.meta.sql).toContain('toStartOfMonth(created_at) AS period');
+    expect(response.meta.sql).toContain("SUM(if((status = 'completed'), amount, 0)) AS completedRevenue");
+    expect(response.meta.sql).toContain('WHERE tenant_id = ? AND status = ?');
+    expect(response.meta.sql).toContain('ORDER BY completedRevenue DESC');
+    expect(response.meta.sql).toContain('LIMIT 25 OFFSET 5');
+    expect(response.meta.rowCount).toBe(1);
+  });
+
+  it('returns metric SQL with tenant scoping from tenantId alias', async () => {
+    const analytics = createDatasetClient({
+      queryBuilder: createSqlBuilderFactory([{ country: 'US', totalRevenue: 100 }]),
+    });
+    const registry = {
+      orders: Object.assign(Orders, { totalRevenue }) as any,
+    };
+
+    const result = await queryMetricTool(registry, analytics, {
+      dataset: 'orders',
+      metric: 'totalRevenue',
+      dimensions: ['country'],
+      tenantId: 'tenant-1',
+    });
+
+    const response = JSON.parse(result.content[0].text) as {
+      meta: { sql?: string; rowCount: number };
+    };
+    expect(response.meta.sql).toContain('SELECT country_code AS country, SUM(amount) AS totalRevenue FROM orders');
+    expect(response.meta.sql).toContain('WHERE tenant_id = ?');
+    expect(response.meta.sql).toContain('GROUP BY country');
+  });
+
+  it('rejects explicit tenant filters when MCP tenant scoping is active', async () => {
+    const analytics = createDatasetClient({ queryBuilder: createSqlBuilderFactory() });
+
+    await expect(queryDatasetTool({ orders: Orders as any }, analytics, {
+      dataset: 'orders',
+      metrics: ['revenue'],
+      filters: [eq('tenantId', 'tenant-1')],
+      tenant: 'tenant-1',
+    })).rejects.toThrow('Cannot filter on tenant field "tenantId"');
+  });
+
+  it('rejects malformed MCP query arguments before execution', async () => {
+    const analytics = createDatasetClient({ queryBuilder: createSqlBuilderFactory() });
+
+    await expect(queryDatasetTool({ orders: Orders as any }, analytics, {
+      dataset: 'orders',
+      dimensions: 'country',
+    })).rejects.toThrow('Invalid query_dataset arguments');
+
+    await expect(queryMetricTool({ orders: Object.assign(Orders, { totalRevenue }) as any }, analytics, {
+      dataset: 'orders',
+      metric: 'totalRevenue',
+      limit: -1,
+    })).rejects.toThrow('Invalid query_metric arguments');
+  });
+});

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -26,8 +26,6 @@ export interface QueryMetricArgs {
   orderBy?: MetricOrderBy[];
   limit?: number;
   offset?: number;
-  tenant?: string;
-  tenantId?: string;
 }
 
 /**
@@ -42,7 +40,9 @@ export interface QueryDatasetArgs {
   orderBy?: MetricOrderBy[];
   limit?: number;
   offset?: number;
-  tenant?: string;
+}
+
+export interface QueryToolOptions {
   tenantId?: string;
 }
 

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -25,6 +25,9 @@ export interface QueryMetricArgs {
   grain?: TimeGrain;
   orderBy?: MetricOrderBy[];
   limit?: number;
+  offset?: number;
+  tenant?: string;
+  tenantId?: string;
 }
 
 /**
@@ -38,6 +41,9 @@ export interface QueryDatasetArgs {
   grain?: TimeGrain;
   orderBy?: MetricOrderBy[];
   limit?: number;
+  offset?: number;
+  tenant?: string;
+  tenantId?: string;
 }
 
 /**

--- a/packages/serve/src/semantic/datasets/dataset-endpoint.ts
+++ b/packages/serve/src/semantic/datasets/dataset-endpoint.ts
@@ -29,7 +29,6 @@ import { ServeHttpError } from '../../errors.js';
 import {
   resolveSemanticExecutionRuntime,
   resolveSemanticQueryBuilder,
-  resolveSemanticTenantHandledByBuilder,
 } from '../query-builder-context.js';
 import { buildDatasetQueryDescription } from './utils/dataset-query-metadata.js';
 import { resolveDatasetEntry, type DatasetEntry } from './utils/dataset-entry.js';
@@ -145,7 +144,6 @@ export function createDatasetEndpoint<TAuth extends AuthContext>(
     const result = await runDatasetQuery(ds, query, {
       builderFactory: runtimeBuilderFactory,
       context: executionContext,
-      tenantHandledByBuilder: resolveSemanticTenantHandledByBuilder(semanticContext),
     });
     const timingMs = Date.now() - start;
 

--- a/packages/serve/src/semantic/datasets/metric-endpoint.ts
+++ b/packages/serve/src/semantic/datasets/metric-endpoint.ts
@@ -23,7 +23,6 @@ import { ServeHttpError } from '../../errors.js';
 import {
   resolveSemanticExecutionRuntime,
   resolveSemanticQueryBuilder,
-  resolveSemanticTenantHandledByBuilder,
 } from '../query-builder-context.js';
 
 // ---------------------------------------------------------------------------
@@ -144,9 +143,6 @@ export function createMetricEndpoint<TAuth extends AuthContext>(
       semanticContext,
       defaultBuilderFactory,
     );
-    const tenantHandledByBuilder = resolveSemanticTenantHandledByBuilder(semanticContext)
-      || (ctx.tenantId != null && runtimeBuilderFactory !== defaultBuilderFactory);
-
     // Build the metric query
     const query = {
       dimensions: input.dimensions,
@@ -186,7 +182,7 @@ export function createMetricEndpoint<TAuth extends AuthContext>(
       runtime: {
         ...runtime,
         builderFactory: runtimeBuilderFactory,
-        tenant: tenantHandledByBuilder ? undefined : runtime?.tenant,
+        tenant: runtime?.tenant,
       },
     });
 

--- a/packages/serve/src/semantic/datasets/serve-integration.test.ts
+++ b/packages/serve/src/semantic/datasets/serve-integration.test.ts
@@ -19,6 +19,33 @@ import type { ServeQueryEvent } from '../../query-logger.js';
 
 const Orders = dataset("orders", {
   source: "orders",
+  timeKey: "created_at",
+  dimensions: {
+    id: dimension.string(),
+    customerId: dimension.string(),
+    country: dimension.string({ label: "Country" }),
+    status: dimension.string({ label: "Order Status" }),
+    amount: dimension.number({ label: "Amount" }),
+    createdAt: dimension.timestamp(),
+  },
+  measures: {
+    revenue: measure.sum('amount', { label: "Revenue" }),
+    count: measure.count('id', { label: "Order Count" }),
+  },
+  filters: {
+    status: {
+      __type: 'filter_definition',
+      field: 'status',
+      operators: ['eq'],
+    },
+  },
+  limits: {
+    maxDimensions: 5,
+  },
+});
+
+const TenantOrders = dataset("tenantOrders", {
+  source: "orders",
   tenantKey: "tenant_id",
   timeKey: "created_at",
   dimensions: {
@@ -103,6 +130,11 @@ const aliasedRevenue = OrdersWithAliases.metric("aliasedRevenue", {
 });
 const tenantFilteredRevenue = OrdersWithTenantFilter.metric("tenantFilteredRevenue", {
   measure: "revenue",
+});
+const tenantScopedTotalRevenue = TenantOrders.metric("totalRevenue", {
+  measure: "revenue",
+  label: "Total Revenue",
+  description: "Sum of all order amounts",
 });
 
 const BASE_PATH = "/api/analytics";
@@ -721,7 +753,7 @@ describe("Serve integration — metrics", () => {
     it("injects tenant ID into metric queries when tenant config is provided", async () => {
       const factory = createMockBuilderFactory();
       const api = createAPI({
-        metrics: { totalRevenue },
+        metrics: { totalRevenue: tenantScopedTotalRevenue },
         queryBuilder: factory,
         auth: async ({ request }) => {
           const key = request.headers['x-api-key'];
@@ -754,7 +786,7 @@ describe("Serve integration — metrics", () => {
     it("falls back to the dataset tenantKey when tenant isolation is enabled without tenant.column", async () => {
       const factory = createMockBuilderFactory();
       const api = createAPI({
-        metrics: { totalRevenue },
+        metrics: { totalRevenue: tenantScopedTotalRevenue },
         queryBuilder: factory,
         auth: async ({ request }) => {
           const key = request.headers['x-api-key'];
@@ -817,10 +849,10 @@ describe("Serve integration — metrics", () => {
       expect(semanticBody(response).error.message).toContain('Cannot filter on tenant field "tenantId"');
     });
 
-    it("prefers the Serve tenant column when auto-inject wraps the internal query builder", async () => {
+    it("uses the dataset tenantKey for semantic metrics even when Serve auto-inject has a different column", async () => {
       const factory = createMockBuilderFactory();
       const api = createAPI({
-        metrics: { totalRevenue },
+        metrics: { totalRevenue: tenantScopedTotalRevenue },
         queryBuilder: factory,
         auth: async ({ request }) => {
           const key = request.headers['x-api-key'];
@@ -848,14 +880,15 @@ describe("Serve integration — metrics", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(factory._calls['where']).toContainEqual(['organization_id', 'eq', 'tenant-123']);
+      expect(factory._calls['where']).toContainEqual(['tenant_id', 'eq', 'tenant-123']);
+      expect(factory._calls['where']).not.toContainEqual(['organization_id', 'eq', 'tenant-123']);
     });
 
     it("does not warn about manual tenant mode for generated metric endpoints", async () => {
       const factory = createMockBuilderFactory();
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
       const api = createAPI({
-        metrics: { totalRevenue },
+        metrics: { totalRevenue: tenantScopedTotalRevenue },
         queryBuilder: factory,
         auth: async ({ request }) => {
           const key = request.headers['x-api-key'];
@@ -1208,7 +1241,7 @@ describe("Serve integration — metrics", () => {
     it("injects tenant filter via builder.where()", async () => {
       const factory = createMockBuilderFactory();
       const api = createAPI({
-        metrics: { totalRevenue },
+        metrics: { totalRevenue: tenantScopedTotalRevenue },
         queryBuilder: factory,
         auth: async ({ request }) => {
           const key = request.headers['x-api-key'];
@@ -1475,7 +1508,7 @@ describe("Serve integration — metrics", () => {
         { country: "US", revenue: 5000 },
       ]);
       const api = createAPI({
-        datasets: { orders: Orders },
+        datasets: { orders: TenantOrders },
         queryBuilder: factory,
         auth: async ({ request }) => {
           const key = request.headers['x-api-key'];
@@ -1513,7 +1546,7 @@ describe("Serve integration — metrics", () => {
         { country: "US", revenue: 5000 },
       ]);
       const api = createAPI({
-        datasets: { orders: Orders },
+        datasets: { orders: TenantOrders },
         queryBuilder: factory,
         auth: async ({ request }) => {
           const key = request.headers['x-api-key'];

--- a/packages/serve/src/semantic/query-builder-context.ts
+++ b/packages/serve/src/semantic/query-builder-context.ts
@@ -1,7 +1,6 @@
 import type { QueryBuilderFactoryLike, SemanticExecutionRuntime } from "@hypequery/datasets";
 
 export const INTERNAL_SEMANTIC_RUNTIME_KEY = "__hypequerySemanticRuntime";
-export const INTERNAL_SEMANTIC_TENANT_HANDLED_BY_BUILDER_KEY = "__hypequerySemanticTenantHandledByBuilder";
 
 function isSemanticExecutionRuntime(value: unknown): value is SemanticExecutionRuntime {
   return typeof value === 'object' && value !== null;
@@ -52,25 +51,15 @@ export function resolveSemanticQueryBuilder(
   return resolveSemanticExecutionRuntime(context)?.builderFactory ?? fallback;
 }
 
-export function resolveSemanticTenantHandledByBuilder(
-  context: Record<string, unknown>,
-): boolean {
-  return context[INTERNAL_SEMANTIC_TENANT_HANDLED_BY_BUILDER_KEY] === true;
-}
-
 export function attachSemanticTenantRuntime<TContext extends Record<string, unknown>>(
   context: TContext,
   options: {
     tenantId: string;
-    tenantHandledByBuilder?: boolean;
   },
 ): TContext {
-  return {
-    ...attachSemanticRuntime(context, {
-      tenant: {
-        id: options.tenantId,
-      },
-    }),
-    [INTERNAL_SEMANTIC_TENANT_HANDLED_BY_BUILDER_KEY]: options.tenantHandledByBuilder === true,
-  };
+  return attachSemanticRuntime(context, {
+    tenant: {
+      id: options.tenantId,
+    },
+  });
 }

--- a/packages/serve/src/semantic/utils/tenant-runtime.ts
+++ b/packages/serve/src/semantic/utils/tenant-runtime.ts
@@ -42,20 +42,9 @@ export function applySemanticTenantRuntime<TContext extends Record<string, unkno
     Object.assign(
       context,
       attachSemanticRuntime(context, {
-        builderFactory: createTenantScope(semanticRuntime.builderFactory, {
-          tenantId: options.tenantId,
-          column: options.column,
-        }),
         tenant: {
           id: options.tenantId,
         },
-      }),
-    );
-    Object.assign(
-      context,
-      attachSemanticTenantRuntime(context, {
-        tenantId: options.tenantId,
-        tenantHandledByBuilder: true,
       }),
     );
   } else {
@@ -63,7 +52,6 @@ export function applySemanticTenantRuntime<TContext extends Record<string, unkno
       context,
       attachSemanticTenantRuntime(context, {
         tenantId: options.tenantId,
-        tenantHandledByBuilder: false,
       }),
     );
   }


### PR DESCRIPTION
## Summary

  Adds stricter dataset query validation and makes MCP tenant scoping fail closed.

  ## Changes

  - Validate dataset and metric pagination inputs:
    - reject negative/non-integer `limit`
    - reject negative/non-integer `offset`
    - enforce dataset `limits.maxResultSize`
  - Require runtime tenant context whenever a dataset declares `tenantKey`
    - dataset queries fail without `context.runtime.tenant.id`
    - metric queries fail without `context.runtime.tenant.id`
  - Move MCP tenant scoping to trusted server config
    - add `MCPServerConfig.tenantId`
    - reject MCP startup when tenant-scoped datasets are registered without `tenantId`
    - remove caller-provided `tenant`/`tenantId` from tool arguments
  - Add strict Zod validation for MCP query tool arguments
  - Add MCP `offset` support for `query_metric` and `query_dataset`
  - Add SQL integration coverage for MCP dataset/metric queries, tenant scoping, filtered measures, pagination, and malformed args

  ## Tenant Scoping Model

  `tenantKey` and `tenantId` are intentionally different:

  - `tenantKey`: dataset column used for isolation, e.g. `tenant_id`
  - `tenantId`: trusted runtime/server tenant value, e.g. `acme`

  Together they produce scoped SQL like:

  ```sql
  WHERE tenant_id = ?

  MCP clients do not provide tenant ids. The MCP server owns the tenant context.