### PR TITLE
Add semantic query result caching keyed by query signature

### DIFF
--- a/.changeset/semantic-query-cache.md
+++ b/.changeset/semantic-query-cache.md
@@ -5,14 +5,22 @@
 
 Semantic query result caching keyed by the query signature.
 
-`createDatasetClient` accepts `cache: { ttlMs, staleWhileRevalidateMs, maxEntries, store }`;
+`createDatasetClient` accepts `cache: { ttlMs, staleWhileRevalidateMs, maxEntries, store, scope }`;
 results are keyed by the canonical query signature (target, dimensions,
-measures, filters, ordering, pagination, grain, and tenant scope), so
-different queries never share entries and tenant-scoped datasets are
-partitioned per tenant. Per-call controls via `ExecutionContext.cache`
-(`{ ttlMs }` to opt in, `false` to bypass, `mode: 'refresh'` to force).
-Errors are never cached, concurrent identical queries share one execution,
-and hits carry `meta.cache = { hit, ageMs, stale? }`.
+measures, filters, ordering, pagination, grain, tenant scope, and cache
+scope), so different queries never share entries and tenant-scoped datasets
+are partitioned per tenant. Per-call controls via `ExecutionContext.cache`
+(`{ ttlMs }` to opt in, `false` to bypass, `mode: 'refresh'` to force a
+fresh execution and re-store). Errors are never cached, concurrent identical
+queries share one execution — including against async stores — and hits
+carry `meta.cache = { hit, ageMs, stale? }`.
+
+Custom stores (e.g. Redis) degrade gracefully: a failed read is treated as
+a miss and a failed write is dropped, so a store outage means "no caching",
+never failed queries. `cache.scope` partitions entries when the same query
+can run against different data sources — client-level for clients sharing
+one store, per-call when overriding the query builder at runtime (unscoped
+builder overrides skip the cache entirely).
 
 Serve metric and dataset entries with a `cache` value now cache results
 server-side with that TTL (previously the value only emitted `Cache-Control`

--- a/.changeset/semantic-query-cache.md
+++ b/.changeset/semantic-query-cache.md
@@ -1,0 +1,21 @@
+---
+"@hypequery/datasets": minor
+"@hypequery/serve": minor
+---
+
+Semantic query result caching keyed by the query signature.
+
+`createDatasetClient` accepts `cache: { ttlMs, staleWhileRevalidateMs, maxEntries, store }`;
+results are keyed by the canonical query signature (target, dimensions,
+measures, filters, ordering, pagination, grain, and tenant scope), so
+different queries never share entries and tenant-scoped datasets are
+partitioned per tenant. Per-call controls via `ExecutionContext.cache`
+(`{ ttlMs }` to opt in, `false` to bypass, `mode: 'refresh'` to force).
+Errors are never cached, concurrent identical queries share one execution,
+and hits carry `meta.cache = { hit, ageMs, stale? }`.
+
+Serve metric and dataset entries with a `cache` value now cache results
+server-side with that TTL (previously the value only emitted `Cache-Control`
+headers, which POST semantic endpoints cannot use). Dataset endpoints now
+execute through the shared `DatasetClient`, so metric and dataset entries
+share one result cache per API.

--- a/packages/datasets/src/api.type-test.ts
+++ b/packages/datasets/src/api.type-test.ts
@@ -10,6 +10,8 @@ import type {
   MeasureOptions,
   MetricFilter,
   QueryBuilderFactoryLike,
+  SemanticCacheOptions,
+  SemanticCacheRuntime,
 } from './index.js';
 
 type Assert<T extends true> = T;
@@ -71,6 +73,15 @@ type _MeasureFilterType = Assert<
 >;
 type _TenantRuntimeShape = Assert<
   Equal<NonNullable<NonNullable<ExecutionContext['runtime']>['tenant']>, string | { id: string } | { in: string[] } | { scope: 'all' }>
+>;
+type _CacheRuntimeIncludesScope = Assert<
+  Equal<NonNullable<ExecutionContext['cache']>, false | SemanticCacheRuntime>
+>;
+type _CacheRuntimeScopeType = Assert<
+  Equal<SemanticCacheRuntime['scope'], string | undefined>
+>;
+type _CacheOptionsScopeType = Assert<
+  Equal<SemanticCacheOptions['scope'], string | undefined>
 >;
 type _DatasetHasNoQueryMethod = Assert<
   Equal<HasKey<typeof Orders, 'query'>, false>

--- a/packages/datasets/src/cache/dataset-client-cache.test.ts
+++ b/packages/datasets/src/cache/dataset-client-cache.test.ts
@@ -12,6 +12,8 @@ import {
   buildMetricQuerySignature,
   stableStringify,
 } from './query-signature.js';
+import { createMemoryCacheStore } from './semantic-query-cache.js';
+import { createInMemoryBackend } from '../in-memory-backend.js';
 
 function createCountingFactory(rows: Array<Record<string, unknown>> = [{ revenue: 100 }]) {
   const executions = vi.fn();
@@ -150,6 +152,95 @@ describe('DatasetClient result caching', () => {
     expect(executions).toHaveBeenCalledTimes(2);
   });
 
+  it('bypasses the cache when the call overrides the query builder without a scope', async () => {
+    const { factory, executions } = createCountingFactory();
+    const { factory: override, executions: overrideExecutions } =
+      createCountingFactory([{ revenue: 999 }]);
+    const analytics = createDatasetClient({ queryBuilder: factory, cache: { ttlMs: 60_000 } });
+
+    const query = { measures: ['revenue'] };
+    await analytics.execute(Orders, query);
+    // Same signature, different data source: must not serve the cached rows.
+    const overridden = await analytics.execute(Orders, query, {
+      runtime: { builderFactory: override },
+    });
+
+    expect(executions).toHaveBeenCalledTimes(1);
+    expect(overrideExecutions).toHaveBeenCalledTimes(1);
+    expect(overridden.data).toEqual([{ revenue: 999 }]);
+    expect(overridden.meta?.cache).toBeUndefined();
+  });
+
+  it('caches builder-override calls when partitioned with cache.scope', async () => {
+    const { factory } = createCountingFactory();
+    const { factory: replicaA, executions: replicaAExecutions } =
+      createCountingFactory([{ revenue: 1 }]);
+    const { factory: replicaB, executions: replicaBExecutions } =
+      createCountingFactory([{ revenue: 2 }]);
+    const analytics = createDatasetClient({ queryBuilder: factory, cache: { ttlMs: 60_000 } });
+
+    const query = { measures: ['revenue'] };
+    const onReplica = (builderFactory: QueryBuilderFactoryLike, scope: string) =>
+      analytics.execute(Orders, query, { runtime: { builderFactory }, cache: { scope } });
+
+    await onReplica(replicaA, 'replica-a');
+    const hitA = await onReplica(replicaA, 'replica-a');
+    expect(replicaAExecutions).toHaveBeenCalledTimes(1);
+    expect(hitA.meta?.cache).toMatchObject({ hit: true });
+    expect(hitA.data).toEqual([{ revenue: 1 }]);
+
+    // A different scope never sees replica A's entries.
+    const missB = await onReplica(replicaB, 'replica-b');
+    expect(replicaBExecutions).toHaveBeenCalledTimes(1);
+    expect(missB.data).toEqual([{ revenue: 2 }]);
+  });
+
+  it('client-level cache.scope separates clients sharing one store', async () => {
+    const store = createMemoryCacheStore();
+    const { factory: factoryA, executions: executionsA } =
+      createCountingFactory([{ revenue: 1 }]);
+    const { factory: factoryB, executions: executionsB } =
+      createCountingFactory([{ revenue: 2 }]);
+    const clientA = createDatasetClient({
+      queryBuilder: factoryA,
+      cache: { ttlMs: 60_000, store, scope: 'warehouse-a' },
+    });
+    const clientB = createDatasetClient({
+      queryBuilder: factoryB,
+      cache: { ttlMs: 60_000, store, scope: 'warehouse-b' },
+    });
+
+    const query = { measures: ['revenue'] };
+    await clientA.execute(Orders, query);
+    const fromB = await clientB.execute(Orders, query);
+
+    expect(executionsA).toHaveBeenCalledTimes(1);
+    expect(executionsB).toHaveBeenCalledTimes(1);
+    expect(fromB.data).toEqual([{ revenue: 2 }]);
+  });
+
+  it('caches metric and dataset queries on backend-only clients', async () => {
+    // Regression: the pre-cache validation must not dry-build SQL through the
+    // throwing placeholder builder that backend clients are constructed with.
+    const backend = createInMemoryBackend({
+      orders: [
+        { country: 'ES', amount: 10 },
+        { country: 'DE', amount: 20 },
+      ],
+    });
+    const analytics = createDatasetClient({ backend, cache: { ttlMs: 60_000 } });
+
+    const metricFirst = await analytics.execute(revenue, { dimensions: ['country'] });
+    const metricSecond = await analytics.execute(revenue, { dimensions: ['country'] });
+    expect(metricFirst.data.length).toBeGreaterThan(0);
+    expect(metricSecond.meta?.cache).toMatchObject({ hit: true });
+
+    const datasetFirst = await analytics.execute(Orders, { measures: ['revenue'] });
+    const datasetSecond = await analytics.execute(Orders, { measures: ['revenue'] });
+    expect(datasetFirst.data.length).toBeGreaterThan(0);
+    expect(datasetSecond.meta?.cache).toMatchObject({ hit: true });
+  });
+
   it('never caches invalid queries', () => {
     const { factory } = createCountingFactory();
     const analytics = createDatasetClient({ queryBuilder: factory, cache: { ttlMs: 60_000 } });
@@ -181,6 +272,30 @@ describe('query signatures', () => {
     })).not.toBe(base);
     expect(buildDatasetQuerySignature(Orders, { measures: ['revenue'], limit: 10 })).not.toBe(base);
     expect(buildDatasetQuerySignature(Orders, { measures: ['revenue'], offset: 10 })).not.toBe(base);
+  });
+
+  it('distinguishes Date and bigint filter values', () => {
+    // Regression: Dates used to serialize as '{}', collapsing every date
+    // filter onto one cache key.
+    const sig = (value: unknown) =>
+      buildDatasetQuerySignature(Orders, {
+        measures: ['revenue'],
+        filters: [{ field: 'status', operator: 'gte', value }],
+      });
+    expect(sig(new Date('2026-01-01'))).not.toBe(sig(new Date('2026-06-01')));
+    expect(sig(new Date('2026-01-01'))).toBe(sig(new Date('2026-01-01')));
+    expect(sig(new Date('2026-01-01'))).toBe(sig('2026-01-01T00:00:00.000Z'));
+    expect(sig(1n)).not.toBe(sig(2n));
+    expect(sig(1n)).not.toBe(sig(1));
+    expect(sig(1n)).not.toBe(sig('1n'));
+  });
+
+  it('embeds the explicit cache scope', () => {
+    const scoped = (scope?: string) =>
+      buildDatasetQuerySignature(Orders, { measures: ['revenue'] }, scope ? { cache: { scope } } : {});
+    expect(scoped('a')).not.toBe(scoped('b'));
+    expect(scoped('a')).not.toBe(scoped());
+    expect(scoped()).toBe(buildDatasetQuerySignature(Orders, { measures: ['revenue'] }));
   });
 
   it('embeds the tenant scope for tenant-keyed datasets only', () => {

--- a/packages/datasets/src/cache/dataset-client-cache.test.ts
+++ b/packages/datasets/src/cache/dataset-client-cache.test.ts
@@ -1,0 +1,195 @@
+/**
+ * End-to-end caching behavior through `createDatasetClient`: identical
+ * queries hit the cache, different queries / tenants / targets do not, and
+ * per-call context controls override client defaults.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { dataset, dimension, measure } from '../index.js';
+import { createDatasetClient } from '../executor.js';
+import type { QueryBuilderFactoryLike, QueryBuilderLike } from '../query-builder-protocol.js';
+import {
+  buildDatasetQuerySignature,
+  buildMetricQuerySignature,
+  stableStringify,
+} from './query-signature.js';
+
+function createCountingFactory(rows: Array<Record<string, unknown>> = [{ revenue: 100 }]) {
+  const executions = vi.fn();
+
+  function createBuilder(): QueryBuilderLike {
+    const builder: QueryBuilderLike = {
+      select: () => builder,
+      sum: () => builder,
+      count: () => builder,
+      countDistinct: () => builder,
+      avg: () => builder,
+      min: () => builder,
+      max: () => builder,
+      where: () => builder,
+      groupBy: () => builder,
+      orderBy: () => builder,
+      limit: () => builder,
+      offset: () => builder,
+      toSQLWithParams: () => ({ sql: 'SELECT 1', parameters: [] }),
+      execute: async <T,>() => {
+        executions();
+        return structuredClone(rows) as T[];
+      },
+    };
+    return builder;
+  }
+
+  const factory: QueryBuilderFactoryLike = {
+    table: () => createBuilder(),
+    rawQuery: async <T,>() => {
+      executions();
+      return structuredClone(rows) as T[];
+    },
+  };
+
+  return { factory, executions };
+}
+
+const Orders = dataset('orders', {
+  source: 'orders',
+  dimensions: {
+    status: dimension.string(),
+    country: dimension.string(),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+  },
+});
+
+const TenantOrders = dataset('tenant_orders', {
+  source: 'tenant_orders',
+  tenantKey: 'tenant_id',
+  dimensions: {
+    tenantId: dimension.string({ column: 'tenant_id' }),
+    status: dimension.string(),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+  },
+});
+
+const revenue = Orders.metric('revenue', { measure: 'revenue' });
+
+describe('DatasetClient result caching', () => {
+  it('caches identical dataset queries within the client TTL', async () => {
+    const { factory, executions } = createCountingFactory();
+    const analytics = createDatasetClient({ queryBuilder: factory, cache: { ttlMs: 60_000 } });
+
+    const query = { dimensions: ['country'], measures: ['revenue'] };
+    const first = await analytics.execute(Orders, query);
+    const second = await analytics.execute(Orders, query);
+
+    expect(executions).toHaveBeenCalledTimes(1);
+    expect(first.meta?.cache).toEqual({ hit: false });
+    expect(second.meta?.cache).toMatchObject({ hit: true });
+    expect(second.data).toEqual(first.data);
+  });
+
+  it('caches identical metric queries and separates different queries', async () => {
+    const { factory, executions } = createCountingFactory();
+    const analytics = createDatasetClient({ queryBuilder: factory, cache: { ttlMs: 60_000 } });
+
+    await analytics.execute(revenue, { dimensions: ['country'] });
+    await analytics.execute(revenue, { dimensions: ['country'] });
+    expect(executions).toHaveBeenCalledTimes(1);
+
+    await analytics.execute(revenue, { dimensions: ['status'] });
+    expect(executions).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache when the client has no cache config', async () => {
+    const { factory, executions } = createCountingFactory();
+    const analytics = createDatasetClient({ queryBuilder: factory });
+
+    await analytics.execute(Orders, { measures: ['revenue'] });
+    await analytics.execute(Orders, { measures: ['revenue'] });
+
+    expect(executions).toHaveBeenCalledTimes(2);
+  });
+
+  it('per-call context TTL opts in without client defaults', async () => {
+    const { factory, executions } = createCountingFactory();
+    const analytics = createDatasetClient({ queryBuilder: factory });
+
+    const context = { cache: { ttlMs: 60_000 } };
+    await analytics.execute(Orders, { measures: ['revenue'] }, context);
+    const hit = await analytics.execute(Orders, { measures: ['revenue'] }, context);
+
+    expect(executions).toHaveBeenCalledTimes(1);
+    expect(hit.meta?.cache).toMatchObject({ hit: true });
+  });
+
+  it('context cache:false bypasses the client default cache', async () => {
+    const { factory, executions } = createCountingFactory();
+    const analytics = createDatasetClient({ queryBuilder: factory, cache: { ttlMs: 60_000 } });
+
+    await analytics.execute(Orders, { measures: ['revenue'] });
+    await analytics.execute(Orders, { measures: ['revenue'] }, { cache: false });
+
+    expect(executions).toHaveBeenCalledTimes(2);
+  });
+
+  it('partitions cache entries per tenant scope', async () => {
+    const { factory, executions } = createCountingFactory();
+    const analytics = createDatasetClient({ queryBuilder: factory, cache: { ttlMs: 60_000 } });
+
+    const query = { measures: ['revenue'] };
+    const tenantA = { runtime: { tenant: 'tenant_a' }, };
+    const tenantB = { runtime: { tenant: 'tenant_b' }, };
+
+    await analytics.execute(TenantOrders, query, tenantA);
+    await analytics.execute(TenantOrders, query, tenantA);
+    expect(executions).toHaveBeenCalledTimes(1);
+
+    await analytics.execute(TenantOrders, query, tenantB);
+    expect(executions).toHaveBeenCalledTimes(2);
+  });
+
+  it('never caches invalid queries', () => {
+    const { factory } = createCountingFactory();
+    const analytics = createDatasetClient({ queryBuilder: factory, cache: { ttlMs: 60_000 } });
+
+    // Validation throws synchronously, before the cache is consulted.
+    expect(() => analytics.execute(Orders, { dimensions: ['nope'] }))
+      .toThrow(/Unknown dimensions/);
+  });
+});
+
+describe('query signatures', () => {
+  it('is insensitive to object key order but sensitive to values', () => {
+    expect(stableStringify({ a: 1, b: [{ y: 2, x: 1 }] }))
+      .toBe(stableStringify({ b: [{ x: 1, y: 2 }], a: 1 }));
+    expect(stableStringify({ a: 1 })).not.toBe(stableStringify({ a: 2 }));
+  });
+
+  it('separates dataset and metric signatures for the same shape', () => {
+    const datasetSig = buildDatasetQuerySignature(Orders, {});
+    const metricSig = buildMetricQuerySignature(revenue, {});
+    expect(datasetSig).not.toBe(metricSig);
+  });
+
+  it('distinguishes filters, pagination, and grain', () => {
+    const base = buildDatasetQuerySignature(Orders, { measures: ['revenue'] });
+    expect(buildDatasetQuerySignature(Orders, {
+      measures: ['revenue'],
+      filters: [{ field: 'status', operator: 'eq', value: 'completed' }],
+    })).not.toBe(base);
+    expect(buildDatasetQuerySignature(Orders, { measures: ['revenue'], limit: 10 })).not.toBe(base);
+    expect(buildDatasetQuerySignature(Orders, { measures: ['revenue'], offset: 10 })).not.toBe(base);
+  });
+
+  it('embeds the tenant scope for tenant-keyed datasets only', () => {
+    const scoped = (tenant: string) =>
+      buildDatasetQuerySignature(TenantOrders, { measures: ['revenue'] }, { runtime: { tenant } });
+    expect(scoped('tenant_a')).not.toBe(scoped('tenant_b'));
+
+    const unscoped = (tenant: string) =>
+      buildDatasetQuerySignature(Orders, { measures: ['revenue'] }, { runtime: { tenant } });
+    expect(unscoped('tenant_a')).toBe(unscoped('tenant_b'));
+  });
+});

--- a/packages/datasets/src/cache/query-signature.ts
+++ b/packages/datasets/src/cache/query-signature.ts
@@ -3,11 +3,12 @@
  *
  * A signature captures everything that changes a query's result set: the
  * target (dataset or metric), selected dimensions/measures, filters, ordering,
- * pagination, time grain, and the effective tenant scope. Two calls with the
+ * pagination, time grain, the effective tenant scope, and any explicit cache
+ * scope (see `SemanticCacheRuntime.scope`). Two calls with the
  * same signature are guaranteed to produce the same rows against the same
  * underlying data, so the signature is safe to use as a result-cache key.
  *
- * Keys are readable canonical JSON rather than hashes so stores can inspect
+ * Keys are readable canonical strings rather than hashes so stores can inspect
  * them and tests can assert on them; stores are free to hash internally.
  */
 
@@ -23,22 +24,20 @@ import type {
 } from '../types.js';
 import { getMetricGrain, getMetricRef, type MetricHandle } from '../utils/metric-handle.js';
 import { getRuntimeTenantPredicate } from '../utils/tenant-runtime.js';
+import { stableStringify } from '../utils/canonical-json.js';
+
+export { stableStringify };
 
 const SIGNATURE_VERSION = 1;
 
-/** JSON.stringify with recursively sorted object keys, so key order never matters. */
-export function stableStringify(value: unknown): string {
-  if (value === null || typeof value !== 'object') {
-    return JSON.stringify(value) ?? 'null';
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(',')}]`;
-  }
-  const entries = Object.entries(value as Record<string, unknown>)
-    .filter(([, entryValue]) => entryValue !== undefined)
-    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-    .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`);
-  return `{${entries.join(',')}}`;
+/**
+ * Explicit cache partition. Callers set `cache.scope` when the same semantic
+ * query can resolve against different data sources (per-call builder
+ * overrides, multiple clients sharing one store).
+ */
+function scopeSignature(context?: ExecutionContext): string | null {
+  const cache = context?.cache;
+  return cache ? cache.scope ?? null : null;
 }
 
 function filterSignature(filters: MetricFilter[] | undefined) {
@@ -92,6 +91,7 @@ export function buildDatasetQuerySignature(
     limit: query.limit ?? null,
     offset: query.offset ?? null,
     tenant: tenantSignature(ds, context),
+    scope: scopeSignature(context),
   });
 }
 
@@ -115,5 +115,6 @@ export function buildMetricQuerySignature(
     limit: query.limit ?? null,
     offset: query.offset ?? null,
     tenant: tenantSignature(ref.dataset, context),
+    scope: scopeSignature(context),
   });
 }

--- a/packages/datasets/src/cache/query-signature.ts
+++ b/packages/datasets/src/cache/query-signature.ts
@@ -1,0 +1,119 @@
+/**
+ * Canonical cache keys for semantic queries.
+ *
+ * A signature captures everything that changes a query's result set: the
+ * target (dataset or metric), selected dimensions/measures, filters, ordering,
+ * pagination, time grain, and the effective tenant scope. Two calls with the
+ * same signature are guaranteed to produce the same rows against the same
+ * underlying data, so the signature is safe to use as a result-cache key.
+ *
+ * Keys are readable canonical JSON rather than hashes so stores can inspect
+ * them and tests can assert on them; stores are free to hash internally.
+ */
+
+import type {
+  AnyDatasetInstance,
+  DatasetQuery,
+  ExecutionContext,
+  GrainedMetricRef,
+  MetricFilter,
+  MetricOrderBy,
+  MetricQuery,
+  MetricRef,
+} from '../types.js';
+import { getMetricGrain, getMetricRef, type MetricHandle } from '../utils/metric-handle.js';
+import { getRuntimeTenantPredicate } from '../utils/tenant-runtime.js';
+
+const SIGNATURE_VERSION = 1;
+
+/** JSON.stringify with recursively sorted object keys, so key order never matters. */
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? 'null';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entryValue]) => entryValue !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`);
+  return `{${entries.join(',')}}`;
+}
+
+function filterSignature(filters: MetricFilter[] | undefined) {
+  return (filters ?? []).map((filter) => ({
+    field: filter.field,
+    operator: filter.operator,
+    value: filter.value ?? null,
+  }));
+}
+
+function orderBySignature(orderBy: MetricOrderBy[] | undefined) {
+  return (orderBy ?? []).map((order) => ({
+    field: order.field,
+    direction: order.direction,
+  }));
+}
+
+/**
+ * Tenant portion of the key. Only datasets with a `tenantKey` apply the
+ * runtime tenant predicate, so tenant-less datasets share entries across
+ * callers while tenant-scoped datasets are strictly partitioned per scope.
+ */
+function tenantSignature(ds: AnyDatasetInstance, context?: ExecutionContext) {
+  if (!ds.tenantKey) {
+    return null;
+  }
+  const predicate = getRuntimeTenantPredicate(context);
+  if (!predicate) {
+    // Trusted cross-tenant scope (`scope: 'all'`) or no runtime tenancy.
+    return { key: ds.tenantKey, scope: 'all' };
+  }
+  return { key: ds.tenantKey, operator: predicate.operator, value: predicate.value };
+}
+
+export function buildDatasetQuerySignature(
+  ds: AnyDatasetInstance,
+  query: DatasetQuery,
+  context?: ExecutionContext,
+): string {
+  return stableStringify({
+    v: SIGNATURE_VERSION,
+    kind: 'dataset',
+    target: ds.name,
+    source: ds.source,
+    dimensions: query.dimensions ?? null,
+    // `null` distinguishes the "all measures" default from an explicit [].
+    measures: query.measures ?? null,
+    filters: filterSignature(query.filters),
+    orderBy: orderBySignature(query.orderBy),
+    by: query.by ?? null,
+    limit: query.limit ?? null,
+    offset: query.offset ?? null,
+    tenant: tenantSignature(ds, context),
+  });
+}
+
+export function buildMetricQuerySignature(
+  metric: MetricRef | GrainedMetricRef,
+  query: MetricQuery,
+  context?: ExecutionContext,
+): string {
+  const ref = getMetricRef(metric as MetricHandle);
+  const grain = getMetricGrain(metric as MetricHandle, query);
+  return stableStringify({
+    v: SIGNATURE_VERSION,
+    kind: 'metric',
+    target: `${ref.dataset.name}.${ref.name}`,
+    source: ref.dataset.source,
+    metricKind: ref.spec.__type,
+    dimensions: query.dimensions ?? null,
+    filters: filterSignature(query.filters),
+    orderBy: orderBySignature(query.orderBy),
+    by: grain ?? null,
+    limit: query.limit ?? null,
+    offset: query.offset ?? null,
+    tenant: tenantSignature(ref.dataset, context),
+  });
+}

--- a/packages/datasets/src/cache/semantic-query-cache.test.ts
+++ b/packages/datasets/src/cache/semantic-query-cache.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMemoryCacheStore,
+  SemanticQueryCache,
+} from './semantic-query-cache.js';
+
+interface TestResult {
+  data: Array<Record<string, unknown>>;
+  meta?: Record<string, unknown>;
+}
+
+function makeRunner(results?: TestResult[]) {
+  let calls = 0;
+  const runner = vi.fn(async (): Promise<TestResult> => {
+    const result = results?.[calls] ?? { data: [{ n: calls }], meta: { timingMs: 1 } };
+    calls += 1;
+    return structuredClone(result);
+  });
+  return runner;
+}
+
+describe('createMemoryCacheStore', () => {
+  it('evicts least-recently-used entries beyond maxEntries', () => {
+    const store = createMemoryCacheStore({ maxEntries: 2 });
+    store.set('a', { value: 1, storedAt: 0 });
+    store.set('b', { value: 2, storedAt: 0 });
+    // Touch "a" so "b" becomes the eviction candidate.
+    store.get('a');
+    store.set('c', { value: 3, storedAt: 0 });
+
+    expect(store.get('a')).toBeDefined();
+    expect(store.get('b')).toBeUndefined();
+    expect(store.get('c')).toBeDefined();
+  });
+});
+
+describe('SemanticQueryCache.through', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('runs uncached when no TTL is configured anywhere', async () => {
+    const cache = new SemanticQueryCache();
+    const run = makeRunner();
+
+    const first = await cache.through('k', run);
+    const second = await cache.through('k', run);
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(first.meta?.cache).toBeUndefined();
+    expect(second.meta?.cache).toBeUndefined();
+  });
+
+  it('serves fresh hits within the TTL and annotates meta.cache', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    const run = makeRunner();
+
+    const miss = await cache.through('k', run);
+    vi.advanceTimersByTime(500);
+    const hit = await cache.through('k', run);
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(miss.meta?.cache).toEqual({ hit: false });
+    expect(hit.meta?.cache).toEqual({ hit: true, ageMs: 500 });
+    expect(hit.data).toEqual(miss.data);
+  });
+
+  it('re-executes after the TTL expires', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    const run = makeRunner();
+
+    await cache.through('k', run);
+    vi.advanceTimersByTime(1001);
+    const result = await cache.through('k', run);
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(result.meta?.cache).toEqual({ hit: false });
+  });
+
+  it('serves stale values inside the SWR window and refreshes in the background', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000, staleWhileRevalidateMs: 1000 });
+    const run = makeRunner([
+      { data: [{ v: 'first' }] },
+      { data: [{ v: 'second' }] },
+    ]);
+
+    await cache.through('k', run);
+    vi.advanceTimersByTime(1500);
+
+    const stale = await cache.through('k', run);
+    expect(stale.data).toEqual([{ v: 'first' }]);
+    expect(stale.meta?.cache).toEqual({ hit: true, ageMs: 1500, stale: true });
+
+    // Let the background refresh land, then the next call is a fresh hit.
+    await vi.runAllTimersAsync();
+    expect(run).toHaveBeenCalledTimes(2);
+
+    const refreshed = await cache.through('k', run);
+    expect(refreshed.data).toEqual([{ v: 'second' }]);
+    expect(refreshed.meta?.cache).toMatchObject({ hit: true });
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the stale entry when a background refresh fails', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000, staleWhileRevalidateMs: 5000 });
+    let calls = 0;
+    const run = vi.fn(async (): Promise<TestResult> => {
+      calls += 1;
+      if (calls > 1) throw new Error('refresh boom');
+      return { data: [{ v: 'first' }] };
+    });
+
+    await cache.through('k', run);
+    vi.advanceTimersByTime(1500);
+    const stale = await cache.through('k', run);
+    await vi.runAllTimersAsync();
+
+    expect(stale.data).toEqual([{ v: 'first' }]);
+    // The failed refresh did not evict; still within SWR window → stale again.
+    const staleAgain = await cache.through('k', run);
+    expect(staleAgain.data).toEqual([{ v: 'first' }]);
+  });
+
+  it('bypass mode skips reads and writes', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    const run = makeRunner();
+
+    await cache.through('k', run);
+    const bypassed = await cache.through('k', run, { mode: 'bypass' });
+    const hit = await cache.through('k', run);
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(bypassed.meta?.cache).toBeUndefined();
+    expect(hit.meta?.cache).toMatchObject({ hit: true });
+  });
+
+  it('`false` runtime disables the cache for the call', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    const run = makeRunner();
+
+    await cache.through('k', run);
+    const bypassed = await cache.through('k', run, false);
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(bypassed.meta?.cache).toBeUndefined();
+  });
+
+  it('refresh mode skips the read but repopulates the entry', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    const run = makeRunner([
+      { data: [{ v: 'first' }] },
+      { data: [{ v: 'second' }] },
+    ]);
+
+    await cache.through('k', run);
+    const refreshed = await cache.through('k', run, { mode: 'refresh' });
+    const hit = await cache.through('k', run);
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(refreshed.data).toEqual([{ v: 'second' }]);
+    expect(hit.data).toEqual([{ v: 'second' }]);
+    expect(hit.meta?.cache).toMatchObject({ hit: true });
+  });
+
+  it('per-call TTL enables caching without client defaults', async () => {
+    const cache = new SemanticQueryCache();
+    const run = makeRunner();
+
+    await cache.through('k', run, { ttlMs: 1000 });
+    const hit = await cache.through('k', run, { ttlMs: 1000 });
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(hit.meta?.cache).toMatchObject({ hit: true });
+  });
+
+  it('deduplicates concurrent identical misses', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    let resolveRun!: (value: TestResult) => void;
+    const run = vi.fn(
+      () => new Promise<TestResult>((resolve) => { resolveRun = resolve; }),
+    );
+
+    const first = cache.through('k', run);
+    const second = cache.through('k', run);
+    resolveRun({ data: [{ v: 'shared' }] });
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(a.data).toEqual([{ v: 'shared' }]);
+    expect(b.data).toEqual([{ v: 'shared' }]);
+    // Concurrent callers never share row objects.
+    expect(a.data[0]).not.toBe(b.data[0]);
+  });
+
+  it('does not cache errors', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    let calls = 0;
+    const run = vi.fn(async (): Promise<TestResult> => {
+      calls += 1;
+      if (calls === 1) throw new Error('boom');
+      return { data: [{ v: 'ok' }] };
+    });
+
+    await expect(cache.through('k', run)).rejects.toThrow('boom');
+    const result = await cache.through('k', run);
+
+    expect(result.data).toEqual([{ v: 'ok' }]);
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('isolates cached values from caller mutation', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    const run = makeRunner([{ data: [{ v: 'original' }] }]);
+
+    const first = await cache.through('k', run);
+    (first.data[0] as Record<string, unknown>).v = 'mutated';
+
+    const hit = await cache.through('k', run);
+    expect(hit.data).toEqual([{ v: 'original' }]);
+  });
+});

--- a/packages/datasets/src/cache/semantic-query-cache.test.ts
+++ b/packages/datasets/src/cache/semantic-query-cache.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createMemoryCacheStore,
   SemanticQueryCache,
+  type SemanticCacheEntry,
+  type SemanticCacheStore,
 } from './semantic-query-cache.js';
 
 interface TestResult {
@@ -166,6 +168,74 @@ describe('SemanticQueryCache.through', () => {
     expect(hit.meta?.cache).toMatchObject({ hit: true });
   });
 
+  it('refresh mode does not piggyback on an in-flight miss', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    const resolvers: Array<(value: TestResult) => void> = [];
+    const run = vi.fn(
+      () => new Promise<TestResult>((resolve) => { resolvers.push(resolve); }),
+    );
+
+    const miss = cache.through('k', run);
+    const refresh = cache.through('k', run, { mode: 'refresh' });
+    expect(run).toHaveBeenCalledTimes(2);
+
+    resolvers[0]({ data: [{ v: 'miss' }] });
+    resolvers[1]({ data: [{ v: 'refresh' }] });
+
+    expect((await miss).data).toEqual([{ v: 'miss' }]);
+    expect((await refresh).data).toEqual([{ v: 'refresh' }]);
+  });
+
+  it('refresh mode without any TTL executes uncached and warns once', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const cache = new SemanticQueryCache();
+      const run = makeRunner();
+
+      const result = await cache.through('k', run, { mode: 'refresh' });
+      await cache.through('k', run, { mode: 'refresh' });
+
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(result.meta?.cache).toBeUndefined();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toMatch(/refresh.*no TTL/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('treats a failing store read as a miss', async () => {
+    const store = createMemoryCacheStore();
+    const failingStore: SemanticCacheStore = {
+      ...store,
+      get: vi.fn(async () => {
+        throw new Error('store down');
+      }),
+    };
+    const cache = new SemanticQueryCache({ ttlMs: 1000, store: failingStore });
+    const run = makeRunner([{ data: [{ v: 'fresh' }] }]);
+
+    const result = await cache.through('k', run);
+    expect(result.data).toEqual([{ v: 'fresh' }]);
+    expect(result.meta?.cache).toEqual({ hit: false });
+  });
+
+  it('returns the fresh result when the store write fails', async () => {
+    const store = createMemoryCacheStore();
+    const failingStore = {
+      ...store,
+      set: vi.fn(async () => {
+        throw new Error('store down');
+      }),
+    };
+    const cache = new SemanticQueryCache({ ttlMs: 1000, store: failingStore });
+    const run = makeRunner([{ data: [{ v: 'fresh' }] }]);
+
+    const result = await cache.through('k', run);
+    expect(result.data).toEqual([{ v: 'fresh' }]);
+    expect(failingStore.set).toHaveBeenCalled();
+  });
+
   it('per-call TTL enables caching without client defaults', async () => {
     const cache = new SemanticQueryCache();
     const run = makeRunner();
@@ -192,7 +262,76 @@ describe('SemanticQueryCache.through', () => {
     expect(run).toHaveBeenCalledTimes(1);
     expect(a.data).toEqual([{ v: 'shared' }]);
     expect(b.data).toEqual([{ v: 'shared' }]);
-    // Concurrent callers never share row objects.
+    // Concurrent callers never share row objects — nor meta.cache objects.
+    expect(a.data[0]).not.toBe(b.data[0]);
+    expect(a.meta?.cache).not.toBe(b.meta?.cache);
+  });
+
+  it('dedupes concurrent misses through an async store', async () => {
+    // Models a Redis-style store: the value is snapshotted when get() is
+    // issued, and the response arrives only when the test releases it.
+    const entries = new Map<string, SemanticCacheEntry>();
+    const reads: Array<() => void> = [];
+    const store: SemanticCacheStore = {
+      get(key) {
+        const snapshot = entries.get(key);
+        return new Promise((resolve) => {
+          reads.push(() => resolve(snapshot));
+        });
+      },
+      async set(key, entry) {
+        entries.set(key, entry);
+      },
+      async delete(key) {
+        entries.delete(key);
+      },
+    };
+    const cache = new SemanticQueryCache({ ttlMs: 1000, store });
+    const run = makeRunner();
+
+    const first = cache.through('k', run);
+    const second = cache.through('k', run);
+
+    // Only the first caller reads the store; the second piggybacks on the
+    // in-flight lookup instead of racing its own read against the write.
+    expect(reads).toHaveLength(1);
+    reads[0]();
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(a.data).toEqual(b.data);
+    expect(a.data[0]).not.toBe(b.data[0]);
+  });
+
+  it('piggybacked concurrent callers receive hit metadata when the lookup hits', async () => {
+    const entries = new Map<string, SemanticCacheEntry>();
+    const reads: Array<() => void> = [];
+    const store: SemanticCacheStore = {
+      get(key) {
+        const snapshot = entries.get(key);
+        return new Promise((resolve) => {
+          reads.push(() => resolve(snapshot));
+        });
+      },
+      async set(key, entry) {
+        entries.set(key, entry);
+      },
+      async delete(key) {
+        entries.delete(key);
+      },
+    };
+    const cache = new SemanticQueryCache({ ttlMs: 1000, store });
+    const run = makeRunner();
+
+    entries.set('k', { value: { data: [{ v: 'stored' }] }, storedAt: Date.now() });
+    const first = cache.through('k', run);
+    const second = cache.through('k', run);
+    reads[0]();
+
+    const [a, b] = await Promise.all([first, second]);
+    expect(run).not.toHaveBeenCalled();
+    expect(a.meta?.cache).toMatchObject({ hit: true });
+    expect(b.meta?.cache).toMatchObject({ hit: true });
     expect(a.data[0]).not.toBe(b.data[0]);
   });
 

--- a/packages/datasets/src/cache/semantic-query-cache.ts
+++ b/packages/datasets/src/cache/semantic-query-cache.ts
@@ -1,0 +1,228 @@
+/**
+ * Semantic query result cache.
+ *
+ * Sits between `DatasetClient.execute()` and the underlying query builder /
+ * backend, keyed by the canonical query signature (see query-signature.ts).
+ * Supports TTL freshness, an optional stale-while-revalidate window, and
+ * deduplication of concurrent identical misses so a burst of the same query
+ * executes once.
+ *
+ * Values are cloned on write and on read: callers can mutate results freely
+ * without contaminating the cache, and cached hits never alias each other.
+ */
+
+export interface SemanticCacheEntry {
+  value: unknown;
+  storedAt: number;
+}
+
+/**
+ * Pluggable store. The default is an in-process LRU; provide a custom store
+ * (e.g. Redis-backed) for multi-instance deployments. Stores hold opaque
+ * entries — freshness is decided by the cache from `storedAt` and the
+ * effective TTL, so per-call TTLs work against shared entries.
+ */
+export interface SemanticCacheStore {
+  get(key: string): SemanticCacheEntry | undefined | Promise<SemanticCacheEntry | undefined>;
+  set(key: string, entry: SemanticCacheEntry): void | Promise<void>;
+  delete(key: string): void | Promise<void>;
+  clear?(): void | Promise<void>;
+}
+
+/** Client-level cache defaults (see `CreateDatasetClientOptions.cache`). */
+export interface SemanticCacheOptions {
+  /** Fresh window in milliseconds. 0 / omitted = only per-call opt-in caches. */
+  ttlMs?: number;
+  /**
+   * Additional window after `ttlMs` during which a stale result is returned
+   * immediately while a background refresh repopulates the entry.
+   */
+  staleWhileRevalidateMs?: number;
+  /** Max entries for the default in-memory store. Ignored when `store` is set. */
+  maxEntries?: number;
+  /** Custom store; defaults to an in-process LRU. */
+  store?: SemanticCacheStore;
+}
+
+/** Per-call cache controls, passed via `ExecutionContext.cache`. */
+export interface SemanticCacheRuntime {
+  /** Overrides the client-level TTL for this call. */
+  ttlMs?: number;
+  /** Overrides the client-level stale-while-revalidate window for this call. */
+  staleWhileRevalidateMs?: number;
+  /**
+   * `bypass` skips the cache entirely (no read, no write);
+   * `refresh` skips the read but stores the fresh result.
+   */
+  mode?: 'bypass' | 'refresh';
+}
+
+/** Cache observability attached to `meta.cache` on cached-path results. */
+export interface SemanticCacheMetaInfo {
+  hit: boolean;
+  /** Milliseconds since the entry was stored; only on hits. */
+  ageMs?: number;
+  /** True when served from the stale-while-revalidate window. */
+  stale?: boolean;
+}
+
+const DEFAULT_MAX_ENTRIES = 500;
+
+export function createMemoryCacheStore(
+  options: { maxEntries?: number } = {},
+): SemanticCacheStore {
+  const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  const entries = new Map<string, SemanticCacheEntry>();
+
+  return {
+    get(key) {
+      const entry = entries.get(key);
+      if (!entry) {
+        return undefined;
+      }
+      // LRU: re-insert on access so iteration order tracks recency.
+      entries.delete(key);
+      entries.set(key, entry);
+      return entry;
+    },
+    set(key, entry) {
+      entries.delete(key);
+      entries.set(key, entry);
+      while (entries.size > maxEntries) {
+        const oldest = entries.keys().next().value;
+        if (oldest === undefined) break;
+        entries.delete(oldest);
+      }
+    },
+    delete(key) {
+      entries.delete(key);
+    },
+    clear() {
+      entries.clear();
+    },
+  };
+}
+
+interface ResolvedCacheConfig {
+  ttlMs: number;
+  staleWhileRevalidateMs: number;
+  mode: 'read-write' | 'refresh';
+}
+
+type CacheableResult = { meta?: object };
+
+function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
+  return typeof (value as { then?: unknown } | null | undefined)?.['then' as never] === 'function';
+}
+
+function cloneValue<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function annotate<T extends CacheableResult>(result: T, info: SemanticCacheMetaInfo): T {
+  return {
+    ...result,
+    meta: { ...(result.meta ?? {}), cache: info },
+  } as T;
+}
+
+export class SemanticQueryCache {
+  private readonly store: SemanticCacheStore;
+  private readonly defaults: SemanticCacheOptions;
+  private readonly pending = new Map<string, Promise<CacheableResult>>();
+  private readonly refreshing = new Set<string>();
+
+  constructor(options: SemanticCacheOptions = {}) {
+    this.defaults = options;
+    this.store = options.store ?? createMemoryCacheStore({ maxEntries: options.maxEntries });
+  }
+
+  private resolveConfig(
+    runtime: SemanticCacheRuntime | false | undefined,
+  ): ResolvedCacheConfig | undefined {
+    if (runtime === false) {
+      return undefined;
+    }
+    if (runtime?.mode === 'bypass') {
+      return undefined;
+    }
+    const ttlMs = runtime?.ttlMs ?? this.defaults.ttlMs ?? 0;
+    if (ttlMs <= 0) {
+      return undefined;
+    }
+    return {
+      ttlMs,
+      staleWhileRevalidateMs:
+        runtime?.staleWhileRevalidateMs ?? this.defaults.staleWhileRevalidateMs ?? 0,
+      mode: runtime?.mode === 'refresh' ? 'refresh' : 'read-write',
+    };
+  }
+
+  /**
+   * Runs `execute` through the cache. Errors are never cached; concurrent
+   * identical misses share one execution.
+   */
+  async through<T extends CacheableResult>(
+    key: string,
+    execute: () => Promise<T>,
+    runtime?: SemanticCacheRuntime | false,
+  ): Promise<T> {
+    const config = this.resolveConfig(runtime);
+    if (!config) {
+      return execute();
+    }
+
+    if (config.mode !== 'refresh') {
+      // Avoid awaiting synchronous stores so the pending-map registration
+      // below happens before control returns to the caller — that is what
+      // makes back-to-back identical calls share one execution.
+      const read = this.store.get(key);
+      const entry = isPromise(read) ? await read : read;
+      if (entry) {
+        const ageMs = Date.now() - entry.storedAt;
+        if (ageMs <= config.ttlMs) {
+          return annotate(cloneValue(entry.value) as T, { hit: true, ageMs });
+        }
+        if (ageMs <= config.ttlMs + config.staleWhileRevalidateMs) {
+          this.refreshInBackground(key, execute);
+          return annotate(cloneValue(entry.value) as T, { hit: true, ageMs, stale: true });
+        }
+      }
+    }
+
+    const inFlight = this.pending.get(key);
+    if (inFlight) {
+      // Piggyback on the identical in-flight execution; clone so concurrent
+      // callers never share a result object.
+      return annotate(cloneValue(await inFlight) as T, { hit: false });
+    }
+
+    const promise = (async () => {
+      const value = await execute();
+      await this.store.set(key, { value: cloneValue(value), storedAt: Date.now() });
+      return value;
+    })();
+
+    this.pending.set(key, promise);
+    try {
+      return annotate((await promise) as T, { hit: false });
+    } finally {
+      this.pending.delete(key);
+    }
+  }
+
+  private refreshInBackground(key: string, execute: () => Promise<CacheableResult>): void {
+    if (this.refreshing.has(key)) {
+      return;
+    }
+    this.refreshing.add(key);
+    void execute()
+      .then((value) => this.store.set(key, { value: cloneValue(value), storedAt: Date.now() }))
+      .catch(() => {
+        // Stale entry stays; the next caller past the SWR window re-executes.
+      })
+      .finally(() => {
+        this.refreshing.delete(key);
+      });
+  }
+}

--- a/packages/datasets/src/cache/semantic-query-cache.ts
+++ b/packages/datasets/src/cache/semantic-query-cache.ts
@@ -4,8 +4,10 @@
  * Sits between `DatasetClient.execute()` and the underlying query builder /
  * backend, keyed by the canonical query signature (see query-signature.ts).
  * Supports TTL freshness, an optional stale-while-revalidate window, and
- * deduplication of concurrent identical misses so a burst of the same query
- * executes once.
+ * deduplication of concurrent identical lookups so a burst of the same query
+ * executes once — including against async stores, where the in-flight lookup
+ * is registered before the store read. Piggybacked callers inherit the
+ * initiating caller's TTL resolution.
  *
  * Values are cloned on write and on read: callers can mutate results freely
  * without contaminating the cache, and cached hits never alias each other.
@@ -21,6 +23,10 @@ export interface SemanticCacheEntry {
  * (e.g. Redis-backed) for multi-instance deployments. Stores hold opaque
  * entries — freshness is decided by the cache from `storedAt` and the
  * effective TTL, so per-call TTLs work against shared entries.
+ *
+ * Store errors are non-fatal: a failed read is treated as a miss and a failed
+ * write is dropped, so a store outage degrades to uncached execution rather
+ * than failing queries.
  */
 export interface SemanticCacheStore {
   get(key: string): SemanticCacheEntry | undefined | Promise<SemanticCacheEntry | undefined>;
@@ -42,6 +48,12 @@ export interface SemanticCacheOptions {
   maxEntries?: number;
   /** Custom store; defaults to an in-process LRU. */
   store?: SemanticCacheStore;
+  /**
+   * Default cache partition included in every key. Set this when multiple
+   * clients pointing at different data sources share one store (e.g. Redis),
+   * so identical queries against different backends never collide.
+   */
+  scope?: string;
 }
 
 /** Per-call cache controls, passed via `ExecutionContext.cache`. */
@@ -52,9 +64,18 @@ export interface SemanticCacheRuntime {
   staleWhileRevalidateMs?: number;
   /**
    * `bypass` skips the cache entirely (no read, no write);
-   * `refresh` skips the read but stores the fresh result.
+   * `refresh` skips the read but stores the fresh result. Refresh needs a
+   * TTL (per-call or client-level) to store under; when neither is
+   * configured it executes uncached and logs a one-time warning.
    */
   mode?: 'bypass' | 'refresh';
+  /**
+   * Cache partition for this call, mixed into the query signature. Required
+   * to cache calls that override the query builder via `runtime.builderFactory`
+   * — without it such calls bypass the cache, because the key alone cannot
+   * tell two data sources apart.
+   */
+  scope?: string;
 }
 
 /** Cache observability attached to `meta.cache` on cached-path results. */
@@ -109,6 +130,12 @@ interface ResolvedCacheConfig {
   mode: 'read-write' | 'refresh';
 }
 
+/** Result of one deduplicated lookup-or-execute, shared by concurrent callers. */
+interface LookupOutcome {
+  value: unknown;
+  info: SemanticCacheMetaInfo;
+}
+
 type CacheableResult = { meta?: object };
 
 function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
@@ -122,15 +149,18 @@ function cloneValue<T>(value: T): T {
 function annotate<T extends CacheableResult>(result: T, info: SemanticCacheMetaInfo): T {
   return {
     ...result,
-    meta: { ...(result.meta ?? {}), cache: info },
+    // Copy `info`: the same outcome is annotated onto every concurrent
+    // caller's result, and results must never alias each other.
+    meta: { ...(result.meta ?? {}), cache: { ...info } },
   } as T;
 }
 
 export class SemanticQueryCache {
   private readonly store: SemanticCacheStore;
   private readonly defaults: SemanticCacheOptions;
-  private readonly pending = new Map<string, Promise<CacheableResult>>();
+  private readonly pending = new Map<string, Promise<LookupOutcome>>();
   private readonly refreshing = new Set<string>();
+  private warnedRefreshWithoutTtl = false;
 
   constructor(options: SemanticCacheOptions = {}) {
     this.defaults = options;
@@ -148,6 +178,15 @@ export class SemanticQueryCache {
     }
     const ttlMs = runtime?.ttlMs ?? this.defaults.ttlMs ?? 0;
     if (ttlMs <= 0) {
+      // A misconfigured refresh must not fail the request — the fresh result
+      // is still correct — but it should not go undiagnosed either.
+      if (runtime?.mode === 'refresh' && !this.warnedRefreshWithoutTtl) {
+        this.warnedRefreshWithoutTtl = true;
+        console.warn(
+          "[hypequery/cache] mode 'refresh' has no TTL to store under; executing uncached. " +
+            'Pass ttlMs on the call or configure cache.ttlMs on the client.',
+        );
+      }
       return undefined;
     }
     return {
@@ -172,42 +211,70 @@ export class SemanticQueryCache {
       return execute();
     }
 
-    if (config.mode !== 'refresh') {
-      // Avoid awaiting synchronous stores so the pending-map registration
-      // below happens before control returns to the caller — that is what
-      // makes back-to-back identical calls share one execution.
-      const read = this.store.get(key);
-      const entry = isPromise(read) ? await read : read;
-      if (entry) {
-        const ageMs = Date.now() - entry.storedAt;
-        if (ageMs <= config.ttlMs) {
-          return annotate(cloneValue(entry.value) as T, { hit: true, ageMs });
-        }
-        if (ageMs <= config.ttlMs + config.staleWhileRevalidateMs) {
-          this.refreshInBackground(key, execute);
-          return annotate(cloneValue(entry.value) as T, { hit: true, ageMs, stale: true });
-        }
-      }
+    if (config.mode === 'refresh') {
+      // Refresh callers asked for an isolated fresh read: never piggyback on
+      // an in-flight miss, just execute and repopulate the entry.
+      const value = await execute();
+      await this.writeEntry(key, value);
+      return annotate(value as T, { hit: false });
     }
 
     const inFlight = this.pending.get(key);
     if (inFlight) {
-      // Piggyback on the identical in-flight execution; clone so concurrent
-      // callers never share a result object.
-      return annotate(cloneValue(await inFlight) as T, { hit: false });
+      // Piggyback on the identical in-flight lookup; clone so concurrent
+      // callers never share a result object. The outcome (hit, staleness) was
+      // resolved with the initiating caller's TTL configuration.
+      const shared = await inFlight;
+      return annotate(cloneValue(shared.value) as T, shared.info);
     }
 
-    const promise = (async () => {
+    // The pending registration below happens synchronously, before the store
+    // read inside the IIFE — that is what makes concurrent identical calls
+    // share one execution even with an async store (e.g. Redis), where a
+    // read snapshot taken before our write would otherwise miss and re-run.
+    const promise = (async (): Promise<LookupOutcome> => {
+      let entry: SemanticCacheEntry | undefined;
+      try {
+        // Avoid the extra microtask when the store answers synchronously.
+        const read = this.store.get(key);
+        entry = isPromise(read) ? await read : read;
+      } catch {
+        // Read failed; treat it as a miss so a store outage degrades to
+        // "no caching" instead of failing the query.
+      }
+      if (entry) {
+        const ageMs = Date.now() - entry.storedAt;
+        if (ageMs <= config.ttlMs) {
+          return { value: entry.value, info: { hit: true, ageMs } };
+        }
+        if (ageMs <= config.ttlMs + config.staleWhileRevalidateMs) {
+          this.refreshInBackground(key, execute);
+          return { value: entry.value, info: { hit: true, ageMs, stale: true } };
+        }
+      }
       const value = await execute();
-      await this.store.set(key, { value: cloneValue(value), storedAt: Date.now() });
-      return value;
+      await this.writeEntry(key, value);
+      return { value, info: { hit: false } };
     })();
 
     this.pending.set(key, promise);
     try {
-      return annotate((await promise) as T, { hit: false });
+      const outcome = await promise;
+      // Hits alias the stored entry and must be cloned; a freshly executed
+      // result is owned by this caller.
+      const value = outcome.info.hit ? cloneValue(outcome.value) : outcome.value;
+      return annotate(value as T, outcome.info);
     } finally {
       this.pending.delete(key);
+    }
+  }
+
+  /** Best-effort write: a failing store degrades to "no caching", never a failed call. */
+  private async writeEntry(key: string, value: unknown): Promise<void> {
+    try {
+      await this.store.set(key, { value: cloneValue(value), storedAt: Date.now() });
+    } catch {
+      // Cache write failed; the fresh result is still returned to the caller.
     }
   }
 
@@ -217,7 +284,7 @@ export class SemanticQueryCache {
     }
     this.refreshing.add(key);
     void execute()
-      .then((value) => this.store.set(key, { value: cloneValue(value), storedAt: Date.now() }))
+      .then((value) => this.writeEntry(key, value))
       .catch(() => {
         // Stale entry stays; the next caller past the SWR window re-executes.
       })

--- a/packages/datasets/src/contract.ts
+++ b/packages/datasets/src/contract.ts
@@ -11,6 +11,7 @@ import {
   type RelationshipCatalogEntry,
 } from './catalog.js';
 import type { DatasetLimits } from './types.js';
+import { sortedRecord, uniqueSorted } from './utils/canonical-json.js';
 
 /**
  * Version of the semantic contract format. Bump when the serialized shape
@@ -243,27 +244,6 @@ export function hashContract(
   contract: SemanticContract | SemanticContractWithoutHash,
 ): string {
   return bytesToHex(sha256(contractToStableJson(contract)));
-}
-
-/**
- * Locale-independent string comparison by UTF-16 code unit. Used everywhere the
- * contract sorts, so the content hash is stable across environments (CI ICU
- * versions, locales) rather than depending on `localeCompare`.
- */
-function compareStrings(left: string, right: string): number {
-  return left < right ? -1 : left > right ? 1 : 0;
-}
-
-/** Builds an object whose keys are inserted in sorted order for stable JSON. */
-function sortedRecord<T>(entries: [string, T][]): Record<string, T> {
-  return Object.fromEntries(
-    [...entries].sort(([left], [right]) => compareStrings(left, right)),
-  );
-}
-
-/** Deduplicates and sorts a list so logically-equal sets serialize identically. */
-function uniqueSorted(values: readonly string[]): string[] {
-  return Array.from(new Set(values)).sort(compareStrings);
 }
 
 /** Normalizes SQL escape-hatch whitespace so equivalent SQL hashes identically. */

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -69,6 +69,14 @@ import {
   validateTenantRuntime,
 } from './utils/tenant-runtime.js';
 import { applyPagination, overfetchLimit } from './utils/pagination.js';
+import {
+  SemanticQueryCache,
+  type SemanticCacheOptions,
+} from './cache/semantic-query-cache.js';
+import {
+  buildDatasetQuerySignature,
+  buildMetricQuerySignature,
+} from './cache/query-signature.js';
 
 function validateQuery(
   metric: MetricHandle,
@@ -203,6 +211,14 @@ export interface CreateDatasetClientOptions {
   queryBuilder?: QueryBuilderFactoryInput;
   /** Semantic backend for executing neutral semantic plans. */
   backend?: SemanticBackend;
+  /**
+   * Result-cache defaults for this client. Results are keyed by the canonical
+   * query signature (target, dimensions, measures, filters, ordering,
+   * pagination, grain, and tenant scope). Individual calls can override or
+   * bypass via `ExecutionContext.cache`; per-call `{ cache: { ttlMs } }` works
+   * even when this option is omitted.
+   */
+  cache?: SemanticCacheOptions;
 }
 
 /** Resolves the per-call builder override, adapted to the call contract. */
@@ -568,6 +584,8 @@ export class MetricQueryEngine {
 
 export class DatasetClientImpl extends MetricQueryEngine implements DatasetClient {
   private backend?: SemanticBackend;
+  private readonly queryCache: SemanticQueryCache;
+  private readonly cacheEnabledByDefault: boolean;
 
   constructor(options: CreateDatasetClientOptions) {
     if (!options.queryBuilder && !options.backend) {
@@ -584,6 +602,23 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
       },
     });
     this.backend = options.backend;
+    this.queryCache = new SemanticQueryCache(options.cache);
+    this.cacheEnabledByDefault = (options.cache?.ttlMs ?? 0) > 0;
+  }
+
+  /**
+   * True when this call can hit the cache — either the client has a default
+   * TTL or the call opts in via `context.cache`. Skips signature building for
+   * the common uncached path.
+   */
+  private isCacheable(context?: ExecutionContext): boolean {
+    if (context?.cache === false || context?.cache?.mode === 'bypass') {
+      return false;
+    }
+    if (context?.cache?.ttlMs != null) {
+      return context.cache.ttlMs > 0;
+    }
+    return this.cacheEnabledByDefault;
   }
 
   planMetric(
@@ -687,17 +722,35 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
     query: MetricQuery,
     context?: ExecutionContext,
   ): Promise<MetricResult<TRow>> {
-    if (this.backend) {
-      const validation = validateQuery(metric, query, context);
-      if (!validation.valid) {
-        throw new Error(`Invalid metric query: ${validation.errors.join('; ')}`);
+    const run = (): Promise<MetricResult<TRow>> => {
+      if (this.backend) {
+        const validation = validateQuery(metric, query, context);
+        if (!validation.valid) {
+          throw new Error(`Invalid metric query: ${validation.errors.join('; ')}`);
+        }
+        return this.backend.execute<TRow>(
+          this.planMetric(metric, query, context),
+        ) as Promise<MetricResult<TRow>>;
       }
-      return this.backend.execute<TRow>(
-        this.planMetric(metric, query, context),
-      ) as Promise<MetricResult<TRow>>;
+
+      return this.run<TRow>(metric, query, context);
+    };
+
+    if (!this.isCacheable(context)) {
+      return run();
     }
 
-    return this.run<TRow>(metric, query, context);
+    // Validate before touching the cache so invalid queries always throw.
+    const validation = this.validate(metric, query, context);
+    if (!validation.valid) {
+      throw new Error(`Invalid metric query: ${validation.errors.join('; ')}`);
+    }
+
+    return this.queryCache.through(
+      buildMetricQuerySignature(metric, query, context),
+      run,
+      context?.cache,
+    );
   }
 
   private executeDataset<TRow>(
@@ -705,24 +758,32 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
     query: DatasetQuery,
     context?: ExecutionContext,
   ): Promise<DatasetQueryResult<TRow>> {
-    if (this.backend) {
-      const validation = this.validate(ds, query, context);
-      if (!validation.valid) {
-        throw new Error(`Invalid dataset query: ${validation.errors.join('; ')}`);
-      }
-      return this.backend.execute<TRow>(
-        this.planDataset(ds, query, context),
-      ) as Promise<DatasetQueryResult<TRow>>;
-    }
-
     const validation = this.validate(ds, query, context);
     if (!validation.valid) {
       throw new Error(`Invalid dataset query: ${validation.errors.join('; ')}`);
     }
-    return runDatasetQuery(ds, query, {
-      builderFactory: resolveBuilderFactory(context, this.getBuilderFactory()),
-      context,
-    }) as Promise<DatasetQueryResult<TRow>>;
+
+    const run = (): Promise<DatasetQueryResult<TRow>> => {
+      if (this.backend) {
+        return this.backend.execute<TRow>(
+          this.planDataset(ds, query, context),
+        ) as Promise<DatasetQueryResult<TRow>>;
+      }
+      return runDatasetQuery(ds, query, {
+        builderFactory: resolveBuilderFactory(context, this.getBuilderFactory()),
+        context,
+      }) as Promise<DatasetQueryResult<TRow>>;
+    };
+
+    if (!this.isCacheable(context)) {
+      return run();
+    }
+
+    return this.queryCache.through(
+      buildDatasetQuerySignature(ds, query, context),
+      run,
+      context?.cache,
+    );
   }
 
   private toDatasetSQL(

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -586,6 +586,7 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
   private backend?: SemanticBackend;
   private readonly queryCache: SemanticQueryCache;
   private readonly cacheEnabledByDefault: boolean;
+  private readonly defaultCacheScope?: string;
 
   constructor(options: CreateDatasetClientOptions) {
     if (!options.queryBuilder && !options.backend) {
@@ -604,6 +605,7 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
     this.backend = options.backend;
     this.queryCache = new SemanticQueryCache(options.cache);
     this.cacheEnabledByDefault = (options.cache?.ttlMs ?? 0) > 0;
+    this.defaultCacheScope = options.cache?.scope;
   }
 
   /**
@@ -615,10 +617,41 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
     if (context?.cache === false || context?.cache?.mode === 'bypass') {
       return false;
     }
+    const builderOverride = context?.runtime?.builderFactory;
+    if (
+      builderOverride &&
+      toQueryBuilderFactory(builderOverride) !== this.getBuilderFactory() &&
+      context.cache?.scope == null
+    ) {
+      // A per-call builder override can point at a different data source; the
+      // query signature alone cannot tell them apart, so caching is unsafe
+      // unless the caller partitions entries with an explicit `cache.scope`.
+      // Passing the client's own factory back in is not an override.
+      return false;
+    }
+    if (context?.cache?.mode === 'refresh') {
+      // Always reach the cache: it warns if refresh has no TTL to write under.
+      return true;
+    }
     if (context?.cache?.ttlMs != null) {
       return context.cache.ttlMs > 0;
     }
     return this.cacheEnabledByDefault;
+  }
+
+  /**
+   * Context used for cache-key building: fills in the client-level default
+   * `cache.scope` unless the call sets its own, so clients sharing a custom
+   * store can be namespaced apart.
+   */
+  private signatureContext(context?: ExecutionContext): ExecutionContext | undefined {
+    if (this.defaultCacheScope === undefined) {
+      return context;
+    }
+    if (context?.cache === false || context?.cache?.scope != null) {
+      return context;
+    }
+    return { ...context, cache: { ...context?.cache, scope: this.defaultCacheScope } };
   }
 
   planMetric(
@@ -740,14 +773,17 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
       return run();
     }
 
-    // Validate before touching the cache so invalid queries always throw.
-    const validation = this.validate(metric, query, context);
+    // Validate semantic rules before cache lookup so invalid queries and
+    // missing tenant runtime cannot be served from cache. Avoid this.validate()
+    // here because it dry-builds SQL, which is unnecessary on cache hits and
+    // invalid for backend-only clients.
+    const validation = validateQuery(metric, query, context);
     if (!validation.valid) {
       throw new Error(`Invalid metric query: ${validation.errors.join('; ')}`);
     }
 
     return this.queryCache.through(
-      buildMetricQuerySignature(metric, query, context),
+      buildMetricQuerySignature(metric, query, this.signatureContext(context)),
       run,
       context?.cache,
     );
@@ -780,7 +816,7 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
     }
 
     return this.queryCache.through(
-      buildDatasetQuerySignature(ds, query, context),
+      buildDatasetQuerySignature(ds, query, this.signatureContext(context)),
       run,
       context?.cache,
     );

--- a/packages/datasets/src/index.ts
+++ b/packages/datasets/src/index.ts
@@ -83,6 +83,20 @@ export type {
 // Dataset client
 export { createDatasetClient } from './executor.js';
 export type { DatasetClient, CreateDatasetClientOptions } from './executor.js';
+
+// Semantic query result cache
+export { createMemoryCacheStore } from './cache/semantic-query-cache.js';
+export type {
+  SemanticCacheEntry,
+  SemanticCacheMetaInfo,
+  SemanticCacheOptions,
+  SemanticCacheRuntime,
+  SemanticCacheStore,
+} from './cache/semantic-query-cache.js';
+export {
+  buildDatasetQuerySignature,
+  buildMetricQuerySignature,
+} from './cache/query-signature.js';
 export { createInMemoryBackend } from './in-memory-backend.js';
 export type { InMemoryTable, InMemoryTables } from './in-memory-backend.js';
 export type {

--- a/packages/datasets/src/types.ts
+++ b/packages/datasets/src/types.ts
@@ -1,5 +1,5 @@
 import type { QueryBuilderFactoryInput } from './query-builder-protocol.js';
-import type { SemanticCacheRuntime } from './cache/semantic-query-cache.js';
+import type { SemanticCacheMetaInfo, SemanticCacheRuntime } from './cache/semantic-query-cache.js';
 import type { SemanticExpression } from './semantic-plan.js';
 
 export type FieldType = 'string' | 'number' | 'boolean' | 'timestamp';
@@ -211,13 +211,7 @@ export interface MetricResultMeta {
     hasMore: boolean;
   };
   /** Result-cache observability. Present when the call went through the cache. */
-  cache?: {
-    hit: boolean;
-    /** Milliseconds since the entry was stored; only on hits. */
-    ageMs?: number;
-    /** True when served from the stale-while-revalidate window. */
-    stale?: boolean;
-  };
+  cache?: SemanticCacheMetaInfo;
 }
 
 export interface MetricResult<T = Record<string, unknown>> {

--- a/packages/datasets/src/types.ts
+++ b/packages/datasets/src/types.ts
@@ -1,4 +1,5 @@
 import type { QueryBuilderFactoryInput } from './query-builder-protocol.js';
+import type { SemanticCacheRuntime } from './cache/semantic-query-cache.js';
 import type { SemanticExpression } from './semantic-plan.js';
 
 export type FieldType = 'string' | 'number' | 'boolean' | 'timestamp';
@@ -209,6 +210,14 @@ export interface MetricResultMeta {
     offset: number;
     hasMore: boolean;
   };
+  /** Result-cache observability. Present when the call went through the cache. */
+  cache?: {
+    hit: boolean;
+    /** Milliseconds since the entry was stored; only on hits. */
+    ageMs?: number;
+    /** True when served from the stale-while-revalidate window. */
+    stale?: boolean;
+  };
 }
 
 export interface MetricResult<T = Record<string, unknown>> {
@@ -234,6 +243,11 @@ export interface SemanticExecutionRuntime {
 
 export interface ExecutionContext {
   runtime?: SemanticExecutionRuntime;
+  /**
+   * Per-call result-cache controls. `false` bypasses the cache entirely;
+   * `{ ttlMs }` opts this call into caching (or overrides the client default).
+   */
+  cache?: SemanticCacheRuntime | false;
 }
 
 export interface SemanticFilterDefinition {

--- a/packages/datasets/src/utils/canonical-json.ts
+++ b/packages/datasets/src/utils/canonical-json.ts
@@ -1,0 +1,55 @@
+/**
+ * Canonical serialization helpers shared by everything that needs stable,
+ * environment-independent output — contract hashing (contract.ts) and
+ * semantic cache keys (cache/query-signature.ts). Keep ordering logic here so
+ * the two paths cannot drift apart.
+ */
+
+/**
+ * Locale-independent string comparison by UTF-16 code unit. Used everywhere
+ * canonical output sorts, so hashes and cache keys are stable across
+ * environments (CI ICU versions, locales) rather than depending on
+ * `localeCompare`.
+ */
+export function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+/** Builds an object whose keys are inserted in sorted order for stable JSON. */
+export function sortedRecord<T>(entries: [string, T][]): Record<string, T> {
+  return Object.fromEntries(
+    [...entries].sort(([left], [right]) => compareStrings(left, right)),
+  );
+}
+
+/** Deduplicates and sorts a list so logically-equal sets serialize identically. */
+export function uniqueSorted(values: readonly string[]): string[] {
+  return Array.from(new Set(values)).sort(compareStrings);
+}
+
+/** JSON.stringify with recursively sorted object keys, so key order never matters. */
+export function stableStringify(value: unknown): string {
+  if (typeof value === 'bigint') {
+    // JSON.stringify throws on bigint. The `n` suffix keeps 1n distinct from
+    // both the number 1 and the string "1n" (strings serialize with quotes).
+    return `${value}n`;
+  }
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? 'null';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  const toJSON = (value as { toJSON?: () => unknown }).toJSON;
+  if (typeof toJSON === 'function') {
+    // Match JSON.stringify semantics for Dates and other toJSON carriers.
+    // Without this, every Date serializes to '{}' (no enumerable props) and
+    // distinct date filters collapse onto one cache key.
+    return stableStringify(toJSON.call(value));
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entryValue]) => entryValue !== undefined)
+    .sort(([a], [b]) => compareStrings(a, b))
+    .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`);
+  return `{${entries.join(',')}}`;
+}

--- a/packages/serve/src/semantic/datasets/dataset-endpoint.ts
+++ b/packages/serve/src/semantic/datasets/dataset-endpoint.ts
@@ -4,7 +4,7 @@
  * The generated endpoint is a POST handler that:
  * - Accepts dimensions, measures, filters, orderBy, limit, offset, by
  * - Validates requested dimensions/measures/filters against the dataset contract
- * - Executes via QueryBuilderFactoryLike
+ * - Executes via the shared DatasetClient (result cache included)
  * - Applies Serve-managed tenant filtering when configured
  * - Returns { data } or { data, meta } based on headers
  */
@@ -18,13 +18,10 @@ import type {
   ServeMiddleware,
 } from '../../types.js';
 import type {
+  DatasetClient,
   QueryBuilderFactoryLike,
 } from '@hypequery/datasets';
 import type { DatasetQuery } from '@hypequery/datasets/internal';
-import {
-  runDatasetQuery,
-  validateDatasetQuery,
-} from '@hypequery/datasets/internal';
 import { ServeHttpError } from '../../errors.js';
 import {
   resolveSemanticExecutionRuntime,
@@ -50,6 +47,11 @@ const datasetResultMetaSchema = z.object({
     offset: z.number(),
     hasMore: z.boolean(),
   }).optional(),
+  cache: z.object({
+    hit: z.boolean(),
+    ageMs: z.number().optional(),
+    stale: z.boolean().optional(),
+  }).optional(),
 }).optional();
 
 const datasetResultSchema = z.object({
@@ -64,6 +66,7 @@ const datasetResultSchema = z.object({
 export function createDatasetEndpoint<TAuth extends AuthContext>(
   name: string,
   entry: DatasetEntry<TAuth>,
+  analytics: DatasetClient,
   builderFactory: QueryBuilderFactoryLike,
 ): ServeEndpoint<z.ZodTypeAny, typeof datasetResultSchema, any, TAuth, any> {
   const resolved = resolveDatasetEntry(entry);
@@ -106,8 +109,8 @@ export function createDatasetEndpoint<TAuth extends AuthContext>(
       offset: input.offset,
       by: input.by,
     };
-    const executionContext = runtime ? { runtime } : undefined;
-    const validation = validateDatasetQuery(ds, query, executionContext);
+    const validationContext = runtime ? { runtime } : undefined;
+    const validation = analytics.validate(ds, query, validationContext);
     if (!validation.valid) {
       throw new ServeHttpError(
         400,
@@ -116,7 +119,7 @@ export function createDatasetEndpoint<TAuth extends AuthContext>(
       );
     }
 
-    // Build query
+    // Execute through the shared client so per-entry cache TTLs apply.
     const runtimeBuilderFactory = resolveSemanticQueryBuilder(
       semanticContext,
       builderFactory,
@@ -130,9 +133,15 @@ export function createDatasetEndpoint<TAuth extends AuthContext>(
         );
       }
     }
-    const result = await runDatasetQuery(ds, query, {
-      builderFactory: runtimeBuilderFactory,
-      context: executionContext,
+    const result = await analytics.execute(ds, query, {
+      runtime: {
+        ...runtime,
+        builderFactory: runtimeBuilderFactory,
+        tenant: runtime?.tenant,
+      },
+      cache: typeof resolved.cache === 'number' && resolved.cache > 0
+        ? { ttlMs: resolved.cache }
+        : undefined,
     });
     const timingMs = Date.now() - start;
 

--- a/packages/serve/src/semantic/datasets/metric-endpoint.ts
+++ b/packages/serve/src/semantic/datasets/metric-endpoint.ts
@@ -40,6 +40,11 @@ const metricResultMetaSchema = z.object({
     offset: z.number(),
     hasMore: z.boolean(),
   }).optional(),
+  cache: z.object({
+    hit: z.boolean(),
+    ageMs: z.number().optional(),
+    stale: z.boolean().optional(),
+  }).optional(),
 }).optional();
 
 const metricResultSchema = z.object({
@@ -175,13 +180,16 @@ export function createMetricEndpoint<TAuth extends AuthContext>(
       );
     }
 
-    // Execute with tenant context
+    // Execute with tenant context; per-entry cache TTL applies server-side.
     const result = await analytics.execute(metricRef, query, {
       runtime: {
         ...runtime,
         builderFactory: runtimeBuilderFactory,
         tenant: runtime?.tenant,
       },
+      cache: typeof resolved.cache === 'number' && resolved.cache > 0
+        ? { ttlMs: resolved.cache }
+        : undefined,
     });
 
     // Decide whether to include meta — `includeMeta` input field or x-include-meta header.

--- a/packages/serve/src/semantic/datasets/serve-integration.test.ts
+++ b/packages/serve/src/semantic/datasets/serve-integration.test.ts
@@ -2060,3 +2060,142 @@ describe("Serve integration — metrics", () => {
     });
   });
 });
+
+// =============================================================================
+// SEMANTIC ENDPOINT RESULT CACHING
+// =============================================================================
+
+describe("semantic endpoint result caching", () => {
+  /**
+   * Counts actual executions (execute/rawQuery), not builder construction —
+   * validation also builds queries via table(), so table() counts would
+   * overstate executions.
+   */
+  function createExecutionCountingFactory() {
+    const inner = createMockBuilderFactory();
+    let executions = 0;
+
+    const factory: QueryBuilderFactoryLike = {
+      table: (name: string) => {
+        const builder = inner.table(name);
+        const originalExecute = builder.execute.bind(builder);
+        builder.execute = (async () => {
+          executions += 1;
+          return originalExecute();
+        }) as QueryBuilderLike['execute'];
+        return builder;
+      },
+      rawQuery: async (sql: string, params?: unknown[]) => {
+        executions += 1;
+        return inner.rawQuery(sql, params);
+      },
+    };
+
+    return { factory, getExecutions: () => executions };
+  }
+
+  it("serves repeated metric queries from the cache when the entry sets cache", async () => {
+    const { factory, getExecutions } = createExecutionCountingFactory();
+    const api = createAPI({
+      metrics: {
+        totalRevenue: { metric: totalRevenue, cache: 60_000 },
+      },
+      queryBuilder: factory,
+    });
+
+    const request = () => api.handler(
+      createRequest({
+        path: "/metrics/totalRevenue",
+        method: "POST",
+        body: { dimensions: ["country"], includeMeta: true },
+      })
+    );
+
+    const first = await request();
+    const second = await request();
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(getExecutions()).toBe(1);
+    expect(semanticBody(second).data).toEqual(semanticBody(first).data);
+
+    const secondMeta = semanticBody(second).meta as { cache?: { hit: boolean } } | undefined;
+    expect(secondMeta?.cache).toMatchObject({ hit: true });
+  });
+
+  it("serves repeated dataset queries from the cache when the entry sets cache", async () => {
+    const { factory, getExecutions } = createExecutionCountingFactory();
+    const api = createAPI({
+      datasets: {
+        orders: { dataset: Orders, cache: 60_000 },
+      },
+      queryBuilder: factory,
+    });
+
+    const request = () => api.handler(
+      createRequest({
+        path: "/datasets/orders/query",
+        method: "POST",
+        body: { dimensions: ["country"], measures: ["revenue"], includeMeta: true },
+      })
+    );
+
+    const first = await request();
+    const second = await request();
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(getExecutions()).toBe(1);
+
+    const secondMeta = semanticBody(second).meta as { cache?: { hit: boolean } } | undefined;
+    expect(secondMeta?.cache).toMatchObject({ hit: true });
+  });
+
+  it("does not cache when the entry has no cache setting", async () => {
+    const { factory, getExecutions } = createExecutionCountingFactory();
+    const api = createAPI({
+      datasets: { orders: Orders },
+      queryBuilder: factory,
+    });
+
+    const request = () => api.handler(
+      createRequest({
+        path: "/datasets/orders/query",
+        method: "POST",
+        body: { dimensions: ["country"], measures: ["revenue"] },
+      })
+    );
+
+    await request();
+    await request();
+
+    expect(getExecutions()).toBe(2);
+  });
+
+  it("different query bodies never share cache entries", async () => {
+    const { factory, getExecutions } = createExecutionCountingFactory();
+    const api = createAPI({
+      datasets: {
+        orders: { dataset: Orders, cache: 60_000 },
+      },
+      queryBuilder: factory,
+    });
+
+    await api.handler(
+      createRequest({
+        path: "/datasets/orders/query",
+        method: "POST",
+        body: { dimensions: ["country"], measures: ["revenue"] },
+      })
+    );
+    await api.handler(
+      createRequest({
+        path: "/datasets/orders/query",
+        method: "POST",
+        body: { dimensions: ["status"], measures: ["revenue"] },
+      })
+    );
+
+    expect(getExecutions()).toBe(2);
+  });
+});

--- a/packages/serve/src/server/create-api.ts
+++ b/packages/serve/src/server/create-api.ts
@@ -203,6 +203,14 @@ export const createAPI = <
     router.register(registeredEndpoint);
   }
 
+  // Shared dataset client for all semantic endpoints, so metric and dataset
+  // entries share one result cache.
+  let sharedAnalytics: ReturnType<typeof createDatasetClient> | undefined;
+  const getAnalytics = (builderFactory: NonNullable<typeof resolvedQueryBuilder>) => {
+    sharedAnalytics ??= createDatasetClient({ queryBuilder: builderFactory });
+    return sharedAnalytics;
+  };
+
   // Process metrics — auto-generate POST endpoints
   if (config.metrics) {
     const metricsEntries = config.metrics;
@@ -216,7 +224,7 @@ export const createAPI = <
       );
     }
 
-    const analytics = createDatasetClient({ queryBuilder: builderFactory });
+    const analytics = getAnalytics(builderFactory);
 
     for (const [name, entry] of Object.entries(metricsEntries)) {
       assertSemanticKeyAvailable(queryEntries as Record<string, unknown>, name, "metric");
@@ -252,6 +260,7 @@ export const createAPI = <
       const datasetEndpoint = createDatasetEndpoint(
         name,
         entry,
+        getAnalytics(builderFactory),
         builderFactory,
       );
       const datasetsPath = config.semanticPaths?.datasets ?? '/datasets';

--- a/plans/semantic-layer-launch-plan.md
+++ b/plans/semantic-layer-launch-plan.md
@@ -430,10 +430,15 @@ describe('ClickHouse edge-case type handling', () => {
 **Timeline:** 5-7 days, ship 2-3 weeks after launch
 **Goal:** Retention signals, production readiness, "is this serious" features
 
-#### 2.1 Semantic Query-Keyed Caching
+#### 2.1 Semantic Query-Keyed Caching [✅ COMPLETE 2026-07-03]
 **Why:** "First production objection is 'every query hits ClickHouse'"
 **Effort:** 2-3 days
-**Current State:** Endpoint-level caching exists but too coarse-grained
+**Shipped:** `createDatasetClient({ cache })` — query-signature-keyed result cache
+(`packages/datasets/src/cache/`) with TTL + stale-while-revalidate, pluggable
+store (in-memory LRU default), per-call overrides via `ExecutionContext.cache`,
+tenant-partitioned keys, and `meta.cache` observability. Serve per-entry
+`cache` values now cache server-side through the shared DatasetClient.
+**Current State (pre-implementation):** Endpoint-level caching existed but was header-only
 
 **Implementation:**
 - Generate cache keys from semantic query structure (not HTTP params)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,7 +402,7 @@ importers:
   packages/mcp-server:
     dependencies:
       '@hypequery/datasets':
-        specifier: ^0.5.0
+        specifier: ^0.6.0
         version: link:../datasets
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
@@ -478,7 +478,7 @@ importers:
   packages/serve:
     dependencies:
       '@hypequery/datasets':
-        specifier: ^0.5.0
+        specifier: ^0.6.0
         version: link:../datasets
       jose:
         specifier: ^5.9.6
@@ -7386,8 +7386,8 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -7406,7 +7406,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@10.2.2)
@@ -7417,22 +7417,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7443,7 +7443,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/website-next/docs/datasets/caching.mdx
+++ b/website-next/docs/datasets/caching.mdx
@@ -5,7 +5,9 @@ description: Cache semantic query results keyed by the query signature.
 
 import { CodeBlock } from 'fumadocs-ui/components/codeblock';
 
-The dataset client can cache query results so repeated semantic queries do not hit ClickHouse. Results are keyed by the full query signature — target, dimensions, measures, filters, ordering, pagination, time grain, and tenant scope — so two different queries never share an entry, and tenant-scoped datasets are partitioned per tenant.
+The dataset client can cache query results so repeated semantic queries do not hit ClickHouse. Results are keyed by the full query signature — target, dimensions, measures, filters, ordering, pagination, time grain, tenant scope, and any explicit cache scope — so two different queries never share an entry, and tenant-scoped datasets are partitioned per tenant.
+
+This is the semantic-layer cache in `@hypequery/datasets`, keyed by what a query *means*. It is independent of [query caching](/docs/query-building/caching) in `@hypequery/clickhouse`, which caches raw `execute()` results on the typed query builder.
 
 ## Enable caching on the client
 
@@ -60,6 +62,8 @@ await analytics.execute(revenue, { dimensions: ['country'] }, {
 ```
 </CodeBlock>
 
+`mode: 'refresh'` needs a TTL to write under — either a per-call `ttlMs` or a client-level `cache.ttlMs`. If neither is configured the call executes uncached and logs a one-time warning, so a config drift never fails requests but does not go undiagnosed. A refresh always runs its own execution, even when an identical query is already in flight.
+
 ## Cache metadata
 
 Results that went through the cache carry `meta.cache`.
@@ -107,33 +111,76 @@ Repeated identical requests within the TTL are served from the cache without que
 
 ## Custom stores
 
-The default store is an in-process LRU (500 entries). For multi-instance deployments, provide a shared store implementing `SemanticCacheStore`.
+The default store is an in-process LRU (500 entries). For multi-instance deployments, provide a shared store implementing `SemanticCacheStore` — three methods, sync or async. Here is a complete Redis-backed store using [ioredis](https://github.com/redis/ioredis):
 
 <CodeBlock>
 ```typescript
-import { createDatasetClient, type SemanticCacheStore } from '@hypequery/datasets';
+import Redis from 'ioredis';
+import {
+  createDatasetClient,
+  type SemanticCacheEntry,
+  type SemanticCacheStore,
+} from '@hypequery/datasets';
+
+const redis = new Redis(process.env.REDIS_URL!);
+
+const TTL_MS = 60_000;
+const SWR_MS = 300_000;
 
 const redisStore: SemanticCacheStore = {
-  async get(key) {
-    // return { value, storedAt } or undefined
-    return undefined;
+  async get(key): Promise<SemanticCacheEntry | undefined> {
+    const raw = await redis.get(key);
+    return raw ? JSON.parse(raw) : undefined;
   },
   async set(key, entry) {
-    // persist entry under key
+    // Expire in Redis once the entry can never be served again. Freshness
+    // within that window is decided by the client from `storedAt`, so the
+    // Redis expiry is only garbage collection.
+    await redis.set(key, JSON.stringify(entry), 'PX', TTL_MS + SWR_MS);
   },
   async delete(key) {
-    // remove key
+    await redis.del(key);
   },
 };
 
 const cachedAnalytics = createDatasetClient({
   queryBuilder: db,
   cache: {
-    ttlMs: 60_000,
+    ttlMs: TTL_MS,
+    staleWhileRevalidateMs: SWR_MS,
     store: redisStore,
   },
 });
 ```
 </CodeBlock>
 
-Stores hold opaque `{ value, storedAt }` entries; freshness is always decided by the client from `storedAt` and the effective TTL, so per-call TTL overrides work against shared entries.
+Behavior to rely on when writing a store:
+
+- Entries are opaque `{ value, storedAt }` objects; freshness is always decided by the client from `storedAt` and the effective TTL, so per-call TTL overrides work against shared entries. Give the store-side expiry (Redis `PX` above) at least `ttlMs + staleWhileRevalidateMs`.
+- Store failures are non-fatal: a failed `get` is treated as a cache miss and a failed `set` is dropped, so a Redis outage degrades to "no caching" instead of failing queries.
+- Concurrent identical queries are deduplicated per process even while an async `get` is in flight — a burst of the same query does one store read and at most one execution per instance.
+- Keys are readable canonical signatures and can get long; stores are free to hash them internally (e.g. SHA-256) as long as the mapping is stable.
+- Values are plain rows plus `meta` and survive `JSON.stringify` round-trips.
+
+## Cache scopes
+
+A cache key describes the query, not the connection it runs against. When the same semantic query can resolve against different data sources, partition entries with `scope`:
+
+<CodeBlock>
+```typescript
+// Client-level: namespace clients that share one store (e.g. one Redis
+// serving several warehouses), so identical queries never collide.
+const euAnalytics = createDatasetClient({
+  queryBuilder: euDb,
+  cache: { ttlMs: 60_000, store: redisStore, scope: 'warehouse-eu' },
+});
+
+// Per-call: required when overriding the query builder at runtime. Without a
+// scope, calls that pass `runtime.builderFactory` skip the cache entirely,
+// because the key alone cannot tell two data sources apart.
+await analytics.execute(revenue, { dimensions: ['country'] }, {
+  runtime: { builderFactory: replicaDb },
+  cache: { scope: 'replica-2' },
+});
+```
+</CodeBlock>

--- a/website-next/docs/datasets/caching.mdx
+++ b/website-next/docs/datasets/caching.mdx
@@ -111,18 +111,23 @@ Repeated identical requests within the TTL are served from the cache without que
 
 ## Custom stores
 
-The default store is an in-process LRU (500 entries). For multi-instance deployments, provide a shared store implementing `SemanticCacheStore` — three methods, sync or async. Here is a complete Redis-backed store using [ioredis](https://github.com/redis/ioredis):
+The default store is an in-process LRU (500 entries). For multi-instance deployments, provide a shared store implementing `SemanticCacheStore` — three methods, sync or async. Here is a Redis-backed store using a Redis client such as [ioredis](https://github.com/redis/ioredis):
 
 <CodeBlock>
 ```typescript
-import Redis from 'ioredis';
 import {
   createDatasetClient,
   type SemanticCacheEntry,
   type SemanticCacheStore,
 } from '@hypequery/datasets';
 
-const redis = new Redis(process.env.REDIS_URL!);
+interface RedisLike {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, mode: 'PX', ttlMs: number): Promise<unknown>;
+  del(key: string): Promise<unknown>;
+}
+
+declare const redis: RedisLike;
 
 const TTL_MS = 60_000;
 const SWR_MS = 300_000;
@@ -168,6 +173,16 @@ A cache key describes the query, not the connection it runs against. When the sa
 
 <CodeBlock>
 ```typescript
+import {
+  createDatasetClient,
+  type QueryBuilderFactoryLike,
+  type SemanticCacheStore,
+} from '@hypequery/datasets';
+
+declare const euDb: QueryBuilderFactoryLike;
+declare const replicaDb: QueryBuilderFactoryLike;
+declare const redisStore: SemanticCacheStore;
+
 // Client-level: namespace clients that share one store (e.g. one Redis
 // serving several warehouses), so identical queries never collide.
 const euAnalytics = createDatasetClient({

--- a/website-next/docs/datasets/caching.mdx
+++ b/website-next/docs/datasets/caching.mdx
@@ -1,0 +1,139 @@
+---
+title: Caching
+description: Cache semantic query results keyed by the query signature.
+---
+
+import { CodeBlock } from 'fumadocs-ui/components/codeblock';
+
+The dataset client can cache query results so repeated semantic queries do not hit ClickHouse. Results are keyed by the full query signature — target, dimensions, measures, filters, ordering, pagination, time grain, and tenant scope — so two different queries never share an entry, and tenant-scoped datasets are partitioned per tenant.
+
+## Enable caching on the client
+
+Pass `cache` to `createDatasetClient` to set a default TTL for every query.
+
+<CodeBlock>
+```typescript
+import { createDatasetClient } from '@hypequery/datasets';
+import { createQueryBuilder } from '@hypequery/clickhouse';
+
+const db = createQueryBuilder({
+  url: process.env.CLICKHOUSE_URL!,
+  username: process.env.CLICKHOUSE_USER!,
+  password: process.env.CLICKHOUSE_PASSWORD!,
+  database: process.env.CLICKHOUSE_DATABASE!,
+});
+
+const analytics = createDatasetClient({
+  queryBuilder: db,
+  cache: {
+    ttlMs: 60_000,
+    staleWhileRevalidateMs: 300_000,
+  },
+});
+```
+</CodeBlock>
+
+- `ttlMs` — how long a result is served as fresh.
+- `staleWhileRevalidateMs` — an optional window after the TTL during which the stale result is returned immediately while a background refresh repopulates the entry.
+- Errors are never cached, and concurrent identical queries share a single execution.
+
+## Per-call overrides
+
+Every `execute` call can override or bypass the cache through the execution context.
+
+<CodeBlock>
+```typescript
+// Opt a single call into caching (works even without client-level cache config).
+await analytics.execute(revenue, { dimensions: ['country'] }, {
+  cache: { ttlMs: 30_000 },
+});
+
+// Bypass the cache for one call.
+await analytics.execute(revenue, { dimensions: ['country'] }, {
+  cache: false,
+});
+
+// Skip the read but store the fresh result (force refresh).
+await analytics.execute(revenue, { dimensions: ['country'] }, {
+  cache: { mode: 'refresh' },
+});
+```
+</CodeBlock>
+
+## Cache metadata
+
+Results that went through the cache carry `meta.cache`.
+
+<CodeBlock>
+```typescript
+const result = await analytics.execute(revenue, {
+  dimensions: ['country'],
+}, {
+  cache: { ttlMs: 60_000 },
+});
+
+result.meta?.cache;
+// { hit: true, ageMs: 1200 } — served fresh from the cache
+// { hit: true, ageMs: 65000, stale: true } — served stale, refreshing in background
+// { hit: false } — executed and stored
+```
+</CodeBlock>
+
+## Serve endpoints
+
+Metric and dataset endpoints registered with a `cache` value cache results server-side with that TTL, in addition to emitting `Cache-Control` headers.
+
+<CodeBlock>
+```typescript
+export const api = serve({
+  queryBuilder: db,
+  metrics: {
+    revenue: {
+      metric: revenue,
+      cache: 60_000,
+    },
+  },
+  datasets: {
+    orders: {
+      dataset: Orders,
+      cache: 60_000,
+    },
+  },
+});
+```
+</CodeBlock>
+
+Repeated identical requests within the TTL are served from the cache without querying ClickHouse. Because tenant scope is part of the cache key, runtime tenancy stays isolated: each tenant only ever sees entries for its own scope.
+
+## Custom stores
+
+The default store is an in-process LRU (500 entries). For multi-instance deployments, provide a shared store implementing `SemanticCacheStore`.
+
+<CodeBlock>
+```typescript
+import { createDatasetClient, type SemanticCacheStore } from '@hypequery/datasets';
+
+const redisStore: SemanticCacheStore = {
+  async get(key) {
+    // return { value, storedAt } or undefined
+    return undefined;
+  },
+  async set(key, entry) {
+    // persist entry under key
+  },
+  async delete(key) {
+    // remove key
+  },
+};
+
+const cachedAnalytics = createDatasetClient({
+  queryBuilder: db,
+  cache: {
+    ttlMs: 60_000,
+    store: redisStore,
+  },
+});
+```
+</CodeBlock>
+
+Stores hold opaque `{ value, storedAt }` entries; freshness is always decided by the client from `storedAt` and the effective TTL, so per-call TTL overrides work against shared entries.

--- a/website-next/docs/meta.json
+++ b/website-next/docs/meta.json
@@ -29,6 +29,7 @@
     "datasets/filters",
     "datasets/time-grains",
     "datasets/execution",
+    "datasets/caching",
     "datasets/multi-tenancy",
     "datasets/serve-integration",
     "datasets/catalog",


### PR DESCRIPTION
Implements launch-plan item 2.1 ("first production objection is 'every query hits ClickHouse'"). Previously there was no server-side result caching anywhere: the per-entry serve `cache` option only emitted `Cache-Control` headers, which do nothing for POST semantic endpoints.

## `@hypequery/datasets`

New `packages/datasets/src/cache/` module:

- **Query signatures** — canonical, readable cache keys covering target (dataset or metric), dimensions, measures, filters, ordering, pagination, time grain, and the effective tenant scope. Different queries never share entries; tenant-keyed datasets are strictly partitioned per tenant scope, while tenant-less datasets share entries across callers.
- **`SemanticQueryCache`** — TTL freshness, optional stale-while-revalidate window (stale results are served immediately while a background refresh repopulates; a failed refresh keeps the stale entry), in-flight deduplication so a burst of identical queries executes once, and clone-isolated values (mutating a returned result never contaminates the cache). Errors are never cached, and invalid queries throw before the cache is consulted.
- **Pluggable store** — in-process LRU by default (`createMemoryCacheStore`, 500 entries); a custom `SemanticCacheStore` (e.g. Redis) slots in for multi-instance deployments. Stores hold opaque `{ value, storedAt }` entries; freshness is decided by the client, so per-call TTLs work against shared entries.

Wiring:

- `createDatasetClient({ cache: { ttlMs, staleWhileRevalidateMs, maxEntries, store } })` sets client defaults.
- `ExecutionContext.cache` controls each call: `{ ttlMs }` opts in (works even without client-level config), `false` bypasses, `mode: 'refresh'` skips the read but stores the fresh result.
- Cached-path results carry `meta.cache = { hit, ageMs, stale? }`.

Integrated at the `DatasetClient.execute` funnel, so direct users, MCP tool consumers, and serve endpoints all benefit — both the query-builder path and the semantic-backend path.

## `@hypequery/serve`

- **Dataset endpoints now execute through the shared `DatasetClient`** instead of calling `runDatasetQuery` directly, so metric and dataset entries share one result cache per API (and the endpoint sheds its `@hypequery/datasets/internal` execution imports).
- **Per-entry `cache` values now actually cache server-side** with that TTL, in addition to the existing `Cache-Control` header. The documented `cache: 60_000` option finally does what users expect on POST endpoints.
- Meta output schemas document the new `cache` field for OpenAPI.

## Docs

New guide: `website-next/docs/datasets/caching.mdx` — client config, per-call overrides, meta observability, serve integration, custom stores. All snippets pass the docs compile check (71 snippets total now).

## Tests

- `semantic-query-cache.test.ts` — 13 unit tests: LRU eviction, TTL expiry, SWR serve + background refresh (+ failure retention), bypass/refresh modes, per-call TTL, concurrent-miss dedup, error non-caching, mutation isolation (fake timers throughout).
- `dataset-client-cache.test.ts` — 11 tests through `createDatasetClient`: hit/miss accounting via an execution-counting builder, tenant partitioning, context overrides, signature properties.
- `serve-integration.test.ts` — 4 new endpoint tests: repeated metric/dataset requests execute once with `cache` set, no caching without it, distinct bodies never share entries.

## Verified

- `@hypequery/datasets`: build, 167 tests, `test:types`
- `@hypequery/serve`: build, 448 tests
- Full workspace test run (serial): all package suites green
- `pnpm smoke:docs-snippets`, `pnpm lint`
- Note: `next-dashboard#build` fails locally in a fresh worktree for lack of a `.env` (`CLICKHOUSE_URL`) — pre-existing environment requirement, unrelated to this change; its compile and type-check pass.

Also includes a `pnpm-lock.yaml` sync for the `@hypequery/datasets@^0.6.0` specifiers from release #251 (required for `--frozen-lockfile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)