### PR TITLE
[codex] Improve datasets onboarding DX

### DIFF
--- a/.changeset/datasets-generator-dx.md
+++ b/.changeset/datasets-generator-dx.md
@@ -1,0 +1,5 @@
+---
+"@hypequery/cli": patch
+---
+
+Improve `generate:datasets` measure heuristics so ID and coordinate columns are emitted as dimensions but not nonsensical sum/avg measures.

--- a/packages/cli/src/generators/dataset-generator.test.ts
+++ b/packages/cli/src/generators/dataset-generator.test.ts
@@ -37,8 +37,13 @@ describe('generateDatasets', () => {
             { name: 'id', type: 'UInt64', default_type: '', default_expression: '' },
             { name: 'tenant_id', type: 'String', default_type: '', default_expression: '' },
             { name: 'product_id', type: 'UInt64', default_type: '', default_expression: '' },
+            { name: 'trip_id', type: 'UInt64', default_type: '', default_expression: '' },
             { name: 'created_at', type: 'DateTime', default_type: '', default_expression: '' },
+            { name: 'latitude', type: 'Float64', default_type: '', default_expression: '' },
+            { name: 'longitude', type: 'Float64', default_type: '', default_expression: '' },
             { name: 'amount', type: 'Float64', default_type: '', default_expression: '' },
+            { name: 'duration_seconds', type: 'UInt32', default_type: '', default_expression: '' },
+            { name: 'payment_type', type: "Enum8('card' = 1, 'cash' = 2)", default_type: '', default_expression: '' },
             { name: 'status', type: 'LowCardinality(String)', default_type: '', default_expression: '' },
           ],
         };
@@ -56,8 +61,21 @@ describe('generateDatasets', () => {
 
     const generated = await readFile(outputPath, 'utf8');
     expect(generated).toContain("totalCount: measure.count('id'");
-    expect(generated).toContain("totalProductId: measure.sum('productId'");
     expect(generated).toContain("totalAmount: measure.sum('amount'");
+    expect(generated).toContain("avgAmount: measure.avg('amount'");
+    expect(generated).toContain("totalDurationSeconds: measure.sum('durationSeconds'");
+    expect(generated).toContain("avgDurationSeconds: measure.avg('durationSeconds'");
+    expect(generated).toContain("paymentType: dimension.string({ column: 'payment_type'");
+    expect(generated).toContain("status: dimension.string({ label: 'Status' })");
+    expect(generated).not.toContain("totalProductId: measure.sum('productId'");
+    expect(generated).not.toContain("avgProductId: measure.avg('productId'");
+    expect(generated).not.toContain("totalTripId: measure.sum('tripId'");
+    expect(generated).not.toContain("avgTripId: measure.avg('tripId'");
+    expect(generated).not.toContain("totalLatitude: measure.sum('latitude'");
+    expect(generated).not.toContain("avgLatitude: measure.avg('latitude'");
+    expect(generated).not.toContain("totalLongitude: measure.sum('longitude'");
+    expect(generated).not.toContain("avgLongitude: measure.avg('longitude'");
+    expect(generated).not.toContain("PaymentType measures");
     expect(generated).not.toContain('measure.count({');
 
     await writeFile(

--- a/packages/cli/src/generators/dataset-generator.ts
+++ b/packages/cli/src/generators/dataset-generator.ts
@@ -104,6 +104,47 @@ function isNumericColumn(column: ColumnInfo): boolean {
 }
 
 /**
+ * Check if a numeric column is more likely an identifier than an additive value.
+ */
+function isIdentifierColumn(column: ColumnInfo): boolean {
+  const originalName = column.name;
+  const name = column.name.toLowerCase();
+
+  return (
+    name === 'id' ||
+    name === 'uuid' ||
+    name.endsWith('_id') ||
+    originalName.endsWith('Id') ||
+    name.includes('uuid') ||
+    isTenantColumn(column)
+  );
+}
+
+/**
+ * Check if a numeric column is a coordinate that should not be summed or averaged.
+ */
+function isCoordinateColumn(column: ColumnInfo): boolean {
+  const name = column.name.toLowerCase();
+
+  return (
+    name === 'lat' ||
+    name === 'lng' ||
+    name === 'lon' ||
+    name === 'latitude' ||
+    name === 'longitude' ||
+    name.endsWith('_lat') ||
+    name.endsWith('_lng') ||
+    name.endsWith('_lon') ||
+    name.endsWith('_latitude') ||
+    name.endsWith('_longitude')
+  );
+}
+
+function isMeasureCandidate(column: ColumnInfo): boolean {
+  return isNumericColumn(column) && !isIdentifierColumn(column) && !isCoordinateColumn(column);
+}
+
+/**
  * Convert table name to PascalCase for dataset variable name
  */
 function tableToPascalCase(tableName: string): string {
@@ -169,8 +210,9 @@ async function generateDatasetForTable(
     }
   }
 
-  // Generate measures (for numeric columns only)
-  const numericColumns = columns.filter(isNumericColumn).filter((c) => !isTenantColumn(c));
+  // Generate measures for numeric value columns only. IDs and coordinates stay
+  // dimensions because summing or averaging them is usually noise.
+  const numericColumns = columns.filter(isMeasureCandidate);
   const measureLines: string[] = [];
 
   if (numericColumns.length > 0) {

--- a/website-next/docs/datasets/execution.mdx
+++ b/website-next/docs/datasets/execution.mdx
@@ -91,6 +91,17 @@ const result = await analytics.execute(revenue, {
 ```
 </CodeBlock>
 
+Use `by` for time bucketing. It is a flat grain value, not an object:
+
+<CodeBlock>
+```typescript
+const result = await analytics.execute(revenue, {
+  by: 'month',
+  dimensions: ['country'],
+});
+```
+</CodeBlock>
+
 ## Execute a dataset
 
 Dataset execution returns an ad hoc selection of dimensions and measures from one dataset.
@@ -102,6 +113,18 @@ const result = await analytics.execute(Orders, {
   measures: ['revenue', 'orderCount'],
   filters: [eq('status', 'completed')],
   limit: 10,
+});
+```
+</CodeBlock>
+
+Dataset queries use the same `by` field when the dataset declares a `timeKey`:
+
+<CodeBlock>
+```typescript
+const result = await analytics.execute(Orders, {
+  by: 'day',
+  dimensions: ['status'],
+  measures: ['revenue', 'orderCount'],
 });
 ```
 </CodeBlock>

--- a/website-next/docs/datasets/multi-tenancy.mdx
+++ b/website-next/docs/datasets/multi-tenancy.mdx
@@ -124,6 +124,32 @@ const api = serve({
 
 Serve tenant `column` configuration is useful for hand-written builder queries. Semantic dataset endpoints use the dataset `tenantKey` for tenant filtering.
 
+For simple internal or first-party apps, the auth strategy can read a tenant header and expose it as auth context:
+
+<CodeBlock>
+```typescript
+import { initServe } from '@hypequery/serve';
+
+const { serve } = initServe({
+  auth: async ({ request }) => ({
+    tenantId: request.headers['x-tenant-id'],
+  }),
+  tenant: {
+    extract: (auth) => auth.tenantId,
+    required: true,
+  },
+});
+
+export const api = serve({
+  queryBuilder: db,
+  datasets: { orders: Orders },
+  metrics: { revenue },
+});
+```
+</CodeBlock>
+
+Only trust tenant headers at a boundary you control, such as a server-to-server call, reverse proxy, or authenticated application route. Public clients should derive tenant identity from verified auth instead of accepting arbitrary header values.
+
 ## MCP tenant context
 
 For MCP, run tenant-scoped servers with a trusted `tenantId`. The MCP server forwards that value as dataset runtime tenant context for `query_dataset` and `query_metric`.

--- a/website-next/docs/nextjs.mdx
+++ b/website-next/docs/nextjs.mdx
@@ -38,6 +38,8 @@ export const OPTIONS = handler;
 ```
 </CodeBlock>
 
+`createFetchHandler` is exported from the root `@hypequery/serve` package, so you do not need to import from an adapter subpath.
+
 </Step>
 
 <Step>
@@ -49,6 +51,8 @@ Use the same definition without HTTP in server components, actions, and jobs:
 <CodeBlock>
 ```typescript
 import { api } from '@/analytics/queries';
+
+export const dynamic = 'force-dynamic';
 
 export default async function Page() {
   const stats = await api.run('dailyStats', {
@@ -62,6 +66,8 @@ export default async function Page() {
 }
 ```
 </CodeBlock>
+
+Use `force-dynamic` on Server Components or pages that query ClickHouse during render. Without it, Next.js may try to prerender the page at build time and fail or time out when the database is unavailable.
 
 </Step>
 

--- a/website-next/docs/quick-start.mdx
+++ b/website-next/docs/quick-start.mdx
@@ -191,6 +191,20 @@ This is the right route when query logic should be shared: when the same table s
   </Step>
 
   <Step>
+    Generate dataset definitions
+
+    Use the CLI to introspect ClickHouse and scaffold dataset definitions from your live schema:
+
+    <CodeBlock>
+      ```bash
+      npx hypequery generate:datasets
+      ```
+    </CodeBlock>
+
+    This writes `analytics/datasets.ts` by default. Generated exports use names like `OrdersDataset`; the examples below alias or rename that export to `Orders` after curation. Re-run generation when your schema changes, then curate the generated dimensions and measures so the semantic names match your product language.
+  </Step>
+
+  <Step>
     Connect a query builder and dataset client
 
     `@hypequery/datasets` plans and validates semantic queries; `@hypequery/clickhouse` constructs and executes them. The dataset client wraps the same query builder you would use for hand-written queries.
@@ -214,9 +228,9 @@ This is the right route when query logic should be shared: when the same table s
   </Step>
 
   <Step>
-    Define a dataset
+    Review or customize a dataset
 
-    A dataset maps a source table to typed dimensions and measures, plus optional tenant and time keys.
+    The generated file gives you a starting point. A curated dataset maps a source table to typed dimensions and measures, plus optional tenant and time keys:
 
     <CodeBlock>
       ```typescript
@@ -251,7 +265,7 @@ This is the right route when query logic should be shared: when the same table s
       ```typescript
       import { eq } from '@hypequery/datasets';
       import { analytics } from './client.js';
-      import { Orders } from './datasets/orders.js';
+      import { Orders } from './datasets.js';
 
       const byCountry = await analytics.execute(Orders, {
         dimensions: ['country'],
@@ -276,7 +290,7 @@ This is the right route when query logic should be shared: when the same table s
       // analytics/metrics.ts
       import { divide, eq, nullIfZero } from '@hypequery/datasets';
       import { analytics } from './client.js';
-      import { Orders } from './datasets/orders.js';
+      import { Orders } from './datasets.js';
 
       export const revenue = Orders.metric('revenue', { measure: 'revenue' });
       export const orderCount = Orders.metric('orderCount', { measure: 'orderCount' });
@@ -302,13 +316,14 @@ If that is all you need, continue with the [Datasets Overview](/docs/datasets/ov
 
 ## Optional: expose over HTTP with serve
 
-Both routes stay in-process until you need an HTTP boundary. Add `@hypequery/serve` when the same logic should have a stable URL, input validation, docs, OpenAPI, auth, or React hooks.
+Both routes stay in-process until you need an HTTP boundary. Add `@hypequery/serve` when the same logic should have a stable URL, input validation, docs, OpenAPI, auth, or React hooks. Add `@hypequery/react` when a React or Next.js UI should call those served endpoints through typed TanStack Query hooks.
 
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']} defaultIndex={0}>
   <Tab value="npm" label="npm">
     <CodeBlock>
       ```bash
       npm install @hypequery/serve zod
+      npm install @hypequery/react @tanstack/react-query
       ```
     </CodeBlock>
   </Tab>
@@ -317,6 +332,7 @@ Both routes stay in-process until you need an HTTP boundary. Add `@hypequery/ser
     <CodeBlock>
       ```bash
       pnpm add @hypequery/serve zod
+      pnpm add @hypequery/react @tanstack/react-query
       ```
     </CodeBlock>
   </Tab>
@@ -325,6 +341,7 @@ Both routes stay in-process until you need an HTTP boundary. Add `@hypequery/ser
     <CodeBlock>
       ```bash
       yarn add @hypequery/serve zod
+      yarn add @hypequery/react @tanstack/react-query
       ```
     </CodeBlock>
   </Tab>
@@ -333,6 +350,7 @@ Both routes stay in-process until you need an HTTP boundary. Add `@hypequery/ser
     <CodeBlock>
       ```bash
       bun add @hypequery/serve zod
+      bun add @hypequery/react @tanstack/react-query
       ```
     </CodeBlock>
   </Tab>
@@ -410,6 +428,27 @@ export const api = serve({
 </CodeBlock>
 
 This generates `POST /metrics/revenue` for the named KPI and `POST /datasets/orders/query` for flexible same-dataset rollups, each prefixed by your `basePath`. Endpoints validate dimensions, measures, filters, time grains, and ordering against the definition. See [Serve integration](/docs/datasets/serve-integration) for per-endpoint auth, caching, and limits.
+
+### Consume served datasets from React
+
+Use `@hypequery/react` when a React or Next.js app should call those endpoints from components:
+
+<CodeBlock>
+```typescript
+import { createAnalyticsHooks } from '@hypequery/react';
+import type { InferApiType } from '@hypequery/serve';
+import { api } from './analytics/api';
+
+type Api = InferApiType<typeof api>;
+
+export const { useMetric, useDataset } = createAnalyticsHooks<Api>({
+  baseUrl: '/api/analytics',
+  manifest: api.manifest(),
+});
+```
+</CodeBlock>
+
+For setup with `QueryClientProvider`, see the [React guide](/docs/react/getting-started).
 
 ### Preview docs and routes [#preview-docs-and-routes]
 


### PR DESCRIPTION
## Summary

Improves the first-time datasets experience based on agent feedback: the quickstart now leads with generated datasets, the execution docs show the actual flat `by` time grain shape, tenancy docs include a simple header-based Serve example, and the Next.js guide calls out both the root `createFetchHandler` import and `force-dynamic` for DB-backed Server Components.

The CLI dataset generator also now avoids creating nonsensical `sum`/`avg` measures for ID-like and coordinate columns while still keeping those fields as dimensions.

## Changes

- Add `@hypequery/cli` patch changeset for improved `generate:datasets` measure heuristics.
- Skip generated `sum`/`avg` measures for `id`, `*_id`, camel-case `*Id`, UUID-like, tenant, and coordinate columns.
- Extend generator tests for product/trip IDs, latitude/longitude, enum dimensions, and valid numeric value columns.
- Update datasets quickstart to lead with `npx hypequery generate:datasets` and mention `@hypequery/react` for UI consumers.
- Add explicit `by: 'month'` / `by: 'day'` execution examples.
- Add header-based tenant extraction docs using `x-tenant-id` plus `tenant.extract`.
- Add Next.js notes for root `createFetchHandler` import and `export const dynamic = 'force-dynamic'`.

## Validation

- `pnpm --filter @hypequery/cli test`
- `pnpm lint`

## Notes

- `analytics.execute()` row typing is intentionally left for a follow-up PR.
- `pnpm --dir website-next lint` is currently blocked by an existing ESLint/minimatch `brace_expansion_1.expand` runtime error.
- `pnpm --dir website-next build` previously hung during `next build`; the process was stopped after several silent minutes.