### PR TITLE
feat(datasets,serve): typed dataset fields in generated API type

### DIFF
--- a/.changeset/typed-dataset-hooks.md
+++ b/.changeset/typed-dataset-hooks.md
@@ -1,0 +1,22 @@
+---
+"@hypequery/datasets": minor
+"@hypequery/serve": minor
+---
+
+Thread dataset field types through the generated API type for typed React hooks.
+
+`@hypequery/datasets` now exports typed query/result helpers
+(`DatasetQueryFor`, `DatasetRow`, `DatasetQueryResultFor`, and the
+`DatasetDimensionNames`/`DatasetMeasureNames`/`DatasetOrderableNames` name
+helpers, plus the metric equivalents).
+
+`@hypequery/serve`'s `SemanticDatasetEndpointMap` now specializes each dataset
+endpoint to its concrete instance, so `InferAPIType` carries field-level types.
+With `@hypequery/react`, `useDataset(name, input)` gets autocomplete and
+type-checking for `dimensions`/`measures`/`orderBy`, and result rows are typed
+by the dataset's dimensions and measures.
+
+Metric endpoints remain on the loose `MetricQuery`/`MetricResult` types for now:
+`MetricRef` does not preserve its dataset's concrete dimension keys, so
+field-level metric typing requires threading the dataset generics through
+`MetricRef` — tracked as a follow-up.

--- a/packages/datasets/src/index.ts
+++ b/packages/datasets/src/index.ts
@@ -102,4 +102,13 @@ export type {
   DerivedMetricConfig,
   DatasetRegistryInstance,
   DatasetFieldNames,
+  DatasetDimensionNames,
+  DatasetMeasureNames,
+  DatasetOrderableNames,
+  DatasetQueryFor,
+  DatasetRow,
+  DatasetQueryResultFor,
+  MetricQueryFor,
+  MetricRow,
+  MetricResultFor,
 } from './types.js';

--- a/packages/datasets/src/types.ts
+++ b/packages/datasets/src/types.ts
@@ -297,5 +297,84 @@ export type AnyDatasetInstance = DatasetInstance<
   string
 >;
 
-export type DatasetFieldNames<TDataset extends DatasetInstance> =
+export type DatasetFieldNames<TDataset extends DatasetInstance<any, any, any, any>> =
   keyof TDataset['dimensions'] & string;
+
+// ---------------------------------------------------------------------------
+// Typed query / result helpers for client codegen and React hooks
+//
+// These constrain a query's dimension/measure/orderBy fields to the names a
+// dataset or metric actually declares, and describe a best-effort typed result
+// row. Filter fields stay `string` because a dataset's `filters` map is widened
+// to `SemanticFiltersDefinition` and does not preserve literal keys.
+// ---------------------------------------------------------------------------
+
+/** Dimension names declared by a dataset. */
+export type DatasetDimensionNames<TDataset extends DatasetInstance<any, any, any, any>> =
+  keyof TDataset['dimensions'] & string;
+
+/** Measure names declared by a dataset. */
+export type DatasetMeasureNames<TDataset extends DatasetInstance<any, any, any, any>> =
+  keyof TDataset['measures'] & string;
+
+/**
+ * Fields a result can be ordered by. This is the selection-independent superset
+ * (every dimension + measure, plus the synthetic `period` column for grained
+ * queries); the runtime validator additionally requires the field to be selected.
+ */
+export type DatasetOrderableNames<TDataset extends DatasetInstance<any, any, any, any>> =
+  | DatasetDimensionNames<TDataset>
+  | DatasetMeasureNames<TDataset>
+  | 'period';
+
+/** A dataset query whose fields are constrained to the dataset's contract. */
+export interface DatasetQueryFor<TDataset extends DatasetInstance<any, any, any, any>> {
+  dimensions?: DatasetDimensionNames<TDataset>[];
+  measures?: DatasetMeasureNames<TDataset>[];
+  filters?: MetricFilter[];
+  orderBy?: MetricOrderBy<DatasetOrderableNames<TDataset>>[];
+  limit?: number;
+  offset?: number;
+  by?: TimeGrain;
+}
+
+/** A best-effort typed result row for a dataset query. */
+export type DatasetRow<TDataset extends DatasetInstance<any, any, any, any>> =
+  & { [K in DatasetDimensionNames<TDataset>]?: InferDimensionType<TDataset['dimensions'][K]> }
+  & { [K in DatasetMeasureNames<TDataset>]?: number }
+  & { period?: string };
+
+export interface DatasetQueryResultFor<TDataset extends DatasetInstance<any, any, any, any>> {
+  data: DatasetRow<TDataset>[];
+  meta?: MetricResultMeta;
+}
+
+/** A metric query whose fields are constrained to the metric's dataset + value column. */
+export interface MetricQueryFor<
+  TDataset extends DatasetInstance<any, any, any, any>,
+  TMetricName extends string,
+> {
+  dimensions?: DatasetDimensionNames<TDataset>[];
+  filters?: MetricFilter[];
+  orderBy?: MetricOrderBy<DatasetDimensionNames<TDataset> | TMetricName | 'period'>[];
+  limit?: number;
+  offset?: number;
+  by?: TimeGrain;
+}
+
+/** A best-effort typed result row for a metric query (dimensions + the metric value). */
+export type MetricRow<
+  TDataset extends DatasetInstance<any, any, any, any>,
+  TMetricName extends string,
+> =
+  & { [K in DatasetDimensionNames<TDataset>]?: InferDimensionType<TDataset['dimensions'][K]> }
+  & { [K in TMetricName]?: number }
+  & { period?: string };
+
+export interface MetricResultFor<
+  TDataset extends DatasetInstance<any, any, any, any>,
+  TMetricName extends string,
+> {
+  data: MetricRow<TDataset, TMetricName>[];
+  meta?: MetricResultMeta;
+}

--- a/packages/datasets/src/types.ts
+++ b/packages/datasets/src/types.ts
@@ -300,6 +300,10 @@ export type AnyDatasetInstance = DatasetInstance<
 export type DatasetFieldNames<TDataset extends DatasetInstance<any, any, any, any>> =
   keyof TDataset['dimensions'] & string;
 
+type NonNeverStringKeys<T extends Record<string, unknown>> = {
+  [K in keyof T]: [T[K]] extends [never] ? never : K;
+}[keyof T] & string;
+
 // ---------------------------------------------------------------------------
 // Typed query / result helpers for client codegen and React hooks
 //
@@ -311,11 +315,11 @@ export type DatasetFieldNames<TDataset extends DatasetInstance<any, any, any, an
 
 /** Dimension names declared by a dataset. */
 export type DatasetDimensionNames<TDataset extends DatasetInstance<any, any, any, any>> =
-  keyof TDataset['dimensions'] & string;
+  NonNeverStringKeys<TDataset['dimensions']>;
 
 /** Measure names declared by a dataset. */
 export type DatasetMeasureNames<TDataset extends DatasetInstance<any, any, any, any>> =
-  keyof TDataset['measures'] & string;
+  NonNeverStringKeys<TDataset['measures']>;
 
 /**
  * Fields a result can be ordered by. This is the selection-independent superset

--- a/packages/serve/src/types.ts
+++ b/packages/serve/src/types.ts
@@ -552,8 +552,8 @@ export type MetricsConfig<TAuth extends AuthContext = AuthContext> =
 
 import type {
   DatasetInstance,
-  DatasetQuery,
-  DatasetQueryResult,
+  DatasetQueryFor,
+  DatasetQueryResultFor,
   MetricHandle,
   MetricQuery,
   MetricResult,
@@ -565,6 +565,26 @@ export type { DatasetEntry } from "./semantic/datasets/dataset-endpoint.js";
 export type DatasetsConfig<TAuth extends AuthContext = AuthContext> =
   Record<string, DatasetEntry<TAuth>>;
 
+// ---------------------------------------------------------------------------
+// Extract the concrete dataset instance from a config entry so the generated
+// endpoint map carries field-level types. When an entry has been widened (e.g.
+// annotated as `AnyDatasetInstance`), this resolves to the wide instance and
+// the map degrades gracefully to loose `string` fields.
+// ---------------------------------------------------------------------------
+
+/** The dataset instance behind a `DatasetEntry` (bare instance or `{ dataset }`). */
+type DatasetInstanceOfEntry<TEntry> =
+  TEntry extends { __type: 'dataset' }
+    ? TEntry
+    : TEntry extends { dataset: infer TDataset }
+      ? (TDataset extends DatasetInstance<any, any, any, any> ? TDataset : never)
+      : never;
+
+// NOTE: Metric endpoints stay on the loose `MetricQuery`/`MetricResult` types.
+// `MetricRef.dataset` is typed with the wide `Record<string, DimensionDefinition>`,
+// so a metric ref does not preserve its dataset's concrete dimension keys.
+// Field-level metric typing requires threading the dataset generics through
+// `MetricRef` in @hypequery/datasets — tracked as a follow-up.
 export type SemanticMetricEndpointMap<
   TMetrics extends MetricsConfig<TAuth>,
   TContext extends Record<string, unknown>,
@@ -585,11 +605,11 @@ export type SemanticDatasetEndpointMap<
   TAuth extends AuthContext,
 > = {
   [TKey in keyof TDatasets & string as `dataset:${TKey}`]: ServeEndpoint<
-    ZodType<DatasetQuery>,
-    ZodType<DatasetQueryResult>,
+    ZodType<DatasetQueryFor<DatasetInstanceOfEntry<TDatasets[TKey]>>>,
+    ZodType<DatasetQueryResultFor<DatasetInstanceOfEntry<TDatasets[TKey]>>>,
     TContext,
     TAuth,
-    DatasetQueryResult
+    DatasetQueryResultFor<DatasetInstanceOfEntry<TDatasets[TKey]>>
   >;
 };
 

--- a/packages/serve/tsconfig.type-tests.json
+++ b/packages/serve/tsconfig.type-tests.json
@@ -2,12 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "./.type-tests",
     "composite": false
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "type-tests/**/*.ts"
   ],
   "exclude": [
     "src/**/*.test.ts",

--- a/packages/serve/type-tests/semantic-hooks.test-d.ts
+++ b/packages/serve/type-tests/semantic-hooks.test-d.ts
@@ -25,8 +25,15 @@ const Orders = dataset('orders', {
 
 const totalRevenue = Orders.metric('totalRevenue', { measure: 'revenue' });
 
+const Countries = dataset('countries', {
+  source: 'countries',
+  dimensions: {
+    country: dimension.string(),
+  },
+});
+
 const api = createAPI({
-  datasets: { orders: Orders },
+  datasets: { orders: Orders, countries: Countries },
   metrics: { totalRevenue },
   // The query builder is irrelevant to the type-level assertions below.
   queryBuilder: {} as never,
@@ -63,6 +70,35 @@ void rowRevenue;
 
 // @ts-expect-error - field is not part of the dataset
 void datasetRow.nonexistent;
+
+// --- Datasets without measures do not widen measure fields to string ---------
+type CountriesInput = Api['dataset:countries']['input'];
+
+const okDimensionOnlyInput: CountriesInput = {
+  dimensions: ['country'],
+  orderBy: [{ field: 'country', direction: 'asc' }],
+};
+void okDimensionOnlyInput;
+
+// @ts-expect-error - dimension-only datasets do not accept arbitrary measures
+const badDimensionOnlyMeasure: CountriesInput = { measures: ['revenue'] };
+void badDimensionOnlyMeasure;
+
+const badDimensionOnlyOrderBy: CountriesInput = {
+  orderBy: [
+    // @ts-expect-error - orderBy cannot reference arbitrary measure fields
+    { field: 'revenue', direction: 'desc' },
+  ],
+};
+void badDimensionOnlyOrderBy;
+
+type CountriesRow = Api['dataset:countries']['output']['data'][number];
+const countriesRow: CountriesRow = {};
+const countryName: string | undefined = countriesRow.country;
+void countryName;
+
+// @ts-expect-error - no broad measure index should be present
+void countriesRow.revenue;
 
 // --- Metric input: intentionally loose (see SemanticMetricEndpointMap note) ---
 // `MetricRef` does not preserve its dataset's concrete dimension keys, so metric

--- a/packages/serve/type-tests/semantic-hooks.test-d.ts
+++ b/packages/serve/type-tests/semantic-hooks.test-d.ts
@@ -1,0 +1,84 @@
+/**
+ * Compile-time checks that `InferAPIType` carries field-level types through the
+ * semantic endpoint map: dataset/metric inputs constrain dimension/measure/
+ * orderBy fields, and result rows are typed. Compiled by `tsc` via
+ * `tsconfig.type-tests.json`; `@ts-expect-error` lines must remain errors.
+ */
+
+import { createAPI } from '../src/server/create-api.js';
+import type { InferAPIType } from '../src/types.js';
+import { dataset, dimension, measure } from '@hypequery/datasets';
+
+const Orders = dataset('orders', {
+  source: 'orders',
+  timeKey: 'created_at',
+  dimensions: {
+    country: dimension.string(),
+    status: dimension.string(),
+    amount: dimension.number(),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+    orderCount: measure.count('country'),
+  },
+});
+
+const totalRevenue = Orders.metric('totalRevenue', { measure: 'revenue' });
+
+const api = createAPI({
+  datasets: { orders: Orders },
+  metrics: { totalRevenue },
+  // The query builder is irrelevant to the type-level assertions below.
+  queryBuilder: {} as never,
+});
+
+type Api = InferAPIType<typeof api>;
+
+// --- Dataset input: dimensions/measures narrowed to the dataset's fields -----
+type OrdersInput = Api['dataset:orders']['input'];
+
+const okDatasetInput: OrdersInput = {
+  dimensions: ['country', 'status', 'amount'],
+  measures: ['revenue', 'orderCount'],
+  orderBy: [{ field: 'revenue', direction: 'desc' }],
+  by: 'month',
+};
+void okDatasetInput;
+
+// @ts-expect-error - unknown dimension name
+const badDatasetDim: OrdersInput = { dimensions: ['nope'] };
+void badDatasetDim;
+
+// @ts-expect-error - unknown measure name
+const badDatasetMeasure: OrdersInput = { measures: ['nope'] };
+void badDatasetMeasure;
+
+// --- Dataset output rows are typed by dimension/measure -----------------------
+type OrdersRow = Api['dataset:orders']['output']['data'][number];
+const datasetRow: OrdersRow = {};
+const rowCountry: string | undefined = datasetRow.country;
+const rowRevenue: number | undefined = datasetRow.revenue;
+void rowCountry;
+void rowRevenue;
+
+// @ts-expect-error - field is not part of the dataset
+void datasetRow.nonexistent;
+
+// --- Metric input: intentionally loose (see SemanticMetricEndpointMap note) ---
+// `MetricRef` does not preserve its dataset's concrete dimension keys, so metric
+// fields stay string-typed until the dataset generics are threaded through
+// `MetricRef`. These assertions document the current contract.
+type MetricInput = Api['totalRevenue']['input'];
+
+const okMetricInput: MetricInput = {
+  dimensions: ['country'],
+  orderBy: [{ field: 'totalRevenue', direction: 'desc' }],
+  by: 'month',
+};
+void okMetricInput;
+
+type MetricRowT = Api['totalRevenue']['output']['data'][number];
+const metricRow: MetricRowT = {};
+void metricRow.totalRevenue;
+
+export {};


### PR DESCRIPTION
## Summary

Dataset semantic endpoints were typed with the generic `DatasetQuery` / `DatasetQueryResult`, so `InferAPIType` → `@hypequery/react` hooks accepted any `string[]` for `dimensions`/`measures` and returned `Record<string, unknown>` rows. This PR threads each dataset's concrete dimension/measure keys through the generated API type.

This is **PR 3 / Phase 3** of the datasets→serve→react production plan (plan doc in #205).

## Changes

- **datasets** — new exported typed helpers: `DatasetQueryFor`, `DatasetRow`, `DatasetQueryResultFor` (plus `DatasetDimensionNames`/`DatasetMeasureNames`/`DatasetOrderableNames`), and the metric equivalents (`MetricQueryFor`/`MetricRow`/`MetricResultFor`) for the follow-up.
- **serve** — `SemanticDatasetEndpointMap` extracts the concrete dataset instance from each entry (`DatasetInstanceOfEntry`) and specializes the endpoint's input/output. With `@hypequery/react`, `useDataset(name, input)` now gets autocomplete + type-checking for `dimensions`/`measures`/`orderBy`, and result rows are typed by the dataset's dimensions and measures. Degrades gracefully to `string` fields when an entry is widened (e.g. annotated as `AnyDatasetInstance`).
- **serve** — adds a compile-time type-test (`tsconfig.type-tests.json` now includes `type-tests/`) asserting the narrowing flows through `InferAPIType`, including `@ts-expect-error` negative cases.

## Scope note: metrics stay loose (for now)

Metric endpoints remain on `MetricQuery`/`MetricResult`. `MetricRef.dataset` is typed with the **wide** `Record<string, DimensionDefinition>`, so a metric ref doesn't preserve its dataset's concrete dimension keys — specializing it would produce a degenerate (`never`-valued) row rather than a useful one. Field-level metric typing requires threading the dataset generics through `MetricRef` in `@hypequery/datasets`, which I've carved out as a focused follow-up rather than expanding this PR into the datasets core.

## Testing

- types: `@hypequery/datasets` ✅, `@hypequery/serve` ✅ (incl. new `test:types`)
- datasets 82 ✅, serve 391 ✅, react 41 ✅

## Notes

- Independent of #205 and #206 (touches the type-level endpoint map + datasets type helpers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)