### PR TITLE
Project infinite hook page rows from query input

### DIFF
--- a/.changeset/infinite-hooks-projection.md
+++ b/.changeset/infinite-hooks-projection.md
@@ -1,0 +1,10 @@
+---
+"@hypequery/react": minor
+---
+
+`useInfiniteDataset` and `useInfiniteMetric` now project page row types from
+the query input, matching `useDataset` / `useMetric`. Selected dimensions and
+measures (and `period` for grained queries) are typed on
+`data.pages[n].data[m]` instead of requiring casts, unselected fields are
+rejected, and infinite-query `options` (e.g. `select`) see the projected page
+type.

--- a/packages/react/src/analyticsHooks.tsx
+++ b/packages/react/src/analyticsHooks.tsx
@@ -1,6 +1,7 @@
 import type {
   UseQueryOptions as TanstackUseQueryOptions,
   UseQueryResult,
+  UseInfiniteQueryOptions as TanstackUseInfiniteQueryOptions,
   UseInfiniteQueryResult,
   InfiniteData,
 } from '@tanstack/react-query';
@@ -28,6 +29,18 @@ type QueryOptions<Api, Key extends ExtractNames<Api>> = Omit<
     QueryKey<Key, QueryInput<Api, Key>>
   >,
   'queryKey' | 'queryFn'
+>;
+
+/** Infinite-query options parameterized by the projected page type. */
+type InfiniteQueryOptions<Api, Key extends ExtractNames<Api>, TPage> = Omit<
+  TanstackUseInfiniteQueryOptions<
+    TPage,
+    HttpError,
+    InfiniteData<TPage, number>,
+    QueryKey<Key, QueryInput<Api, Key>>,
+    number
+  >,
+  'queryKey' | 'queryFn' | 'getNextPageParam' | 'initialPageParam'
 >;
 
 export interface CreateAnalyticsHooksConfig<
@@ -84,20 +97,33 @@ export function createAnalyticsHooks<
     return (hooks.useQuery as any)(key, ...rest);
   }
 
-  function useInfiniteMetric<Name extends MetricName>(
+  function useInfiniteMetric<Name extends MetricName, const TInput extends QueryInput<Api, Name>>(
     name: Name,
-    input: QueryInput<Api, Name>,
-    options?: Parameters<typeof hooks.useInfiniteQuery>[2],
-  ): UseInfiniteQueryResult<InfiniteData<QueryOutput<Api, Name>, number>, HttpError> {
+    input: TInput,
+    options?: InfiniteQueryOptions<Api, Name, QueryOutputForInput<Api, Name, TInput>>,
+  ): UseInfiniteQueryResult<
+    InfiniteData<QueryOutputForInput<Api, Name, TInput>, number>,
+    HttpError
+  > {
     return (hooks.useInfiniteQuery as any)(name, input, options);
   }
 
-  function useInfiniteDataset<Name extends DatasetNamesFromApi<Api>>(
+  function useInfiniteDataset<
+    Name extends DatasetNamesFromApi<Api>,
+    const TInput extends QueryInput<Api, Extract<ExtractNames<Api>, DatasetKey<Name>>>,
+  >(
     name: Name,
-    input: QueryInput<Api, Extract<ExtractNames<Api>, DatasetKey<Name>>>,
-    options?: Parameters<typeof hooks.useInfiniteQuery>[2],
+    input: TInput,
+    options?: InfiniteQueryOptions<
+      Api,
+      Extract<ExtractNames<Api>, DatasetKey<Name>>,
+      QueryOutputForInput<Api, Extract<ExtractNames<Api>, DatasetKey<Name>>, TInput>
+    >,
   ): UseInfiniteQueryResult<
-    InfiniteData<QueryOutput<Api, Extract<ExtractNames<Api>, DatasetKey<Name>>>, number>,
+    InfiniteData<
+      QueryOutputForInput<Api, Extract<ExtractNames<Api>, DatasetKey<Name>>, TInput>,
+      number
+    >,
     HttpError
   > {
     const key = `dataset:${String(name)}` as Extract<ExtractNames<Api>, DatasetKey<Name>>;

--- a/packages/react/type-tests/serve-integration.test-d.ts
+++ b/packages/react/type-tests/serve-integration.test-d.ts
@@ -79,6 +79,51 @@ void metricCountry;
 // @ts-expect-error unselected dimensions are not exposed
 void metricRow?.status;
 
+// --- Infinite hooks follow the same projection ---------------------------------
+const infiniteDatasetResult = hooks.useInfiniteDataset('orders', {
+  dimensions: ['country'] as const,
+  measures: ['revenue'] as const,
+  limit: 50,
+});
+const infiniteDatasetRow = infiniteDatasetResult.data?.pages[0]?.data[0];
+const infiniteDatasetCountry: string | undefined = infiniteDatasetRow?.country;
+const infiniteDatasetRevenue: number | undefined = infiniteDatasetRow?.revenue;
+void infiniteDatasetCountry;
+void infiniteDatasetRevenue;
+
+// @ts-expect-error unselected dimensions are not exposed on infinite pages
+void infiniteDatasetRow?.status;
+// @ts-expect-error unselected measures are not exposed on infinite pages
+void infiniteDatasetRow?.orderCount;
+
+const infiniteGrainedResult = hooks.useInfiniteDataset('orders', {
+  measures: ['revenue'] as const,
+  by: 'month',
+  limit: 50,
+});
+const infiniteGrainedPeriod: string | undefined =
+  infiniteGrainedResult.data?.pages[0]?.data[0]?.period;
+void infiniteGrainedPeriod;
+
+const infiniteMetricResult = hooks.useInfiniteMetric('totalRevenue', {
+  dimensions: ['country'] as const,
+  limit: 50,
+});
+const infiniteMetricRow = infiniteMetricResult.data?.pages[0]?.data[0];
+const infiniteMetricValue: number | undefined = infiniteMetricRow?.totalRevenue;
+const infiniteMetricCountry: string | undefined = infiniteMetricRow?.country;
+void infiniteMetricValue;
+void infiniteMetricCountry;
+
+// @ts-expect-error unselected dimensions are not exposed on infinite metric pages
+void infiniteMetricRow?.status;
+
+// @ts-expect-error unknown infinite dataset dimensions should be rejected
+hooks.useInfiniteDataset('orders', { dimensions: ['missing'] as const });
+
+// @ts-expect-error unknown infinite metric names should be rejected
+hooks.useInfiniteMetric('missing', {});
+
 // --- Unknown names and fields are rejected -------------------------------------
 // @ts-expect-error unknown metric names should be rejected
 hooks.useMetric('missing');


### PR DESCRIPTION
## Problem

Follow-up to #245: `useDataset` / `useMetric` gained projection-typed overloads (row types derived from the literal `dimensions` / `measures` in the query input), but `useInfiniteDataset` / `useInfiniteMetric` were left returning the broad `QueryOutput<Api, Key>` pages — so dimension fields on infinite query rows were inaccessible without casting:

```ts
const result = hooks.useInfiniteDataset('orders', {
  dimensions: ['country'] as const,
  measures: ['revenue'] as const,
  limit: 50,
});
result.data?.pages[0]?.data[0]?.country; // was: not typed — needed a cast
```

## Fix

Thread the same `const TInput` + `QueryOutputForInput<Api, Key, TInput>` projection through both infinite hooks in `analyticsHooks.tsx`:

- `data.pages[n].data[m]` rows expose selected dimensions/measures (and `period` for grained queries) with proper value types; unselected fields are compile errors.
- Infinite-query `options` are now typed against the projected page type (a new `InfiniteQueryOptions<Api, Key, TPage>` mirroring the base hook's Omit set), replacing the previous loose `Parameters<typeof hooks.useInfiniteQuery>[2]`, so `select` and callbacks see typed pages.
- Runtime behavior unchanged — both hooks still delegate to `hooks.useInfiniteQuery`.

## Tests

Extended `packages/react/type-tests/serve-integration.test-d.ts` (the real-`createAPI` seam test) with infinite-hook assertions: projected dimension/measure/period access, `@ts-expect-error` on unselected fields, and rejection of unknown names/dimensions.

## Verified

- `@hypequery/react`: build, `test:types` (tsc over type-tests), 49 unit tests
- `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)