### PR TITLE
Export substituteParameters and escapeValue for adapter authors

### DIFF
--- a/.changeset/export-render-utils.md
+++ b/.changeset/export-render-utils.md
@@ -1,0 +1,5 @@
+---
+"@hypequery/clickhouse": patch
+---
+
+Export `substituteParameters` and `escapeValue` from the package entrypoint so third-party adapters can reuse the same SQL parameter rendering as the built-in ClickHouse adapter.

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -14,6 +14,10 @@ export type {
   ExecuteOptions
 } from './core/query-builder.js';
 export { isClientConfig } from './core/query-builder.js';
+
+// SQL rendering used by the built-in adapter; exported so third-party DatabaseAdapter
+// implementations (e.g. embedded engines) reproduce identical ?-param rendering.
+export { substituteParameters, escapeValue } from './core/utils.js';
 export type {
   CacheOptions,
   CacheConfig,


### PR DESCRIPTION
Follow-up to the embedded-chDB discussion in #237.

A third-party `DatabaseAdapter` (an embedded chDB backend, in our case) needs to render
`?`-positional params exactly the way the built-in `ClickHouseAdapter` does. Those helpers
(`substituteParameters`, `escapeValue`) live in `core/utils.ts` but aren't exported, so an
adapter has to copy them and can drift if the escaping ever changes.

This re-exports both from the package entry. No behavior change. Both functions are already
`export function` in `core/utils.ts`; this only surfaces them so adapter authors can import
the exact same rendering instead of duplicating it.

```ts
export { substituteParameters, escapeValue } from './core/utils.js';
```

Once this is published, our `chdb/hypequery` adapter (separate, in the chdb package) will
switch from its copied helpers to importing these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)