### PR TITLE
fix(serve,mcp): wire CORS config in createAPI and surface MCP pagination

### DIFF
--- a/packages/mcp-server/src/tools/query-dataset.ts
+++ b/packages/mcp-server/src/tools/query-dataset.ts
@@ -63,6 +63,7 @@ export async function queryDatasetTool(
       sql: result.meta?.sql,
       timingMs: result.meta?.timingMs,
       rowCount: result.data.length,
+      ...(result.meta?.pagination ? { pagination: result.meta.pagination } : {}),
     },
   };
 

--- a/packages/mcp-server/src/tools/query-metric.ts
+++ b/packages/mcp-server/src/tools/query-metric.ts
@@ -70,6 +70,7 @@ export async function queryMetricTool(
       sql: result.meta?.sql,
       timingMs: result.meta?.timingMs,
       rowCount: result.data.length,
+      ...(result.meta?.pagination ? { pagination: result.meta.pagination } : {}),
     },
   };
 

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -136,6 +136,15 @@ export interface QueryResultMeta {
   sql?: string;
   timingMs?: number;
   rowCount: number;
+  /**
+   * Offset pagination state. Present when the query specified a `limit`.
+   * `hasMore` lets callers know whether to request the next `offset` page.
+   */
+  pagination?: {
+    limit: number;
+    offset: number;
+    hasMore: boolean;
+  };
 }
 
 /**

--- a/packages/serve/src/create-api.test.ts
+++ b/packages/serve/src/create-api.test.ts
@@ -77,6 +77,60 @@ describe("createAPI", () => {
     expect(received[0]).toEqual({ from: "2024-01-01" });
   });
 
+  it("handles CORS preflight and injects headers when cors is configured", async () => {
+    const api = createAPI({
+      cors: true,
+      queries: {
+        ping: { query: async () => ({ ok: true }) },
+      },
+    });
+
+    // Preflight OPTIONS gets a 204 with Access-Control-* headers (not a 404)
+    const preflight = await api.handler(
+      createRequest({
+        method: "OPTIONS",
+        path: "/queries/ping",
+        headers: { origin: "https://app.example.com" },
+      })
+    );
+
+    expect(preflight.status).toBe(204);
+    expect(preflight.headers["access-control-allow-origin"]).toBe("*");
+    expect(preflight.headers["access-control-allow-methods"]).toBeDefined();
+    expect(preflight.headers["access-control-allow-headers"]).toBeDefined();
+
+    // Actual requests echo CORS headers onto the response
+    const actual = await api.handler(
+      createRequest({
+        path: "/queries/ping",
+        headers: { origin: "https://app.example.com" },
+      })
+    );
+
+    expect(actual.status).toBe(200);
+    expect(actual.headers["access-control-allow-origin"]).toBe("*");
+  });
+
+  it("omits CORS handling when cors is not configured", async () => {
+    const api = createAPI({
+      queries: {
+        ping: { query: async () => ({ ok: true }) },
+      },
+    });
+
+    const preflight = await api.handler(
+      createRequest({
+        method: "OPTIONS",
+        path: "/queries/ping",
+        headers: { origin: "https://app.example.com" },
+      })
+    );
+
+    // No CORS config → OPTIONS is not a registered route → 404, no CORS headers
+    expect(preflight.status).toBe(404);
+    expect(preflight.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
   it("enforces auth strategies and populates auth context", async () => {
     const authContexts: Array<Record<string, unknown> | null> = [];
     const api = createAPI({

--- a/packages/serve/src/server/create-api.ts
+++ b/packages/serve/src/server/create-api.ts
@@ -20,6 +20,7 @@ import { ensureArray } from "../utils.js";
 import { ServeQueryLogger, formatQueryEvent, formatQueryEventJSON } from "../query-logger.js";
 import { createServeHandler } from "../pipeline.js";
 import { createDocsEndpoint, createOpenApiEndpoint } from "../pipeline.js";
+import { resolveCorsConfig } from "../cors.js";
 import { createExecuteQuery } from "./execute-query.js";
 import { createAPImethods } from "./api-builder.js";
 import { createDatasetClient } from "@hypequery/datasets";
@@ -258,6 +259,8 @@ export const createAPI = <
     }
   }
 
+  const corsConfig = resolveCorsConfig(config.cors);
+
   const handler: ServeHandler = createServeHandler<TContext, TAuth>({
     router,
     globalMiddlewares,
@@ -267,6 +270,7 @@ export const createAPI = <
     hooks,
     queryLogger,
     verboseAuthErrors: config.security?.verboseAuthErrors ?? false,
+    corsConfig,
   });
 
   const executeQuery = createExecuteQuery<TContext, TAuth>(


### PR DESCRIPTION
 ### Summary

  - Wire configured CORS handling into createAPI
  - Handle CORS preflight requests and attach headers to API responses
  - Surface dataset and metric pagination metadata through MCP query responses
  - Add coverage for enabled and disabled CORS behavior
