### PR TITLE
feat:(datasets,serve) semantic contract JSON export

### DIFF
--- a/.changeset/semantic-contract-json-export.md
+++ b/.changeset/semantic-contract-json-export.md
@@ -9,6 +9,7 @@ Add a stable, hashable semantic contract export.
 - Add `serializeSemanticContract`, `contractToStableJson`, `hashContract`, and `SEMANTIC_CONTRACT_VERSION`. The contract is a deterministic, sorted projection of the dataset catalog (dimensions, measures, metrics, filters, relationships, tenant/time policy, limits) with a version marker and SHA-256 content hash, so logically equal models produce identical JSON and hashes. This is the shared source for snapshots, diffs, CI validation, docs, and codegen.
 - `serializeSemanticContract` accepts `{ includeSql }` (default `true`) to omit raw SQL escape hatches for untrusted consumers.
 - Export the `DatasetCatalogSource` type.
+- Adds a dependency on `@noble/hashes` for the contract content hash, keeping the package isomorphic (no `node:crypto`).
 
 `@hypequery/serve`:
 - Expose the contract via a `GET /contract` endpoint (configurable through `semanticPaths.contract`) that serializes the registered datasets with their named metrics grouped onto each dataset. Raw SQL is redacted on this public endpoint by default.

--- a/.changeset/semantic-contract-json-export.md
+++ b/.changeset/semantic-contract-json-export.md
@@ -7,7 +7,8 @@ Add a stable, hashable semantic contract export.
 
 `@hypequery/datasets`:
 - Add `serializeSemanticContract`, `contractToStableJson`, `hashContract`, and `SEMANTIC_CONTRACT_VERSION`. The contract is a deterministic, sorted projection of the dataset catalog (dimensions, measures, metrics, filters, relationships, tenant/time policy, limits) with a version marker and SHA-256 content hash, so logically equal models produce identical JSON and hashes. This is the shared source for snapshots, diffs, CI validation, docs, and codegen.
+- `serializeSemanticContract` accepts `{ includeSql }` (default `true`) to omit raw SQL escape hatches for untrusted consumers.
 - Export the `DatasetCatalogSource` type.
 
 `@hypequery/serve`:
-- Expose the contract via a `GET /contract` endpoint (configurable through `semanticPaths.contract`) that serializes the registered datasets with their named metrics grouped onto each dataset.
+- Expose the contract via a `GET /contract` endpoint (configurable through `semanticPaths.contract`) that serializes the registered datasets with their named metrics grouped onto each dataset. Raw SQL is redacted on this public endpoint by default.

--- a/.changeset/semantic-contract-json-export.md
+++ b/.changeset/semantic-contract-json-export.md
@@ -1,0 +1,13 @@
+---
+"@hypequery/datasets": minor
+"@hypequery/serve": minor
+---
+
+Add a stable, hashable semantic contract export.
+
+`@hypequery/datasets`:
+- Add `serializeSemanticContract`, `contractToStableJson`, `hashContract`, and `SEMANTIC_CONTRACT_VERSION`. The contract is a deterministic, sorted projection of the dataset catalog (dimensions, measures, metrics, filters, relationships, tenant/time policy, limits) with a version marker and SHA-256 content hash, so logically equal models produce identical JSON and hashes. This is the shared source for snapshots, diffs, CI validation, docs, and codegen.
+- Export the `DatasetCatalogSource` type.
+
+`@hypequery/serve`:
+- Expose the contract via a `GET /contract` endpoint (configurable through `semanticPaths.contract`) that serializes the registered datasets with their named metrics grouped onto each dataset.

--- a/packages/datasets/package.json
+++ b/packages/datasets/package.json
@@ -39,6 +39,7 @@
     "dist"
   ],
   "dependencies": {
+    "@noble/hashes": "^1.8.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/datasets/src/contract.test.ts
+++ b/packages/datasets/src/contract.test.ts
@@ -4,11 +4,17 @@ import { dimension } from './field.js';
 import { measure } from './measure.js';
 import { belongsTo } from './relationships.js';
 import {
+  divide,
   serializeSemanticContract,
   contractToStableJson,
   hashContract,
   SEMANTIC_CONTRACT_VERSION,
-} from './contract.js';
+  type DatasetCatalogSource,
+} from './index.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
 
 const Customers = dataset('customers', {
   source: 'customers',
@@ -21,91 +27,262 @@ const Customers = dataset('customers', {
   },
 });
 
-const Orders = dataset('orders', {
-  source: 'orders',
-  tenantKey: 'tenant_id',
-  timeKey: 'created_at',
-  dimensions: {
-    id: dimension.string(),
-    customerId: dimension.string({ column: 'customer_id' }),
-    status: dimension.string({ label: 'Status', filterable: false }),
-    amount: dimension.number(),
-  },
-  measures: {
-    revenue: measure.sum('amount', { label: 'Revenue' }),
-    orderCount: measure.count('id'),
-  },
-  filters: {
-    status: {
-      __type: 'filter_definition',
-      field: 'status',
-      operators: ['in', 'eq'],
+function makeOrders() {
+  return dataset('orders', {
+    source: 'orders',
+    tenantKey: 'tenant_id',
+    timeKey: 'created_at',
+    dimensions: {
+      id: dimension.string(),
+      customerId: dimension.string({ column: 'customer_id' }),
+      status: dimension.string({ label: 'Status', filterable: false }),
+      amount: dimension.number(),
     },
-  },
-  relationships: {
-    customer: belongsTo(() => Customers, { from: 'customerId', to: 'id' }),
-  },
-  limits: {
-    maxMeasures: 2,
-  },
-});
+    measures: {
+      revenue: measure.sum('amount', { label: 'Revenue' }),
+      orderCount: measure.count('id'),
+    },
+    filters: {
+      status: {
+        __type: 'filter_definition',
+        field: 'status',
+        operators: ['in', 'eq'],
+      },
+    },
+    relationships: {
+      customer: belongsTo(() => Customers, { from: 'customerId', to: 'id' }),
+    },
+    limits: {
+      maxMeasures: 2,
+      maxDimensions: 4,
+    },
+  });
+}
 
-describe('semantic contract', () => {
-  it('serializes datasets into a versioned, hashed contract', () => {
-    const contract = serializeSemanticContract({ orders: Orders, customers: Customers });
+const Orders = makeOrders();
+
+/** Serializes and strips the content hash for structural comparisons. */
+function contractBody(datasets: Record<string, DatasetCatalogSource>) {
+  const { contentHash, ...rest } = serializeSemanticContract(datasets);
+  return rest;
+}
+
+function hashOf(datasets: Record<string, DatasetCatalogSource>): string {
+  return serializeSemanticContract(datasets).contentHash;
+}
+
+// ---------------------------------------------------------------------------
+// Shape
+// ---------------------------------------------------------------------------
+
+describe('semantic contract — shape', () => {
+  it('serializes a full dataset into the contract surface', () => {
+    const contract = serializeSemanticContract({ orders: Orders });
 
     expect(contract.version).toBe(SEMANTIC_CONTRACT_VERSION);
     expect(contract.contentHash).toMatch(/^[a-f0-9]{64}$/);
+
     expect(contract.datasets.orders).toMatchObject({
       name: 'orders',
       source: 'orders',
       tenantKey: 'tenant_id',
       timeKey: 'created_at',
       requiresTenant: true,
-      limits: { maxMeasures: 2 },
+      supportedGrains: ['day', 'month', 'quarter', 'week', 'year'],
+      limits: { maxDimensions: 4, maxMeasures: 2 },
     });
-    expect(contract.datasets.orders.filters.status).toMatchObject({
+    expect(contract.datasets.orders.dimensions.customerId).toEqual({
+      type: 'string',
+      column: 'customer_id',
+      filterable: true,
+      groupable: true,
+    });
+    expect(contract.datasets.orders.dimensions.status).toMatchObject({
+      type: 'string',
+      label: 'Status',
+      filterable: false,
+    });
+    expect(contract.datasets.orders.measures.revenue).toEqual({
+      aggregation: 'sum',
+      field: 'amount',
+      label: 'Revenue',
+    });
+    expect(contract.datasets.orders.filters.status).toEqual({
       field: 'status',
+      operators: ['eq', 'in'],
       valueType: 'string',
     });
+    expect(contract.datasets.orders.relationships.customer).toEqual({
+      kind: 'belongsTo',
+      target: 'customers',
+      from: 'customerId',
+      to: 'id',
+    });
   });
 
-  it('sorts dataset keys, field keys, and unordered arrays deterministically', () => {
-    const contract = serializeSemanticContract({ orders: Orders, customers: Customers });
+  it('omits catalog-only convenience/derived fields', () => {
+    const contract = serializeSemanticContract({ orders: Orders });
+    const ds = contract.datasets.orders as Record<string, unknown>;
 
-    // Dataset keys sorted, regardless of input order.
-    expect(Object.keys(contract.datasets)).toEqual(['customers', 'orders']);
-    // Dimension keys sorted.
-    expect(Object.keys(contract.datasets.orders.dimensions)).toEqual([
-      'amount',
-      'customerId',
-      'id',
-      'status',
-    ]);
-    // Operators sorted, regardless of declaration order (declared ['in','eq']).
-    expect(contract.datasets.orders.filters.status.operators).toEqual(['eq', 'in']);
-    // Grains sorted.
-    expect(contract.datasets.orders.supportedGrains).toEqual([
-      'day',
-      'month',
-      'quarter',
-      'week',
-      'year',
-    ]);
+    // Derived conveniences from the catalog are intentionally not in the contract.
+    expect(ds).not.toHaveProperty('orderableFields');
+    expect(ds).not.toHaveProperty('maxLimit');
+    expect(contract.datasets.orders.measures.revenue).not.toHaveProperty('filterCount');
+    expect(contract.datasets.orders.relationships.customer).not.toHaveProperty('execution');
   });
 
-  it('produces the same hash regardless of dataset input order', () => {
-    const a = serializeSemanticContract({ orders: Orders, customers: Customers });
-    const b = serializeSemanticContract({ customers: Customers, orders: Orders });
+  it('drops optional fields when absent rather than emitting undefined', () => {
+    const contract = serializeSemanticContract({ customers: Customers });
+    const customers = contract.datasets.customers as Record<string, unknown>;
 
-    expect(a.contentHash).toBe(b.contentHash);
+    expect(customers).not.toHaveProperty('tenantKey');
+    expect(customers).not.toHaveProperty('timeKey');
+    expect(customers).not.toHaveProperty('limits');
+    expect(customers.requiresTenant).toBe(false);
+    expect(customers.supportedGrains).toEqual([]);
+    expect(contract.datasets.customers.dimensions.id).not.toHaveProperty('label');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Determinism — equal models hash identically
+// ---------------------------------------------------------------------------
+
+describe('semantic contract — determinism', () => {
+  it('produces identical output regardless of dataset input order', () => {
+    const a = contractBody({ orders: Orders, customers: Customers });
+    const b = contractBody({ customers: Customers, orders: Orders });
+
     expect(contractToStableJson(a)).toBe(contractToStableJson(b));
+    expect(hashOf({ orders: Orders, customers: Customers })).toBe(
+      hashOf({ customers: Customers, orders: Orders }),
+    );
   });
 
-  it('changes the hash when a meaningful field changes', () => {
-    const baseline = serializeSemanticContract({ orders: Orders });
+  it('is independent of dimension/measure declaration order', () => {
+    const A = dataset('orders', {
+      source: 'orders',
+      dimensions: { a: dimension.string(), b: dimension.string() },
+      measures: { x: measure.count('a'), y: measure.count('b') },
+    });
+    const B = dataset('orders', {
+      source: 'orders',
+      dimensions: { b: dimension.string(), a: dimension.string() },
+      measures: { y: measure.count('b'), x: measure.count('a') },
+    });
 
-    const Renamed = dataset('orders', {
+    expect(hashOf({ orders: A })).toBe(hashOf({ orders: B }));
+    // Keys are emitted in sorted order.
+    expect(Object.keys(contractBody({ orders: B }).datasets.orders.dimensions)).toEqual(['a', 'b']);
+  });
+
+  it('is independent of the author-controlled limits key order', () => {
+    const A = dataset('orders', {
+      source: 'orders',
+      dimensions: { id: dimension.string() },
+      measures: { c: measure.count('id') },
+      limits: { maxMeasures: 2, maxDimensions: 5 },
+    });
+    const B = dataset('orders', {
+      source: 'orders',
+      dimensions: { id: dimension.string() },
+      measures: { c: measure.count('id') },
+      limits: { maxDimensions: 5, maxMeasures: 2 },
+    });
+
+    expect(hashOf({ orders: A })).toBe(hashOf({ orders: B }));
+  });
+
+  it('sorts and de-duplicates filter operators', () => {
+    const A = dataset('orders', {
+      source: 'orders',
+      dimensions: { status: dimension.string() },
+      measures: { c: measure.count('status') },
+      filters: {
+        status: { __type: 'filter_definition', field: 'status', operators: ['in', 'eq', 'eq'] },
+      },
+    });
+
+    const contract = serializeSemanticContract({ orders: A });
+    expect(contract.datasets.orders.filters.status.operators).toEqual(['eq', 'in']);
+  });
+
+  it('round-trips hashContract over the hash-free body', () => {
+    const contract = serializeSemanticContract({ orders: Orders });
+    const { contentHash, ...withoutHash } = contract;
+
+    expect(hashContract(withoutHash)).toBe(contentHash);
+    // Recomputing from a fresh serialization is stable too.
+    expect(serializeSemanticContract({ orders: Orders }).contentHash).toBe(contentHash);
+  });
+
+  it('contractToStableJson is 2-space indented and round-trips', () => {
+    const contract = serializeSemanticContract({ orders: Orders });
+    const json = contractToStableJson(contract);
+
+    expect(json).toContain('\n  "version"');
+    expect(JSON.parse(json)).toEqual(contract);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SQL normalization
+// ---------------------------------------------------------------------------
+
+describe('semantic contract — SQL normalization', () => {
+  it('normalizes SQL whitespace/indentation in the serialized value', () => {
+    const A = dataset('orders', {
+      source: 'orders',
+      dimensions: {
+        bucket: dimension.string({ sql: '   upper(status)   ' }),
+      },
+      measures: { c: measure.count('bucket') },
+    });
+
+    const contract = serializeSemanticContract({ orders: A });
+    expect(contract.datasets.orders.dimensions.bucket.sql).toBe('upper(status)');
+  });
+
+  it('ignores whitespace-only SQL differences in the hash', () => {
+    const A = dataset('orders', {
+      source: 'orders',
+      dimensions: { bucket: dimension.string({ sql: 'upper(status)' }) },
+      measures: { c: measure.count('bucket') },
+    });
+    const B = dataset('orders', {
+      source: 'orders',
+      dimensions: { bucket: dimension.string({ sql: '\n   upper(status)  \n' }) },
+      measures: { c: measure.count('bucket') },
+    });
+
+    expect(hashOf({ orders: A })).toBe(hashOf({ orders: B }));
+  });
+
+  it('reflects a meaningful SQL change in the hash', () => {
+    const A = dataset('orders', {
+      source: 'orders',
+      dimensions: { bucket: dimension.string({ sql: 'upper(status)' }) },
+      measures: { c: measure.count('bucket') },
+    });
+    const B = dataset('orders', {
+      source: 'orders',
+      dimensions: { bucket: dimension.string({ sql: 'lower(status)' }) },
+      measures: { c: measure.count('bucket') },
+    });
+
+    expect(hashOf({ orders: A })).not.toBe(hashOf({ orders: B }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hash sensitivity — meaningful changes flip the hash
+// ---------------------------------------------------------------------------
+
+describe('semantic contract — breaking-change sensitivity', () => {
+  const baseline = hashOf({ orders: Orders });
+
+  it('changes when a dimension is added', () => {
+    const next = dataset('orders', {
       source: 'orders',
       tenantKey: 'tenant_id',
       timeKey: 'created_at',
@@ -114,23 +291,152 @@ describe('semantic contract', () => {
         customerId: dimension.string({ column: 'customer_id' }),
         status: dimension.string({ label: 'Status', filterable: false }),
         amount: dimension.number(),
-        // Added dimension changes the semantic surface.
         channel: dimension.string(),
       },
+      measures: { revenue: measure.sum('amount'), orderCount: measure.count('id') },
+    });
+    expect(hashOf({ orders: next })).not.toBe(baseline);
+  });
+
+  it('changes when a dimension type changes', () => {
+    const next = dataset('orders', {
+      source: 'orders',
+      tenantKey: 'tenant_id',
+      timeKey: 'created_at',
+      dimensions: {
+        id: dimension.string(),
+        customerId: dimension.string({ column: 'customer_id' }),
+        status: dimension.string({ label: 'Status', filterable: false }),
+        amount: dimension.string(), // was number
+      },
+      measures: { revenue: measure.sum('amount'), orderCount: measure.count('id') },
+    });
+    expect(hashOf({ orders: next })).not.toBe(baseline);
+  });
+
+  it('changes when a measure aggregation changes', () => {
+    const next = makeOrdersWith({ revenueAgg: 'avg' });
+    expect(hashOf({ orders: next })).not.toBe(baseline);
+  });
+
+  it('changes when the tenant policy changes', () => {
+    const next = dataset('orders', {
+      source: 'orders',
+      timeKey: 'created_at', // tenantKey removed
+      dimensions: {
+        id: dimension.string(),
+        customerId: dimension.string({ column: 'customer_id' }),
+        status: dimension.string({ label: 'Status', filterable: false }),
+        amount: dimension.number(),
+      },
+      measures: { revenue: measure.sum('amount'), orderCount: measure.count('id') },
+    });
+    expect(hashOf({ orders: next })).not.toBe(baseline);
+  });
+
+  it('changes when a named metric is added', () => {
+    const withMetric: DatasetCatalogSource = {
+      ...Orders,
+      metrics: { revenueKpi: Orders.metric('revenueKpi', { measure: 'revenue' }) },
+    };
+    expect(hashOf({ orders: withMetric })).not.toBe(baseline);
+  });
+
+  function makeOrdersWith(opts: { revenueAgg: 'sum' | 'avg' }) {
+    return dataset('orders', {
+      source: 'orders',
+      tenantKey: 'tenant_id',
+      timeKey: 'created_at',
+      dimensions: {
+        id: dimension.string(),
+        customerId: dimension.string({ column: 'customer_id' }),
+        status: dimension.string({ label: 'Status', filterable: false }),
+        amount: dimension.number(),
+      },
       measures: {
-        revenue: measure.sum('amount', { label: 'Revenue' }),
+        revenue:
+          opts.revenueAgg === 'sum' ? measure.sum('amount') : measure.avg('amount'),
         orderCount: measure.count('id'),
       },
     });
-    const changed = serializeSemanticContract({ orders: Renamed });
+  }
+});
 
-    expect(changed.contentHash).not.toBe(baseline.contentHash);
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+describe('semantic contract — metrics', () => {
+  it('captures base and derived metric kinds with sorted field lists', () => {
+    const revenueKpi = Orders.metric('revenueKpi', { measure: 'revenue', label: 'Revenue KPI' });
+    const avgOrder = Orders.metric('avgOrder', {
+      uses: { revenue: revenueKpi },
+      formula: ({ revenue }) => divide(revenue, revenue),
+    });
+
+    const withMetrics: DatasetCatalogSource = {
+      ...Orders,
+      metrics: { revenueKpi, avgOrder },
+    };
+
+    const contract = serializeSemanticContract({ orders: withMetrics });
+    expect(contract.datasets.orders.metrics.revenueKpi).toMatchObject({
+      kind: 'metric',
+      valueType: 'number',
+      label: 'Revenue KPI',
+    });
+    expect(contract.datasets.orders.metrics.avgOrder.kind).toBe('derived_metric');
+    // Dimension list is sorted.
+    const dims = contract.datasets.orders.metrics.revenueKpi.dimensions;
+    expect([...dims].sort()).toEqual(dims);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty / edge inputs
+// ---------------------------------------------------------------------------
+
+describe('semantic contract — edge inputs', () => {
+  it('serializes an empty registry', () => {
+    const contract = serializeSemanticContract({});
+    expect(contract).toMatchObject({ version: SEMANTIC_CONTRACT_VERSION, datasets: {} });
+    expect(contract.contentHash).toMatch(/^[a-f0-9]{64}$/);
   });
 
-  it('hashContract excludes the contentHash field itself (stable round-trip)', () => {
-    const contract = serializeSemanticContract({ orders: Orders });
-    const { contentHash, ...withoutHash } = contract;
+  it('serializes a minimal dataset with empty relationships/metrics', () => {
+    const Empty = dataset('empty', {
+      source: 'empty',
+      dimensions: { id: dimension.string() },
+      measures: { c: measure.count('id') },
+    });
+    const contract = serializeSemanticContract({ empty: Empty });
 
-    expect(hashContract(withoutHash)).toBe(contentHash);
+    expect(contract.datasets.empty.relationships).toEqual({});
+    expect(contract.datasets.empty.metrics).toEqual({});
+  });
+
+  it('captures filters auto-derived from filterable dimensions (default operators)', () => {
+    const Auto = dataset('auto', {
+      source: 'auto',
+      dimensions: {
+        country: dimension.string(),
+        secret: dimension.string({ filterable: false }),
+      },
+      measures: { c: measure.count('country') },
+      // No explicit `filters` → derived from filterable dimensions only.
+    });
+    const contract = serializeSemanticContract({ auto: Auto });
+
+    expect(Object.keys(contract.datasets.auto.filters)).toEqual(['country']);
+    // Default operator set is applied and sorted.
+    expect(contract.datasets.auto.filters.country.operators).toEqual([
+      'between', 'eq', 'gt', 'gte', 'in', 'like', 'lt', 'lte', 'neq', 'notIn',
+    ]);
+  });
+
+  it('keys the contract by the registry key, not the dataset name', () => {
+    const contract = serializeSemanticContract({ ordersAlias: Orders });
+    expect(Object.keys(contract.datasets)).toEqual(['ordersAlias']);
+    expect(contract.datasets.ordersAlias.name).toBe('orders');
   });
 });

--- a/packages/datasets/src/contract.test.ts
+++ b/packages/datasets/src/contract.test.ts
@@ -272,6 +272,24 @@ describe('semantic contract — SQL normalization', () => {
 
     expect(hashOf({ orders: A })).not.toBe(hashOf({ orders: B }));
   });
+
+  it('includes SQL by default and omits it when includeSql is false', () => {
+    const A = dataset('orders', {
+      source: 'orders',
+      dimensions: { bucket: dimension.string({ sql: 'upper(status)' }) },
+      measures: { revenue: measure.sum('amount', { sql: 'sum(amount)' }) },
+    });
+
+    const withSql = serializeSemanticContract({ orders: A });
+    expect(withSql.datasets.orders.dimensions.bucket.sql).toBe('upper(status)');
+    expect(withSql.datasets.orders.measures.revenue.sql).toBe('sum(amount)');
+
+    const redacted = serializeSemanticContract({ orders: A }, { includeSql: false });
+    expect(redacted.datasets.orders.dimensions.bucket).not.toHaveProperty('sql');
+    expect(redacted.datasets.orders.measures.revenue).not.toHaveProperty('sql');
+    // Redaction changes the hash (different serialized surface).
+    expect(redacted.contentHash).not.toBe(withSql.contentHash);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/datasets/src/contract.test.ts
+++ b/packages/datasets/src/contract.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { dataset } from './dataset.js';
+import { dimension } from './field.js';
+import { measure } from './measure.js';
+import { belongsTo } from './relationships.js';
+import {
+  serializeSemanticContract,
+  contractToStableJson,
+  hashContract,
+  SEMANTIC_CONTRACT_VERSION,
+} from './contract.js';
+
+const Customers = dataset('customers', {
+  source: 'customers',
+  dimensions: {
+    id: dimension.string(),
+    country: dimension.string({ label: 'Country' }),
+  },
+  measures: {
+    customerCount: measure.count('id'),
+  },
+});
+
+const Orders = dataset('orders', {
+  source: 'orders',
+  tenantKey: 'tenant_id',
+  timeKey: 'created_at',
+  dimensions: {
+    id: dimension.string(),
+    customerId: dimension.string({ column: 'customer_id' }),
+    status: dimension.string({ label: 'Status', filterable: false }),
+    amount: dimension.number(),
+  },
+  measures: {
+    revenue: measure.sum('amount', { label: 'Revenue' }),
+    orderCount: measure.count('id'),
+  },
+  filters: {
+    status: {
+      __type: 'filter_definition',
+      field: 'status',
+      operators: ['in', 'eq'],
+    },
+  },
+  relationships: {
+    customer: belongsTo(() => Customers, { from: 'customerId', to: 'id' }),
+  },
+  limits: {
+    maxMeasures: 2,
+  },
+});
+
+describe('semantic contract', () => {
+  it('serializes datasets into a versioned, hashed contract', () => {
+    const contract = serializeSemanticContract({ orders: Orders, customers: Customers });
+
+    expect(contract.version).toBe(SEMANTIC_CONTRACT_VERSION);
+    expect(contract.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(contract.datasets.orders).toMatchObject({
+      name: 'orders',
+      source: 'orders',
+      tenantKey: 'tenant_id',
+      timeKey: 'created_at',
+      requiresTenant: true,
+      limits: { maxMeasures: 2 },
+    });
+    expect(contract.datasets.orders.filters.status).toMatchObject({
+      field: 'status',
+      valueType: 'string',
+    });
+  });
+
+  it('sorts dataset keys, field keys, and unordered arrays deterministically', () => {
+    const contract = serializeSemanticContract({ orders: Orders, customers: Customers });
+
+    // Dataset keys sorted, regardless of input order.
+    expect(Object.keys(contract.datasets)).toEqual(['customers', 'orders']);
+    // Dimension keys sorted.
+    expect(Object.keys(contract.datasets.orders.dimensions)).toEqual([
+      'amount',
+      'customerId',
+      'id',
+      'status',
+    ]);
+    // Operators sorted, regardless of declaration order (declared ['in','eq']).
+    expect(contract.datasets.orders.filters.status.operators).toEqual(['eq', 'in']);
+    // Grains sorted.
+    expect(contract.datasets.orders.supportedGrains).toEqual([
+      'day',
+      'month',
+      'quarter',
+      'week',
+      'year',
+    ]);
+  });
+
+  it('produces the same hash regardless of dataset input order', () => {
+    const a = serializeSemanticContract({ orders: Orders, customers: Customers });
+    const b = serializeSemanticContract({ customers: Customers, orders: Orders });
+
+    expect(a.contentHash).toBe(b.contentHash);
+    expect(contractToStableJson(a)).toBe(contractToStableJson(b));
+  });
+
+  it('changes the hash when a meaningful field changes', () => {
+    const baseline = serializeSemanticContract({ orders: Orders });
+
+    const Renamed = dataset('orders', {
+      source: 'orders',
+      tenantKey: 'tenant_id',
+      timeKey: 'created_at',
+      dimensions: {
+        id: dimension.string(),
+        customerId: dimension.string({ column: 'customer_id' }),
+        status: dimension.string({ label: 'Status', filterable: false }),
+        amount: dimension.number(),
+        // Added dimension changes the semantic surface.
+        channel: dimension.string(),
+      },
+      measures: {
+        revenue: measure.sum('amount', { label: 'Revenue' }),
+        orderCount: measure.count('id'),
+      },
+    });
+    const changed = serializeSemanticContract({ orders: Renamed });
+
+    expect(changed.contentHash).not.toBe(baseline.contentHash);
+  });
+
+  it('hashContract excludes the contentHash field itself (stable round-trip)', () => {
+    const contract = serializeSemanticContract({ orders: Orders });
+    const { contentHash, ...withoutHash } = contract;
+
+    expect(hashContract(withoutHash)).toBe(contentHash);
+  });
+});

--- a/packages/datasets/src/contract.ts
+++ b/packages/datasets/src/contract.ts
@@ -120,7 +120,7 @@ function datasetToContract(catalog: DatasetCatalog): ContractDataset {
     ...(catalog.tenantKey !== undefined ? { tenantKey: catalog.tenantKey } : {}),
     ...(catalog.timeKey !== undefined ? { timeKey: catalog.timeKey } : {}),
     requiresTenant: catalog.requiresTenant,
-    supportedGrains: [...catalog.supportedGrains].sort(),
+    supportedGrains: uniqueSorted(catalog.supportedGrains),
     dimensions: sortedRecord(
       Object.entries(catalog.dimensions).map(([name, entry]) => [name, dimensionToContract(entry)]),
     ),
@@ -136,7 +136,21 @@ function datasetToContract(catalog: DatasetCatalog): ContractDataset {
     relationships: sortedRecord(
       Object.entries(catalog.relationships).map(([name, entry]) => [name, relationshipToContract(entry)]),
     ),
-    ...(catalog.limits !== undefined ? { limits: catalog.limits } : {}),
+    ...(catalog.limits !== undefined ? { limits: limitsToContract(catalog.limits) } : {}),
+  };
+}
+
+/**
+ * Emits dataset limits with a fixed key order. The source object's key order is
+ * author-controlled, so normalizing it keeps the contract hash stable for
+ * logically identical limits.
+ */
+function limitsToContract(limits: DatasetLimits): DatasetLimits {
+  return {
+    ...(limits.maxDimensions !== undefined ? { maxDimensions: limits.maxDimensions } : {}),
+    ...(limits.maxFilters !== undefined ? { maxFilters: limits.maxFilters } : {}),
+    ...(limits.maxMeasures !== undefined ? { maxMeasures: limits.maxMeasures } : {}),
+    ...(limits.maxResultSize !== undefined ? { maxResultSize: limits.maxResultSize } : {}),
   };
 }
 
@@ -168,12 +182,12 @@ function metricToContract(entry: MetricCatalogEntry): ContractMetric {
     valueType: entry.valueType,
     ...(entry.label !== undefined ? { label: entry.label } : {}),
     ...(entry.description !== undefined ? { description: entry.description } : {}),
-    dimensions: [...entry.dimensions].sort(),
-    ...(entry.measures !== undefined ? { measures: [...entry.measures].sort() } : {}),
-    filters: [...entry.filters].sort(),
-    grains: [...entry.grains].sort(),
+    dimensions: uniqueSorted(entry.dimensions),
+    ...(entry.measures !== undefined ? { measures: uniqueSorted(entry.measures) } : {}),
+    filters: uniqueSorted(entry.filters),
+    grains: uniqueSorted(entry.grains),
     ...(entry.grain !== undefined ? { grain: entry.grain } : {}),
-    ...(entry.requires !== undefined ? { requires: [...entry.requires].sort() } : {}),
+    ...(entry.requires !== undefined ? { requires: uniqueSorted(entry.requires) } : {}),
   };
 }
 
@@ -182,7 +196,7 @@ function filterToContract(entry: FilterCatalogEntry): ContractFilter {
     field: entry.field,
     ...(entry.label !== undefined ? { label: entry.label } : {}),
     ...(entry.description !== undefined ? { description: entry.description } : {}),
-    operators: [...(entry.operators ?? [])].sort(),
+    operators: uniqueSorted(entry.operators ?? []),
     ...(entry.valueType !== undefined ? { valueType: entry.valueType } : {}),
   };
 }
@@ -214,11 +228,25 @@ export function hashContract(
   return createHash('sha256').update(contractToStableJson(contract)).digest('hex');
 }
 
+/**
+ * Locale-independent string comparison by UTF-16 code unit. Used everywhere the
+ * contract sorts, so the content hash is stable across environments (CI ICU
+ * versions, locales) rather than depending on `localeCompare`.
+ */
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
 /** Builds an object whose keys are inserted in sorted order for stable JSON. */
 function sortedRecord<T>(entries: [string, T][]): Record<string, T> {
   return Object.fromEntries(
-    [...entries].sort(([left], [right]) => left.localeCompare(right)),
+    [...entries].sort(([left], [right]) => compareStrings(left, right)),
   );
+}
+
+/** Deduplicates and sorts a list so logically-equal sets serialize identically. */
+function uniqueSorted(values: readonly string[]): string[] {
+  return Array.from(new Set(values)).sort(compareStrings);
 }
 
 /** Normalizes SQL escape-hatch whitespace so equivalent SQL hashes identically. */

--- a/packages/datasets/src/contract.ts
+++ b/packages/datasets/src/contract.ts
@@ -1,4 +1,5 @@
-import { createHash } from 'node:crypto';
+import { sha256 } from '@noble/hashes/sha2';
+import { bytesToHex } from '@noble/hashes/utils';
 import {
   getDatasetCatalogs,
   type DatasetCatalog,
@@ -234,11 +235,14 @@ export function contractToStableJson(
 
 /**
  * Computes the SHA-256 content hash for a normalized contract.
+ *
+ * Uses `@noble/hashes` (audited, isomorphic, synchronous) rather than
+ * `node:crypto` so the contract stays usable in browser/edge runtimes.
  */
 export function hashContract(
   contract: SemanticContract | SemanticContractWithoutHash,
 ): string {
-  return createHash('sha256').update(contractToStableJson(contract)).digest('hex');
+  return bytesToHex(sha256(contractToStableJson(contract)));
 }
 
 /**

--- a/packages/datasets/src/contract.ts
+++ b/packages/datasets/src/contract.ts
@@ -86,6 +86,17 @@ export interface SemanticContract {
 
 type SemanticContractWithoutHash = Omit<SemanticContract, 'contentHash'>;
 
+export interface SerializeSemanticContractOptions {
+  /**
+   * Include raw `sql` escape-hatch expressions for dimensions/measures.
+   *
+   * Defaults to `true` for trusted contexts (snapshots, CI, codegen) where the
+   * SQL already lives in the developer's source. Set to `false` when serving the
+   * contract to untrusted consumers so internal SQL is not exposed.
+   */
+  includeSql?: boolean;
+}
+
 /**
  * Builds a deterministic semantic contract from dataset instances.
  *
@@ -97,13 +108,15 @@ type SemanticContractWithoutHash = Omit<SemanticContract, 'contentHash'>;
  */
 export function serializeSemanticContract(
   datasets: Record<string, DatasetCatalogSource>,
+  options: SerializeSemanticContractOptions = {},
 ): SemanticContract {
+  const includeSql = options.includeSql ?? true;
   const catalogs = getDatasetCatalogs(datasets);
 
   const contract: SemanticContractWithoutHash = {
     version: SEMANTIC_CONTRACT_VERSION,
     datasets: sortedRecord(
-      Object.entries(catalogs).map(([name, catalog]) => [name, datasetToContract(catalog)]),
+      Object.entries(catalogs).map(([name, catalog]) => [name, datasetToContract(catalog, includeSql)]),
     ),
   };
 
@@ -113,7 +126,7 @@ export function serializeSemanticContract(
   };
 }
 
-function datasetToContract(catalog: DatasetCatalog): ContractDataset {
+function datasetToContract(catalog: DatasetCatalog, includeSql: boolean): ContractDataset {
   return {
     name: catalog.name,
     source: catalog.source,
@@ -122,10 +135,10 @@ function datasetToContract(catalog: DatasetCatalog): ContractDataset {
     requiresTenant: catalog.requiresTenant,
     supportedGrains: uniqueSorted(catalog.supportedGrains),
     dimensions: sortedRecord(
-      Object.entries(catalog.dimensions).map(([name, entry]) => [name, dimensionToContract(entry)]),
+      Object.entries(catalog.dimensions).map(([name, entry]) => [name, dimensionToContract(entry, includeSql)]),
     ),
     measures: sortedRecord(
-      Object.entries(catalog.measures).map(([name, entry]) => [name, measureToContract(entry)]),
+      Object.entries(catalog.measures).map(([name, entry]) => [name, measureToContract(entry, includeSql)]),
     ),
     metrics: sortedRecord(
       Object.entries(catalog.metrics).map(([name, entry]) => [name, metricToContract(entry)]),
@@ -154,11 +167,11 @@ function limitsToContract(limits: DatasetLimits): DatasetLimits {
   };
 }
 
-function dimensionToContract(entry: DimensionCatalogEntry): ContractDimension {
+function dimensionToContract(entry: DimensionCatalogEntry, includeSql: boolean): ContractDimension {
   return {
     type: entry.type,
     ...(entry.column !== undefined ? { column: entry.column } : {}),
-    ...(entry.sql !== undefined ? { sql: normalizeSql(entry.sql) } : {}),
+    ...(includeSql && entry.sql !== undefined ? { sql: normalizeSql(entry.sql) } : {}),
     ...(entry.label !== undefined ? { label: entry.label } : {}),
     ...(entry.description !== undefined ? { description: entry.description } : {}),
     filterable: entry.filterable,
@@ -166,11 +179,11 @@ function dimensionToContract(entry: DimensionCatalogEntry): ContractDimension {
   };
 }
 
-function measureToContract(entry: MeasureCatalogEntry): ContractMeasure {
+function measureToContract(entry: MeasureCatalogEntry, includeSql: boolean): ContractMeasure {
   return {
     aggregation: entry.aggregation,
     field: entry.field,
-    ...(entry.sql !== undefined ? { sql: normalizeSql(entry.sql) } : {}),
+    ...(includeSql && entry.sql !== undefined ? { sql: normalizeSql(entry.sql) } : {}),
     ...(entry.label !== undefined ? { label: entry.label } : {}),
     ...(entry.description !== undefined ? { description: entry.description } : {}),
   };

--- a/packages/datasets/src/contract.ts
+++ b/packages/datasets/src/contract.ts
@@ -1,0 +1,247 @@
+import { createHash } from 'node:crypto';
+import {
+  getDatasetCatalogs,
+  type DatasetCatalog,
+  type DatasetCatalogSource,
+  type DimensionCatalogEntry,
+  type MeasureCatalogEntry,
+  type MetricCatalogEntry,
+  type FilterCatalogEntry,
+  type RelationshipCatalogEntry,
+} from './catalog.js';
+import type { DatasetLimits } from './types.js';
+
+/**
+ * Version of the semantic contract format. Bump when the serialized shape
+ * changes in a way that snapshot consumers must account for.
+ */
+export const SEMANTIC_CONTRACT_VERSION = 1;
+
+export interface ContractDimension {
+  type: DimensionCatalogEntry['type'];
+  column?: string;
+  sql?: string;
+  label?: string;
+  description?: string;
+  filterable: boolean;
+  groupable: boolean;
+}
+
+export interface ContractMeasure {
+  aggregation: MeasureCatalogEntry['aggregation'];
+  field: string;
+  sql?: string;
+  label?: string;
+  description?: string;
+}
+
+export interface ContractMetric {
+  kind: MetricCatalogEntry['kind'];
+  valueType: MetricCatalogEntry['valueType'];
+  label?: string;
+  description?: string;
+  dimensions: string[];
+  measures?: string[];
+  filters: string[];
+  grains: string[];
+  grain?: string;
+  requires?: string[];
+}
+
+export interface ContractFilter {
+  field: string;
+  label?: string;
+  description?: string;
+  operators: string[];
+  valueType?: FilterCatalogEntry['valueType'];
+}
+
+export interface ContractRelationship {
+  kind: RelationshipCatalogEntry['kind'];
+  target: string;
+  from: string;
+  to: string;
+}
+
+export interface ContractDataset {
+  name: string;
+  source: string;
+  tenantKey?: string;
+  timeKey?: string;
+  requiresTenant: boolean;
+  supportedGrains: string[];
+  dimensions: Record<string, ContractDimension>;
+  measures: Record<string, ContractMeasure>;
+  metrics: Record<string, ContractMetric>;
+  filters: Record<string, ContractFilter>;
+  relationships: Record<string, ContractRelationship>;
+  limits?: DatasetLimits;
+}
+
+export interface SemanticContract {
+  version: number;
+  datasets: Record<string, ContractDataset>;
+  contentHash: string;
+}
+
+type SemanticContractWithoutHash = Omit<SemanticContract, 'contentHash'>;
+
+/**
+ * Builds a deterministic semantic contract from dataset instances.
+ *
+ * The contract is a normalized, sorted projection of the dataset catalog with a
+ * version marker and content hash. Object keys and unordered arrays are sorted,
+ * and SQL escape hatches are whitespace-normalized so logically equal models
+ * produce identical JSON and hashes. This is the shared source consumed by
+ * snapshots, diffs, CI validation, docs, and codegen.
+ */
+export function serializeSemanticContract(
+  datasets: Record<string, DatasetCatalogSource>,
+): SemanticContract {
+  const catalogs = getDatasetCatalogs(datasets);
+
+  const contract: SemanticContractWithoutHash = {
+    version: SEMANTIC_CONTRACT_VERSION,
+    datasets: sortedRecord(
+      Object.entries(catalogs).map(([name, catalog]) => [name, datasetToContract(catalog)]),
+    ),
+  };
+
+  return {
+    ...contract,
+    contentHash: hashContract(contract),
+  };
+}
+
+function datasetToContract(catalog: DatasetCatalog): ContractDataset {
+  return {
+    name: catalog.name,
+    source: catalog.source,
+    ...(catalog.tenantKey !== undefined ? { tenantKey: catalog.tenantKey } : {}),
+    ...(catalog.timeKey !== undefined ? { timeKey: catalog.timeKey } : {}),
+    requiresTenant: catalog.requiresTenant,
+    supportedGrains: [...catalog.supportedGrains].sort(),
+    dimensions: sortedRecord(
+      Object.entries(catalog.dimensions).map(([name, entry]) => [name, dimensionToContract(entry)]),
+    ),
+    measures: sortedRecord(
+      Object.entries(catalog.measures).map(([name, entry]) => [name, measureToContract(entry)]),
+    ),
+    metrics: sortedRecord(
+      Object.entries(catalog.metrics).map(([name, entry]) => [name, metricToContract(entry)]),
+    ),
+    filters: sortedRecord(
+      Object.entries(catalog.filters).map(([name, entry]) => [name, filterToContract(entry)]),
+    ),
+    relationships: sortedRecord(
+      Object.entries(catalog.relationships).map(([name, entry]) => [name, relationshipToContract(entry)]),
+    ),
+    ...(catalog.limits !== undefined ? { limits: catalog.limits } : {}),
+  };
+}
+
+function dimensionToContract(entry: DimensionCatalogEntry): ContractDimension {
+  return {
+    type: entry.type,
+    ...(entry.column !== undefined ? { column: entry.column } : {}),
+    ...(entry.sql !== undefined ? { sql: normalizeSql(entry.sql) } : {}),
+    ...(entry.label !== undefined ? { label: entry.label } : {}),
+    ...(entry.description !== undefined ? { description: entry.description } : {}),
+    filterable: entry.filterable,
+    groupable: entry.groupable,
+  };
+}
+
+function measureToContract(entry: MeasureCatalogEntry): ContractMeasure {
+  return {
+    aggregation: entry.aggregation,
+    field: entry.field,
+    ...(entry.sql !== undefined ? { sql: normalizeSql(entry.sql) } : {}),
+    ...(entry.label !== undefined ? { label: entry.label } : {}),
+    ...(entry.description !== undefined ? { description: entry.description } : {}),
+  };
+}
+
+function metricToContract(entry: MetricCatalogEntry): ContractMetric {
+  return {
+    kind: entry.kind,
+    valueType: entry.valueType,
+    ...(entry.label !== undefined ? { label: entry.label } : {}),
+    ...(entry.description !== undefined ? { description: entry.description } : {}),
+    dimensions: [...entry.dimensions].sort(),
+    ...(entry.measures !== undefined ? { measures: [...entry.measures].sort() } : {}),
+    filters: [...entry.filters].sort(),
+    grains: [...entry.grains].sort(),
+    ...(entry.grain !== undefined ? { grain: entry.grain } : {}),
+    ...(entry.requires !== undefined ? { requires: [...entry.requires].sort() } : {}),
+  };
+}
+
+function filterToContract(entry: FilterCatalogEntry): ContractFilter {
+  return {
+    field: entry.field,
+    ...(entry.label !== undefined ? { label: entry.label } : {}),
+    ...(entry.description !== undefined ? { description: entry.description } : {}),
+    operators: [...(entry.operators ?? [])].sort(),
+    ...(entry.valueType !== undefined ? { valueType: entry.valueType } : {}),
+  };
+}
+
+function relationshipToContract(entry: RelationshipCatalogEntry): ContractRelationship {
+  return {
+    kind: entry.kind,
+    target: entry.target,
+    from: entry.from,
+    to: entry.to,
+  };
+}
+
+/**
+ * Serializes a contract with stable formatting for writing to disk and hashing.
+ */
+export function contractToStableJson(
+  contract: SemanticContract | SemanticContractWithoutHash,
+): string {
+  return JSON.stringify(contract, null, 2);
+}
+
+/**
+ * Computes the SHA-256 content hash for a normalized contract.
+ */
+export function hashContract(
+  contract: SemanticContract | SemanticContractWithoutHash,
+): string {
+  return createHash('sha256').update(contractToStableJson(contract)).digest('hex');
+}
+
+/** Builds an object whose keys are inserted in sorted order for stable JSON. */
+function sortedRecord<T>(entries: [string, T][]): Record<string, T> {
+  return Object.fromEntries(
+    [...entries].sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+/** Normalizes SQL escape-hatch whitespace so equivalent SQL hashes identically. */
+function normalizeSql(sql: string): string {
+  const lines = sql
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map(line => line.replace(/\s+$/g, ''));
+
+  while (lines.length > 0 && lines[0].trim() === '') {
+    lines.shift();
+  }
+  while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+    lines.pop();
+  }
+
+  const indents = lines
+    .filter(line => line.trim().length > 0)
+    .map(line => line.match(/^\s*/)?.[0].length ?? 0);
+  const minIndent = indents.length > 0 ? Math.min(...indents) : 0;
+
+  return lines
+    .map(line => line.slice(minIndent))
+    .join('\n')
+    .trim();
+}

--- a/packages/datasets/src/index.ts
+++ b/packages/datasets/src/index.ts
@@ -36,12 +36,30 @@ export { getDatasetCatalog, getDatasetCatalogs } from './catalog.js';
 export type {
   DatasetCatalog,
   DatasetCatalogMap,
+  DatasetCatalogSource,
   DimensionCatalogEntry,
   MeasureCatalogEntry,
   MetricCatalogEntry,
   FilterCatalogEntry,
   RelationshipCatalogEntry,
 } from './catalog.js';
+
+// Semantic contract (stable, hashable export for snapshots/diffs/validation)
+export {
+  serializeSemanticContract,
+  contractToStableJson,
+  hashContract,
+  SEMANTIC_CONTRACT_VERSION,
+} from './contract.js';
+export type {
+  SemanticContract,
+  ContractDataset,
+  ContractDimension,
+  ContractMeasure,
+  ContractMetric,
+  ContractFilter,
+  ContractRelationship,
+} from './contract.js';
 
 // Agent/tool metadata
 export {

--- a/packages/datasets/src/index.ts
+++ b/packages/datasets/src/index.ts
@@ -53,6 +53,7 @@ export {
 } from './contract.js';
 export type {
   SemanticContract,
+  SerializeSemanticContractOptions,
   ContractDataset,
   ContractDimension,
   ContractMeasure,

--- a/packages/serve/src/semantic/datasets/contract-endpoint.ts
+++ b/packages/serve/src/semantic/datasets/contract-endpoint.ts
@@ -1,0 +1,51 @@
+/**
+ * Exposes the semantic contract for registered datasets/metrics as a GET endpoint.
+ *
+ * The contract is a stable, hashed JSON projection of the semantic layer
+ * (dimensions, measures, metrics, filters, relationships, tenant/time policy).
+ * It is the shared source consumed by snapshots, CI validation, docs, and
+ * codegen. The serialized document is cached after the first request since the
+ * registered datasets do not change at runtime.
+ */
+
+import { z } from 'zod';
+import { serializeSemanticContract, type SemanticContract } from '@hypequery/datasets';
+import type { AuthContext, ServeEndpoint } from '../../types.js';
+
+export function createSemanticContractEndpoint(
+  path: string,
+  getContract: () => SemanticContract,
+): ServeEndpoint<any, any, Record<string, unknown>, AuthContext> {
+  let cached: SemanticContract | null = null;
+  return {
+    key: '__hypequery_semantic_contract__',
+    method: 'GET',
+    inputSchema: undefined,
+    outputSchema: z.any(),
+    handler: async () => {
+      if (!cached) {
+        cached = getContract();
+      }
+      return cached;
+    },
+    query: undefined,
+    middlewares: [],
+    auth: null,
+    metadata: {
+      path,
+      method: 'GET',
+      name: 'Semantic contract',
+      summary: 'Semantic contract',
+      description:
+        'Stable, hashed JSON contract for the registered semantic datasets and metrics. ' +
+        'Use it for snapshots, CI validation, docs, and codegen.',
+      tags: ['datasets'],
+      requiresAuth: false,
+      deprecated: false,
+      visibility: 'public',
+    },
+    cacheTtlMs: null,
+  } satisfies ServeEndpoint<any, any, Record<string, unknown>, AuthContext>;
+}
+
+export { serializeSemanticContract };

--- a/packages/serve/src/semantic/datasets/contract-endpoint.ts
+++ b/packages/serve/src/semantic/datasets/contract-endpoint.ts
@@ -1,5 +1,6 @@
 /**
- * Exposes the semantic contract for registered datasets/metrics as a GET endpoint.
+ * Serve integration for the semantic contract: assembles the contract source
+ * from registered datasets/metrics and exposes it as a cached GET endpoint.
  *
  * The contract is a stable, hashed JSON projection of the semantic layer
  * (dimensions, measures, metrics, filters, relationships, tenant/time policy).
@@ -9,8 +10,33 @@
  */
 
 import { z } from 'zod';
-import { serializeSemanticContract, type SemanticContract } from '@hypequery/datasets';
-import type { AuthContext, ServeEndpoint } from '../../types.js';
+import type { DatasetCatalogSource, SemanticContract } from '@hypequery/datasets';
+import type { AuthContext, DatasetsConfig, MetricsConfig, ServeEndpoint } from '../../types.js';
+import { resolveDatasetEntry } from './utils/dataset-entry.js';
+import { resolveMetricEntry } from './metric-endpoint.js';
+
+/**
+ * Builds the `serializeSemanticContract` input from the registered datasets and
+ * metrics, grouping each named metric onto its dataset by dataset name.
+ */
+export function buildSemanticContractSource(
+  datasets: DatasetsConfig<any>,
+  metrics?: MetricsConfig<any>,
+): Record<string, DatasetCatalogSource> {
+  const metricsByDatasetName: Record<string, Record<string, unknown>> = {};
+  for (const [metricName, entry] of Object.entries(metrics ?? {})) {
+    const metric = resolveMetricEntry(entry).metric;
+    const datasetName = metric.contract().dataset;
+    (metricsByDatasetName[datasetName] ??= {})[metricName] = metric;
+  }
+
+  const source: Record<string, DatasetCatalogSource> = {};
+  for (const [name, entry] of Object.entries(datasets)) {
+    const ds = resolveDatasetEntry(entry).dataset;
+    source[name] = { ...ds, metrics: metricsByDatasetName[ds.name] } as DatasetCatalogSource;
+  }
+  return source;
+}
 
 export function createSemanticContractEndpoint(
   path: string,
@@ -47,5 +73,3 @@ export function createSemanticContractEndpoint(
     cacheTtlMs: null,
   } satisfies ServeEndpoint<any, any, Record<string, unknown>, AuthContext>;
 }
-
-export { serializeSemanticContract };

--- a/packages/serve/src/semantic/datasets/index.ts
+++ b/packages/serve/src/semantic/datasets/index.ts
@@ -82,8 +82,10 @@ export type {
 } from '@hypequery/datasets';
 
 // Serve-specific endpoint integration
-export { createMetricEndpoint, resolveMetricEntry } from './metric-endpoint.js';
+export { createMetricEndpoint } from './metric-endpoint.js';
 export { createDatasetEndpoint } from './dataset-endpoint.js';
-export { resolveDatasetEntry } from './utils/dataset-entry.js';
-export { createSemanticContractEndpoint } from './contract-endpoint.js';
+export {
+  createSemanticContractEndpoint,
+  buildSemanticContractSource,
+} from './contract-endpoint.js';
 export type { DatasetEntry } from './dataset-endpoint.js';

--- a/packages/serve/src/semantic/datasets/index.ts
+++ b/packages/serve/src/semantic/datasets/index.ts
@@ -82,6 +82,8 @@ export type {
 } from '@hypequery/datasets';
 
 // Serve-specific endpoint integration
-export { createMetricEndpoint } from './metric-endpoint.js';
+export { createMetricEndpoint, resolveMetricEntry } from './metric-endpoint.js';
 export { createDatasetEndpoint } from './dataset-endpoint.js';
+export { resolveDatasetEntry } from './utils/dataset-entry.js';
+export { createSemanticContractEndpoint } from './contract-endpoint.js';
 export type { DatasetEntry } from './dataset-endpoint.js';

--- a/packages/serve/src/semantic/datasets/metric-endpoint.ts
+++ b/packages/serve/src/semantic/datasets/metric-endpoint.ts
@@ -70,7 +70,7 @@ function isMetricEntryOptions<TAuth extends AuthContext>(
   return !!entry && typeof entry === 'object' && 'metric' in entry;
 }
 
-function resolveMetricEntry<TAuth extends AuthContext>(
+export function resolveMetricEntry<TAuth extends AuthContext>(
   entry: MetricEntry<TAuth>,
 ): {
   metric: MetricHandle<any, any>;

--- a/packages/serve/src/semantic/datasets/serve-integration.test.ts
+++ b/packages/serve/src/semantic/datasets/serve-integration.test.ts
@@ -6,6 +6,7 @@ import {
   measure,
   divide,
   nullIfZero,
+  serializeSemanticContract,
   type QueryBuilderLike,
   type QueryBuilderFactoryLike,
 } from '@hypequery/datasets';
@@ -1981,6 +1982,57 @@ describe("Serve integration — metrics", () => {
       );
 
       expect(response.status).toBe(404);
+    });
+
+    it("matches the library serialization (endpoint does not mangle the contract)", async () => {
+      const api = createAPI({
+        datasets: { orders: Orders },
+        metrics: { totalRevenue },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      const response = await api.handler(
+        createRequest({ path: "/contract", method: "GET" })
+      );
+      const served = response.body as { contentHash: string };
+
+      const expected = serializeSemanticContract({
+        orders: { ...Orders, metrics: { totalRevenue } },
+      } as any);
+
+      expect(served.contentHash).toBe(expected.contentHash);
+    });
+
+    it("honors a custom semanticPaths.contract path", async () => {
+      const api = createAPI({
+        datasets: { orders: Orders },
+        semanticPaths: { contract: "/semantic-contract" },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      const custom = await api.handler(
+        createRequest({ path: "/semantic-contract", method: "GET" })
+      );
+      const defaulted = await api.handler(
+        createRequest({ path: "/contract", method: "GET" })
+      );
+
+      expect(custom.status).toBe(200);
+      expect(defaulted.status).toBe(404);
+    });
+
+    it("returns a stable hash across repeated requests (cached)", async () => {
+      const api = createAPI({
+        datasets: { orders: Orders },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      const first = await api.handler(createRequest({ path: "/contract", method: "GET" }));
+      const second = await api.handler(createRequest({ path: "/contract", method: "GET" }));
+
+      expect((first.body as { contentHash: string }).contentHash).toBe(
+        (second.body as { contentHash: string }).contentHash,
+      );
     });
   });
 });

--- a/packages/serve/src/semantic/datasets/serve-integration.test.ts
+++ b/packages/serve/src/semantic/datasets/serve-integration.test.ts
@@ -1928,4 +1928,59 @@ describe("Serve integration — metrics", () => {
     });
 
   });
+
+  describe("semantic contract endpoint", () => {
+    it("serves a stable, hashed contract for registered datasets", async () => {
+      const api = createAPI({
+        datasets: { orders: Orders },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      const response = await api.handler(
+        createRequest({ path: "/contract", method: "GET" })
+      );
+
+      expect(response.status).toBe(200);
+      const body = response.body as {
+        version: number;
+        contentHash: string;
+        datasets: Record<string, { source: string; dimensions: Record<string, unknown> }>;
+      };
+      expect(body.version).toBe(1);
+      expect(body.contentHash).toMatch(/^[a-f0-9]{64}$/);
+      expect(body.datasets.orders.source).toBe("orders");
+      expect(Object.keys(body.datasets.orders.dimensions)).toContain("country");
+    });
+
+    it("includes named metrics grouped onto their dataset", async () => {
+      const api = createAPI({
+        datasets: { orders: Orders },
+        metrics: { totalRevenue },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      const response = await api.handler(
+        createRequest({ path: "/contract", method: "GET" })
+      );
+
+      expect(response.status).toBe(200);
+      const body = response.body as {
+        datasets: Record<string, { metrics: Record<string, unknown> }>;
+      };
+      expect(Object.keys(body.datasets.orders.metrics)).toContain("totalRevenue");
+    });
+
+    it("is not registered when no datasets are configured", async () => {
+      const api = createAPI({
+        metrics: { totalRevenue },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      const response = await api.handler(
+        createRequest({ path: "/contract", method: "GET" })
+      );
+
+      expect(response.status).toBe(404);
+    });
+  });
 });

--- a/packages/serve/src/semantic/datasets/serve-integration.test.ts
+++ b/packages/serve/src/semantic/datasets/serve-integration.test.ts
@@ -1996,11 +1996,35 @@ describe("Serve integration — metrics", () => {
       );
       const served = response.body as { contentHash: string };
 
-      const expected = serializeSemanticContract({
-        orders: { ...Orders, metrics: { totalRevenue } },
-      } as any);
+      // Endpoint redacts SQL on the public surface, so compare with the same option.
+      const expected = serializeSemanticContract(
+        { orders: { ...Orders, metrics: { totalRevenue } } } as any,
+        { includeSql: false },
+      );
 
       expect(served.contentHash).toBe(expected.contentHash);
+    });
+
+    it("redacts raw SQL from the public contract endpoint", async () => {
+      const SqlOrders = dataset("sqlOrders", {
+        source: "orders",
+        dimensions: { bucket: dimension.string({ sql: "upper(status)" }) },
+        measures: { c: measure.count("bucket") },
+      });
+      const api = createAPI({
+        datasets: { sqlOrders: SqlOrders },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      const response = await api.handler(
+        createRequest({ path: "/contract", method: "GET" })
+      );
+
+      const body = response.body as {
+        datasets: Record<string, { dimensions: Record<string, { sql?: string }> }>;
+      };
+      expect(response.status).toBe(200);
+      expect(body.datasets.sqlOrders.dimensions.bucket).not.toHaveProperty("sql");
     });
 
     it("honors a custom semanticPaths.contract path", async () => {

--- a/packages/serve/src/server/create-api.ts
+++ b/packages/serve/src/server/create-api.ts
@@ -23,8 +23,15 @@ import { createDocsEndpoint, createOpenApiEndpoint } from "../pipeline.js";
 import { resolveCorsConfig } from "../cors.js";
 import { createExecuteQuery } from "./execute-query.js";
 import { createAPImethods } from "./api-builder.js";
-import { createDatasetClient } from "@hypequery/datasets";
-import { createMetricEndpoint, createDatasetEndpoint } from "../semantic/datasets/index.js";
+import { createDatasetClient, serializeSemanticContract } from "@hypequery/datasets";
+import type { DatasetCatalogSource } from "@hypequery/datasets";
+import {
+  createMetricEndpoint,
+  createDatasetEndpoint,
+  createSemanticContractEndpoint,
+  resolveDatasetEntry,
+  resolveMetricEntry,
+} from "../semantic/datasets/index.js";
 import { attachSemanticQueryBuilder, extractQueryBuilderFromContext } from "../semantic/query-builder-context.js";
 
 const assertSemanticKeyAvailable = (
@@ -257,6 +264,37 @@ export const createAPI = <
       (queryEntries as Record<string, any>)[`dataset:${name}`] = registeredEndpoint;
       router.register(registeredEndpoint);
     }
+  }
+
+  // Process semantic contract — expose a stable, hashed JSON contract for the
+  // registered datasets (with named metrics grouped onto their datasets).
+  if (config.datasets) {
+    const datasetEntries = config.datasets;
+
+    // Group named metrics by their dataset name so the contract includes them.
+    const metricsByDatasetName: Record<string, Record<string, any>> = {};
+    for (const [metricName, entry] of Object.entries(config.metrics ?? {})) {
+      const metric = resolveMetricEntry(entry).metric;
+      const datasetName = metric.contract().dataset;
+      (metricsByDatasetName[datasetName] ??= {})[metricName] = metric;
+    }
+
+    const contractSource: Record<string, DatasetCatalogSource> = {};
+    for (const [name, entry] of Object.entries(datasetEntries)) {
+      const ds = resolveDatasetEntry(entry).dataset;
+      contractSource[name] = {
+        ...ds,
+        metrics: metricsByDatasetName[ds.name],
+      } as DatasetCatalogSource;
+    }
+
+    const contractPath = config.semanticPaths?.contract ?? '/contract';
+    const routePath = normalizeRoutePath(contractPath);
+    const contractEndpoint = createSemanticContractEndpoint(
+      routePath,
+      () => serializeSemanticContract(contractSource),
+    );
+    router.register(contractEndpoint);
   }
 
   const corsConfig = resolveCorsConfig(config.cors);

--- a/packages/serve/src/server/create-api.ts
+++ b/packages/serve/src/server/create-api.ts
@@ -24,13 +24,11 @@ import { resolveCorsConfig } from "../cors.js";
 import { createExecuteQuery } from "./execute-query.js";
 import { createAPImethods } from "./api-builder.js";
 import { createDatasetClient, serializeSemanticContract } from "@hypequery/datasets";
-import type { DatasetCatalogSource } from "@hypequery/datasets";
 import {
   createMetricEndpoint,
   createDatasetEndpoint,
   createSemanticContractEndpoint,
-  resolveDatasetEntry,
-  resolveMetricEntry,
+  buildSemanticContractSource,
 } from "../semantic/datasets/index.js";
 import { attachSemanticQueryBuilder, extractQueryBuilderFromContext } from "../semantic/query-builder-context.js";
 
@@ -269,30 +267,13 @@ export const createAPI = <
   // Process semantic contract — expose a stable, hashed JSON contract for the
   // registered datasets (with named metrics grouped onto their datasets).
   if (config.datasets) {
-    const datasetEntries = config.datasets;
-
-    // Group named metrics by their dataset name so the contract includes them.
-    const metricsByDatasetName: Record<string, Record<string, any>> = {};
-    for (const [metricName, entry] of Object.entries(config.metrics ?? {})) {
-      const metric = resolveMetricEntry(entry).metric;
-      const datasetName = metric.contract().dataset;
-      (metricsByDatasetName[datasetName] ??= {})[metricName] = metric;
-    }
-
-    const contractSource: Record<string, DatasetCatalogSource> = {};
-    for (const [name, entry] of Object.entries(datasetEntries)) {
-      const ds = resolveDatasetEntry(entry).dataset;
-      contractSource[name] = {
-        ...ds,
-        metrics: metricsByDatasetName[ds.name],
-      } as DatasetCatalogSource;
-    }
-
-    const contractPath = config.semanticPaths?.contract ?? '/contract';
-    const routePath = normalizeRoutePath(contractPath);
+    const contractSource = buildSemanticContractSource(config.datasets, config.metrics);
+    const routePath = normalizeRoutePath(config.semanticPaths?.contract ?? '/contract');
     const contractEndpoint = createSemanticContractEndpoint(
       routePath,
-      () => serializeSemanticContract(contractSource),
+      // Redact raw SQL on this public, unauthenticated surface; the contract is
+      // still served for snapshots/docs/codegen without exposing internal SQL.
+      () => serializeSemanticContract(contractSource, { includeSql: false }),
     );
     router.register(contractEndpoint);
   }

--- a/packages/serve/src/types.ts
+++ b/packages/serve/src/types.ts
@@ -794,6 +794,8 @@ export interface ServeConfig<
   semanticPaths?: {
     metrics?: string;
     datasets?: string;
+    /** Path for the GET semantic-contract endpoint. Defaults to `/contract`. */
+    contract?: string;
   };
 }
 

--- a/plans/dynamic-dataset-api-tasks.md
+++ b/plans/dynamic-dataset-api-tasks.md
@@ -397,8 +397,8 @@ hypequery semantic doctor
 
 ### Implementation Work
 
-- Define a stable semantic contract JSON format.
-- Export contracts from datasets and metric refs.
+- Done in this PR: Define a stable semantic contract JSON format (`serializeSemanticContract`, versioned + content-hashed).
+- Done in this PR: Export contracts from datasets and metric refs (`@hypequery/datasets`) and expose over HTTP (`@hypequery/serve` `GET /contract`).
 - Compare snapshots in CI.
 - Detect breaking changes:
   - removed dataset
@@ -1306,9 +1306,9 @@ Includes:
 
 | PR | Status | Scope | Packages | Change Size | Reason |
 |---|---|---|---|---:|---|
-| 1 | Complete | Catalog export, MCP introspection fix, Serve/OpenAPI catalog metadata, dashboard/tool metadata, and initial AI tool generation | `datasets`, `mcp-server`, `serve`, `website-next` | Medium | Fixes agent/dashboard metadata, removes measures/metrics drift, and gives agents catalog-backed tool schemas. |
-| 2 | Complete in this PR | Trust-boundary docs and unsafe SQL audit | `website-next`, `datasets`, `clickhouse`, `cli` | Minor | Low-risk enterprise/security foundation. |
-| 3 | Next | Semantic contract JSON export | `datasets`, `serve` | Medium | Enables validation, snapshots, docs, MCP, and codegen to share one source. |
+| 1 | Complete in this PR | Catalog export, MCP introspection fix, Serve/OpenAPI catalog metadata, dashboard/tool metadata, and initial AI tool generation | `datasets`, `mcp-server`, `serve`, `website-next` | Medium | Fixes agent/dashboard metadata, removes measures/metrics drift, and gives agents catalog-backed tool schemas. |
+| 2 | Next | Trust-boundary docs and unsafe SQL audit | `website-next`, `datasets`, `clickhouse`, `cli` | Minor | Low-risk enterprise/security foundation. |
+| 3 | Complete in this PR | Semantic contract JSON export (`serializeSemanticContract` + Serve `GET /contract`) | `datasets`, `serve` | Medium | Enables validation, snapshots, docs, MCP, and codegen to share one source. |
 | 4 | Next | `hypequery semantic validate` CLI | `cli`, `datasets`, `schema` | Medium | Immediate CI value. |
 | 5 | Planned | Semantic audit event hooks | `serve`, `datasets`, `mcp-server` | Medium | Required for enterprise deployment. |
 | 6 | Planned | Field/dataset/metric access metadata | `datasets`, `serve` | Major | Starts governance before relationship complexity. |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,13 +320,13 @@ importers:
         version: 2.4.9
       '@vitest/coverage-v8':
         specifier: ^2.1.6
-        version: 2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
       vitest:
         specifier: ^2.1.6
-        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/clickhouse:
     dependencies:
@@ -351,7 +351,7 @@ importers:
         version: 18.19.130
       '@vitest/coverage-v8':
         specifier: ^2.1.6
-        version: 2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       glob:
         specifier: ^10.5.0
         version: 10.5.0
@@ -369,10 +369,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.6
-        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/datasets:
     dependencies:
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -382,13 +385,13 @@ importers:
         version: 18.19.130
       '@vitest/coverage-v8':
         specifier: ^2.1.6
-        version: 2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
       vitest:
         specifier: ^2.1.6
-        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/mcp-server:
     dependencies:
@@ -410,7 +413,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.6
-        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/react:
     devDependencies:
@@ -428,10 +431,10 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitest/coverage-v8':
         specifier: ^2.1.6
-        version: 2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       jsdom:
         specifier: ^27.4.0
-        version: 27.4.0
+        version: 27.4.0(@noble/hashes@1.8.0)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -443,7 +446,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.6
-        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/schema:
     devDependencies:
@@ -452,13 +455,13 @@ importers:
         version: 18.19.130
       '@vitest/coverage-v8':
         specifier: ^2.1.6
-        version: 2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
       vitest:
         specifier: ^2.1.6
-        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/serve:
     dependencies:
@@ -483,7 +486,7 @@ importers:
         version: 20.19.31
       '@vitest/coverage-v8':
         specifier: ^2.1.9
-        version: 2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -492,7 +495,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.6
-        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -1267,6 +1270,10 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -5272,7 +5279,9 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
-  '@exodus/bytes@1.11.0': {}
+  '@exodus/bytes@1.11.0(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
 
   '@floating-ui/core@1.7.4':
     dependencies:
@@ -5604,6 +5613,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.5.18':
     optional: true
+
+  '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6405,7 +6416,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -6419,11 +6430,11 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -6437,7 +6448,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -7677,9 +7688,9 @@ snapshots:
 
   hono@4.12.23: {}
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
-      '@exodus/bytes': 1.11.0
+      '@exodus/bytes': 1.11.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -7951,15 +7962,15 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@27.4.0:
+  jsdom@27.4.0(@noble/hashes@1.8.0):
     dependencies:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.7.7
-      '@exodus/bytes': 1.11.0
+      '@exodus/bytes': 1.11.0(@noble/hashes@1.8.0)
       cssstyle: 5.3.7
       data-urls: 6.0.1
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       is-potential-custom-element-name: 1.0.1
@@ -9380,7 +9391,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@6.4.2(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -9405,7 +9416,7 @@ snapshots:
     optionalDependencies:
       '@edge-runtime/vm': 3.2.0
       '@types/node': 18.19.130
-      jsdom: 27.4.0
+      jsdom: 27.4.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -9420,7 +9431,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@2.1.9(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@6.4.2(@types/node@20.19.31)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -9445,7 +9456,7 @@ snapshots:
     optionalDependencies:
       '@edge-runtime/vm': 3.2.0
       '@types/node': 20.19.31
-      jsdom: 27.4.0
+      jsdom: 27.4.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
Add a stable, deterministic semantic contract derived from the dataset catalog, plus an HTTP endpoint to expose it. This is the shared source that future snapshot/diff/validate tooling, docs, MCP, and codegen can consume.

@hypequery/datasets:
- serializeSemanticContract / contractToStableJson / hashContract and SEMANTIC_CONTRACT_VERSION. The contract sorts object keys and unordered arrays and normalizes SQL whitespace so logically equal models produce identical JSON and SHA-256 hashes.
- Export the DatasetCatalogSource type.

@hypequery/serve:
- GET /contract endpoint (configurable via semanticPaths.contract) that serializes the registered datasets with named metrics grouped onto each dataset. Mirrors the cached OpenAPI endpoint pattern.

Tests cover contract shape, determinism, hash stability under reordering, hash sensitivity to meaningful changes, and the Serve endpoint.