### PR TITLE
feat: (mcp) restrict mcp acces to sql metadata

### DIFF
--- a/.changeset/semantic-catalogue-tools-and-mcp-sql-redaction.md
+++ b/.changeset/semantic-catalogue-tools-and-mcp-sql-redaction.md
@@ -1,0 +1,19 @@
+---
+"@hypequery/datasets": minor
+"@hypequery/serve": minor
+"@hypequery/mcp": minor
+---
+
+Add catalog-backed semantic tool generation and harden SQL exposure across MCP and generated tools.
+
+`@hypequery/datasets`:
+- Add `generateDatasetTools` with `catalog`, `per-dataset`, and `per-metric` modes, plus `toOpenAITools`, `toAISDKTools`, and `toMcpTools` adapters. Generated tools validate agent inputs against catalog metadata and redact SQL from results by default.
+- Expand the dataset catalog with default filter operators, filter value types, supported time grains, tenant requirement, orderable fields, max result limit, and measure filter counts.
+- Export `SEMANTIC_FILTER_OPERATORS` and `SUPPORTED_TIME_GRAINS` and use the shared operator list across packages.
+
+`@hypequery/serve`:
+- Build semantic input schemas and endpoint descriptions from catalog metadata, including supported grains, filters, relationships, and tenant scoping.
+
+`@hypequery/mcp`:
+- Distinguish measures from named metrics in dataset listing and introspection (`metricCount` no longer falls back to the measure count).
+- Add an `includeSql` server option (default `false`) so `get_dataset_schema`, `query_dataset`, and `query_metric` no longer expose generated SQL to agents unless explicitly enabled for trusted debugging.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -280,7 +280,7 @@ const analytics = createDatasetClient({
 
 1. Verify your ClickHouse connection is working
 2. Check that dataset definitions match your database schema
-3. Use the `meta.sql` field in responses to debug generated SQL
+3. For trusted local debugging, start the programmatic server with `includeSql: true` and inspect `meta.sql` in responses
 
 ## Related Packages
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -18,6 +18,7 @@ export type {
   QueryMetricArgs,
   QueryDatasetArgs,
   QueryToolOptions,
+  SchemaToolOptions,
   GetDatasetSchemaArgs,
   MCPToolResponse,
   DatasetSchema,

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -194,6 +194,59 @@ describe('HypequeryMCPServer', () => {
       },
     );
   });
+
+  it('should only include generated SQL when server config enables it', async () => {
+    const analytics: DatasetClient = {
+      execute: vi.fn().mockResolvedValue({
+        data: [{ revenue: 100 }],
+        meta: { sql: 'SELECT SUM(amount) AS revenue FROM orders', timingMs: 12 },
+      }),
+    } as any;
+    const orders = {
+      dimensions: {},
+      metrics: {},
+    };
+
+    new HypequeryMCPServer({
+      datasets: { orders },
+      analytics,
+    });
+
+    let handler = requestHandlers.get(CallToolRequestSchema);
+    const redactedResult = await handler?.({
+      params: {
+        name: 'query_dataset',
+        arguments: {
+          dataset: 'orders',
+          measures: ['revenue'],
+        },
+      },
+    });
+
+    const redactedBody = JSON.parse((redactedResult as any).content[0].text);
+    expect(redactedBody.meta.sql).toBeUndefined();
+
+    requestHandlers.clear();
+    new HypequeryMCPServer({
+      datasets: { orders },
+      analytics,
+      includeSql: true,
+    });
+
+    handler = requestHandlers.get(CallToolRequestSchema);
+    const debugResult = await handler?.({
+      params: {
+        name: 'query_dataset',
+        arguments: {
+          dataset: 'orders',
+          measures: ['revenue'],
+        },
+      },
+    });
+
+    const debugBody = JSON.parse((debugResult as any).content[0].text);
+    expect(debugBody.meta.sql).toBe('SELECT SUM(amount) AS revenue FROM orders');
+  });
 });
 
 describe('HypequeryMCPServer config validation', () => {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -46,6 +46,14 @@ export interface MCPServerConfig {
    * Trusted tenant id used to scope tenant-keyed datasets.
    */
   tenantId?: string;
+
+  /**
+   * Include generated SQL in query tool responses.
+   *
+   * Defaults to false so agent-facing responses do not expose SQL text unless
+   * explicitly enabled for trusted debugging.
+   */
+  includeSql?: boolean;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -271,14 +279,18 @@ export class HypequeryMCPServer {
             return await listDatasetsTool(this.config.datasets);
 
           case 'get_dataset_schema':
-            return await getDatasetSchemaTool(this.config.datasets, args);
+            return await getDatasetSchemaTool(
+              this.config.datasets,
+              args,
+              { includeSql: this.config.includeSql },
+            );
 
           case 'query_metric':
             return await queryMetricTool(
               this.config.datasets,
               this.config.analytics,
               args,
-              { tenantId: this.config.tenantId },
+              { tenantId: this.config.tenantId, includeSql: this.config.includeSql },
             );
 
           case 'query_dataset':
@@ -286,7 +298,7 @@ export class HypequeryMCPServer {
               this.config.datasets,
               this.config.analytics,
               args,
-              { tenantId: this.config.tenantId },
+              { tenantId: this.config.tenantId, includeSql: this.config.includeSql },
             );
 
           default:

--- a/packages/mcp-server/src/tools/introspect.test.ts
+++ b/packages/mcp-server/src/tools/introspect.test.ts
@@ -303,4 +303,46 @@ describe('getDatasetSchemaTool', () => {
 
     expect(schema.dimensions.field.examples).toEqual([]);
   });
+
+  it('should redact SQL-backed field expressions by default', async () => {
+    const Orders = dataset('orders', {
+      source: 'orders',
+      dimensions: {
+        countryUpper: dimension.string({ sql: 'upper(country_code)' }),
+        amount: dimension.number(),
+      },
+      measures: {
+        taxedRevenue: measure.sum('amount', { sql: 'amount * 1.2' }),
+      },
+    });
+
+    const result = await getDatasetSchemaTool({ orders: Orders }, { dataset: 'orders' });
+    const schema = JSON.parse(result.content[0].text);
+
+    expect(schema.dimensions.countryUpper.sql).toBeNull();
+    expect(schema.measures.taxedRevenue.sql).toBeNull();
+  });
+
+  it('should include SQL-backed field expressions when explicitly enabled', async () => {
+    const Orders = dataset('orders', {
+      source: 'orders',
+      dimensions: {
+        countryUpper: dimension.string({ sql: 'upper(country_code)' }),
+        amount: dimension.number(),
+      },
+      measures: {
+        taxedRevenue: measure.sum('amount', { sql: 'amount * 1.2' }),
+      },
+    });
+
+    const result = await getDatasetSchemaTool(
+      { orders: Orders },
+      { dataset: 'orders' },
+      { includeSql: true },
+    );
+    const schema = JSON.parse(result.content[0].text);
+
+    expect(schema.dimensions.countryUpper.sql).toBe('upper(country_code)');
+    expect(schema.measures.taxedRevenue.sql).toBe('amount * 1.2');
+  });
 });

--- a/packages/mcp-server/src/tools/introspect.ts
+++ b/packages/mcp-server/src/tools/introspect.ts
@@ -16,6 +16,7 @@ import type {
   FilterSchema,
   MetricSchema,
   RelationshipSchema,
+  SchemaToolOptions,
 } from '../types.js';
 
 function isDatasetInstance(value: unknown): value is Parameters<typeof getDatasetCatalog>[0] {
@@ -24,7 +25,8 @@ function isDatasetInstance(value: unknown): value is Parameters<typeof getDatase
 
 export async function getDatasetSchemaTool(
   datasets: DatasetRegistry,
-  args: unknown
+  args: unknown,
+  options: SchemaToolOptions = {},
 ): Promise<MCPToolResponse> {
   // Parse and validate args
   const validatedArgs = args as GetDatasetSchemaArgs;
@@ -66,7 +68,7 @@ export async function getDatasetSchemaTool(
       const dimSchema: DimensionSchema = {
         type: dimension.type,
         column: dimension.column ?? name,
-        sql: dimension.sql ?? null,
+        sql: options.includeSql ? dimension.sql ?? null : null,
         label: dimension.label || name,
         description: dimension.description || '',
         examples: [],
@@ -80,7 +82,7 @@ export async function getDatasetSchemaTool(
       const measureSchema: MeasureSchema = {
         aggregation: measure.aggregation,
         field: measure.field,
-        sql: measure.sql ?? null,
+        sql: options.includeSql ? measure.sql ?? null : null,
         label: measure.label || name,
         description: measure.description || '',
       };
@@ -126,7 +128,7 @@ export async function getDatasetSchemaTool(
         const dimSchema: DimensionSchema = {
           type: (dimension as { fieldType?: string; type?: string }).fieldType || (dimension as { type?: string }).type || 'unknown',
           column: (dimension as { column?: string }).column || name,
-          sql: (dimension as { sql?: string }).sql || null,
+          sql: options.includeSql ? (dimension as { sql?: string }).sql || null : null,
           label: (dimension as { label?: string }).label || name,
           description: (dimension as { description?: string }).description || '',
           examples: (dimension as { examples?: string[] }).examples || [],
@@ -142,7 +144,7 @@ export async function getDatasetSchemaTool(
         const measureSchema: MeasureSchema = {
           aggregation: (measure as { aggregation?: string; type?: string }).aggregation || (measure as { type?: string }).type || 'unknown',
           field: (measure as { field?: string }).field || name,
-          sql: (measure as { sql?: string }).sql || null,
+          sql: options.includeSql ? (measure as { sql?: string }).sql || null : null,
           label: (measure as { label?: string }).label || name,
           description: (measure as { description?: string }).description || '',
         };

--- a/packages/mcp-server/src/tools/query-dataset.test.ts
+++ b/packages/mcp-server/src/tools/query-dataset.test.ts
@@ -62,6 +62,7 @@ describe('queryDatasetTool', () => {
 
     const data = JSON.parse(result.content[0].text);
     expect(data.data).toHaveLength(2);
+    expect(data.meta.sql).toBeUndefined();
     expect(data.meta.rowCount).toBe(2);
 
     expect(analytics.execute).toHaveBeenCalledWith(
@@ -78,6 +79,34 @@ describe('queryDatasetTool', () => {
         },
       }
     );
+  });
+
+  it('should include generated SQL only when explicitly enabled', async () => {
+    const mockResult = {
+      data: [{ region: 'US' }],
+      meta: {
+        sql: 'SELECT DISTINCT region FROM orders',
+        timingMs: 30,
+      },
+    };
+
+    const datasets = {
+      orders: {},
+    };
+
+    const analytics = createMockAnalytics(mockResult);
+    const result = await queryDatasetTool(
+      datasets,
+      analytics,
+      {
+        dataset: 'orders',
+        dimensions: ['region'],
+      },
+      { includeSql: true },
+    );
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.meta.sql).toBe('SELECT DISTINCT region FROM orders');
   });
 
   it('should execute query with measures only', async () => {

--- a/packages/mcp-server/src/tools/query-dataset.ts
+++ b/packages/mcp-server/src/tools/query-dataset.ts
@@ -60,7 +60,7 @@ export async function queryDatasetTool(
   const response: QueryResultResponse = {
     data: result.data,
     meta: {
-      sql: result.meta?.sql,
+      ...(options.includeSql ? { sql: result.meta?.sql } : {}),
       timingMs: result.meta?.timingMs,
       rowCount: result.data.length,
       ...(result.meta?.pagination ? { pagination: result.meta.pagination } : {}),

--- a/packages/mcp-server/src/tools/query-metric.test.ts
+++ b/packages/mcp-server/src/tools/query-metric.test.ts
@@ -74,7 +74,7 @@ describe('queryMetricTool', () => {
     const data = JSON.parse(result.content[0].text);
 
     expect(data.data).toEqual([{ revenue: 1000 }]);
-    expect(data.meta.sql).toBe('SELECT SUM(amount) as revenue FROM orders');
+    expect(data.meta.sql).toBeUndefined();
     expect(data.meta.timingMs).toBe(45);
     expect(data.meta.rowCount).toBe(1);
 
@@ -91,6 +91,36 @@ describe('queryMetricTool', () => {
         },
       }
     );
+  });
+
+  it('should include generated SQL only when explicitly enabled', async () => {
+    const mockResult = {
+      data: [{ revenue: 1000 }],
+      meta: {
+        sql: 'SELECT SUM(amount) as revenue FROM orders',
+        timingMs: 45,
+      },
+    };
+
+    const datasets = {
+      orders: {
+        revenue: { type: 'sum' },
+      },
+    };
+
+    const analytics = createMockAnalytics(mockResult);
+    const result = await queryMetricTool(
+      datasets,
+      analytics,
+      {
+        dataset: 'orders',
+        metric: 'revenue',
+      },
+      { includeSql: true },
+    );
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.meta.sql).toBe('SELECT SUM(amount) as revenue FROM orders');
   });
 
   it('should execute metric query with dimensions', async () => {

--- a/packages/mcp-server/src/tools/query-metric.ts
+++ b/packages/mcp-server/src/tools/query-metric.ts
@@ -67,7 +67,7 @@ export async function queryMetricTool(
   const response: QueryResultResponse = {
     data: result.data,
     meta: {
-      sql: result.meta?.sql,
+      ...(options.includeSql ? { sql: result.meta?.sql } : {}),
       timingMs: result.meta?.timingMs,
       rowCount: result.data.length,
       ...(result.meta?.pagination ? { pagination: result.meta.pagination } : {}),

--- a/packages/mcp-server/src/tools/query-sql.integration.test.ts
+++ b/packages/mcp-server/src/tools/query-sql.integration.test.ts
@@ -143,6 +143,7 @@ describe('MCP query tools SQL integration', () => {
       offset: 5,
     }, {
       tenantId: 'tenant-1',
+      includeSql: true,
     });
 
     const response = parseToolResponse(result);
@@ -169,6 +170,7 @@ describe('MCP query tools SQL integration', () => {
       dimensions: ['country'],
     }, {
       tenantId: 'tenant-1',
+      includeSql: true,
     });
 
     const response = JSON.parse(result.content[0].text) as {

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -44,6 +44,11 @@ export interface QueryDatasetArgs {
 
 export interface QueryToolOptions {
   tenantId?: string;
+  includeSql?: boolean;
+}
+
+export interface SchemaToolOptions {
+  includeSql?: boolean;
 }
 
 /**

--- a/plans/dynamic-dataset-api-tasks.md
+++ b/plans/dynamic-dataset-api-tasks.md
@@ -1306,8 +1306,8 @@ Includes:
 
 | PR | Status | Scope | Packages | Change Size | Reason |
 |---|---|---|---|---:|---|
-| 1 | Complete in this PR | Catalog export, MCP introspection fix, Serve/OpenAPI catalog metadata, dashboard/tool metadata, and initial AI tool generation | `datasets`, `mcp-server`, `serve`, `website-next` | Medium | Fixes agent/dashboard metadata, removes measures/metrics drift, and gives agents catalog-backed tool schemas. |
-| 2 | Next | Trust-boundary docs and unsafe SQL audit | `website-next`, `datasets`, `clickhouse`, `cli` | Minor | Low-risk enterprise/security foundation. |
+| 1 | Complete | Catalog export, MCP introspection fix, Serve/OpenAPI catalog metadata, dashboard/tool metadata, and initial AI tool generation | `datasets`, `mcp-server`, `serve`, `website-next` | Medium | Fixes agent/dashboard metadata, removes measures/metrics drift, and gives agents catalog-backed tool schemas. |
+| 2 | Complete in this PR | Trust-boundary docs and unsafe SQL audit | `website-next`, `datasets`, `clickhouse`, `cli` | Minor | Low-risk enterprise/security foundation. |
 | 3 | Next | Semantic contract JSON export | `datasets`, `serve` | Medium | Enables validation, snapshots, docs, MCP, and codegen to share one source. |
 | 4 | Next | `hypequery semantic validate` CLI | `cli`, `datasets`, `schema` | Medium | Immediate CI value. |
 | 5 | Planned | Semantic audit event hooks | `serve`, `datasets`, `mcp-server` | Medium | Required for enterprise deployment. |

--- a/website-next/docs/datasets/dimensions.mdx
+++ b/website-next/docs/datasets/dimensions.mdx
@@ -3,6 +3,7 @@ title: Dimensions
 description: Define typed fields for selecting, grouping, and filtering dataset queries.
 ---
 
+import { Callout } from 'fumadocs-ui/components/callout';
 import { CodeBlock } from 'fumadocs-ui/components/codeblock';
 
 Dimensions are the non-aggregated fields in a dataset. They are the fields callers can select, group by, filter on, and order by.
@@ -134,6 +135,10 @@ dimensions: {
 </CodeBlock>
 
 Use SQL-backed dimensions sparingly. Schema compatibility checks can inspect simple column references, but complex SQL expressions can only produce warnings because they cannot be fully verified from the table schema.
+
+<Callout type="warn" title="Trusted model code">
+  The `sql` option is authored in your dataset definition. Runtime callers should only reference the semantic dimension name, not provide SQL. See [Trust Boundaries](/docs/reference/trust-boundaries).
+</Callout>
 
 ## Filterable and groupable
 

--- a/website-next/docs/datasets/measures.mdx
+++ b/website-next/docs/datasets/measures.mdx
@@ -3,6 +3,7 @@ title: Measures
 description: Define aggregations such as revenue, counts, averages, minimums, and maximums.
 ---
 
+import { Callout } from 'fumadocs-ui/components/callout';
 import { CodeBlock } from 'fumadocs-ui/components/codeblock';
 
 Measures are aggregations over fields in a dataset. They are the numeric values callers can request in dataset queries, such as revenue, order count, average order amount, minimum value, or maximum value.
@@ -130,6 +131,10 @@ measures: {
 The `field` argument still names the logical backing field, while `sql` provides the expression to aggregate. Use SQL-backed measures sparingly. Schema compatibility checks can inspect simple fields, but complex SQL expressions can only produce warnings because they cannot be fully verified from the table schema.
 
 SQL-backed measures require builder-backed execution. Generic semantic backend plans reject SQL-backed measures because cross-backend adapters cannot assume the same SQL expression syntax.
+
+<Callout type="warn" title="Trusted model code">
+  The `sql` option is authored in your dataset definition. Runtime callers should only request the semantic measure name, not provide SQL. See [Trust Boundaries](/docs/reference/trust-boundaries).
+</Callout>
 
 ## Filtered measures
 

--- a/website-next/docs/mcp/programmatic.mdx
+++ b/website-next/docs/mcp/programmatic.mdx
@@ -74,6 +74,9 @@ type MCPServerConfig = {
   name?: string;
   version?: string;
   tenantId?: string;
+  includeSql?: boolean;
 };
 ```
 </CodeBlock>
+
+Set `includeSql: true` only in trusted debugging contexts. Query tools redact generated SQL by default.

--- a/website-next/docs/mcp/safety.mdx
+++ b/website-next/docs/mcp/safety.mdx
@@ -38,7 +38,7 @@ Prefer one of these patterns:
 - attach only the named metrics agents should call
 - run a tenant-specific MCP process with `tenantId`
 - keep sensitive tables out of the exported `datasets` registry
-- inspect generated SQL in tool response metadata while testing
+- enable `includeSql` only in trusted debugging sessions
 
 ## Registry boundary
 
@@ -87,3 +87,7 @@ The MCP server exposes semantic tools:
 - `query_metric`
 
 It does not expose a generic `run_sql` tool.
+
+Generated SQL and SQL-backed field expressions are also redacted from MCP responses by default. Programmatic servers can opt in with `includeSql: true` for trusted local debugging.
+
+For the broader application boundary between semantic runtime input and trusted raw SQL APIs, see [Trust Boundaries](/docs/reference/trust-boundaries).

--- a/website-next/docs/meta.json
+++ b/website-next/docs/meta.json
@@ -64,6 +64,7 @@
     "reference/connection",
     "reference/inside-the-query-builder",
     "reference/clickhouse-behavior",
+    "reference/trust-boundaries",
     "---Resources---",
     "changelog",
     "roadmap",

--- a/website-next/docs/query-building/sql-expressions.mdx
+++ b/website-next/docs/query-building/sql-expressions.mdx
@@ -12,6 +12,10 @@ The fluent query builder covers most workflows, but you can always run raw SQL o
   These examples use a typed standalone `db` client so the query builder stays the focus.
 </Callout>
 
+<Callout type="warn" title="Trusted code only">
+  Raw SQL helpers are escape hatches for developer-authored SQL. Do not expose them as a public query language or build raw fragments from user or agent input. For public analytics input, expose semantic dataset or metric APIs instead. See [Trust Boundaries](/docs/reference/trust-boundaries).
+</Callout>
+
 ## Raw SQL Queries
 
 Execute raw SQL when you need complete control:
@@ -184,3 +188,4 @@ const rows = await db.rawQuery<{ day: string; signups: number }>(sql, [accountId
 - **Prefer fluent API**: Use expression helpers only when the fluent API doesn't support your use case
 - **Alias all expressions**: Computed columns need aliases for type safety
 - **Type raw queries**: Always provide type arguments to `rawQuery()`
+- **Use semantic APIs for runtime input**: Dataset, metric, Serve, MCP, and generated tool schemas are the constrained public surfaces

--- a/website-next/docs/reference/trust-boundaries.mdx
+++ b/website-next/docs/reference/trust-boundaries.mdx
@@ -1,0 +1,110 @@
+---
+title: Trust Boundaries
+description: Understand which hypequery APIs are safe for public semantic input and which APIs execute trusted developer-authored SQL.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { CodeBlock } from 'fumadocs-ui/components/codeblock';
+
+hypequery has two different API surfaces:
+
+- **Semantic query APIs** accept constrained dataset and metric requests from users, dashboards, and agents.
+- **Query builder and raw SQL APIs** execute trusted developer-authored SQL.
+
+Keep those surfaces separate. Semantic endpoints are the public input boundary. Raw SQL helpers are for application code you control.
+
+## Public semantic input
+
+Dataset and metric requests are designed for public-facing runtime input:
+
+<CodeBlock>
+```typescript
+await analytics.execute(Orders, {
+  dimensions: ['status'],
+  measures: ['revenue'],
+  filters: [{ field: 'status', operator: 'eq', value: 'completed' }],
+  limit: 100,
+});
+```
+</CodeBlock>
+
+Callers choose from declared semantic fields. Validation rejects unknown dimensions, measures, filters, order fields, time grains, and limits before SQL is generated.
+
+This is the surface Serve, OpenAPI schemas, MCP tools, and generated dataset tools should expose.
+
+## Trusted developer code
+
+The ClickHouse query builder is a developer API. It intentionally exposes escape hatches for ClickHouse features that are not modeled by the fluent builder:
+
+<CodeBlock>
+```typescript
+await db.rawQuery(
+  `SELECT count() AS signups FROM signups WHERE account_id = ?`,
+  [accountId],
+);
+
+db.table('events')
+  .select([rawAs('JSONExtractString(metadata, \'country\')', 'country')]);
+```
+</CodeBlock>
+
+Raw SQL fragments, raw queries, table names, aliases, and custom expressions are not a safe public query language. Do not assemble those strings from user or agent input.
+
+<Callout type="warn" title="Raw SQL is a trusted-code escape hatch">
+  Use raw SQL only in code you own. If an end user or agent needs analytics access, expose a semantic dataset, metric, Serve endpoint, MCP tool, or generated tool schema instead.
+</Callout>
+
+## SQL-backed semantic fields
+
+Datasets also support SQL-backed dimensions and measures:
+
+<CodeBlock>
+```typescript
+dimensions: {
+  countryUpper: dimension.string({ sql: 'upper(country_code)' }),
+},
+measures: {
+  taxedRevenue: measure.sum('amount', { sql: 'amount * 1.2' }),
+}
+```
+</CodeBlock>
+
+These expressions are part of the semantic model and should be authored by trusted application code. Runtime callers can reference `countryUpper` or `taxedRevenue`, but they should not provide the SQL expression itself.
+
+Schema compatibility checks can validate simple column references more deeply than complex SQL expressions. Treat SQL-backed fields as reviewed model code.
+
+## Agent access
+
+Agents should receive semantic tools, not generic SQL execution:
+
+- expose dataset and metric names through a catalog
+- constrain field names and operators with JSON Schema enums
+- hide tenant selection from tool input
+- redact generated SQL unless debugging in a trusted environment
+- keep raw query APIs out of MCP and function-calling tool definitions
+
+## CLI and module loading
+
+CLI workflows that load a project API module execute application code. They are useful for local development, generation, and CI, but they are not static analysis of untrusted files.
+
+Only run model-loading CLI commands against code you trust, such as your repository in CI or a reviewed local checkout.
+
+## Checklist
+
+- Public request bodies should use semantic field names, not SQL strings.
+- Raw query builder helpers should stay in server-side code.
+- Generated tools should be built from catalog metadata.
+- Tenant context should come from trusted auth/runtime state, not user filters.
+- SQL-backed dataset fields should be reviewed like application code.
+
+## Current Audit
+
+The current trusted-code escape hatches are:
+
+- `db.rawQuery(...)`
+- query builder `raw(...)`, `rawAs(...)`, and `selectExpr(...)`
+- predicate builder `expr.raw(...)`
+- dataset `dimension.*({ sql })` and `measure.*(..., { sql })`
+- internal semantic planner calls to `rawQuery(...)` for derived metric SQL assembled from validated model definitions
+
+The public semantic surfaces do not expose a generic SQL execution tool. Serve returns generated SQL only through opt-in metadata (`includeMeta` or `x-include-meta`). MCP tools redact generated SQL and SQL-backed field expressions by default, and require programmatic `includeSql: true` for trusted debugging.


### PR DESCRIPTION

## Summary

Before this change, MCP exposed SQL in two places by default:

  - query_dataset / query_metric returned generated meta.sql
  - get_dataset_schema returned SQL-backed dimension/measure expressions

That is not arbitrary SQL execution, but it still leaks implementation details: table names, column names, tenant filters, calculated field expressions, and possibly business logic encoded in SQL. For local debugging that’s useful. For an agent/tool surface, it should be opt-in.

So the change makes the default safer:
  - Agents get semantic fields and results.
  - SQL stays hidden unless the app explicitly enables includeSql: true.
  - Debug workflows still work.
  - Serve and MCP now have a consistent posture: SQL metadata is opt-in.