### PR TITLE
Fix datasets semantic SQL planning

### DIFF
--- a/.changeset/datasets-semantic-fixes.md
+++ b/.changeset/datasets-semantic-fixes.md
@@ -1,0 +1,19 @@
+---
+"@hypequery/datasets": patch
+---
+
+Fix three semantic-layer deviations surfaced by manual testing.
+
+- **SQL-backed measures now carry through metrics.** A metric built from a
+  measure with a `sql` override (e.g. `measure.sum('amount', { sql: 'amount * 1.2' })`)
+  previously dropped the override on the query-builder path, emitting a plain
+  `SUM(amount)`. The override is now threaded through `AggregationSpec`, so the
+  metric compiles to `SUM(amount * 1.2)` like the dataset path already did. The
+  semantic (non-SQL) backend rejects such metrics with a clear error instead of
+  silently ignoring the expression.
+- **Unsupported time grains are rejected.** `by: 'hour'` (or any grain outside
+  `day | week | month | quarter | year`) now fails validation with
+  `Unsupported time grain "hour"` instead of emitting `undefined(created_at)`.
+  The planner also throws defensively if it ever receives an unknown grain.
+- **`quoteSQLIdentifier` uses ClickHouse backtick quoting** (`` `col` ``) rather
+  than ANSI double quotes, escaping embedded backticks by doubling them.

--- a/packages/datasets/src/constants.ts
+++ b/packages/datasets/src/constants.ts
@@ -25,5 +25,5 @@ export const SUPPORTED_TIME_GRAINS = Object.keys(GRAIN_FUNCTIONS) as TimeGrain[]
  * Narrowing guard for a runtime-provided grain value.
  */
 export function isSupportedTimeGrain(grain: unknown): grain is TimeGrain {
-  return typeof grain === 'string' && grain in GRAIN_FUNCTIONS;
+  return typeof grain === 'string' && Object.hasOwn(GRAIN_FUNCTIONS, grain);
 }

--- a/packages/datasets/src/constants.ts
+++ b/packages/datasets/src/constants.ts
@@ -14,3 +14,16 @@ export const GRAIN_FUNCTIONS: Record<TimeGrain, string> = {
   quarter: 'toStartOfQuarter',
   year: 'toStartOfYear',
 };
+
+/**
+ * The set of time grains supported by the planner. Derived from
+ * {@link GRAIN_FUNCTIONS} so the two never drift apart.
+ */
+export const SUPPORTED_TIME_GRAINS = Object.keys(GRAIN_FUNCTIONS) as TimeGrain[];
+
+/**
+ * Narrowing guard for a runtime-provided grain value.
+ */
+export function isSupportedTimeGrain(grain: unknown): grain is TimeGrain {
+  return typeof grain === 'string' && grain in GRAIN_FUNCTIONS;
+}

--- a/packages/datasets/src/datasets.test.ts
+++ b/packages/datasets/src/datasets.test.ts
@@ -1523,6 +1523,20 @@ describe("dataset SQL generation matrix", () => {
     );
   });
 
+  it("rejects inherited object properties as unsupported time grains", () => {
+    const analytics = createDatasetClient({ queryBuilder: createSqlBuilderFactory() });
+
+    const result = analytics.validate(MatrixOrders, {
+      measures: ["revenue"],
+      by: "toString" as never,
+    }, TENANT_CONTEXT);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "Unsupported time grain \"toString\". Supported: day, week, month, quarter, year",
+    );
+  });
+
   it("rejects SQL-backed measures on the semantic backend rather than silently dropping them", async () => {
     const analytics = createDatasetClient({
       backend: createInMemoryBackend({ orders: [] }),

--- a/packages/datasets/src/datasets.test.ts
+++ b/packages/datasets/src/datasets.test.ts
@@ -10,6 +10,7 @@ import { createDatasetRegistry } from './registry.js';
 import { buildDatasetQueryBuilder, runDatasetQuery, validateDatasetQuery } from './dataset-query.js';
 import { createDatasetClient, MetricQueryEngine } from './executor.js';
 import { createInMemoryBackend } from './in-memory-backend.js';
+import { quoteSQLIdentifier } from './sql-utils.js';
 import type { QueryBuilderFactoryLike, QueryBuilderLike } from './query-builder-protocol.js';
 
 // =============================================================================
@@ -1497,5 +1498,62 @@ describe("dataset SQL generation matrix", () => {
       measures: ["revenue"],
       limit: 501,
     }).errors).toContain("Too many results requested: 501 (max 500)");
+  });
+
+  it("carries a SQL-backed measure override through the metric (builder) path", () => {
+    const analytics = createDatasetClient({ queryBuilder: createSqlBuilderFactory() });
+    const taxedRevenue = MatrixOrders.metric("taxedRevenue", { measure: "taxedRevenue" });
+
+    const sql = analytics.toSQL(taxedRevenue, { dimensions: ["country"] }, TENANT_CONTEXT);
+
+    expect(sql).toContain("SUM(amount * 1.2) AS taxedRevenue");
+  });
+
+  it("rejects an unsupported time grain before SQL generation", () => {
+    const analytics = createDatasetClient({ queryBuilder: createSqlBuilderFactory() });
+
+    const result = analytics.validate(MatrixOrders, {
+      measures: ["revenue"],
+      by: "hour" as never,
+    }, TENANT_CONTEXT);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "Unsupported time grain \"hour\". Supported: day, week, month, quarter, year",
+    );
+  });
+
+  it("rejects SQL-backed measures on the semantic backend rather than silently dropping them", async () => {
+    const analytics = createDatasetClient({
+      backend: createInMemoryBackend({ orders: [] }),
+    });
+
+    await expect((async () => analytics.execute(MatrixOrders, {
+      measures: ["taxedRevenue"],
+    }, TENANT_CONTEXT))()).rejects.toThrow(
+      'Semantic backend plans do not support SQL-backed measure "taxedRevenue".',
+    );
+  });
+
+  it("rejects SQL-backed metrics on the semantic backend", async () => {
+    const analytics = createDatasetClient({
+      backend: createInMemoryBackend({ orders: [] }),
+    });
+    const taxedRevenue = MatrixOrders.metric("taxedRevenue", { measure: "taxedRevenue" });
+
+    await expect((async () => analytics.execute(taxedRevenue, {}, TENANT_CONTEXT))()).rejects.toThrow(
+      'Semantic backend plans do not support SQL-backed metric "taxedRevenue".',
+    );
+  });
+});
+
+describe("quoteSQLIdentifier()", () => {
+  it("quotes identifiers with backticks for ClickHouse", () => {
+    expect(quoteSQLIdentifier("col")).toBe("`col`");
+    expect(quoteSQLIdentifier("tenant_id")).toBe("`tenant_id`");
+  });
+
+  it("escapes embedded backticks by doubling them", () => {
+    expect(quoteSQLIdentifier("we`ird")).toBe("`we``ird`");
   });
 });

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -30,6 +30,7 @@ import type {
 } from './semantic-plan.js';
 
 import { validateSQLIdentifier } from './sql-utils.js';
+import { SUPPORTED_TIME_GRAINS, isSupportedTimeGrain } from './constants.js';
 import { validateFilterValue, type ValidationResult } from './validation.js';
 import {
   applyAggregationSpec,
@@ -144,6 +145,11 @@ function validateQuery(
   // Validate grain requires timeKey
   if (query.by && !ds.timeKey) {
     errors.push(`Cannot use "by" grain — dataset "${ds.name}" has no timeKey.`);
+  }
+
+  // Validate grain is one the planner can bucket on
+  if (query.by && !isSupportedTimeGrain(query.by)) {
+    errors.push(`Unsupported time grain "${query.by}". Supported: ${SUPPORTED_TIME_GRAINS.join(', ')}`);
   }
 
   if (query.limit != null && (!Number.isInteger(query.limit) || query.limit < 0)) {

--- a/packages/datasets/src/query-planner.ts
+++ b/packages/datasets/src/query-planner.ts
@@ -43,6 +43,9 @@ export function buildDimensionSelectionPlan(
 
   if (grain) {
     const fn = GRAIN_FUNCTIONS[grain];
+    if (!fn) {
+      throw new Error(`Unsupported time grain "${grain}".`);
+    }
     selectParts.push(`${fn}(${ds.timeKey}) AS period`);
     groupByParts.add("period");
   }
@@ -69,7 +72,7 @@ export function applyAggregationSpec(
   const fieldOrExpr = applyFilteredAggregationExpression(
     ds,
     spec,
-    resolveDimensionExpression(ds, spec.field),
+    spec.sql ?? resolveDimensionExpression(ds, spec.field),
   );
 
   switch (spec.aggregation) {

--- a/packages/datasets/src/semantic-planner.ts
+++ b/packages/datasets/src/semantic-planner.ts
@@ -18,6 +18,7 @@ import {
   type MetricHandle,
 } from './utils/metric-handle.js';
 import { validateDatasetQuery } from './dataset-query.js';
+import { isSupportedTimeGrain } from './constants.js';
 import { getRuntimeTenantPredicate } from './utils/tenant-runtime.js';
 
 function resolveField(ds: AnyDatasetInstance, field: string): string {
@@ -92,6 +93,9 @@ function grainForQuery(ds: AnyDatasetInstance, unit: MetricQuery['by'] | undefin
   if (!ds.timeKey) {
     throw new Error(`Cannot use grain "${unit}" because dataset "${ds.name}" has no timeKey.`);
   }
+  if (!isSupportedTimeGrain(unit)) {
+    throw new Error(`Unsupported time grain "${unit}".`);
+  }
   return {
     field: ds.timeKey,
     unit,
@@ -147,6 +151,12 @@ function buildBaseMetricPlan(
   if (spec.__type !== 'aggregation_spec') {
     throw new Error(`Metric "${metric.name}" is not a base metric.`);
   }
+  if (spec.sql) {
+    throw new Error(
+      `Semantic backend plans do not support SQL-backed metric "${metric.name}". ` +
+      'Use a backend-specific query builder for raw SQL expressions.',
+    );
+  }
 
   return aggregatePlan(
     metric.dataset,
@@ -179,6 +189,12 @@ function buildDerivedMetricPlan(
     const baseSpec = baseMetric.spec;
     if (baseSpec.__type !== 'aggregation_spec') {
       throw new Error(`Derived metric "${metric.name}" references non-base metric "${alias}".`);
+    }
+    if (baseSpec.sql) {
+      throw new Error(
+        `Semantic backend plans do not support SQL-backed metric "${alias}" used by derived metric "${metric.name}". ` +
+        'Use a backend-specific query builder for raw SQL expressions.',
+      );
     }
     return {
       name: alias,

--- a/packages/datasets/src/sql-utils.test.ts
+++ b/packages/datasets/src/sql-utils.test.ts
@@ -33,9 +33,9 @@ describe('sql-utils', () => {
     expect(() => validateSQLIdentifier('order_id', 'dimension name')).not.toThrow();
   });
 
-  it('quotes identifiers and escapes embedded quotes', () => {
-    expect(quoteSQLIdentifier('orders')).toBe('"orders"');
-    expect(quoteSQLIdentifier('bad"name')).toBe('"bad""name"');
+  it('quotes identifiers with backticks and escapes embedded backticks', () => {
+    expect(quoteSQLIdentifier('orders')).toBe('`orders`');
+    expect(quoteSQLIdentifier('bad`name')).toBe('`bad``name`');
   });
 });
 

--- a/packages/datasets/src/sql-utils.ts
+++ b/packages/datasets/src/sql-utils.ts
@@ -31,13 +31,13 @@ export function validateSQLIdentifier(identifier: string, context: string): void
 
 /**
  * Quotes a SQL identifier for safe use in queries.
- * Uses double quotes which is standard SQL.
+ * Uses backticks, which is how ClickHouse quotes identifiers.
  *
  * @param identifier - The identifier to quote
  * @returns Quoted identifier
  */
 export function quoteSQLIdentifier(identifier: string): string {
-  // Escape any existing double quotes by doubling them
-  const escaped = identifier.replace(/"/g, '""');
-  return `"${escaped}"`;
+  // Escape any existing backticks by doubling them
+  const escaped = identifier.replace(/`/g, '``');
+  return `\`${escaped}\``;
 }

--- a/packages/datasets/src/types.ts
+++ b/packages/datasets/src/types.ts
@@ -48,6 +48,7 @@ export interface AggregationSpec {
   __type: 'aggregation_spec';
   aggregation: AggregationType;
   field: string;
+  sql?: string;
   filters?: MetricFilter[];
 }
 

--- a/packages/datasets/src/utils/dataset-normalization.ts
+++ b/packages/datasets/src/utils/dataset-normalization.ts
@@ -61,6 +61,7 @@ export function measureToAggregationSpec(
     __type: 'aggregation_spec',
     aggregation: definition.aggregation,
     field: definition.field,
+    sql: definition.sql,
     filters: definition.filters,
   };
 }

--- a/packages/datasets/src/utils/dataset-query-validation.ts
+++ b/packages/datasets/src/utils/dataset-query-validation.ts
@@ -4,6 +4,7 @@ import type {
   ExecutionContext,
 } from '../types.js';
 import { validateFilterValue, type ValidationResult } from '../validation.js';
+import { SUPPORTED_TIME_GRAINS, isSupportedTimeGrain } from '../constants.js';
 import {
   getRuntimeTenantPredicate,
   validateTenantRuntime,
@@ -97,6 +98,10 @@ export function validateDatasetQueryInput(
 
   if (query.by && !ds.timeKey) {
     errors.push(`Cannot use "by" grain — dataset "${ds.name}" has no timeKey.`);
+  }
+
+  if (query.by && !isSupportedTimeGrain(query.by)) {
+    errors.push(`Unsupported time grain "${query.by}". Supported: ${SUPPORTED_TIME_GRAINS.join(', ')}`);
   }
 
   if (query.limit != null && (!Number.isInteger(query.limit) || query.limit < 0)) {


### PR DESCRIPTION
  ## Summary

  Fix semantic SQL planning inconsistencies in `@hypequery/datasets`.

  - Preserve measure SQL overrides when measures are promoted to metrics
  - Reject SQL-backed measures and metrics on semantic backends instead of silently ignoring their expressions
  - Validate time grains before planning and return a clear error for unsupported values
  - Quote ClickHouse identifiers with backticks and escape embedded backticks
  - Add regression coverage for each behavior