### PR TITLE
fix (clickhouse) harden ClickHouse interval SQL rendering

### DIFF
--- a/packages/clickhouse/src/core/dialects/clickhouse-dialect.ts
+++ b/packages/clickhouse/src/core/dialects/clickhouse-dialect.ts
@@ -1,5 +1,6 @@
 import type { CompiledQuery, SelectQueryNode } from '../../types/index.js';
 import { SQLFormatter } from '../formatters/sql-formatter.js';
+import { formatIntervalLiteral } from '../utils/sql-literals.js';
 import type { CompileQueryContext, SqlDialect } from './sql-dialect.js';
 
 export class ClickHouseDialect implements SqlDialect {
@@ -69,7 +70,7 @@ export class ClickHouseDialect implements SqlDialect {
 
   formatTimeInterval(column: string, interval: string, method: string): string {
     if (method === 'toStartOfInterval') {
-      return `${method}(${column}, INTERVAL ${interval})`;
+      return `${method}(${column}, INTERVAL ${formatIntervalLiteral(interval)})`;
     }
 
     return `${method}(${column})`;

--- a/packages/clickhouse/src/core/tests/query-builder-analytics.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder-analytics.test.ts
@@ -18,7 +18,7 @@ describe('QueryBuilder Analytics Features', () => {
 
       expect(sql).toBe(
         'SELECT * FROM test_table ' +
-        'GROUP BY toStartOfInterval(created_at, INTERVAL 1 day)'
+        'GROUP BY toStartOfInterval(created_at, INTERVAL 1 DAY)'
       );
     });
 
@@ -55,8 +55,38 @@ describe('QueryBuilder Analytics Features', () => {
       expect(sql).toBe(
         'SELECT created_at, name FROM test_table ' +
         `WHERE active = 'true' ` +
-        'GROUP BY toStartOfInterval(created_at, INTERVAL 1 hour)'
+        'GROUP BY toStartOfInterval(created_at, INTERVAL 1 HOUR)'
       );
+    });
+
+    it('should accept plural and mixed-case interval units', () => {
+      const sql = queryBuilder
+        .groupByTimeInterval('created_at', '15 Minutes')
+        .toSQL();
+
+      expect(sql).toBe(
+        'SELECT * FROM test_table ' +
+        'GROUP BY toStartOfInterval(created_at, INTERVAL 15 MINUTE)'
+      );
+    });
+
+    it('should support documented sub-second interval units', () => {
+      const sql = queryBuilder
+        .groupByTimeInterval('created_at', '500 milliseconds')
+        .toSQL();
+
+      expect(sql).toBe(
+        'SELECT * FROM test_table ' +
+        'GROUP BY toStartOfInterval(created_at, INTERVAL 500 MILLISECOND)'
+      );
+    });
+
+    it('should reject an interval that is not a "<number> <unit>" literal (SQL injection guard)', () => {
+      expect(() =>
+        queryBuilder
+          .groupByTimeInterval('created_at', '1 DAY); DROP TABLE x --')
+          .toSQL()
+      ).toThrow(/Invalid time interval/);
     });
   });
 

--- a/packages/clickhouse/src/core/tests/sql-expressions.test.ts
+++ b/packages/clickhouse/src/core/tests/sql-expressions.test.ts
@@ -55,12 +55,34 @@ describe('SQL Expressions', () => {
       expect(aliasedExprWithTz.toSql()).toBe('formatDateTime(created_at, \'Y-m-d\', \'UTC\') AS formatted_date');
     });
 
+    it('should escape formatDateTime string literals', () => {
+      const expr = formatDateTime('created_at', "Y-m-d'); DROP TABLE x --", {
+        timezone: "UTC'); DROP TABLE y --",
+      });
+
+      expect(expr.toSql()).toBe(
+        "formatDateTime(created_at, 'Y-m-d''); DROP TABLE x --', 'UTC''); DROP TABLE y --')"
+      );
+    });
+
     it('should provide helper for toStartOfInterval function', () => {
       const expr = toStartOfInterval('created_at', '1 day');
-      expect(expr.toSql()).toBe('toStartOfInterval(created_at, INTERVAL 1 day)');
+      expect(expr.toSql()).toBe('toStartOfInterval(created_at, INTERVAL 1 DAY)');
 
       const aliasedExpr = toStartOfInterval('created_at', '1 day', 'day_start');
-      expect(aliasedExpr.toSql()).toBe('toStartOfInterval(created_at, INTERVAL 1 day) AS day_start');
+      expect(aliasedExpr.toSql()).toBe('toStartOfInterval(created_at, INTERVAL 1 DAY) AS day_start');
+    });
+
+    it('should canonicalize and validate toStartOfInterval intervals', () => {
+      expect(toStartOfInterval('created_at', '15 Minutes').toSql()).toBe(
+        'toStartOfInterval(created_at, INTERVAL 15 MINUTE)'
+      );
+      expect(toStartOfInterval('created_at', '500 milliseconds').toSql()).toBe(
+        'toStartOfInterval(created_at, INTERVAL 500 MILLISECOND)'
+      );
+      expect(() => toStartOfInterval('created_at', '1 DAY); DROP TABLE x --')).toThrow(
+        /Invalid time interval/
+      );
     });
 
     it('should provide helpers for built-in start-of time buckets', () => {
@@ -145,7 +167,7 @@ describe('SQL Expressions', () => {
       type Expected = { day: Date; month: number }[];
       type _Assert = Expect<Equal<Result, Expected>>;
 
-      expect(query.toSQL()).toBe('SELECT toStartOfInterval(created_at, INTERVAL 1 day) AS day, toMonth(created_at) AS month FROM test_table GROUP BY day, month');
+      expect(query.toSQL()).toBe('SELECT toStartOfInterval(created_at, INTERVAL 1 DAY) AS day, toMonth(created_at) AS month FROM test_table GROUP BY day, month');
     });
 
     it('should handle complex expressions with joins', () => {

--- a/packages/clickhouse/src/core/utils/sql-expressions.ts
+++ b/packages/clickhouse/src/core/utils/sql-expressions.ts
@@ -1,3 +1,5 @@
+import { formatIntervalLiteral, quoteStringLiteral } from './sql-literals.js';
+
 /**
  * Represents a raw SQL expression that can be used in queries
  */
@@ -103,10 +105,10 @@ export function formatDateTime(
 ): SqlExpression<string> | AliasedExpression<string> {
   const { timezone, alias } = options;
 
-  let sql = `formatDateTime(${field}, '${format}'`;
+  let sql = `formatDateTime(${field}, ${quoteStringLiteral(format)}`;
 
   if (timezone) {
-    sql += `, '${timezone}'`;
+    sql += `, ${quoteStringLiteral(timezone)}`;
   }
 
   sql += ')';
@@ -124,9 +126,10 @@ export function formatDateTime(
 export function toStartOfInterval(field: string, interval: string): SqlExpression<Date>;
 export function toStartOfInterval<T extends string>(field: string, interval: string, alias: T): AliasedExpression<Date, T>;
 export function toStartOfInterval(field: string, interval: string, alias?: string): SqlExpression<Date> | AliasedExpression<Date> {
+  const sql = `toStartOfInterval(${field}, INTERVAL ${formatIntervalLiteral(interval)})`;
   return alias
-    ? rawAs<Date>(`toStartOfInterval(${field}, INTERVAL ${interval})`, alias)
-    : raw<Date>(`toStartOfInterval(${field}, INTERVAL ${interval})`);
+    ? rawAs<Date>(sql, alias)
+    : raw<Date>(sql);
 }
 
 function toStartOfUnit<T = Date>(functionName: string, field: string): SqlExpression<T>;

--- a/packages/clickhouse/src/core/utils/sql-literals.ts
+++ b/packages/clickhouse/src/core/utils/sql-literals.ts
@@ -1,0 +1,46 @@
+const INTERVAL_UNITS: Record<string, string> = {
+  second: 'SECOND',
+  seconds: 'SECOND',
+  minute: 'MINUTE',
+  minutes: 'MINUTE',
+  hour: 'HOUR',
+  hours: 'HOUR',
+  day: 'DAY',
+  days: 'DAY',
+  week: 'WEEK',
+  weeks: 'WEEK',
+  month: 'MONTH',
+  months: 'MONTH',
+  quarter: 'QUARTER',
+  quarters: 'QUARTER',
+  year: 'YEAR',
+  years: 'YEAR',
+  millisecond: 'MILLISECOND',
+  milliseconds: 'MILLISECOND',
+  microsecond: 'MICROSECOND',
+  microseconds: 'MICROSECOND',
+  nanosecond: 'NANOSECOND',
+  nanoseconds: 'NANOSECOND',
+};
+
+const INTERVAL_PATTERN = /^(\d+)\s+([a-z]+)$/i;
+
+export function formatIntervalLiteral(interval: string): string {
+  const normalized = interval.trim();
+  const match = normalized.match(INTERVAL_PATTERN);
+  const unit = match ? INTERVAL_UNITS[match[2].toLowerCase()] : undefined;
+
+  if (!match || !unit) {
+    throw new Error(
+      `Invalid time interval: "${interval}". Expected "<number> <unit>" where unit is ` +
+      'one of second, minute, hour, day, week, month, quarter, year, millisecond, microsecond, nanosecond ' +
+      '(e.g. "1 day", "15 minute").',
+    );
+  }
+
+  return `${match[1]} ${unit}`;
+}
+
+export function quoteStringLiteral(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "''")}'`;
+}


### PR DESCRIPTION
## Summary

Hardens ClickHouse SQL rendering for time intervals and string literals.

  - Validates and canonicalizes interval literals
  - Supports singular, plural, mixed-case, and sub-second interval units
  - Rejects malformed or injectable interval input
  - Escapes formatDateTime format and timezone strings
  - Applies interval handling consistently across the dialect and expression helpers