### PR TITLE
feat(datasets,serve): typed metric fields via MetricRef dataset generic

### DIFF
--- a/.changeset/typed-metric-hooks.md
+++ b/.changeset/typed-metric-hooks.md
@@ -1,0 +1,18 @@
+---
+"@hypequery/datasets": minor
+"@hypequery/serve": minor
+---
+
+Carry a metric's dataset type through `MetricRef` for field-level metric hooks.
+
+`MetricRef` / `GrainedMetricRef` / `MetricHandle` (and `BaseMetricRef` /
+`DerivedMetricRef`) gain an optional `TDataset` type parameter that defaults to
+the previous wide instance, so existing usages are unchanged. `DatasetInstance.metric()`
+now returns a ref carrying its dataset's concrete dimension/measure types.
+
+`@hypequery/serve`'s `SemanticMetricEndpointMap` uses this to specialize each
+metric endpoint, so via `@hypequery/react` `useMetric(name, input)` gets
+autocomplete and type-checking for `dimensions`/`orderBy`, and result rows are
+typed by the dataset's dimensions plus the metric's value column. This completes
+the typed-hooks work started for datasets; metric endpoints degrade gracefully to
+loose `string` fields when a ref has been widened.

--- a/packages/datasets/src/api.type-test.ts
+++ b/packages/datasets/src/api.type-test.ts
@@ -113,10 +113,10 @@ type _BaseMetricDatasetNameLiteral = Assert<
   Equal<typeof revenueMetric['datasetName'], 'orders'>
 >;
 type _BaseMetricRefKind = Assert<
-  Equal<typeof revenueMetric, BaseMetricRef<'orders', 'revenueMetric'>>
+  Equal<typeof revenueMetric, BaseMetricRef<'orders', 'revenueMetric', typeof Orders>>
 >;
 type _DerivedMetricRefKind = Assert<
-  Equal<typeof averageRevenueMetric, DerivedMetricRef<'orders', 'averageRevenueMetric'>>
+  Equal<typeof averageRevenueMetric, DerivedMetricRef<'orders', 'averageRevenueMetric', typeof Orders>>
 >;
 type _DerivedUsesRequireBaseMetricsFromSameDataset = Assert<
   Equal<DerivedMetricConfig<'orders'>['uses'], Record<string, BaseMetricRef<'orders'>>>

--- a/packages/datasets/src/dataset.ts
+++ b/packages/datasets/src/dataset.ts
@@ -71,18 +71,19 @@ export function dataset<
   const filters = normalizeFilters(dimensions, config.filters);
   const relationships = normalizeRelationships(config.relationships);
 
+  type ThisDataset = DatasetInstance<TDimensions, TMeasures, TRelationships, TDatasetName>;
   function metric<TName extends string>(
     metricName: TName,
     metricConfig: BaseMetricConfig<TMeasures>,
-  ): BaseMetricRef<TDatasetName, TName>;
+  ): BaseMetricRef<TDatasetName, TName, ThisDataset>;
   function metric<TName extends string>(
     metricName: TName,
     metricConfig: DerivedMetricConfig<TDatasetName>,
-  ): DerivedMetricRef<TDatasetName, TName>;
+  ): DerivedMetricRef<TDatasetName, TName, ThisDataset>;
   function metric<TName extends string>(
     metricName: TName,
     metricConfig: BaseMetricConfig<TMeasures> | DerivedMetricConfig<TDatasetName>,
-  ): BaseMetricRef<TDatasetName, TName> | DerivedMetricRef<TDatasetName, TName> {
+  ): BaseMetricRef<TDatasetName, TName, ThisDataset> | DerivedMetricRef<TDatasetName, TName, ThisDataset> {
     if (isDerivedMetricConfig(metricConfig)) {
       validateDerivedMetric(ds, metricName, metricConfig);
       const derivedSpec = createDerivedMetricSpec(metricConfig);

--- a/packages/datasets/src/types.ts
+++ b/packages/datasets/src/types.ts
@@ -80,10 +80,24 @@ export interface DerivedMetricSpec<TDatasetName extends string = string> {
   formula: (inputs: Record<string, string>) => FormulaExpr;
 }
 
+/**
+ * The wide dataset instance used as the default `TDataset` for a metric ref.
+ * Refs created via `DatasetInstance.metric()` carry their dataset's concrete
+ * dimension/measure types instead, enabling field-level typing downstream.
+ */
+export type DefaultMetricDataset<TDatasetName extends string = string> =
+  DatasetInstance<
+    Record<string, DimensionDefinition>,
+    Record<string, MeasureDefinition>,
+    Record<string, RelationshipDefinition>,
+    TDatasetName
+  >;
+
 export interface MetricRef<
   TDatasetName extends string = string,
   TMetricName extends string = string,
   TSpec extends AggregationSpec | DerivedMetricSpec<TDatasetName> = AggregationSpec | DerivedMetricSpec<TDatasetName>,
+  TDataset extends DatasetInstance<any, any, any, TDatasetName> = DefaultMetricDataset<TDatasetName>,
 > {
   __type: 'metric_ref';
   datasetName: TDatasetName;
@@ -91,33 +105,31 @@ export interface MetricRef<
   spec: TSpec;
   label?: string;
   description?: string;
-  dataset: DatasetInstance<
-    Record<string, DimensionDefinition>,
-    Record<string, MeasureDefinition>,
-    Record<string, RelationshipDefinition>,
-    TDatasetName
-  >;
-  by(grain: TimeGrain): GrainedMetricRef<TDatasetName, TMetricName, TSpec>;
+  dataset: TDataset;
+  by(grain: TimeGrain): GrainedMetricRef<TDatasetName, TMetricName, TSpec, TDataset>;
   contract(): MetricContract;
 }
 
 export type BaseMetricRef<
   TDatasetName extends string = string,
   TMetricName extends string = string,
-> = MetricRef<TDatasetName, TMetricName, AggregationSpec>;
+  TDataset extends DatasetInstance<any, any, any, TDatasetName> = DefaultMetricDataset<TDatasetName>,
+> = MetricRef<TDatasetName, TMetricName, AggregationSpec, TDataset>;
 
 export type DerivedMetricRef<
   TDatasetName extends string = string,
   TMetricName extends string = string,
-> = MetricRef<TDatasetName, TMetricName, DerivedMetricSpec<TDatasetName>>;
+  TDataset extends DatasetInstance<any, any, any, TDatasetName> = DefaultMetricDataset<TDatasetName>,
+> = MetricRef<TDatasetName, TMetricName, DerivedMetricSpec<TDatasetName>, TDataset>;
 
 export interface GrainedMetricRef<
   TDatasetName extends string = string,
   TMetricName extends string = string,
   TSpec extends AggregationSpec | DerivedMetricSpec<TDatasetName> = AggregationSpec | DerivedMetricSpec<TDatasetName>,
+  TDataset extends DatasetInstance<any, any, any, TDatasetName> = DefaultMetricDataset<TDatasetName>,
 > {
   __type: 'grained_metric_ref';
-  metric: MetricRef<TDatasetName, TMetricName, TSpec>;
+  metric: MetricRef<TDatasetName, TMetricName, TSpec, TDataset>;
   grain: TimeGrain;
   contract(): MetricContract;
 }
@@ -126,7 +138,8 @@ export type MetricHandle<
   TDatasetName extends string = string,
   TMetricName extends string = string,
   TSpec extends AggregationSpec | DerivedMetricSpec<TDatasetName> = AggregationSpec | DerivedMetricSpec<TDatasetName>,
-> = MetricRef<TDatasetName, TMetricName, TSpec> | GrainedMetricRef<TDatasetName, TMetricName, TSpec>;
+  TDataset extends DatasetInstance<any, any, any, TDatasetName> = DefaultMetricDataset<TDatasetName>,
+> = MetricRef<TDatasetName, TMetricName, TSpec, TDataset> | GrainedMetricRef<TDatasetName, TMetricName, TSpec, TDataset>;
 
 export type TimeGrain = 'day' | 'week' | 'month' | 'quarter' | 'year';
 
@@ -276,11 +289,11 @@ export interface DatasetInstance<
   metric<TName extends string>(
     metricName: TName,
     metricConfig: BaseMetricConfig<TMeasures>,
-  ): BaseMetricRef<TDatasetName, TName>;
+  ): BaseMetricRef<TDatasetName, TName, DatasetInstance<TDimensions, TMeasures, TRelationships, TDatasetName>>;
   metric<TName extends string>(
     metricName: TName,
     metricConfig: DerivedMetricConfig<TDatasetName>,
-  ): DerivedMetricRef<TDatasetName, TName>;
+  ): DerivedMetricRef<TDatasetName, TName, DatasetInstance<TDimensions, TMeasures, TRelationships, TDatasetName>>;
 }
 
 export interface DatasetRegistryInstance {

--- a/packages/datasets/src/utils/dataset-metric-ref.ts
+++ b/packages/datasets/src/utils/dataset-metric-ref.ts
@@ -32,14 +32,15 @@ export function createMetricRef<
   TDatasetName extends string,
   TMetricName extends string,
   TSpec extends AggregationSpec | DerivedMetricSpec<TDatasetName>,
+  TDataset extends DatasetInstance<AnyDimensions, AnyMeasures, AnyRelationships, TDatasetName>,
 >(
-  ds: DatasetInstance<AnyDimensions, AnyMeasures, AnyRelationships, TDatasetName>,
+  ds: TDataset,
   name: TMetricName,
   spec: TSpec,
   label?: string,
   description?: string,
-): MetricRef<TDatasetName, TMetricName, TSpec> {
-  const ref: MetricRef<TDatasetName, TMetricName, TSpec> = {
+): MetricRef<TDatasetName, TMetricName, TSpec, TDataset> {
+  const ref: MetricRef<TDatasetName, TMetricName, TSpec, TDataset> = {
     __type: 'metric_ref',
     datasetName: ds.name,
     name,
@@ -48,7 +49,7 @@ export function createMetricRef<
     description,
     dataset: ds,
 
-    by(grain: TimeGrain): GrainedMetricRef<TDatasetName, TMetricName, TSpec> {
+    by(grain: TimeGrain): GrainedMetricRef<TDatasetName, TMetricName, TSpec, TDataset> {
       if (!ds.timeKey) {
         throw new Error(
           `Cannot apply .by("${grain}") to metric "${name}" — dataset "${ds.name}" has no timeKey defined.`,

--- a/packages/serve/src/types.ts
+++ b/packages/serve/src/types.ts
@@ -555,8 +555,8 @@ import type {
   DatasetQueryFor,
   DatasetQueryResultFor,
   MetricHandle,
-  MetricQuery,
-  MetricResult,
+  MetricQueryFor,
+  MetricResultFor,
 } from "@hypequery/datasets";
 import type { DatasetEntry } from "./semantic/datasets/dataset-endpoint.js";
 export type { DatasetEntry } from "./semantic/datasets/dataset-endpoint.js";
@@ -566,10 +566,11 @@ export type DatasetsConfig<TAuth extends AuthContext = AuthContext> =
   Record<string, DatasetEntry<TAuth>>;
 
 // ---------------------------------------------------------------------------
-// Extract the concrete dataset instance from a config entry so the generated
-// endpoint map carries field-level types. When an entry has been widened (e.g.
-// annotated as `AnyDatasetInstance`), this resolves to the wide instance and
-// the map degrades gracefully to loose `string` fields.
+// Extract the concrete dataset instance / metric name from a config entry so
+// the generated endpoint map carries field-level types. When an entry has been
+// widened (e.g. annotated as `AnyDatasetInstance` / `MetricHandle<any, any>`),
+// these resolve to the wide instance and the maps degrade gracefully to loose
+// `string` fields.
 // ---------------------------------------------------------------------------
 
 /** The dataset instance behind a `DatasetEntry` (bare instance or `{ dataset }`). */
@@ -580,22 +581,43 @@ type DatasetInstanceOfEntry<TEntry> =
       ? (TDataset extends DatasetInstance<any, any, any, any> ? TDataset : never)
       : never;
 
-// NOTE: Metric endpoints stay on the loose `MetricQuery`/`MetricResult` types.
-// `MetricRef.dataset` is typed with the wide `Record<string, DimensionDefinition>`,
-// so a metric ref does not preserve its dataset's concrete dimension keys.
-// Field-level metric typing requires threading the dataset generics through
-// `MetricRef` in @hypequery/datasets — tracked as a follow-up.
+/** The `MetricHandle` behind a `MetricEntry` (bare handle or `{ metric }`). */
+type MetricHandleOfEntry<TEntry> =
+  TEntry extends { __type: 'metric_ref' | 'grained_metric_ref' }
+    ? TEntry
+    : TEntry extends { metric: infer THandle }
+      ? THandle
+      : never;
+
+/** Unwrap a grained metric ref to its underlying base ref. */
+type BaseMetricRefOf<THandle> =
+  THandle extends { __type: 'grained_metric_ref'; metric: infer TRef }
+    ? TRef
+    : THandle;
+
+/** The concrete dataset instance a metric is defined on. */
+type MetricDatasetOfEntry<TEntry> =
+  BaseMetricRefOf<MetricHandleOfEntry<TEntry>> extends { dataset: infer TDataset }
+    ? (TDataset extends DatasetInstance<any, any, any, any> ? TDataset : never)
+    : never;
+
+/** The metric's output column name (used for typed rows and orderBy). */
+type MetricNameOfEntry<TEntry> =
+  BaseMetricRefOf<MetricHandleOfEntry<TEntry>> extends { name: infer TName }
+    ? (TName extends string ? TName : string)
+    : string;
+
 export type SemanticMetricEndpointMap<
   TMetrics extends MetricsConfig<TAuth>,
   TContext extends Record<string, unknown>,
   TAuth extends AuthContext,
 > = {
   [TKey in keyof TMetrics & string]: ServeEndpoint<
-    ZodType<MetricQuery>,
-    ZodType<MetricResult>,
+    ZodType<MetricQueryFor<MetricDatasetOfEntry<TMetrics[TKey]>, MetricNameOfEntry<TMetrics[TKey]>>>,
+    ZodType<MetricResultFor<MetricDatasetOfEntry<TMetrics[TKey]>, MetricNameOfEntry<TMetrics[TKey]>>>,
     TContext,
     TAuth,
-    MetricResult
+    MetricResultFor<MetricDatasetOfEntry<TMetrics[TKey]>, MetricNameOfEntry<TMetrics[TKey]>>
   >;
 };
 

--- a/packages/serve/type-tests/semantic-hooks.test-d.ts
+++ b/packages/serve/type-tests/semantic-hooks.test-d.ts
@@ -100,21 +100,26 @@ void countryName;
 // @ts-expect-error - no broad measure index should be present
 void countriesRow.revenue;
 
-// --- Metric input: intentionally loose (see SemanticMetricEndpointMap note) ---
-// `MetricRef` does not preserve its dataset's concrete dimension keys, so metric
-// fields stay string-typed until the dataset generics are threaded through
-// `MetricRef`. These assertions document the current contract.
+// --- Metric input: dimensions narrowed; orderBy accepts the metric column -----
 type MetricInput = Api['totalRevenue']['input'];
 
 const okMetricInput: MetricInput = {
-  dimensions: ['country'],
+  dimensions: ['country', 'status'],
   orderBy: [{ field: 'totalRevenue', direction: 'desc' }],
   by: 'month',
 };
 void okMetricInput;
 
+// @ts-expect-error - unknown dimension name
+const badMetricDim: MetricInput = { dimensions: ['nope'] };
+void badMetricDim;
+
+// --- Metric output row carries dimensions + the metric value column -----------
 type MetricRowT = Api['totalRevenue']['output']['data'][number];
 const metricRow: MetricRowT = {};
-void metricRow.totalRevenue;
+const metricValue: number | undefined = metricRow.totalRevenue;
+const metricDimValue: string | undefined = metricRow.country;
+void metricValue;
+void metricDimValue;
 
 export {};


### PR DESCRIPTION
## Summary

Completes the typed-hooks work for **metrics** (follow-up to #207). `MetricRef` erased its dataset's concrete dimension/measure keys — `MetricRef.dataset` was typed with the wide `Record<string, DimensionDefinition>` — so metric endpoints stayed on the loose `MetricQuery`/`MetricResult` types even after #207.

This PR now targets `main`; the branch is rebased on the latest `origin/main`.

## Changes

- **datasets** — add an optional `TDataset` generic to `MetricRef` / `GrainedMetricRef` / `MetricHandle` / `BaseMetricRef` / `DerivedMetricRef`, defaulting to the previous wide instance (`DefaultMetricDataset`) so **existing usages are unchanged**. `DatasetInstance.metric()` and `createMetricRef` thread the concrete dataset type through, so a ref preserves its dataset's dimensions/measures.
- **serve** — `SemanticMetricEndpointMap` extracts the concrete dataset + metric name from each entry and specializes the endpoint via `MetricQueryFor`/`MetricResultFor`. With `@hypequery/react`, `useMetric(name, input)` now gets dimension/`orderBy` autocomplete and typed rows (dimensions + the metric's value column). Degrades gracefully to `string` fields when a ref is widened (e.g. `MetricHandle<any, any>`).
- **tests** — updated `datasets/src/api.type-test.ts` assertions to the concrete-dataset ref shape (a stronger check); extended the serve `type-tests/` with metric narrowing + `@ts-expect-error` negatives.

## Back-compat

The `TDataset` param is the **4th, optional** generic with a default equal to the old `MetricRef.dataset` type, so 3-arg `MetricRef<...>` / `MetricHandle<any, any>` usages keep working. No external consumers of these types exist outside `datasets`/`serve`.

## Testing

- `npm test --workspace=@hypequery/datasets`
- `npm run build --workspace=@hypequery/datasets`
- `npm run test:types --workspace=@hypequery/serve`
- `npm test --workspace=@hypequery/serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)