### PR TITLE
Accept schema-typed query builders at semantic entry points

### DIFF
--- a/.changeset/typed-builder-acceptance.md
+++ b/.changeset/typed-builder-acceptance.md
@@ -1,0 +1,19 @@
+---
+"@hypequery/datasets": minor
+"@hypequery/serve": patch
+---
+
+Accept schema-typed query builders at semantic entry points without casts.
+
+`createQueryBuilder<Schema>` results narrow column parameters to literal
+unions, type `execute()` rows concretely, and overload `where`, so they could
+not structurally satisfy `QueryBuilderFactoryLike` — passing the documented
+`createDatasetClient({ queryBuilder: db })` / `createAPI({ queryBuilder: db })`
+pattern failed to compile for typed-schema users.
+
+Public acceptance points (`CreateDatasetClientOptions.queryBuilder`,
+`SemanticExecutionRuntime.builderFactory`, serve's `ServeConfig.queryBuilder`)
+now take the new `QueryBuilderFactoryInput`, which admits both protocol-shaped
+and schema-typed builders. The strict `QueryBuilderFactoryLike` remains the
+internal call contract; the exported `toQueryBuilderFactory` adapter converts
+between them.

--- a/packages/clickhouse/type-tests/datasets-protocol.test.ts
+++ b/packages/clickhouse/type-tests/datasets-protocol.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Schema-typed builders must be accepted by the @hypequery/datasets semantic
+ * entry points without casts. The strict `QueryBuilderFactoryLike` protocol is
+ * not structurally satisfiable by a typed builder (literal column params,
+ * concrete `execute()` row types, overloaded `where`), so acceptance points
+ * take `QueryBuilderFactoryInput` instead — this file pins that contract.
+ */
+import { createQueryBuilder } from '../src/core/query-builder.js';
+import { createDatasetClient } from '@hypequery/datasets';
+import type {
+  CreateDatasetClientOptions,
+  ExecutionContext,
+  QueryBuilderFactoryInput,
+} from '@hypequery/datasets';
+
+interface TypedSchema {
+  orders: {
+    id: 'UInt64';
+    status: 'String';
+    amount: 'Float64';
+    created_at: 'DateTime';
+  };
+}
+
+const typedDb = createQueryBuilder<TypedSchema>({ url: 'http://localhost:8123' });
+
+// A schema-typed builder is a valid factory input...
+const acceptedInput: QueryBuilderFactoryInput = typedDb;
+
+// ...directly in client options...
+const acceptedOptions: CreateDatasetClientOptions = { queryBuilder: typedDb };
+const client = createDatasetClient({ queryBuilder: typedDb });
+
+// ...and as a per-call runtime builder override.
+const acceptedContext: ExecutionContext = {
+  runtime: { builderFactory: typedDb },
+};
+
+// Non-builder values are still rejected.
+// @ts-expect-error a plain object is not a query builder factory
+const rejectedObject: QueryBuilderFactoryInput = { foo: 1 };
+// @ts-expect-error a ClickHouse client (query/exec, no table) is not a factory
+const rejectedClient: QueryBuilderFactoryInput = { query() { }, exec() { } };
+
+void acceptedInput;
+void acceptedOptions;
+void client;
+void acceptedContext;
+void rejectedObject;
+void rejectedClient;

--- a/packages/datasets/src/api.type-test.ts
+++ b/packages/datasets/src/api.type-test.ts
@@ -211,3 +211,58 @@ void analytics.execute<DatasetQueryResult['data'][number]>(Orders, datasetQuery,
 
 void runtimeContext;
 void explicitAnalytics;
+
+// -----------------------------------------------------------------------------
+// Schema-typed builder acceptance (QueryBuilderFactoryInput)
+//
+// Simulates the shape of a schema-typed builder (e.g. createQueryBuilder<S>
+// from @hypequery/clickhouse): literal column params, overloaded `where` with
+// an expression-builder first overload, and a concrete `execute()` row type.
+// Such builders cannot satisfy QueryBuilderFactoryLike structurally, but must
+// be accepted by the public entry points. The real-builder counterpart lives
+// in packages/clickhouse/type-tests/datasets-protocol.test.ts.
+// -----------------------------------------------------------------------------
+
+interface SimulatedTypedRow { id: number; status: string; amount: number }
+
+interface SimulatedTypedBuilder {
+  select(columns: ReadonlyArray<'id' | 'status' | 'amount'>): SimulatedTypedBuilder;
+  sum<C extends 'amount' | 'id'>(column: C, alias?: string): SimulatedTypedBuilder;
+  count(column: 'id' | 'status' | 'amount', alias?: string): SimulatedTypedBuilder;
+  countDistinct(column: 'id' | 'status' | 'amount', alias?: string): SimulatedTypedBuilder;
+  avg(column: 'amount', alias?: string): SimulatedTypedBuilder;
+  min(column: 'amount', alias?: string): SimulatedTypedBuilder;
+  max(column: 'amount', alias?: string): SimulatedTypedBuilder;
+  where(expressionBuilder: (expr: { col: 'id' | 'status' | 'amount' }) => boolean): SimulatedTypedBuilder;
+  where<C extends 'id' | 'status' | 'amount'>(column: C, operator: 'eq' | 'gt', value: SimulatedTypedRow[C]): SimulatedTypedBuilder;
+  groupBy(columns: 'id' | 'status' | 'amount' | Array<'id' | 'status' | 'amount'>): SimulatedTypedBuilder;
+  orderBy(column: 'id' | 'status' | 'amount', direction?: 'ASC' | 'DESC'): SimulatedTypedBuilder;
+  limit(count: number): SimulatedTypedBuilder;
+  offset(count: number): SimulatedTypedBuilder;
+  toSQLWithParams(): { sql: string; parameters: unknown[] };
+  execute(): Promise<SimulatedTypedRow[]>;
+}
+
+interface SimulatedTypedFactory {
+  table<T extends 'orders'>(name: T): SimulatedTypedBuilder;
+  rawQuery<T = SimulatedTypedRow>(sql: string, params?: unknown[]): Promise<T[]>;
+}
+
+declare const simulatedTypedFactory: SimulatedTypedFactory;
+
+// Sanity: the simulated shape reproduces the original incompatibility.
+// @ts-expect-error a schema-typed builder does not satisfy the strict protocol
+const strictRejection: QueryBuilderFactoryLike = simulatedTypedFactory;
+
+const typedAccepted: import('./index.js').QueryBuilderFactoryInput = simulatedTypedFactory;
+const typedClient = createDatasetClient({ queryBuilder: simulatedTypedFactory });
+const typedRuntime: ExecutionContext = { runtime: { builderFactory: simulatedTypedFactory } };
+
+// @ts-expect-error non-builder objects are still rejected
+const rejectedFactory: import('./index.js').QueryBuilderFactoryInput = { notABuilder: true };
+
+void strictRejection;
+void typedAccepted;
+void typedClient;
+void typedRuntime;
+void rejectedFactory;

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -27,7 +27,9 @@ import type {
 import type {
   QueryBuilderLike,
   QueryBuilderFactoryLike,
+  QueryBuilderFactoryInput,
 } from './query-builder-protocol.js';
+import { toQueryBuilderFactory } from './query-builder-protocol.js';
 import type {
   PlanNode,
   SemanticBackend,
@@ -193,14 +195,23 @@ function isDatasetInstance(target: unknown): target is AnyDatasetInstance {
 
 export interface MetricQueryEngineOptions {
   /** Query builder factory for executing metrics. */
-  builderFactory: QueryBuilderFactoryLike;
+  builderFactory: QueryBuilderFactoryInput;
 }
 
 export interface CreateDatasetClientOptions {
   /** Query builder factory for executing semantic metric and dataset queries. */
-  queryBuilder?: QueryBuilderFactoryLike;
+  queryBuilder?: QueryBuilderFactoryInput;
   /** Semantic backend for executing neutral semantic plans. */
   backend?: SemanticBackend;
+}
+
+/** Resolves the per-call builder override, adapted to the call contract. */
+function resolveBuilderFactory(
+  context: ExecutionContext | undefined,
+  fallback: QueryBuilderFactoryLike,
+): QueryBuilderFactoryLike {
+  const override = context?.runtime?.builderFactory;
+  return override ? toQueryBuilderFactory(override) : fallback;
 }
 
 export type SemanticTarget = MetricRef | GrainedMetricRef | AnyDatasetInstance;
@@ -280,7 +291,7 @@ export class MetricQueryEngine {
   private builderFactory: QueryBuilderFactoryLike;
 
   constructor(options: MetricQueryEngineOptions) {
-    this.builderFactory = options.builderFactory;
+    this.builderFactory = toQueryBuilderFactory(options.builderFactory);
   }
 
   protected getBuilderFactory(): QueryBuilderFactoryLike {
@@ -378,7 +389,7 @@ export class MetricQueryEngine {
     const ref = getMetricRef(metric);
     const grain = getMetricGrain(metric, query);
     const spec = ref.spec;
-    const activeBuilderFactory = context?.runtime?.builderFactory ?? this.builderFactory;
+    const activeBuilderFactory = resolveBuilderFactory(context, this.builderFactory);
 
     // Over-fetch one row so we can report `hasMore` without a count query.
     const buildQuery = { ...query, limit: overfetchLimit(query.limit) };
@@ -409,7 +420,7 @@ export class MetricQueryEngine {
     grain: TimeGrain | undefined,
     context?: ExecutionContext,
   ): QueryBuilderLike {
-    const activeBuilderFactory = context?.runtime?.builderFactory ?? this.builderFactory;
+    const activeBuilderFactory = resolveBuilderFactory(context, this.builderFactory);
     let qb: QueryBuilderLike = activeBuilderFactory.table(ds.source);
     const { selectParts, groupByParts } = buildDimensionSelectionPlan(
       ds,
@@ -460,7 +471,7 @@ export class MetricQueryEngine {
     grain: TimeGrain | undefined,
     context?: ExecutionContext,
   ): { sql: string; params: unknown[] } {
-    const activeBuilderFactory = context?.runtime?.builderFactory ?? this.builderFactory;
+    const activeBuilderFactory = resolveBuilderFactory(context, this.builderFactory);
     const ds = ref.dataset;
 
     // Build the CTE inner query using the builder
@@ -709,7 +720,7 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
       throw new Error(`Invalid dataset query: ${validation.errors.join('; ')}`);
     }
     return runDatasetQuery(ds, query, {
-      builderFactory: context?.runtime?.builderFactory ?? this.getBuilderFactory(),
+      builderFactory: resolveBuilderFactory(context, this.getBuilderFactory()),
       context,
     }) as Promise<DatasetQueryResult<TRow>>;
   }
@@ -720,7 +731,7 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
     context?: ExecutionContext,
   ): string {
     const builder = buildDatasetQueryBuilder(ds, query, {
-      builderFactory: context?.runtime?.builderFactory ?? this.getBuilderFactory(),
+      builderFactory: resolveBuilderFactory(context, this.getBuilderFactory()),
       context,
     });
     return builder.toSQLWithParams().sql;

--- a/packages/datasets/src/index.ts
+++ b/packages/datasets/src/index.ts
@@ -100,7 +100,13 @@ export type { ValidationResult } from './validation.js';
 export { validateFilterValue, matchesFieldType } from './validation.js';
 
 // Query builder protocol (duck-typed interfaces for DB-agnostic builder usage)
-export type { QueryBuilderLike, QueryBuilderFactoryLike } from './query-builder-protocol.js';
+export type {
+  QueryBuilderLike,
+  QueryBuilderFactoryLike,
+  QueryBuilderFactoryCompatible,
+  QueryBuilderFactoryInput,
+} from './query-builder-protocol.js';
+export { toQueryBuilderFactory } from './query-builder-protocol.js';
 
 // SQL utilities
 export { validateSQLIdentifier, isSafeSQLIdentifier, quoteSQLIdentifier } from './sql-utils.js';

--- a/packages/datasets/src/query-builder-protocol.ts
+++ b/packages/datasets/src/query-builder-protocol.ts
@@ -42,3 +42,34 @@ export interface QueryBuilderFactoryLike {
   table(name: string): QueryBuilderLike;
   rawQuery<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]>;
 }
+
+/**
+ * Acceptance shape for query builder factories at public entry points.
+ *
+ * Schema-typed builders (e.g. `createQueryBuilder<Schema>` from
+ * `@hypequery/clickhouse`) narrow column parameters to literal unions, type
+ * `execute()` rows concretely, and overload `where`, so they cannot
+ * structurally satisfy `QueryBuilderFactoryLike` even though they honor its
+ * runtime contract. This looser shape admits both protocol-shaped and
+ * schema-typed builders; entry points adapt with `toQueryBuilderFactory`.
+ */
+export interface QueryBuilderFactoryCompatible {
+  table(name: never): unknown;
+  rawQuery(sql: string, params?: never): Promise<unknown>;
+}
+
+/** Any query builder factory accepted by public entry points. */
+export type QueryBuilderFactoryInput =
+  | QueryBuilderFactoryLike
+  | QueryBuilderFactoryCompatible;
+
+/**
+ * Adapts an accepted factory to the internal `QueryBuilderFactoryLike` call
+ * contract. Safe because the semantic layer only calls protocol methods with
+ * plain strings, which schema-typed builders handle at runtime.
+ */
+export function toQueryBuilderFactory(
+  factory: QueryBuilderFactoryInput,
+): QueryBuilderFactoryLike {
+  return factory as QueryBuilderFactoryLike;
+}

--- a/packages/datasets/src/types.ts
+++ b/packages/datasets/src/types.ts
@@ -1,4 +1,4 @@
-import type { QueryBuilderFactoryLike } from './query-builder-protocol.js';
+import type { QueryBuilderFactoryInput } from './query-builder-protocol.js';
 import type { SemanticExpression } from './semantic-plan.js';
 
 export type FieldType = 'string' | 'number' | 'boolean' | 'timestamp';
@@ -228,7 +228,7 @@ export type SemanticTenantRuntime =
   | { scope: 'all' };
 
 export interface SemanticExecutionRuntime {
-  builderFactory?: QueryBuilderFactoryLike;
+  builderFactory?: QueryBuilderFactoryInput;
   tenant?: SemanticTenantRuntime;
 }
 

--- a/packages/serve/src/semantic/query-builder-context.ts
+++ b/packages/serve/src/semantic/query-builder-context.ts
@@ -1,4 +1,5 @@
 import type { QueryBuilderFactoryLike, SemanticExecutionRuntime } from "@hypequery/datasets";
+import { toQueryBuilderFactory } from "@hypequery/datasets";
 
 export const INTERNAL_SEMANTIC_RUNTIME_KEY = "__hypequerySemanticRuntime";
 
@@ -36,7 +37,7 @@ export function extractQueryBuilderFromContext(
   // Check if it's already in the semantic runtime
   const runtime = resolveSemanticExecutionRuntime(context);
   if (runtime?.builderFactory) {
-    return runtime.builderFactory;
+    return toQueryBuilderFactory(runtime.builderFactory);
   }
 
   return undefined;
@@ -84,7 +85,8 @@ export function resolveSemanticQueryBuilder(
   context: Record<string, unknown>,
   fallback: QueryBuilderFactoryLike,
 ): QueryBuilderFactoryLike {
-  return resolveSemanticExecutionRuntime(context)?.builderFactory ?? fallback;
+  const override = resolveSemanticExecutionRuntime(context)?.builderFactory;
+  return override ? toQueryBuilderFactory(override) : fallback;
 }
 
 export function attachSemanticTenantRuntime<TContext extends Record<string, unknown>>(

--- a/packages/serve/src/server/create-api.ts
+++ b/packages/serve/src/server/create-api.ts
@@ -22,7 +22,7 @@ import { createDocsEndpoint, createOpenApiEndpoint } from "../pipeline.js";
 import { resolveCorsConfig } from "../cors.js";
 import { createExecuteQuery } from "./execute-query.js";
 import { createAPImethods } from "./api-builder.js";
-import { createDatasetClient, serializeSemanticContract } from "@hypequery/datasets";
+import { createDatasetClient, serializeSemanticContract, toQueryBuilderFactory } from "@hypequery/datasets";
 import {
   createMetricEndpoint,
   createDatasetEndpoint,
@@ -96,8 +96,12 @@ export const createAPI = <
   const globalTenantConfig = config.tenant;
   const baseContextFactory = config.context as ServeContextFactory<TContext, TAuth> | undefined;
 
-  // Extract queryBuilder from context.db if not provided in config
-  let resolvedQueryBuilder = config.queryBuilder;
+  // Extract queryBuilder from context.db if not provided in config.
+  // Schema-typed builders are accepted and adapted to the call contract.
+  const explicitQueryBuilder = config.queryBuilder
+    ? toQueryBuilderFactory(config.queryBuilder)
+    : undefined;
+  let resolvedQueryBuilder = explicitQueryBuilder;
   let extractedFromContext = false;
 
   if (!resolvedQueryBuilder && baseContextFactory && (config.metrics || config.datasets)) {
@@ -120,10 +124,10 @@ export const createAPI = <
 
         // If queryBuilder was explicitly passed in config (not extracted from context),
         // attach it to context for backward compatibility
-        if (config.queryBuilder) {
+        if (explicitQueryBuilder) {
           return attachSemanticQueryBuilder(
             { ...(baseContext as TContext) },
-            config.queryBuilder,
+            explicitQueryBuilder,
           ) as TContext;
         }
 

--- a/packages/serve/src/types.ts
+++ b/packages/serve/src/types.ts
@@ -8,7 +8,7 @@ import type {
   MetricHandle,
   MetricQueryFor,
   MetricResultFor,
-  QueryBuilderFactoryLike,
+  QueryBuilderFactoryInput,
 } from "@hypequery/datasets";
 
 /** Supported HTTP verbs for serve-managed endpoints. */
@@ -762,7 +762,7 @@ export interface ServeConfig<
    * });
    * ```
    */
-  queryBuilder?: QueryBuilderFactoryLike;
+  queryBuilder?: QueryBuilderFactoryInput;
   basePath?: string;
   middlewares?: ServeMiddleware<any, any, TContext, TAuth>[];
   auth?: AuthStrategy<TAuth> | AuthStrategy<TAuth>[];


### PR DESCRIPTION
## Problem

The documented happy path for typed-schema users did not compile:

```ts
const db = createQueryBuilder<Schema>(config);
const analytics = createDatasetClient({ queryBuilder: db }); // TS2322
const api = createAPI({ metrics, queryBuilder: db });        // TS2322
```

A schema-typed builder cannot structurally satisfy `QueryBuilderFactoryLike`: its column parameters are literal unions, `execute()` returns concrete row types (the protocol's caller-chosen `execute<T>()` generic is unsatisfiable by any concrete builder), and `where` is an overload set whose first overload takes an expression builder. Untyped builders assign fine but then `db.table('orders')` infers table names as `never` — so users could not have typed local queries *and* semantic execution from the same builder. Both serve's JSDoc and the datasets docs show exactly this pattern.

## Fix

Keep `QueryBuilderFactoryLike` as the strict internal call contract, and introduce a loose acceptance shape at the public boundaries:

- New `QueryBuilderFactoryInput` (= `QueryBuilderFactoryLike | QueryBuilderFactoryCompatible`) exported from `@hypequery/datasets`, where `QueryBuilderFactoryCompatible` is the minimal duck shape (`table`, `rawQuery`) that both protocol-shaped and schema-typed builders satisfy — while plain non-builder objects are still rejected.
- Acceptance points widened: `CreateDatasetClientOptions.queryBuilder`, `SemanticExecutionRuntime.builderFactory` (per-call override), and serve's `ServeConfig.queryBuilder`.
- New `toQueryBuilderFactory` adapter converts at the boundary; runtime-safe because the semantic layer only calls protocol methods with plain strings, which typed builders handle at runtime.

## Regression coverage

- `packages/clickhouse/type-tests/datasets-protocol.test.ts` — the real `createQueryBuilder<Schema>` is accepted by `QueryBuilderFactoryInput`, `createDatasetClient`, and runtime overrides; non-builders rejected.
- `packages/datasets/src/api.type-test.ts` — a simulated typed-builder shape reproduces the strict-protocol rejection (`@ts-expect-error`) and is accepted by the entry points, so the contract is pinned even without the clickhouse package.

## Verified

- `@hypequery/datasets`: build, 143 unit tests, `test:types`
- `@hypequery/serve`: build, 444 tests
- `@hypequery/clickhouse`: 500 unit tests, `test:types`
- `@hypequery/react` tests, `pnpm smoke:semantic-consumer`, `pnpm lint`

Follow-up: once this and #246 both land, the compensating casts in `scripts/utils/write-docs-snippet-fixtures.mjs` can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)