### PR TITLE
feat(serve,react): add route manifest to bridge serve and react

### DIFF
--- a/.changeset/route-manifest.md
+++ b/.changeset/route-manifest.md
@@ -1,0 +1,17 @@
+---
+"@hypequery/serve": minor
+"@hypequery/react": minor
+---
+
+Add a route manifest to bridge serve and react for metric/dataset endpoints.
+
+`@hypequery/serve` now exposes `api.manifest()` (and `ServeBuilder.manifest()`),
+a serializable map of every query/metric/dataset key to its `{ method, path }`
+(full path, including the base path; datasets keyed as `dataset:<name>`).
+
+`@hypequery/react`'s `createHooks`/`createAnalyticsHooks` accept a `manifest`
+option to resolve client routes without importing server code into the bundle.
+This fixes metric/dataset hooks (POST routes whose paths differ from their map
+keys) silently defaulting to `GET {baseUrl}/{key}`. Hooks now also derive routes
+from a runtime `api` object via `api.manifest()`, and throw a clear error when a
+semantic (`dataset:`) key has no resolved route instead of calling the wrong URL.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -141,6 +141,49 @@ const { useQuery } = createHooks<AnalyticsApi>({
 > require a `manifest` (or explicit `config`); calling them without one throws a
 > clear error rather than hitting the wrong URL.
 
+#### Generating the manifest at build time
+
+The cleanest way to keep server code out of the browser bundle is to generate a
+JSON file at build time and import that on the client. `api.manifest()` is pure —
+it reads the configured routes and never touches your database — so this step is
+cheap and safe to run in CI.
+
+```ts
+// scripts/gen-manifest.ts — run before your client build
+import { writeFileSync } from 'node:fs';
+import { api } from '../server/api.js';
+
+writeFileSync('src/generated/manifest.json', JSON.stringify(api.manifest(), null, 2));
+```
+
+```jsonc
+// package.json
+{
+  "scripts": {
+    "gen:manifest": "tsx scripts/gen-manifest.ts",
+    "build": "npm run gen:manifest && <your client build>"
+  }
+}
+```
+
+```ts
+// client side — imports plain JSON, no server code in the bundle
+import manifest from './generated/manifest.json';
+
+const { useQuery } = createHooks<AnalyticsApi>({
+  baseUrl: '/api/analytics',
+  manifest,
+});
+```
+
+The manifest is derived entirely from your serve config (`basePath`, route keys,
+and `semanticPaths`), so the generated file is deterministic and only changes when
+your API shape does — commit it or regenerate it on every build.
+
+> `baseUrl` supplies the origin/host; the per-endpoint path comes from the
+> manifest (it already includes the server's `basePath`), so there's no
+> double-prefixing. Keep `baseUrl` aligned with where the API is mounted.
+
 ### Explicit config
 
 If a manifest is not available at runtime, pass route config explicitly. This

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -83,9 +83,11 @@ function RevenuePanel() {
 import { createAnalyticsHooks } from '@hypequery/react';
 import type { AnalyticsApi } from '../server/api.js';
 
+import { manifest } from '../server/api.js'; // serve api.manifest(), serialized
+
 export const { useMetric, useDataset } = createAnalyticsHooks<AnalyticsApi>({
   baseUrl: '/api/analytics',
-  api: {} as AnalyticsApi,
+  manifest,
   metrics: ['revenue', 'averageOrderValue'] as const,
 });
 
@@ -112,7 +114,37 @@ function Dashboard() {
 
 ## Route Configuration
 
-If your API type is not available at runtime, pass route config explicitly.
+Hooks need to know each endpoint's HTTP method and path. There are three ways to
+supply that, in increasing precedence: a route manifest, a runtime `api` object,
+or explicit `config`.
+
+### Route manifest (recommended)
+
+`@hypequery/serve`'s `api.manifest()` returns a serializable map of every
+query/metric/dataset key to its `{ method, path }`. Export it from a server-only
+module and pass it to the hooks — this avoids importing server code into the
+browser bundle while keeping client routes in sync with the server.
+
+```ts
+// server side (server-only module)
+export const manifest = api.manifest();
+
+// client side
+const { useQuery } = createHooks<AnalyticsApi>({
+  baseUrl: '/api/analytics',
+  manifest,
+});
+```
+
+> Metric and dataset endpoints are POST routes whose paths differ from their map
+> keys (e.g. `dataset:orders` → `POST /api/analytics/datasets/orders/query`). They
+> require a `manifest` (or explicit `config`); calling them without one throws a
+> clear error rather than hitting the wrong URL.
+
+### Explicit config
+
+If a manifest is not available at runtime, pass route config explicitly. This
+overrides any manifest entry.
 
 ```ts
 const { useQuery } = createHooks<AnalyticsApi>({

--- a/packages/react/src/createHooks.test.tsx
+++ b/packages/react/src/createHooks.test.tsx
@@ -341,6 +341,104 @@ describe('createHooks', () => {
     });
   });
 
+  describe('Route manifest', () => {
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+      fetchMock.mockReset();
+      fetchMock.mockResolvedValue(mockSuccessResponse({ success: true }));
+    });
+
+    it('resolves method and path from a manifest', async () => {
+      const { useQuery } = createHooks<TestApi>({
+        baseUrl: 'https://api.example.com',
+        fetchFn: fetchMock as unknown as typeof fetch,
+        manifest: {
+          getUser: { method: 'POST', path: '/api/analytics/metrics/getUser' },
+        },
+      });
+
+      const { result } = renderHook(() => useQuery('getUser', { id: '123' }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.example.com/api/analytics/metrics/getUser',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ id: '123' }),
+        })
+      );
+    });
+
+    it('lets explicit config override the manifest', async () => {
+      const { useQuery } = createHooks<TestApi>({
+        baseUrl: 'https://api.example.com',
+        fetchFn: fetchMock as unknown as typeof fetch,
+        manifest: {
+          getUser: { method: 'POST', path: '/manifest/getUser' },
+        },
+        config: {
+          getUser: { method: 'POST', path: '/override/getUser' },
+        },
+      });
+
+      const { result } = renderHook(() => useQuery('getUser', { id: '123' }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.example.com/override/getUser',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('derives method config from an api object exposing manifest()', async () => {
+      const mockApi = {
+        manifest: () => ({
+          getUser: { method: 'PATCH', path: '/api/analytics/queries/getUser' },
+        }),
+      } as unknown as TestApi;
+
+      const { useQuery } = createHooks<TestApi>({
+        baseUrl: 'https://api.example.com',
+        fetchFn: fetchMock as unknown as typeof fetch,
+        api: mockApi,
+      });
+
+      const { result } = renderHook(() => useQuery('getUser', { id: '123' }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.example.com/api/analytics/queries/getUser',
+        expect.objectContaining({ method: 'PATCH' })
+      );
+    });
+
+    it('throws for an unresolved semantic (dataset:) key', async () => {
+      const { useQuery } = createHooks<Record<string, { input: unknown; output: unknown }>>({
+        baseUrl: 'https://api.example.com',
+        fetchFn: fetchMock as unknown as typeof fetch,
+      });
+
+      const { result } = renderHook(
+        () => useQuery('dataset:orders' as never, { dimensions: ['country'] } as never),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.message).toContain('No route configured for "dataset:orders"');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Query Parameter Serialization', () => {
     const fetchMock = vi.fn();
 

--- a/packages/react/src/createHooks.tsx
+++ b/packages/react/src/createHooks.tsx
@@ -14,6 +14,19 @@ export interface QueryMethodConfig {
   path?: string;
 }
 
+/** A single route as produced by `@hypequery/serve`'s `api.manifest()`. */
+export interface RouteManifestEntry {
+  method?: string;
+  path?: string;
+}
+
+/**
+ * Map of query/metric/dataset keys to their HTTP method and full path. Pair
+ * with `InferAPIType` and `api.manifest()` from `@hypequery/serve` to resolve
+ * routes on the client without importing server code into the bundle.
+ */
+export type RouteManifest = Record<string, RouteManifestEntry>;
+
 type HeaderMap = Record<string, string | undefined>;
 type HeadersInput = HeaderMap | (() => HeaderMap);
 
@@ -22,6 +35,12 @@ export interface CreateHooksConfig<TApi = Record<string, { input: unknown; outpu
   fetchFn?: typeof fetch;
   headers?: HeadersInput;
   config?: Record<string, QueryMethodConfig>;
+  /**
+   * Route manifest from `@hypequery/serve`'s `api.manifest()`. Resolves the
+   * method and full path for each key — required for metric/dataset endpoints,
+   * which are POST routes whose paths differ from their map keys.
+   */
+  manifest?: RouteManifest;
   api?: TApi;
 }
 
@@ -41,6 +60,14 @@ const normalizeMethodConfig = (source?: Record<string, { method?: string; path?:
 const deriveMethodConfig = (api: unknown): Record<string, QueryMethodConfig> => {
   if (typeof api !== 'object' || api === null) {
     return {};
+  }
+
+  // Preferred: the serve API exposes a manifest() with full method + path.
+  if (typeof (api as Record<string, unknown>).manifest === 'function') {
+    const manifest = (api as { manifest: () => RouteManifest }).manifest();
+    if (manifest && typeof manifest === 'object') {
+      return normalizeMethodConfig(manifest);
+    }
   }
 
   if (
@@ -125,8 +152,13 @@ const resolveHeaders = (headers?: HeadersInput): Record<string, string> => {
 export function createHooks<Api extends Record<string, { input: any; output: any }>>(
   config: CreateHooksConfig<Api>
 ) {
-  const { baseUrl, fetchFn = fetch, headers = {}, config: explicitConfig = {}, api } = config;
-  const finalConfig = { ...deriveMethodConfig(api), ...explicitConfig };
+  const { baseUrl, fetchFn = fetch, headers = {}, config: explicitConfig = {}, manifest, api } = config;
+  // Precedence: explicit config > manifest > derived from a runtime api object.
+  const finalConfig = {
+    ...deriveMethodConfig(api),
+    ...(manifest ? normalizeMethodConfig(manifest) : {}),
+    ...explicitConfig,
+  };
 
   const fetchQuery = async (
     name: string,
@@ -134,6 +166,17 @@ export function createHooks<Api extends Record<string, { input: any; output: any
     defaultMethod: string = 'GET'
   ): Promise<unknown> => {
     const methodConfig = finalConfig[name];
+
+    // Semantic endpoints (dataset:<name>) live at paths that differ from their
+    // map key, so without a resolved path we'd call the wrong URL. Fail loudly
+    // instead of silently requesting `${baseUrl}/dataset:<name>`.
+    if (name.includes(':') && !methodConfig?.path) {
+      throw new Error(
+        `No route configured for "${name}". Pass \`manifest\` (from the serve ` +
+        `api.manifest()) or an explicit \`config\` entry to createHooks().`
+      );
+    }
+
     const url = buildUrl(baseUrl, name, methodConfig?.path);
     const method = methodConfig?.method ?? defaultMethod;
 

--- a/packages/serve/src/semantic/datasets/serve-integration.test.ts
+++ b/packages/serve/src/semantic/datasets/serve-integration.test.ts
@@ -412,6 +412,60 @@ describe("Serve integration — metrics", () => {
     });
   });
 
+  describe("manifest()", () => {
+    it("maps queries, metrics, and datasets to full method + path", () => {
+      const api = createAPI({
+        queries: {
+          ping: { query: async () => ({ ok: true }) },
+        },
+        metrics: { totalRevenue },
+        datasets: { orders: Orders },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      const manifest = api.manifest();
+
+      // Plain queries default to GET under /queries.
+      expect(manifest.ping).toEqual({
+        method: "GET",
+        path: "/api/analytics/queries/ping",
+      });
+      // Metrics are POST under /metrics/<name>.
+      expect(manifest.totalRevenue).toEqual({
+        method: "POST",
+        path: "/api/analytics/metrics/totalRevenue",
+      });
+      // Datasets are keyed `dataset:<name>` and POST under /datasets/<name>/query.
+      expect(manifest["dataset:orders"]).toEqual({
+        method: "POST",
+        path: "/api/analytics/datasets/orders/query",
+      });
+    });
+
+    it("respects a custom basePath", () => {
+      const api = createAPI({
+        basePath: "/v1/analytics",
+        metrics: { totalRevenue },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      expect(api.manifest().totalRevenue).toEqual({
+        method: "POST",
+        path: "/v1/analytics/metrics/totalRevenue",
+      });
+    });
+
+    it("excludes internal openapi and docs routes", () => {
+      const api = createAPI({
+        metrics: { totalRevenue },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      const keys = Object.keys(api.manifest());
+      expect(keys).toEqual(["totalRevenue"]);
+    });
+  });
+
   describe("metric endpoints", () => {
     it("responds to POST /metrics/:name", async () => {
       const factory = createMockBuilderFactory();

--- a/packages/serve/src/server/api-builder.ts
+++ b/packages/serve/src/server/api-builder.ts
@@ -3,6 +3,7 @@ import type {
   AuthStrategy,
   HypeQueryAPI,
   HttpMethod,
+  RouteManifest,
   ServeEndpoint,
   ServeEndpointMap,
   ServeMiddleware,
@@ -15,7 +16,7 @@ import type {
 import type { ServeRouter } from "../router.js";
 import { ServeQueryLogger } from "../query-logger.js";
 import { mergeTags } from "../utils.js";
-import { normalizeRoutePath } from "../router.js";
+import { applyBasePath, normalizeRoutePath } from "../router.js";
 import { mapEndpointToToolkit } from "./mapper.js";
 
 export const createAPImethods = <
@@ -35,6 +36,22 @@ export const createAPImethods = <
   const api: HypeQueryAPI<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth> = {
     queries: queryEntries,
     queryLogger,
+
+    manifest: (): RouteManifest => {
+      const manifest: RouteManifest = {};
+      for (const [key, endpoint] of Object.entries(queryEntries) as [
+        string,
+        ServeEndpoint<any, any, TContext, TAuth>,
+      ][]) {
+        manifest[key] = {
+          method: endpoint.method,
+          // queryEntries store the pre-basePath route; re-apply so the manifest
+          // carries the full request path clients should call.
+          path: applyBasePath(basePath, endpoint.metadata.path),
+        };
+      }
+      return manifest;
+    },
 
     route: (path: string, endpoint: ServeEndpoint<any, any, TContext, TAuth>, options: Partial<RouteRegistrationOptions<TContext, TAuth>> = {}) => {
       if (!endpoint) {

--- a/packages/serve/src/server/builder.ts
+++ b/packages/serve/src/server/builder.ts
@@ -2,6 +2,7 @@ import type {
   AuthContext,
   AuthStrategy,
   HttpMethod,
+  RouteManifest,
   ServeBuilder,
   ServeEndpoint,
   ServeEndpointMap,
@@ -15,7 +16,7 @@ import type {
 import type { ServeRouter } from "../router.js";
 import { ServeQueryLogger } from "../query-logger.js";
 import { mergeTags } from "../utils.js";
-import { normalizeRoutePath } from "../router.js";
+import { applyBasePath, normalizeRoutePath } from "../router.js";
 import { mapEndpointToToolkit } from "./mapper.js";
 
 const loadNodeAdapter = async () => {
@@ -45,6 +46,20 @@ export const createBuilderMethods = <
     basePath: basePath || undefined,
     queryLogger,
     _routeConfig: routeConfig,
+
+    manifest: (): RouteManifest => {
+      const manifest: RouteManifest = {};
+      for (const [key, endpoint] of Object.entries(queryEntries) as [
+        string,
+        ServeEndpoint<any, any, TContext, TAuth>,
+      ][]) {
+        manifest[key] = {
+          method: routeConfig[key]?.method ?? endpoint.method,
+          path: applyBasePath(basePath, endpoint.metadata.path),
+        };
+      }
+      return manifest;
+    },
 
     route: (path: string, endpoint: ServeEndpoint<any, any, TContext, TAuth>, options: Partial<RouteRegistrationOptions<TContext, TAuth>> = {}) => {
       if (!endpoint) {

--- a/packages/serve/src/types.ts
+++ b/packages/serve/src/types.ts
@@ -862,6 +862,22 @@ export type ExecuteQueryFunction<
  * export default toFetchHandler(api);
  * ```
  */
+/** A single route in a {@link RouteManifest}. */
+export interface RouteManifestEntry {
+  method: HttpMethod;
+  /** Full request path including the API base path. */
+  path: string;
+}
+
+/**
+ * Serializable map of query/metric/dataset keys to their HTTP method and full
+ * path. Keys match {@link HypeQueryAPI.queries} (including `dataset:<name>`
+ * keys for datasets), so it can be paired with `InferAPIType` and handed to
+ * `@hypequery/react`'s `createHooks({ manifest })` to resolve client routes
+ * without importing server code into the browser bundle.
+ */
+export type RouteManifest = Record<string, RouteManifestEntry>;
+
 export interface HypeQueryAPI<
   TQueries extends Record<string, ServeEndpoint<any, any, any, any>> = Record<
     string,
@@ -875,6 +891,11 @@ export interface HypeQueryAPI<
   readonly queryLogger: ServeQueryLogger;
   /** The underlying request handler. Can be passed directly to transport adapters. */
   readonly handler: ServeHandler;
+  /**
+   * Build a serializable {@link RouteManifest} of every query/metric/dataset
+   * route (method + full path). Safe to JSON-serialize and ship to the client.
+   */
+  manifest(): RouteManifest;
   route<Path extends string, TKey extends keyof TQueries>(
     path: Path,
     endpoint: TQueries[TKey],
@@ -957,6 +978,11 @@ export interface ServeBuilder<
   readonly queryLogger: ServeQueryLogger;
   /** Internal route configuration mapping query names to their HTTP methods */
   readonly _routeConfig?: Record<string, { method: HttpMethod }>;
+  /**
+   * Build a serializable {@link RouteManifest} of every query/metric/dataset
+   * route (method + full path). Safe to JSON-serialize and ship to the client.
+   */
+  manifest(): RouteManifest;
   route<Path extends string, TKey extends keyof TQueries>(
     path: Path,
     endpoint: TQueries[TKey],

--- a/plans/datasets-serve-react-production-plan.md
+++ b/plans/datasets-serve-react-production-plan.md
@@ -1,0 +1,144 @@
+# Plan: Production-Ready Datasets → Serve → React Integration
+
+> Status: proposed. Source of analysis: `packages/datasets`, `packages/serve`, `packages/react`.
+> Created 2026-06-11.
+
+## Background / gap analysis
+
+How it fits together today:
+
+- `createAPI` / `defineServe` accept `metrics` and `datasets` config maps. Each metric
+  becomes `POST {basePath}/metrics/{name}`; each dataset becomes
+  `POST {basePath}/datasets/{name}/query` (`serve/src/server/create-api.ts:167-220`).
+- Both are registered into `api.queries` under keys `name` (metrics) and `dataset:{name}`
+  (datasets), so they appear in OpenAPI/docs and `InferAPIType`.
+- React consumes the inferred type via `createHooks` / `createAnalyticsHooks`
+  (`useMetric`, `useDataset`).
+
+Identified gaps:
+
+1. **Flexible API creation** — solid coverage (validation, tenant runtime, auth/roles/scopes,
+   caching, max-limit clamp, meta gating). But semantic endpoints are second-class:
+   `middlewares: []` and `defaultHeaders: undefined` are hardcoded
+   (`metric-endpoint.ts`, `dataset-endpoint.ts`); no per-endpoint middleware/headers/rate-limit.
+2. **Docs via `hypequery dev`** — request schema is untyped: `dimensions: z.array(z.string())`,
+   `filters[].field: z.string()`, output `z.array(z.record(z.unknown()))`. Valid field names
+   live only in the prose description, so OpenAPI advertises "array of arbitrary strings" and
+   you cannot codegen a typed client.
+3. **Flexible typed React hooks** — typed at the envelope, not the field.
+   `SemanticMetricEndpointMap` / `SemanticDatasetEndpointMap` type every endpoint with generic
+   `DatasetQuery` / `DatasetQueryResult` (`serve/src/types.ts:568-595`), so `useDataset` accepts
+   any `string[]` and rows are `Record<string, unknown>`. **Bigger gap:** no generated route
+   manifest — in a client/server split you import only `InferApiType`, so `deriveMethodConfig`
+   finds nothing → defaults to `GET baseUrl/dataset:orders`, never the real
+   `POST {basePath}/datasets/orders/query`. Even passing the runtime `api` fails because
+   `deriveMethodConfig` reads `endpoint.path` while the value lives at `endpoint.metadata.path`
+   (`react/src/createHooks.tsx:30-40`; every test hand-writes `config: {...}`).
+4. **Pagination** — offset-only in body; `MetricResultMeta` is only `{ timingMs, sql, tenant }`
+   (`datasets/src/types.ts:182`); no `hasMore`/total; React has only `useQuery`/`useMutation`;
+   clickhouse builder has no cursor pagination.
+5. **params vs body** — POST+body for semantic queries is the right call, but defeats
+   CDN/browser caching despite server-side `cacheTtlMs`; meta is requested via the
+   `x-include-meta` header side-channel (not in OpenAPI, not first-class in React).
+6. **Auth** — good primitives (apiKey, bearer, roles/scopes, tenancy, CORS, pluggable
+   rate-limit store) but no built-in JWT/JWKS verification, React auth is header-only with no
+   refresh/401 retry, and the default rate-limit store is in-memory only.
+
+---
+
+## Phase 1 — Route manifest (kills the GET/path-drift footgun) [highest leverage]
+
+Generate a serializable manifest at define time and let React consume it.
+
+1. Add `api.manifest()` to `createAPI` (`server/api-builder.ts` / `create-api.ts`), sourced from
+   `router.list()` (carries full basePath-applied paths). Shape:
+   `Record<string, { method: HttpMethod; path: string }>` keyed by the same keys as `api.queries`
+   (including `dataset:{name}` and metric names). Exclude internal endpoints (`/openapi.json`, `/docs`).
+2. Export paths:
+   - Server-only modules: `export const manifest = api.manifest()` (plain JSON, no server code in bundle).
+   - CLI emit `hypequery client:manifest` → `hypequery.manifest.json` for pure SPAs.
+3. React: add `manifest?: RouteManifest` to `CreateHooksConfig`. Resolution order in `fetchQuery`:
+   `explicitConfig[name]` → `manifest[name]` → `deriveMethodConfig(api)` → defaults.
+   Fix the `deriveMethodConfig` runtime-`api` branch to read `endpoint.metadata.path` / `endpoint.method`.
+4. Throw a clear error when a `dataset:`-prefixed key resolves to no manifest/config entry instead of
+   silently GETting `baseUrl/dataset:orders`.
+
+Files: `serve/src/server/api-builder.ts`, `create-api.ts`, `serve/src/types.ts`,
+`react/src/createHooks.tsx`, `packages/cli`. Tests: manifest snapshot; React resolves POST/path with no `config`.
+
+## Phase 2 — Per-dataset Zod schemas with field enums [foundation]
+
+Build the input schema per dataset/metric from the contract.
+
+1. In `createDatasetEndpoint`, replace the shared `datasetQueryInputSchema` with a factory using
+   `Object.keys(ds.dimensions)` / `Object.keys(ds.measures)` → `z.enum([...])` (fallback `z.string()`
+   when empty). `filters[].field` / `orderBy[].field` = union of dim+measure enums. `by` only when a
+   `timeKey` exists. Same for `createMetricEndpoint` from `contract.dimensions` / `contract.grains`.
+2. Add `.max()` guards on `dimensions` / `measures` / `filters` arrays (payload-guard gap).
+3. Keep `data` row output as `z.record(z.unknown())` (row typing is TS-level in Phase 3); add Phase 4
+   meta fields to the output schema so OpenAPI documents them.
+4. Watch-outs: empty-tuple `z.enum`; relationship-qualified field names (e.g. `orders.country`) must be
+   in the enum list — mirror exactly what `validateDatasetQuery` accepts.
+
+Files: `serve/src/semantic/datasets/dataset-endpoint.ts`, `metric-endpoint.ts`.
+
+## Phase 3 — Field-level types in React hooks
+
+Thread the dataset/metric generics through the endpoint map so `useDataset` / `useMetric` get
+field-level autocomplete and typed rows.
+
+1. Parameterize `SemanticDatasetEndpointMap` / `SemanticMetricEndpointMap` (`serve/src/types.ts`) with the
+   concrete instance type per key. `DatasetQueryFor<DS>` narrows `dimensions` / `measures` to
+   `DatasetFieldNames<DS>[]` / new `DatasetMeasureNames<DS>[]`; `DatasetRow<DS>` builds the row type.
+2. `InferApiType` / `InferAPIType` already map `SchemaInput` / `SchemaOutput`, so hooks inherit types for free.
+3. Source types from `DatasetInstance` (value types), type-level only — decoupled from Zod inference.
+
+Files: `serve/src/types.ts`, `datasets/src/types.ts`. Tests: `react/type-tests/create-hooks.test-d.ts`.
+
+## Phase 4 — Production-grade pagination
+
+1. Extend meta (`datasets/src/types.ts`): `pagination?: { limit; offset; hasMore; total? }`. Populate by
+   fetching `limit + 1` rows and trimming (reliable `hasMore`, no extra count query). Mirror in output schemas.
+2. Optional `includeTotal` via clickhouse `withTotals()` (`query-builder.ts:902`), off by default.
+3. React `useInfiniteDataset` / `useInfiniteQuery` deriving `getNextPageParam` from `meta.pagination.hasMore`.
+4. Cursor/keyset pagination = separate follow-up (needs clickhouse builder support).
+
+Files: `datasets/src/types.ts`, `datasets/src/executor.ts`, endpoint files, `react/src/createHooks.tsx`,
+`analyticsHooks.tsx`.
+
+## Phase 5 — Auth hardening
+
+1. `createJwksStrategy` in `serve/src/auth.ts` (`jose`-backed, JWKS cache, RS256/ES256), tree-shakeable.
+2. React: allow async `headers` (Promise) + `onUnauthorized`/`getToken` for refresh-and-retry-once.
+3. Document a Redis `RateLimitStore`; note in-memory default is single-instance.
+
+Files: `serve/src/auth.ts`, `react/src/createHooks.tsx`, docs/examples.
+
+## Phase 6 — Caching & observability
+
+1. Emit `Cache-Control` when `cacheTtlMs` is set; document POST = no CDN cache.
+2. Add `includeMeta?: boolean` to input schema (keep `x-include-meta` header for back-compat); surface
+   meta through React result.
+3. Add `requestId` / `rowCount` to meta; correlate with `query-logger.ts` events.
+
+Files: endpoint files, `serve/src/pipeline.ts`, `query-logger.ts`, React result plumbing.
+
+---
+
+## PR sequencing
+
+| PR | Phase | Why |
+|----|-------|-----|
+| 1 | Phase 1 manifest | Unblocks correct client wiring; fixes most likely production breakage |
+| 2 | Phase 2 schemas | Single source of truth for docs + validation; prerequisite for codegen |
+| 3 | Phase 3 types | Builds on Phase 2 source; pure type work |
+| 4 | Phase 4 pagination | Independent; high product value |
+| 5 | Phase 5 auth | Independent; needed for SaaS GA |
+| 6 | Phase 6 caching/obs | Polish |
+
+## Cross-cutting risks
+
+- `create-api.ts` / `metric-endpoint.ts` just moved to the `DatasetClient` abstraction
+  (`createDatasetClient` / `analytics.execute`). Phases 2 & 4 touch these — land after refactor settles.
+- `z.enum` empty-tuple and relationship-qualified field names are the Phase 2 correctness traps.
+- Type-instantiation depth in Phase 3 over many datasets can stress `tsc` — keep helper types shallow.


### PR DESCRIPTION
## Summary

Serve metric/dataset endpoints are POST routes whose paths (`/metrics/<name>`, `/datasets/<name>/query`) differ from their `api.queries` keys (`<name>`, `dataset:<name>`). React's `createHooks` couldn't derive these from a type-only `InferAPIType`, so semantic hooks silently defaulted to `GET {baseUrl}/{key}` and hit the wrong URL.

This PR adds a serializable **route manifest** to bridge the two packages.

## Changes

- **serve** — `api.manifest()` (and `ServeBuilder.manifest()` for `defineServe`) returns a serializable `{ method, path }` map keyed exactly like `api.queries` (including `dataset:<name>`), with the full base-path-applied path. Built from `queryEntries`, so internal `/openapi.json` and `/docs` are excluded.
- **react** — `createHooks`/`createAnalyticsHooks` accept a `manifest` option (precedence: explicit `config` > `manifest` > runtime `api`). `deriveMethodConfig` now prefers `api.manifest()` when a runtime api object is passed. Calling a semantic (`dataset:`) key with no resolved route now throws a clear error instead of requesting `{baseUrl}/dataset:<name>`.
- **docs** — README "Route Configuration" rewritten to recommend the manifest; the analytics example no longer uses a fake `api: {} as AnalyticsApi` that would have thrown at runtime.
- **changeset** — minor bump for `@hypequery/serve` and `@hypequery/react`.
- **plan** — adds `plans/datasets-serve-react-production-plan.md` (full gap analysis + phased roadmap; this is PR 1 / Phase 1).

## Testing

- `@hypequery/serve` types ✅, `@hypequery/react` types ✅
- serve tests: **394 passed** (3 new `manifest()` tests)
- react tests: **45 passed** (4 new manifest tests, incl. the unresolved-key guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)