### PR TITLE
Make to-one relationships executable as query-time LEFT JOINs

### DIFF
--- a/packages/datasets/src/api.type-test.ts
+++ b/packages/datasets/src/api.type-test.ts
@@ -199,6 +199,7 @@ const builderFactory: QueryBuilderFactoryLike = {
     min: () => builderFactory.table('orders'),
     max: () => builderFactory.table('orders'),
     where: () => builderFactory.table('orders'),
+    leftJoin: () => builderFactory.table('orders'),
     groupBy: () => builderFactory.table('orders'),
     orderBy: () => builderFactory.table('orders'),
     limit: () => builderFactory.table('orders'),

--- a/packages/datasets/src/dataset-query.ts
+++ b/packages/datasets/src/dataset-query.ts
@@ -19,6 +19,11 @@ import {
   getRuntimeTenantPredicate,
 } from './utils/tenant-runtime.js';
 import { applyPagination, overfetchLimit } from './utils/pagination.js';
+import {
+  applyRelationshipJoins,
+  buildRelationshipBuilderContext,
+  qualifyBaseColumn,
+} from './utils/relationship-builder-plan.js';
 
 function toResultMeta(
   qb: QueryBuilderLike,
@@ -60,8 +65,11 @@ export function buildDatasetQueryBuilder(
     throw new Error(`Invalid dataset query: ${validation.errors.join('; ')}`);
   }
 
+  const joinCtx = buildRelationshipBuilderContext(ds, query, options.context);
+
   let qb = options.builderFactory.table(ds.source);
-  const { selectParts, groupByParts } = buildDimensionSelectionPlan(ds, query.dimensions ?? [], query.by);
+  qb = applyRelationshipJoins(qb, joinCtx);
+  const { selectParts, groupByParts } = buildDimensionSelectionPlan(ds, query.dimensions ?? [], query.by, joinCtx);
   const measureNames = query.measures ?? Object.keys(ds.measures);
 
   if (selectParts.length > 0) {
@@ -69,7 +77,7 @@ export function buildDatasetQueryBuilder(
   }
 
   for (const measureName of measureNames) {
-    qb = applyMeasureDefinition(qb, ds, measureName, ds.measures[measureName]);
+    qb = applyMeasureDefinition(qb, ds, measureName, ds.measures[measureName], joinCtx);
   }
 
   if (groupByParts.length > 0) {
@@ -79,11 +87,11 @@ export function buildDatasetQueryBuilder(
   const tenantColumn = resolveTenantFilterColumn(ds, options.context);
   const tenantPredicate = getRuntimeTenantPredicate(options.context);
   if (tenantPredicate && tenantColumn) {
-    qb = qb.where(tenantColumn, tenantPredicate.operator, tenantPredicate.value);
+    qb = qb.where(qualifyBaseColumn(joinCtx, tenantColumn), tenantPredicate.operator, tenantPredicate.value);
   }
 
   for (const filter of query.filters ?? []) {
-    const resolvedField = resolveFilterField(ds, filter.field);
+    const resolvedField = resolveFilterField(ds, filter.field, joinCtx);
     qb = qb.where(resolvedField, filter.operator, filter.value);
   }
 
@@ -93,6 +101,7 @@ export function buildDatasetQueryBuilder(
     query.by,
     options.executionLimit ?? query.limit,
     query.offset,
+    joinCtx,
   );
 }
 

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -35,7 +35,7 @@ import type {
   SemanticBackend,
 } from './semantic-plan.js';
 
-import { validateSQLIdentifier } from './sql-utils.js';
+import { quoteSQLIdentifier, validateSQLIdentifier } from './sql-utils.js';
 import { SUPPORTED_TIME_GRAINS, isSupportedTimeGrain } from './constants.js';
 import { validateFilterValue, type ValidationResult } from './validation.js';
 import {
@@ -77,6 +77,13 @@ import {
   buildDatasetQuerySignature,
   buildMetricQuerySignature,
 } from './cache/query-signature.js';
+import { isQualifiedField, resolveQualifiedField } from './utils/relationship-fields.js';
+import { validateQualifiedFilter } from './utils/relationship-validation.js';
+import {
+  applyRelationshipJoins,
+  buildRelationshipBuilderContext,
+  qualifyBaseColumn,
+} from './utils/relationship-builder-plan.js';
 
 function validateQuery(
   metric: MetricHandle,
@@ -110,6 +117,13 @@ function validateQuery(
 
   // Validate dimensions
   for (const dim of query.dimensions ?? []) {
+    if (isQualifiedField(dim)) {
+      const resolution = resolveQualifiedField(ds, dim);
+      if (resolution?.error) {
+        errors.push(resolution.error);
+      }
+      continue;
+    }
     if (!dimensionNames.includes(dim)) {
       errors.push(`Unknown dimension "${dim}". Available: ${dimensionNames.join(', ')}`);
     }
@@ -117,6 +131,13 @@ function validateQuery(
 
   // Validate filters
   for (const filter of query.filters ?? []) {
+    if (isQualifiedField(filter.field)) {
+      const filterError = validateQualifiedFilter(ds, filter, context);
+      if (filterError) {
+        errors.push(filterError);
+      }
+      continue;
+    }
     if (!filterNames.includes(filter.field)) {
       errors.push(`Unknown filter field "${filter.field}". Available: ${filterNames.join(', ')}`);
       continue;
@@ -437,11 +458,14 @@ export class MetricQueryEngine {
     context?: ExecutionContext,
   ): QueryBuilderLike {
     const activeBuilderFactory = resolveBuilderFactory(context, this.builderFactory);
+    const joinCtx = buildRelationshipBuilderContext(ds, query, context);
     let qb: QueryBuilderLike = activeBuilderFactory.table(ds.source);
+    qb = applyRelationshipJoins(qb, joinCtx);
     const { selectParts, groupByParts } = buildDimensionSelectionPlan(
       ds,
       query.dimensions ?? [],
       grain,
+      joinCtx,
     );
 
     if (selectParts.length > 0) {
@@ -449,7 +473,7 @@ export class MetricQueryEngine {
     }
 
     // Aggregation (appends to select, auto-sets groupBy on non-agg columns)
-    qb = applyAggregationSpec(qb, ds, spec, ref.name);
+    qb = applyAggregationSpec(qb, ds, spec, ref.name, joinCtx);
 
     // Explicit groupBy (ensures period + dims are grouped even if aggregation auto-groupBy misses them)
     if (groupByParts.length > 0) {
@@ -460,7 +484,7 @@ export class MetricQueryEngine {
     const tenantColumn = resolveTenantFilterColumn(ds, context);
     const tenantPredicate = getRuntimeTenantPredicate(context);
     if (tenantPredicate && tenantColumn) {
-      qb = qb.where(tenantColumn, tenantPredicate.operator, tenantPredicate.value);
+      qb = qb.where(qualifyBaseColumn(joinCtx, tenantColumn), tenantPredicate.operator, tenantPredicate.value);
     }
 
     // User filters
@@ -470,12 +494,12 @@ export class MetricQueryEngine {
           `Cannot filter on tenant field "${filter.field}" when runtime tenancy enforcement is active.`,
         );
       }
-      const resolvedField = resolveFilterField(ds, filter.field);
+      const resolvedField = resolveFilterField(ds, filter.field, joinCtx);
       qb = qb.where(resolvedField, filter.operator, filter.value);
     }
 
     // Order, limit, offset
-    qb = appendOrderLimitOffset(qb, query.orderBy, grain, query.limit, query.offset);
+    qb = appendOrderLimitOffset(qb, query.orderBy, grain, query.limit, query.offset, joinCtx);
 
     return qb;
   }
@@ -489,13 +513,16 @@ export class MetricQueryEngine {
   ): { sql: string; params: unknown[] } {
     const activeBuilderFactory = resolveBuilderFactory(context, this.builderFactory);
     const ds = ref.dataset;
+    const joinCtx = buildRelationshipBuilderContext(ds, query, context);
 
     // Build the CTE inner query using the builder
     let cteBuilder: QueryBuilderLike = activeBuilderFactory.table(ds.source);
+    cteBuilder = applyRelationshipJoins(cteBuilder, joinCtx);
     const { selectParts, groupByParts } = buildDimensionSelectionPlan(
       ds,
       query.dimensions ?? [],
       grain,
+      joinCtx,
     );
 
     if (selectParts.length > 0) {
@@ -510,7 +537,7 @@ export class MetricQueryEngine {
       if (baseSpec.__type !== 'aggregation_spec') {
         throw new Error(`Derived metric "${ref.name}" references non-base metric "${alias}".`);
       }
-      cteBuilder = applyAggregationSpec(cteBuilder, ds, baseSpec, alias);
+      cteBuilder = applyAggregationSpec(cteBuilder, ds, baseSpec, alias, joinCtx);
       refAliases[alias] = alias;
       aggregateAliases.push(alias);
     }
@@ -523,7 +550,7 @@ export class MetricQueryEngine {
     const tenantColumn = resolveTenantFilterColumn(ds, context);
     const tenantPredicate = getRuntimeTenantPredicate(context);
     if (tenantPredicate && tenantColumn) {
-      cteBuilder = cteBuilder.where(tenantColumn, tenantPredicate.operator, tenantPredicate.value);
+      cteBuilder = cteBuilder.where(qualifyBaseColumn(joinCtx, tenantColumn), tenantPredicate.operator, tenantPredicate.value);
     }
     for (const filter of query.filters ?? []) {
       if (isTenantScopedFilter(ds, filter, context)) {
@@ -531,7 +558,7 @@ export class MetricQueryEngine {
           `Cannot filter on tenant field "${filter.field}" when runtime tenancy enforcement is active.`,
         );
       }
-      const resolvedField = resolveFilterField(ds, filter.field);
+      const resolvedField = resolveFilterField(ds, filter.field, joinCtx);
       cteBuilder = cteBuilder.where(resolvedField, filter.operator, filter.value);
     }
 
@@ -546,6 +573,11 @@ export class MetricQueryEngine {
     const outerSelectParts: string[] = [];
     if (grain) outerSelectParts.push('period');
     for (const dim of query.dimensions ?? []) {
+      // Joined dimensions surface from the CTE under their quoted qualified alias.
+      if (joinCtx && isQualifiedField(dim)) {
+        outerSelectParts.push(quoteSQLIdentifier(dim));
+        continue;
+      }
       validateSQLIdentifier(dim, 'dimension name');
       outerSelectParts.push(dim);
     }
@@ -559,6 +591,9 @@ export class MetricQueryEngine {
     // ORDER BY
     if (query.orderBy && query.orderBy.length > 0) {
       const orderParts = query.orderBy.map(o => {
+        if (joinCtx && isQualifiedField(o.field)) {
+          return `${quoteSQLIdentifier(o.field)} ${o.direction.toUpperCase()}`;
+        }
         validateSQLIdentifier(o.field, 'order by field');
         return `${o.field} ${o.direction.toUpperCase()}`;
       });

--- a/packages/datasets/src/in-memory-backend.ts
+++ b/packages/datasets/src/in-memory-backend.ts
@@ -9,6 +9,7 @@ import type {
   SemanticBackendResult,
   SemanticExpression,
   SemanticGrainPlan,
+  SemanticJoinPlan,
 } from './semantic-plan.js';
 
 export type InMemoryTable = Array<Record<string, unknown>>;
@@ -65,6 +66,47 @@ function applyTenant(
     return rows.filter((row) => tenant.value.includes(String(row[tenant.field])));
   }
   return rows.filter((row) => row[tenant.field] === tenant.value);
+}
+
+/**
+ * Enriches base rows with columns from to-one joined targets, keyed by the
+ * qualified name `<relationship>.<column>`. Mirrors a query-time LEFT JOIN:
+ * base rows without a matching target keep the joined columns undefined.
+ */
+function applyJoins(
+  rows: InMemoryTable,
+  joins: SemanticJoinPlan[] | undefined,
+  tables: InMemoryTables,
+): InMemoryTable {
+  if (!joins || joins.length === 0) {
+    return rows;
+  }
+
+  const indexes = joins.map((join) => {
+    const targetRows = applyTenant(tables[join.source] ?? [], join.tenant);
+    const index = new Map<string, Record<string, unknown>>();
+    for (const row of targetRows) {
+      const key = String(row[join.to]);
+      // To-one: first matching target wins; a mis-declared to-many still won't fan out.
+      if (!index.has(key)) {
+        index.set(key, row);
+      }
+    }
+    return { join, index };
+  });
+
+  return rows.map((row) => {
+    const enriched: Record<string, unknown> = { ...row };
+    for (const { join, index } of indexes) {
+      const match = index.get(String(row[join.from]));
+      if (match) {
+        for (const [column, value] of Object.entries(match)) {
+          enriched[`${join.relationship}.${column}`] = value;
+        }
+      }
+    }
+    return enriched;
+  });
 }
 
 function periodForValue(value: unknown, grain: SemanticGrainPlan): string {
@@ -211,7 +253,8 @@ function serializeMeasures(rows: InMemoryTable, measures: string[]): InMemoryTab
 export function createInMemoryBackend(tables: InMemoryTables): SemanticBackend {
   function executeAggregate(plan: Extract<PlanNode, { kind: 'aggregate' }>): InMemoryTable {
     const table = tables[plan.source] ?? [];
-    const filteredRows = applyFilters(applyTenant(table, plan.tenant), plan.filters);
+    const joinedRows = applyJoins(table, plan.joins, tables);
+    const filteredRows = applyFilters(applyTenant(joinedRows, plan.tenant), plan.filters);
     const groups = new Map<string, InMemoryTable>();
 
     for (const row of filteredRows) {

--- a/packages/datasets/src/query-builder-protocol.ts
+++ b/packages/datasets/src/query-builder-protocol.ts
@@ -24,6 +24,14 @@ export interface QueryBuilderLike {
   // Filtering
   where(column: string, operator: string, value: unknown): QueryBuilderLike;
 
+  // Joins (to-one relationship traversal)
+  leftJoin(
+    table: string,
+    leftColumn: string,
+    rightColumn: string,
+    alias?: string,
+  ): QueryBuilderLike;
+
   // Grouping
   groupBy(columns: string | string[]): QueryBuilderLike;
 

--- a/packages/datasets/src/query-planner.ts
+++ b/packages/datasets/src/query-planner.ts
@@ -24,6 +24,29 @@ function toOrderDirection(direction: MetricOrderBy['direction']): 'ASC' | 'DESC'
   return direction === 'asc' ? 'ASC' : 'DESC';
 }
 
+/**
+ * Raw SQL expressions on the base dataset are emitted verbatim, so their column
+ * references are not table-qualified. When relationship joins are active a bare
+ * `price` in such an expression is ambiguous if the joined table also has a
+ * `price` column. Until the builder rewrites identifiers inside expressions,
+ * reject the combination rather than emit ambiguous SQL.
+ */
+function assertNoRawSqlUnderJoins(
+  kind: 'dimension' | 'measure',
+  name: string,
+  sql: string,
+  joinCtx?: RelationshipBuilderContext,
+): void {
+  if (!joinCtx) {
+    return;
+  }
+  throw new Error(
+    `SQL-backed ${kind} "${name}" cannot be combined with relationship joins: its expression ` +
+    `("${sql}") is not table-qualified and may collide with joined columns. Query it without ` +
+    `relationship-qualified fields, or redeclare it as a plain column.`,
+  );
+}
+
 export function resolveDimensionExpression(
   ds: DatasetShape,
   dimensionName: string,
@@ -34,6 +57,7 @@ export function resolveDimensionExpression(
   }
   const definition = ds.dimensions[dimensionName];
   if (definition?.sql) {
+    assertNoRawSqlUnderJoins('dimension', dimensionName, definition.sql, joinCtx);
     return definition.sql;
   }
   return qualifyBaseColumn(joinCtx, definition?.column ?? dimensionName);
@@ -99,6 +123,9 @@ export function applyAggregationSpec(
   alias: string,
   joinCtx?: RelationshipBuilderContext,
 ): QueryBuilderLike {
+  if (spec.sql) {
+    assertNoRawSqlUnderJoins('measure', alias, spec.sql, joinCtx);
+  }
   const fieldOrExpr = applyFilteredAggregationExpression(
     ds,
     spec,
@@ -131,6 +158,9 @@ export function applyMeasureDefinition(
   definition: MeasureDefinition,
   joinCtx?: RelationshipBuilderContext,
 ): QueryBuilderLike {
+  if (definition.sql) {
+    assertNoRawSqlUnderJoins('measure', name, definition.sql, joinCtx);
+  }
   const baseFieldOrExpr = definition.sql ?? resolveDimensionExpression(ds, definition.field, joinCtx);
   const fieldOrExpr = applyFilteredAggregationExpression(
     ds,

--- a/packages/datasets/src/query-planner.ts
+++ b/packages/datasets/src/query-planner.ts
@@ -10,6 +10,13 @@ import type { QueryBuilderLike } from "./query-builder-protocol.js";
 import { GRAIN_FUNCTIONS } from "./constants.js";
 import { applyFilteredAggregationExpression } from './utils/filtered-aggregation-sql.js';
 import { getRuntimeTenantPredicate } from './utils/tenant-runtime.js';
+import { quoteSQLIdentifier } from './sql-utils.js';
+import { isQualifiedField } from './utils/relationship-fields.js';
+import {
+  qualifyBaseColumn,
+  resolveQualifiedColumn,
+  type RelationshipBuilderContext,
+} from './utils/relationship-builder-plan.js';
 
 type DatasetShape = AnyDatasetInstance;
 
@@ -20,23 +27,35 @@ function toOrderDirection(direction: MetricOrderBy['direction']): 'ASC' | 'DESC'
 export function resolveDimensionExpression(
   ds: DatasetShape,
   dimensionName: string,
+  joinCtx?: RelationshipBuilderContext,
 ): string {
+  if (joinCtx && isQualifiedField(dimensionName)) {
+    return resolveQualifiedColumn(ds, dimensionName);
+  }
   const definition = ds.dimensions[dimensionName];
-  return definition?.sql ?? definition?.column ?? dimensionName;
+  if (definition?.sql) {
+    return definition.sql;
+  }
+  return qualifyBaseColumn(joinCtx, definition?.column ?? dimensionName);
 }
 
 export function resolveFilterField(
   ds: DatasetShape,
   filterField: string,
+  joinCtx?: RelationshipBuilderContext,
 ): string {
+  if (joinCtx && isQualifiedField(filterField)) {
+    return resolveQualifiedColumn(ds, filterField);
+  }
   const resolvedField = ds.filters[filterField]?.field ?? filterField;
-  return resolveDimensionExpression(ds, resolvedField);
+  return resolveDimensionExpression(ds, resolvedField, joinCtx);
 }
 
 export function buildDimensionSelectionPlan(
   ds: DatasetShape,
   dimensions: string[],
   grain: TimeGrain | undefined,
+  joinCtx?: RelationshipBuilderContext,
 ): { selectParts: string[]; groupByParts: string[] } {
   const selectParts: string[] = [];
   const groupByParts = new Set<string>();
@@ -46,18 +65,28 @@ export function buildDimensionSelectionPlan(
     if (!fn) {
       throw new Error(`Unsupported time grain "${grain}".`);
     }
-    selectParts.push(`${fn}(${ds.timeKey}) AS period`);
+    selectParts.push(`${fn}(${qualifyBaseColumn(joinCtx, String(ds.timeKey))}) AS period`);
     groupByParts.add("period");
   }
 
   for (const dimensionName of dimensions) {
-    const expression = resolveDimensionExpression(ds, dimensionName);
-    if (expression === dimensionName) {
+    const expression = resolveDimensionExpression(ds, dimensionName, joinCtx);
+
+    if (joinCtx) {
+      // With joins in scope, every selection is table-qualified and aliased so
+      // grouping/ordering can reference the alias unambiguously.
+      const alias = isQualifiedField(dimensionName)
+        ? quoteSQLIdentifier(dimensionName)
+        : dimensionName;
+      selectParts.push(`${expression} AS ${alias}`);
+      groupByParts.add(alias);
+    } else if (expression === dimensionName) {
       selectParts.push(dimensionName);
+      groupByParts.add(dimensionName);
     } else {
       selectParts.push(`${expression} AS ${dimensionName}`);
+      groupByParts.add(dimensionName);
     }
-    groupByParts.add(dimensionName);
   }
 
   return { selectParts, groupByParts: Array.from(groupByParts) };
@@ -68,11 +97,13 @@ export function applyAggregationSpec(
   ds: DatasetShape,
   spec: AggregationSpec,
   alias: string,
+  joinCtx?: RelationshipBuilderContext,
 ): QueryBuilderLike {
   const fieldOrExpr = applyFilteredAggregationExpression(
     ds,
     spec,
-    spec.sql ?? resolveDimensionExpression(ds, spec.field),
+    spec.sql ?? resolveDimensionExpression(ds, spec.field, joinCtx),
+    joinCtx,
   );
 
   switch (spec.aggregation) {
@@ -98,8 +129,9 @@ export function applyMeasureDefinition(
   ds: DatasetShape,
   name: string,
   definition: MeasureDefinition,
+  joinCtx?: RelationshipBuilderContext,
 ): QueryBuilderLike {
-  const baseFieldOrExpr = definition.sql ?? resolveDimensionExpression(ds, definition.field);
+  const baseFieldOrExpr = definition.sql ?? resolveDimensionExpression(ds, definition.field, joinCtx);
   const fieldOrExpr = applyFilteredAggregationExpression(
     ds,
     {
@@ -109,6 +141,7 @@ export function applyMeasureDefinition(
       filters: definition.filters,
     },
     baseFieldOrExpr,
+    joinCtx,
   );
 
   switch (definition.aggregation) {
@@ -135,10 +168,14 @@ export function appendOrderLimitOffset(
   grain: TimeGrain | undefined,
   limit?: number,
   offset?: number,
+  joinCtx?: RelationshipBuilderContext,
 ): QueryBuilderLike {
   if (orderBy && orderBy.length > 0) {
     for (const order of orderBy) {
-      qb = qb.orderBy(order.field, toOrderDirection(order.direction));
+      const column = joinCtx && isQualifiedField(order.field)
+        ? quoteSQLIdentifier(order.field)
+        : order.field;
+      qb = qb.orderBy(column, toOrderDirection(order.direction));
     }
   } else if (grain) {
     qb = qb.orderBy("period", "ASC");

--- a/packages/datasets/src/relationships-query.test.ts
+++ b/packages/datasets/src/relationships-query.test.ts
@@ -6,6 +6,7 @@ import { belongsTo, hasMany, hasOne } from './relationships.js';
 import { createDatasetClient } from './executor.js';
 import { validateDatasetQuery } from './dataset-query.js';
 import { createInMemoryBackend, type InMemoryTables } from './in-memory-backend.js';
+import { buildDatasetPlan } from './semantic-planner.js';
 import type { QueryBuilderFactoryLike, QueryBuilderLike } from './query-builder-protocol.js';
 import type { ExecutionContext } from './types.js';
 
@@ -269,6 +270,26 @@ describe('relationship-qualified validation', () => {
     expect(result.valid).toBe(false);
     expect(result.errors.join(' ')).toMatch(/hasMany|not queryable/i);
   });
+
+  it('rejects a hasMany qualified orderBy field with an actionable message', () => {
+    const result = validateDatasetQuery(Orders, {
+      dimensions: ['status'],
+      measures: ['revenue'],
+      orderBy: [{ field: 'items.sku', direction: 'asc' }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/hasMany|not queryable/i);
+  });
+
+  it('rejects an unknown-relationship qualified orderBy field', () => {
+    const result = validateDatasetQuery(Orders, {
+      dimensions: ['status'],
+      measures: ['revenue'],
+      orderBy: [{ field: 'supplier.name', direction: 'asc' }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/Unknown relationship "supplier"/);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -294,8 +315,8 @@ describe('relationship joins on the semantic backend', () => {
       dimensions: ['customer.country'],
       measures: ['revenue'],
     });
-    expect(data).toContainEqual({ 'customer.country': 'US', revenue: 100 });
-    expect(data).toContainEqual({ 'customer.country': 'DE', revenue: 50 });
+    expect(data).toContainEqual({ 'customer.country': 'US', revenue: '100' });
+    expect(data).toContainEqual({ 'customer.country': 'DE', revenue: '50' });
   });
 
   it('keeps base rows whose FK has no match (LEFT JOIN semantics)', async () => {
@@ -306,8 +327,8 @@ describe('relationship joins on the semantic backend', () => {
     });
     // Order 3 (customer_id 99) has no matching customer -> country is undefined but the row survives.
     const unmatched = data.find((row) => row['customer.country'] === undefined);
-    expect(unmatched).toEqual({ 'customer.country': undefined, revenue: 70 });
-    const total = data.reduce((sum, row) => sum + (row.revenue as number), 0);
+    expect(unmatched).toEqual({ 'customer.country': undefined, revenue: '70' });
+    const total = data.reduce((sum, row) => sum + Number(row.revenue), 0);
     expect(total).toBe(220);
   });
 
@@ -318,7 +339,19 @@ describe('relationship joins on the semantic backend', () => {
       measures: ['revenue'],
       filters: [{ field: 'customer.tier', operator: 'eq', value: 'enterprise' }],
     });
-    expect(data).toEqual([{ status: 'paid', revenue: 100 }]);
+    expect(data).toEqual([{ status: 'paid', revenue: '100' }]);
+  });
+
+  it('collects the join for an orderBy-only qualified field', () => {
+    const plan = buildDatasetPlan(Orders, {
+      dimensions: ['status'],
+      measures: ['revenue'],
+      orderBy: [{ field: 'customer.country', direction: 'asc' }],
+    });
+    if (plan.kind !== 'aggregate') throw new Error('expected an aggregate plan');
+    expect(plan.joins).toEqual([
+      expect.objectContaining({ relationship: 'customer', source: 'customers', type: 'left' }),
+    ]);
   });
 
   it('scopes joined targets by tenant (defense in depth)', async () => {
@@ -340,8 +373,8 @@ describe('relationship joins on the semantic backend', () => {
       context,
     );
     // Order 2's customer (id 20) belongs to tenant t2, so it must not leak across the join.
-    expect(data).toContainEqual({ 'customer.country': 'US', revenue: 100 });
-    expect(data).toContainEqual({ 'customer.country': undefined, revenue: 50 });
+    expect(data).toContainEqual({ 'customer.country': 'US', revenue: '100' });
+    expect(data).toContainEqual({ 'customer.country': undefined, revenue: '50' });
     expect(data.find((row) => row['customer.country'] === 'FR')).toBeUndefined();
   });
 });

--- a/packages/datasets/src/relationships-query.test.ts
+++ b/packages/datasets/src/relationships-query.test.ts
@@ -53,6 +53,22 @@ const Orders = dataset('orders', {
 
 const revenueMetric = Orders.metric('revenue', { measure: 'revenue' });
 
+// Dataset with SQL-backed fields, to exercise the "raw SQL under joins" guard.
+const SqlOrders = dataset('orders', {
+  source: 'orders',
+  dimensions: {
+    status: dimension.string(),
+    lineTotal: dimension.number({ sql: 'price * quantity' }),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+    rawRevenue: measure.sum('amount', { sql: 'sum(amount)' }),
+  },
+  relationships: {
+    customer: belongsTo(() => Customers, { from: 'customer_id', to: 'id' }),
+  },
+});
+
 // Tenant-scoped datasets for defense-in-depth join tenancy.
 const TenantCustomers = dataset('tenant_customers', {
   source: 'tenant_customers',
@@ -445,5 +461,27 @@ describe('relationship joins on the query-builder path', () => {
       measures: ['revenue'],
     });
     expect(sql).toBe('SELECT status, SUM(amount) AS revenue FROM orders GROUP BY status');
+  });
+
+  it('rejects a SQL-backed base dimension combined with a join', () => {
+    expect(() => builderClient().toSQL(SqlOrders, {
+      dimensions: ['lineTotal', 'customer.country'],
+      measures: ['revenue'],
+    })).toThrow(/SQL-backed dimension "lineTotal" cannot be combined with relationship joins/);
+  });
+
+  it('rejects a SQL-backed measure combined with a join', () => {
+    expect(() => builderClient().toSQL(SqlOrders, {
+      dimensions: ['customer.country'],
+      measures: ['rawRevenue'],
+    })).toThrow(/SQL-backed measure "rawRevenue" cannot be combined with relationship joins/);
+  });
+
+  it('still allows a SQL-backed base dimension without joins', () => {
+    const sql = builderClient().toSQL(SqlOrders, {
+      dimensions: ['lineTotal'],
+      measures: ['revenue'],
+    });
+    expect(sql).toContain('price * quantity AS lineTotal');
   });
 });

--- a/packages/datasets/src/relationships-query.test.ts
+++ b/packages/datasets/src/relationships-query.test.ts
@@ -1,0 +1,398 @@
+import { describe, it, expect } from 'vitest';
+import { dataset } from './dataset.js';
+import { dimension } from './field.js';
+import { measure } from './measure.js';
+import { belongsTo, hasMany, hasOne } from './relationships.js';
+import { createDatasetClient } from './executor.js';
+import { validateDatasetQuery } from './dataset-query.js';
+import { createInMemoryBackend, type InMemoryTables } from './in-memory-backend.js';
+import type { QueryBuilderFactoryLike, QueryBuilderLike } from './query-builder-protocol.js';
+import type { ExecutionContext } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const Customers = dataset('customers', {
+  source: 'customers',
+  dimensions: {
+    id: dimension.number(),
+    country: dimension.string({ column: 'country_code' }),
+    tier: dimension.string(),
+  },
+});
+
+const Items = dataset('items', {
+  source: 'items',
+  dimensions: {
+    id: dimension.number(),
+    orderId: dimension.number({ column: 'order_id' }),
+    sku: dimension.string(),
+  },
+});
+
+const Orders = dataset('orders', {
+  source: 'orders',
+  timeKey: 'created_at',
+  dimensions: {
+    id: dimension.number(),
+    status: dimension.string(),
+    amount: dimension.number(),
+    createdAt: dimension.timestamp({ column: 'created_at' }),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+    orderCount: measure.count('id'),
+  },
+  relationships: {
+    customer: belongsTo(() => Customers, { from: 'customer_id', to: 'id' }),
+    profile: hasOne(() => Customers, { from: 'id', to: 'order_id' }),
+    items: hasMany(() => Items, { from: 'id', to: 'order_id' }),
+  },
+});
+
+const revenueMetric = Orders.metric('revenue', { measure: 'revenue' });
+
+// Tenant-scoped datasets for defense-in-depth join tenancy.
+const TenantCustomers = dataset('tenant_customers', {
+  source: 'tenant_customers',
+  tenantKey: 'tenant_id',
+  dimensions: {
+    id: dimension.number(),
+    country: dimension.string(),
+    tenantId: dimension.string({ column: 'tenant_id' }),
+  },
+});
+
+const TenantOrders = dataset('tenant_orders', {
+  source: 'tenant_orders',
+  tenantKey: 'tenant_id',
+  dimensions: {
+    id: dimension.number(),
+    amount: dimension.number(),
+    tenantId: dimension.string({ column: 'tenant_id' }),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+  },
+  relationships: {
+    customer: belongsTo(() => TenantCustomers, { from: 'customer_id', to: 'id' }),
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Mock builder factory that supports leftJoin and records SQL faithfully.
+// ---------------------------------------------------------------------------
+
+function createJoinMockBuilderFactory(): QueryBuilderFactoryLike {
+  function createBuilder(table: string): QueryBuilderLike {
+    const state = {
+      select: [] as string[],
+      joins: [] as string[],
+      where: [] as string[],
+      groupBy: [] as string[],
+      orderBy: [] as string[],
+      limit: undefined as number | undefined,
+      offset: undefined as number | undefined,
+    };
+
+    const agg = (fn: string) => (column: string, alias?: string) => {
+      state.select.push(`${fn}(${column}) AS ${alias ?? `${column}_${fn.toLowerCase()}`}`);
+      return builder;
+    };
+
+    const buildSql = () => {
+      let sql = `SELECT ${state.select.length ? state.select.join(', ') : '*'} FROM ${table}`;
+      if (state.joins.length) sql += ` ${state.joins.join(' ')}`;
+      if (state.where.length) sql += ` WHERE ${state.where.join(' AND ')}`;
+      if (state.groupBy.length) sql += ` GROUP BY ${state.groupBy.join(', ')}`;
+      if (state.orderBy.length) sql += ` ORDER BY ${state.orderBy.join(', ')}`;
+      if (state.limit != null) sql += ` LIMIT ${state.limit}`;
+      if (state.offset != null) sql += ` OFFSET ${state.offset}`;
+      return sql;
+    };
+
+    const builder: QueryBuilderLike = {
+      select: (args) => {
+        state.select.push(...(Array.isArray(args) ? args : [args]));
+        return builder;
+      },
+      sum: agg('SUM'),
+      count: agg('COUNT'),
+      countDistinct: (column, alias) => {
+        state.select.push(`COUNT(DISTINCT ${column}) AS ${alias ?? `${column}_countDistinct`}`);
+        return builder;
+      },
+      avg: agg('AVG'),
+      min: agg('MIN'),
+      max: agg('MAX'),
+      where: (column, operator, _value) => {
+        const op = operator === 'eq' ? '=' : operator;
+        state.where.push(`${column} ${op} ?`);
+        return builder;
+      },
+      leftJoin: (joinTable, leftColumn, rightColumn, alias) => {
+        // Mirror @hypequery/clickhouse: aliasing rewrites the ON right column.
+        const rendered = alias ? rightColumn.replace(`${joinTable}.`, `${alias}.`) : rightColumn;
+        const tableClause = alias ? `${joinTable} AS ${alias}` : joinTable;
+        state.joins.push(`LEFT JOIN ${tableClause} ON ${leftColumn} = ${rendered}`);
+        return builder;
+      },
+      groupBy: (args) => {
+        state.groupBy.push(...(Array.isArray(args) ? args : [args]));
+        return builder;
+      },
+      orderBy: (column, direction) => {
+        state.orderBy.push(`${column} ${direction ?? 'ASC'}`);
+        return builder;
+      },
+      limit: (count) => { state.limit = count; return builder; },
+      offset: (count) => { state.offset = count; return builder; },
+      toSQLWithParams: () => ({ sql: buildSql(), parameters: [] }),
+      execute: async () => [],
+    };
+    return builder;
+  }
+
+  return {
+    table: (name: string) => createBuilder(name),
+    rawQuery: async () => [],
+  };
+}
+
+const builderClient = () => createDatasetClient({ queryBuilder: createJoinMockBuilderFactory() });
+const backendClient = (tables: InMemoryTables) => createDatasetClient({ backend: createInMemoryBackend(tables) });
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+describe('relationship-qualified validation', () => {
+  it('accepts a to-one qualified dimension', () => {
+    const result = validateDatasetQuery(Orders, {
+      dimensions: ['customer.country'],
+      measures: ['revenue'],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts hasOne qualified dimensions', () => {
+    const result = validateDatasetQuery(Orders, {
+      dimensions: ['profile.country'],
+      measures: ['revenue'],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects hasMany relationships with a fan-out message', () => {
+    const result = validateDatasetQuery(Orders, {
+      dimensions: ['items.sku'],
+      measures: ['revenue'],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/hasMany|fan out|not queryable/i);
+  });
+
+  it('rejects multi-hop paths', () => {
+    const result = validateDatasetQuery(Orders, {
+      dimensions: ['customer.region.name'],
+      measures: ['revenue'],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/one.*hop|single hop/i);
+  });
+
+  it('rejects unknown relationships', () => {
+    const result = validateDatasetQuery(Orders, {
+      dimensions: ['supplier.name'],
+      measures: ['revenue'],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/Unknown relationship "supplier"/);
+  });
+
+  it('rejects unknown dimensions on the target', () => {
+    const result = validateDatasetQuery(Orders, {
+      dimensions: ['customer.unknownField'],
+      measures: ['revenue'],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/Unknown dimension "unknownField"/);
+  });
+
+  it('rejects relationship-qualified measures', () => {
+    const result = validateDatasetQuery(Orders, {
+      dimensions: ['status'],
+      measures: ['customer.total'],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/Measure "customer.total" is relationship-qualified/);
+  });
+
+  it('type-checks qualified filter values', () => {
+    const result = validateDatasetQuery(Orders, {
+      dimensions: ['status'],
+      measures: ['revenue'],
+      filters: [{ field: 'customer.tier', operator: 'eq', value: 42 }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/expects a string value/);
+  });
+
+  it('accepts a valid qualified filter', () => {
+    const result = validateDatasetQuery(Orders, {
+      dimensions: ['status'],
+      measures: ['revenue'],
+      filters: [{ field: 'customer.tier', operator: 'eq', value: 'enterprise' }],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects explicit filters on a joined target tenant column under runtime tenancy', () => {
+    const context: ExecutionContext = { runtime: { tenant: { id: 't1' } } };
+    const result = validateDatasetQuery(
+      TenantOrders,
+      {
+        dimensions: ['customer.country'],
+        measures: ['revenue'],
+        filters: [{ field: 'customer.tenantId', operator: 'eq', value: 't1' }],
+      },
+      context,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/tenant field "customer.tenantId"/);
+  });
+
+  it('validates qualified dimensions for metric queries too', () => {
+    const client = builderClient();
+    const result = client.validate(revenueMetric, { dimensions: ['items.sku'] });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/hasMany|not queryable/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Semantic-backend execution (in-memory hash join)
+// ---------------------------------------------------------------------------
+
+describe('relationship joins on the semantic backend', () => {
+  const tables: InMemoryTables = {
+    orders: [
+      { id: 1, status: 'paid', amount: 100, customer_id: 10, created_at: '2024-01-01' },
+      { id: 2, status: 'paid', amount: 50, customer_id: 11, created_at: '2024-01-02' },
+      { id: 3, status: 'open', amount: 70, customer_id: 99, created_at: '2024-01-03' },
+    ],
+    customers: [
+      { id: 10, country_code: 'US', tier: 'enterprise' },
+      { id: 11, country_code: 'DE', tier: 'free' },
+    ],
+  };
+
+  it('groups a base measure by a joined dimension', async () => {
+    const client = backendClient(tables);
+    const { data } = await client.execute(Orders, {
+      dimensions: ['customer.country'],
+      measures: ['revenue'],
+    });
+    expect(data).toContainEqual({ 'customer.country': 'US', revenue: 100 });
+    expect(data).toContainEqual({ 'customer.country': 'DE', revenue: 50 });
+  });
+
+  it('keeps base rows whose FK has no match (LEFT JOIN semantics)', async () => {
+    const client = backendClient(tables);
+    const { data } = await client.execute(Orders, {
+      dimensions: ['customer.country'],
+      measures: ['revenue'],
+    });
+    // Order 3 (customer_id 99) has no matching customer -> country is undefined but the row survives.
+    const unmatched = data.find((row) => row['customer.country'] === undefined);
+    expect(unmatched).toEqual({ 'customer.country': undefined, revenue: 70 });
+    const total = data.reduce((sum, row) => sum + (row.revenue as number), 0);
+    expect(total).toBe(220);
+  });
+
+  it('filters on a joined dimension', async () => {
+    const client = backendClient(tables);
+    const { data } = await client.execute(Orders, {
+      dimensions: ['status'],
+      measures: ['revenue'],
+      filters: [{ field: 'customer.tier', operator: 'eq', value: 'enterprise' }],
+    });
+    expect(data).toEqual([{ status: 'paid', revenue: 100 }]);
+  });
+
+  it('scopes joined targets by tenant (defense in depth)', async () => {
+    const tenantTables: InMemoryTables = {
+      tenant_orders: [
+        { id: 1, amount: 100, customer_id: 10, tenant_id: 't1' },
+        { id: 2, amount: 50, customer_id: 20, tenant_id: 't1' },
+      ],
+      tenant_customers: [
+        { id: 10, country: 'US', tenant_id: 't1' },
+        { id: 20, country: 'FR', tenant_id: 't2' },
+      ],
+    };
+    const client = backendClient(tenantTables);
+    const context: ExecutionContext = { runtime: { tenant: { id: 't1' } } };
+    const { data } = await client.execute(
+      TenantOrders,
+      { dimensions: ['customer.country'], measures: ['revenue'] },
+      context,
+    );
+    // Order 2's customer (id 20) belongs to tenant t2, so it must not leak across the join.
+    expect(data).toContainEqual({ 'customer.country': 'US', revenue: 100 });
+    expect(data).toContainEqual({ 'customer.country': undefined, revenue: 50 });
+    expect(data.find((row) => row['customer.country'] === 'FR')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query-builder path SQL
+// ---------------------------------------------------------------------------
+
+describe('relationship joins on the query-builder path', () => {
+  it('emits a LEFT JOIN and qualified, aliased columns', () => {
+    const sql = builderClient().toSQL(Orders, {
+      dimensions: ['status', 'customer.country'],
+      measures: ['revenue'],
+      orderBy: [{ field: 'customer.country', direction: 'asc' }],
+    });
+    expect(sql).toContain('LEFT JOIN customers AS customer ON orders.customer_id = customer.id');
+    expect(sql).toContain('orders.status AS status');
+    expect(sql).toContain('customer.country_code AS `customer.country`');
+    expect(sql).toContain('SUM(orders.amount) AS revenue');
+    expect(sql).toContain('GROUP BY status, `customer.country`');
+    expect(sql).toContain('ORDER BY `customer.country` ASC');
+  });
+
+  it('deduplicates joins referenced by both a dimension and a filter', () => {
+    const sql = builderClient().toSQL(Orders, {
+      dimensions: ['customer.country'],
+      measures: ['revenue'],
+      filters: [{ field: 'customer.tier', operator: 'eq', value: 'enterprise' }],
+    });
+    const joinCount = (sql.match(/LEFT JOIN customers AS customer/g) ?? []).length;
+    expect(joinCount).toBe(1);
+    expect(sql).toContain('customer.tier = ?');
+  });
+
+  it('injects the joined tenant predicate under runtime tenancy', () => {
+    const context: ExecutionContext = { runtime: { tenant: { id: 't1' } } };
+    const sql = builderClient().toSQL(
+      TenantOrders,
+      { dimensions: ['customer.country'], measures: ['revenue'] },
+      context,
+    );
+    expect(sql).toContain('LEFT JOIN tenant_customers AS customer ON tenant_orders.customer_id = customer.id');
+    expect(sql).toContain('tenant_orders.tenant_id = ?');
+    expect(sql).toContain('customer.tenant_id = ?');
+  });
+
+  it('leaves non-join queries unqualified (no regression)', () => {
+    const sql = builderClient().toSQL(Orders, {
+      dimensions: ['status'],
+      measures: ['revenue'],
+    });
+    expect(sql).toBe('SELECT status, SUM(amount) AS revenue FROM orders GROUP BY status');
+  });
+});

--- a/packages/datasets/src/relationships-query.test.ts
+++ b/packages/datasets/src/relationships-query.test.ts
@@ -148,10 +148,8 @@ function createJoinMockBuilderFactory(): QueryBuilderFactoryLike {
         return builder;
       },
       leftJoin: (joinTable, leftColumn, rightColumn, alias) => {
-        // Mirror @hypequery/clickhouse: aliasing rewrites the ON right column.
-        const rendered = alias ? rightColumn.replace(`${joinTable}.`, `${alias}.`) : rightColumn;
         const tableClause = alias ? `${joinTable} AS ${alias}` : joinTable;
-        state.joins.push(`LEFT JOIN ${tableClause} ON ${leftColumn} = ${rendered}`);
+        state.joins.push(`LEFT JOIN ${tableClause} ON ${leftColumn} = ${rightColumn}`);
         return builder;
       },
       groupBy: (args) => {

--- a/packages/datasets/src/relationships-query.test.ts
+++ b/packages/datasets/src/relationships-query.test.ts
@@ -6,7 +6,6 @@ import { belongsTo, hasMany, hasOne } from './relationships.js';
 import { createDatasetClient } from './executor.js';
 import { validateDatasetQuery } from './dataset-query.js';
 import { createInMemoryBackend, type InMemoryTables } from './in-memory-backend.js';
-import { buildDatasetPlan } from './semantic-planner.js';
 import type { QueryBuilderFactoryLike, QueryBuilderLike } from './query-builder-protocol.js';
 import type { ExecutionContext } from './types.js';
 
@@ -290,6 +289,25 @@ describe('relationship-qualified validation', () => {
     expect(result.valid).toBe(false);
     expect(result.errors.join(' ')).toMatch(/Unknown relationship "supplier"/);
   });
+
+  it('rejects a resolvable qualified orderBy field that is not selected as a dimension', () => {
+    const result = validateDatasetQuery(Orders, {
+      dimensions: ['status'],
+      measures: ['revenue'],
+      orderBy: [{ field: 'customer.country', direction: 'asc' }],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/Unknown orderBy fields: customer\.country/);
+  });
+
+  it('accepts a qualified orderBy field when it is also selected as a dimension', () => {
+    const result = validateDatasetQuery(Orders, {
+      dimensions: ['customer.country'],
+      measures: ['revenue'],
+      orderBy: [{ field: 'customer.country', direction: 'asc' }],
+    });
+    expect(result.valid).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -342,16 +360,16 @@ describe('relationship joins on the semantic backend', () => {
     expect(data).toEqual([{ status: 'paid', revenue: '100' }]);
   });
 
-  it('collects the join for an orderBy-only qualified field', () => {
-    const plan = buildDatasetPlan(Orders, {
-      dimensions: ['status'],
+  it('sorts by a selected joined dimension (orderBy on a joined field works end to end)', async () => {
+    const client = backendClient(tables);
+    const { data } = await client.execute(Orders, {
+      dimensions: ['customer.country'],
       measures: ['revenue'],
-      orderBy: [{ field: 'customer.country', direction: 'asc' }],
+      orderBy: [{ field: 'customer.country', direction: 'desc' }],
     });
-    if (plan.kind !== 'aggregate') throw new Error('expected an aggregate plan');
-    expect(plan.joins).toEqual([
-      expect.objectContaining({ relationship: 'customer', source: 'customers', type: 'left' }),
-    ]);
+    // Descending by country_code, the matched rows sort US before DE.
+    const matched = data.map((row) => row['customer.country']).filter((c) => c !== undefined);
+    expect(matched).toEqual(['US', 'DE']);
   });
 
   it('scopes joined targets by tenant (defense in depth)', async () => {

--- a/packages/datasets/src/semantic-plan.ts
+++ b/packages/datasets/src/semantic-plan.ts
@@ -37,6 +37,25 @@ export interface SemanticAggregationPlan {
   filters?: MetricFilter[];
 }
 
+export type SemanticTenantPredicate =
+  | { field: string; operator: 'eq'; value: string }
+  | { field: string; operator: 'in'; value: string[] };
+
+/**
+ * A query-time LEFT JOIN for a to-one relationship. `relationship` is the alias
+ * used to qualify joined columns (`<relationship>.<column>`); `from`/`to` are
+ * the unqualified base and target join columns. An optional `tenant` predicate
+ * scopes the joined target when runtime tenancy is active on the target.
+ */
+export interface SemanticJoinPlan {
+  relationship: string;
+  source: string;
+  from: string;
+  to: string;
+  type: 'left';
+  tenant?: SemanticTenantPredicate;
+}
+
 export interface SemanticGrainPlan {
   field: string;
   unit: TimeGrain;
@@ -56,7 +75,13 @@ export type PlanNode =
     orderBy?: MetricOrderBy[];
     limit?: number;
     offset?: number;
-    tenant?: { field: string; operator: 'eq'; value: string } | { field: string; operator: 'in'; value: string[] };
+    tenant?: SemanticTenantPredicate;
+    /**
+     * To-one relationship LEFT JOINs. When present, joined columns referenced by
+     * dimensions/filters are qualified as `<relationship>.<column>`; base columns
+     * stay unqualified (SQL backends qualify them with `source` as needed).
+     */
+    joins?: SemanticJoinPlan[];
   }
   | {
     kind: 'derive';

--- a/packages/datasets/src/semantic-planner.ts
+++ b/packages/datasets/src/semantic-planner.ts
@@ -3,6 +3,7 @@ import type {
   DatasetQuery,
   ExecutionContext,
   MetricFilter,
+  MetricOrderBy,
   MetricQuery,
   MetricRef,
   GrainedMetricRef,
@@ -87,18 +88,20 @@ function normalizeFilters(
 
 /**
  * Collects deduped to-one LEFT JOINs for every relationship referenced by the
- * query's dimensions or filters, scoping each joined target with the runtime
- * tenant predicate when the target declares a `tenantKey`.
+ * query's dimensions, filters, or orderBy, scoping each joined target with the
+ * runtime tenant predicate when the target declares a `tenantKey`.
  */
 function collectJoins(
   ds: AnyDatasetInstance,
   dimensions: string[] = [],
   filters: MetricFilter[] = [],
+  orderBy: MetricOrderBy[] = [],
   context?: ExecutionContext,
 ): SemanticJoinPlan[] | undefined {
   const referenced = [
     ...dimensions,
     ...filters.map((filter) => filter.field),
+    ...orderBy.map((order) => order.field),
   ].filter(isQualifiedField);
   if (referenced.length === 0) {
     return undefined;
@@ -189,7 +192,7 @@ function aggregatePlan(
     limit: query.limit,
     offset: query.offset,
     tenant: tenantForContext(ds, context),
-    joins: collectJoins(ds, query.dimensions, query.filters, context),
+    joins: collectJoins(ds, query.dimensions, query.filters, query.orderBy, context),
   };
 }
 

--- a/packages/datasets/src/semantic-planner.ts
+++ b/packages/datasets/src/semantic-planner.ts
@@ -11,6 +11,7 @@ import type {
   PlanNode,
   SemanticAggregationPlan,
   SemanticDimensionPlan,
+  SemanticJoinPlan,
 } from './semantic-plan.js';
 import {
   getMetricGrain,
@@ -20,6 +21,7 @@ import {
 import { validateDatasetQuery } from './dataset-query.js';
 import { isSupportedTimeGrain } from './constants.js';
 import { getRuntimeTenantPredicate } from './utils/tenant-runtime.js';
+import { isQualifiedField, resolveQualifiedField } from './utils/relationship-fields.js';
 
 function resolveField(ds: AnyDatasetInstance, field: string): string {
   const dimension = ds.dimensions[field];
@@ -32,15 +34,38 @@ function resolveField(ds: AnyDatasetInstance, field: string): string {
   return dimension?.column ?? field;
 }
 
+/**
+ * Resolves a relationship-qualified field to its plan field name
+ * (`<relationship>.<targetColumn>`). Validation runs before planning, so an
+ * unresolved qualified name here is a programming error.
+ */
+function resolveQualifiedPlanField(ds: AnyDatasetInstance, name: string) {
+  const resolution = resolveQualifiedField(ds, name);
+  if (!resolution || !resolution.resolved) {
+    throw new Error(resolution?.error ?? `Cannot resolve relationship field "${name}".`);
+  }
+  return resolution.resolved;
+}
+
 function dimensionsForQuery(
   ds: AnyDatasetInstance,
   dimensions: string[] = [],
 ): SemanticDimensionPlan[] {
-  return dimensions.map((name) => ({
-    name,
-    field: resolveField(ds, name),
-    fieldType: ds.dimensions[name]?.fieldType,
-  }));
+  return dimensions.map((name) => {
+    if (isQualifiedField(name)) {
+      const { relationshipName, targetColumn, targetDimension } = resolveQualifiedPlanField(ds, name);
+      return {
+        name,
+        field: `${relationshipName}.${targetColumn}`,
+        fieldType: targetDimension.fieldType,
+      };
+    }
+    return {
+      name,
+      field: resolveField(ds, name),
+      fieldType: ds.dimensions[name]?.fieldType,
+    };
+  });
 }
 
 function normalizeFilters(
@@ -48,12 +73,56 @@ function normalizeFilters(
   filters: MetricFilter[] = [],
 ): MetricFilter[] {
   return filters.map((filter) => {
+    if (isQualifiedField(filter.field)) {
+      const { relationshipName, targetColumn } = resolveQualifiedPlanField(ds, filter.field);
+      return { ...filter, field: `${relationshipName}.${targetColumn}` };
+    }
     const resolvedField = ds.filters[filter.field]?.field ?? filter.field;
     return {
       ...filter,
       field: resolveField(ds, resolvedField),
     };
   });
+}
+
+/**
+ * Collects deduped to-one LEFT JOINs for every relationship referenced by the
+ * query's dimensions or filters, scoping each joined target with the runtime
+ * tenant predicate when the target declares a `tenantKey`.
+ */
+function collectJoins(
+  ds: AnyDatasetInstance,
+  dimensions: string[] = [],
+  filters: MetricFilter[] = [],
+  context?: ExecutionContext,
+): SemanticJoinPlan[] | undefined {
+  const referenced = [
+    ...dimensions,
+    ...filters.map((filter) => filter.field),
+  ].filter(isQualifiedField);
+  if (referenced.length === 0) {
+    return undefined;
+  }
+
+  const tenantPredicate = getRuntimeTenantPredicate(context);
+  const joins = new Map<string, SemanticJoinPlan>();
+  for (const name of referenced) {
+    const { relationshipName, relationship, target } = resolveQualifiedPlanField(ds, name);
+    if (joins.has(relationshipName)) {
+      continue;
+    }
+    joins.set(relationshipName, {
+      relationship: relationshipName,
+      source: target.source,
+      from: relationship.from,
+      to: relationship.to,
+      type: 'left',
+      tenant: tenantPredicate && target.tenantKey
+        ? { field: target.tenantKey, ...tenantPredicate }
+        : undefined,
+    });
+  }
+  return Array.from(joins.values());
 }
 
 function aggregationForMeasure(
@@ -120,6 +189,7 @@ function aggregatePlan(
     limit: query.limit,
     offset: query.offset,
     tenant: tenantForContext(ds, context),
+    joins: collectJoins(ds, query.dimensions, query.filters, context),
   };
 }
 

--- a/packages/datasets/src/utils/dataset-query-validation.ts
+++ b/packages/datasets/src/utils/dataset-query-validation.ts
@@ -124,8 +124,12 @@ export function validateDatasetQueryInput(
         const resolution = resolveQualifiedField(ds, order.field);
         if (resolution?.error) {
           errors.push(resolution.error);
+          continue;
         }
-        continue;
+        // A resolvable qualified field is only orderable when it is also
+        // selected as a dimension (same rule as unqualified fields). Otherwise
+        // the sort silently no-ops in-memory and breaks the SQL alias, so fall
+        // through to the orderableFields check rather than accepting it.
       }
       if (!orderableFields.has(order.field)) {
         invalid.push(order.field);

--- a/packages/datasets/src/utils/dataset-query-validation.ts
+++ b/packages/datasets/src/utils/dataset-query-validation.ts
@@ -9,6 +9,11 @@ import {
   getRuntimeTenantPredicate,
   validateTenantRuntime,
 } from './tenant-runtime.js';
+import {
+  isQualifiedField,
+  resolveQualifiedField,
+} from './relationship-fields.js';
+import { validateQualifiedFilter } from './relationship-validation.js';
 
 export function validateDatasetQueryInput(
   ds: AnyDatasetInstance,
@@ -37,26 +42,49 @@ export function validateDatasetQueryInput(
   }
 
   if (query.dimensions) {
-    const invalid = query.dimensions.filter(dimension => !dimensionNames.includes(dimension));
-    if (invalid.length > 0) {
-      errors.push(`Unknown dimensions: ${invalid.join(', ')}. Available: ${dimensionNames.join(', ')}`);
+    for (const dimension of query.dimensions) {
+      if (isQualifiedField(dimension)) {
+        const resolution = resolveQualifiedField(ds, dimension);
+        if (resolution?.error) {
+          errors.push(resolution.error);
+        }
+        continue;
+      }
+      if (!dimensionNames.includes(dimension)) {
+        errors.push(`Unknown dimensions: ${dimension}. Available: ${dimensionNames.join(', ')}`);
+      }
     }
   }
 
   if (query.measures) {
-    const invalid = query.measures.filter(measure => !measureNames.includes(measure));
-    if (invalid.length > 0) {
-      errors.push(`Unknown measures: ${invalid.join(', ')}. Available: ${measureNames.join(', ')}`);
+    for (const measure of query.measures) {
+      if (isQualifiedField(measure)) {
+        errors.push(
+          `Measure "${measure}" is relationship-qualified. Measures can only be defined on the base dataset "${ds.name}", not traversed through relationships.`,
+        );
+        continue;
+      }
+      if (!measureNames.includes(measure)) {
+        errors.push(`Unknown measures: ${measure}. Available: ${measureNames.join(', ')}`);
+      }
     }
   }
 
   if (query.filters) {
-    const invalid = query.filters.filter(filter => !filterNames.includes(filter.field));
-    if (invalid.length > 0) {
-      errors.push(`Unknown filter fields: ${invalid.map(filter => filter.field).join(', ')}. Available: ${filterNames.join(', ')}`);
-    }
-
     for (const filter of query.filters) {
+      if (isQualifiedField(filter.field)) {
+        const filterError = validateQualifiedFilter(ds, filter, context);
+        if (filterError) {
+          errors.push(filterError);
+        }
+        continue;
+      }
+
+      if (!filterNames.includes(filter.field)) {
+        errors.push(`Unknown filter fields: ${filter.field}. Available: ${filterNames.join(', ')}`);
+        continue;
+      }
+
       const filterDefinition = ds.filters[filter.field];
       if (filterDefinition?.operators && !filterDefinition.operators.includes(filter.operator)) {
         errors.push(

--- a/packages/datasets/src/utils/dataset-query-validation.ts
+++ b/packages/datasets/src/utils/dataset-query-validation.ts
@@ -118,9 +118,21 @@ export function validateDatasetQueryInput(
   }
 
   if (query.orderBy) {
-    const invalid = query.orderBy.filter(order => !orderableFields.has(order.field));
+    const invalid: string[] = [];
+    for (const order of query.orderBy) {
+      if (isQualifiedField(order.field)) {
+        const resolution = resolveQualifiedField(ds, order.field);
+        if (resolution?.error) {
+          errors.push(resolution.error);
+        }
+        continue;
+      }
+      if (!orderableFields.has(order.field)) {
+        invalid.push(order.field);
+      }
+    }
     if (invalid.length > 0) {
-      errors.push(`Unknown orderBy fields: ${invalid.map(order => order.field).join(', ')}. Available: ${Array.from(orderableFields).join(', ')}`);
+      errors.push(`Unknown orderBy fields: ${invalid.join(', ')}. Available: ${Array.from(orderableFields).join(', ')}`);
     }
   }
 

--- a/packages/datasets/src/utils/filtered-aggregation-sql.ts
+++ b/packages/datasets/src/utils/filtered-aggregation-sql.ts
@@ -1,5 +1,6 @@
 import type { AggregationSpec, AnyDatasetInstance, MetricFilter } from '../types.js';
 import { resolveFilterField } from '../query-planner.js';
+import type { RelationshipBuilderContext } from './relationship-builder-plan.js';
 
 type DatasetShape = AnyDatasetInstance;
 
@@ -29,8 +30,9 @@ function renderMeasureFilterLiteral(value: unknown): string {
 function renderMeasureFilterCondition(
   ds: DatasetShape,
   filter: MetricFilter,
+  joinCtx?: RelationshipBuilderContext,
 ): string {
-  const field = resolveFilterField(ds, filter.field);
+  const field = resolveFilterField(ds, filter.field, joinCtx);
 
   switch (filter.operator) {
     case 'eq':
@@ -70,13 +72,14 @@ export function applyFilteredAggregationExpression(
   ds: DatasetShape,
   spec: AggregationSpec,
   fieldOrExpr: string,
+  joinCtx?: RelationshipBuilderContext,
 ): string {
   if (!spec.filters?.length) {
     return fieldOrExpr;
   }
 
   const combinedCondition = spec.filters
-    .map(filter => renderMeasureFilterCondition(ds, filter))
+    .map(filter => renderMeasureFilterCondition(ds, filter, joinCtx))
     .map(condition => `(${condition})`)
     .join(' AND ');
 

--- a/packages/datasets/src/utils/relationship-builder-plan.ts
+++ b/packages/datasets/src/utils/relationship-builder-plan.ts
@@ -1,0 +1,145 @@
+/**
+ * Query-builder-path planning for to-one relationship joins.
+ *
+ * When a dataset/metric query references relationship-qualified fields
+ * (`<relationship>.<field>`), the builder path aliases the joined target with
+ * the relationship name, table-qualifies base columns with the base source
+ * name, and aliases joined selections back to their quoted qualified name. When
+ * no qualified field is referenced, no context is produced and the builder path
+ * behaves exactly as before.
+ */
+
+import type {
+  AnyDatasetInstance,
+  DatasetQuery,
+  ExecutionContext,
+  MetricQuery,
+} from '../types.js';
+import type { QueryBuilderLike } from '../query-builder-protocol.js';
+import { getRuntimeTenantPredicate, type TenantPredicate } from './tenant-runtime.js';
+import { isQualifiedField, resolveQualifiedField } from './relationship-fields.js';
+
+export interface ResolvedBuilderJoin {
+  /** Relationship name, used as the joined table's SQL alias. */
+  relationship: string;
+  /** Physical target source table. */
+  source: string;
+  /** Base join column (unqualified). */
+  from: string;
+  /** Target join column (unqualified). */
+  to: string;
+  /** Tenant predicate applied to the joined target, when active. */
+  tenant?: TenantPredicate & { field: string };
+}
+
+export interface RelationshipBuilderContext {
+  baseSource: string;
+  joins: ResolvedBuilderJoin[];
+  joinByRelationship: Map<string, ResolvedBuilderJoin>;
+}
+
+type QueryLike = Pick<DatasetQuery & MetricQuery, 'dimensions' | 'filters' | 'orderBy'>;
+
+/**
+ * Builds the join context for a query, or returns undefined when the query
+ * references no relationship-qualified fields. Validation runs first, so any
+ * qualified name that fails to resolve here is skipped defensively.
+ */
+export function buildRelationshipBuilderContext(
+  ds: AnyDatasetInstance,
+  query: QueryLike,
+  context?: ExecutionContext,
+): RelationshipBuilderContext | undefined {
+  const referenced = [
+    ...(query.dimensions ?? []),
+    ...(query.filters ?? []).map((filter) => filter.field),
+    ...(query.orderBy ?? []).map((order) => order.field),
+  ].filter(isQualifiedField);
+
+  if (referenced.length === 0) {
+    return undefined;
+  }
+
+  const tenantPredicate = getRuntimeTenantPredicate(context);
+  const joinByRelationship = new Map<string, ResolvedBuilderJoin>();
+
+  for (const name of referenced) {
+    const resolution = resolveQualifiedField(ds, name);
+    if (!resolution || !resolution.resolved) {
+      continue;
+    }
+    const { relationshipName, relationship, target } = resolution.resolved;
+    if (joinByRelationship.has(relationshipName)) {
+      continue;
+    }
+    joinByRelationship.set(relationshipName, {
+      relationship: relationshipName,
+      source: target.source,
+      from: relationship.from,
+      to: relationship.to,
+      tenant: tenantPredicate && target.tenantKey
+        ? { field: target.tenantKey, ...tenantPredicate }
+        : undefined,
+    });
+  }
+
+  return {
+    baseSource: ds.source,
+    joins: Array.from(joinByRelationship.values()),
+    joinByRelationship,
+  };
+}
+
+/** Qualifies a base physical column with the base source when joins are active. */
+export function qualifyBaseColumn(
+  ctx: RelationshipBuilderContext | undefined,
+  column: string,
+): string {
+  return ctx ? `${ctx.baseSource}.${column}` : column;
+}
+
+/**
+ * Resolves a relationship-qualified field to its SQL column reference
+ * (`<relationship>.<targetColumn>`). Throws if the name cannot be resolved,
+ * which should be unreachable after validation.
+ */
+export function resolveQualifiedColumn(
+  ds: AnyDatasetInstance,
+  name: string,
+): string {
+  const resolution = resolveQualifiedField(ds, name);
+  if (!resolution || !resolution.resolved) {
+    throw new Error(resolution?.error ?? `Cannot resolve relationship field "${name}".`);
+  }
+  const { relationshipName, targetColumn } = resolution.resolved;
+  return `${relationshipName}.${targetColumn}`;
+}
+
+/**
+ * Applies each relationship LEFT JOIN to the builder and, when runtime tenancy
+ * is active on a target, scopes the joined rows with the tenant predicate.
+ */
+export function applyRelationshipJoins(
+  qb: QueryBuilderLike,
+  ctx: RelationshipBuilderContext | undefined,
+): QueryBuilderLike {
+  if (!ctx) {
+    return qb;
+  }
+  for (const join of ctx.joins) {
+    qb = qb.leftJoin(
+      join.source,
+      `${ctx.baseSource}.${join.from}`,
+      `${join.source}.${join.to}`,
+      join.relationship,
+    );
+    if (join.tenant) {
+      qb = qb.where(
+        `${join.relationship}.${join.tenant.field}`,
+        join.tenant.operator,
+        join.tenant.value,
+      );
+    }
+  }
+  return qb;
+}

--- a/packages/datasets/src/utils/relationship-builder-plan.ts
+++ b/packages/datasets/src/utils/relationship-builder-plan.ts
@@ -130,7 +130,7 @@ export function applyRelationshipJoins(
     qb = qb.leftJoin(
       join.source,
       `${ctx.baseSource}.${join.from}`,
-      `${join.source}.${join.to}`,
+      `${join.relationship}.${join.to}`,
       join.relationship,
     );
     if (join.tenant) {

--- a/packages/datasets/src/utils/relationship-builder-plan.ts
+++ b/packages/datasets/src/utils/relationship-builder-plan.ts
@@ -134,6 +134,14 @@ export function applyRelationshipJoins(
       join.relationship,
     );
     if (join.tenant) {
+      // NOTE: applying the tenant predicate in WHERE (rather than the JOIN ON
+      // clause) turns this LEFT JOIN into an effective INNER JOIN — base rows
+      // whose FK matches a different tenant, or no target at all, are dropped
+      // instead of surviving with undefined joined columns (as the in-memory
+      // backend does). Correct LEFT semantics require an ON-clause predicate,
+      // which needs `leftJoin` to carry extra conditions; that lands with the
+      // @hypequery/clickhouse join changes in PR 2. Until then this over-filters
+      // (safe: it never leaks cross-tenant rows).
       qb = qb.where(
         `${join.relationship}.${join.tenant.field}`,
         join.tenant.operator,

--- a/packages/datasets/src/utils/relationship-fields.ts
+++ b/packages/datasets/src/utils/relationship-fields.ts
@@ -1,0 +1,126 @@
+/**
+ * Resolution helpers for relationship-qualified field names (`relationship.field`).
+ *
+ * v1 supports one hop over to-one relationships (`belongsTo`, `hasOne`) only,
+ * addressing dimensions declared on the target dataset. `hasMany` stays
+ * metadata-only to avoid fan-out corruption of aggregates. See
+ * `plans/relationship-aware-semantics-design.md`.
+ */
+
+import type {
+  AnyDatasetInstance,
+  DimensionDefinition,
+  RelationshipDefinition,
+} from '../types.js';
+
+export interface ParsedQualifiedField {
+  /** The relationship name (prefix before the first dot). */
+  relationship: string;
+  /** Everything after the first dot — the target field, possibly multi-hop. */
+  field: string;
+}
+
+/** True when a field name is relationship-qualified (contains a dot). */
+export function isQualifiedField(name: string): boolean {
+  return name.includes('.');
+}
+
+/**
+ * Splits a qualified name into its relationship prefix and remaining field.
+ * Returns null when `name` is not qualified (no dot), so callers can treat it
+ * as a local field.
+ */
+export function parseQualifiedField(name: string): ParsedQualifiedField | null {
+  const dot = name.indexOf('.');
+  if (dot === -1) {
+    return null;
+  }
+  return { relationship: name.slice(0, dot), field: name.slice(dot + 1) };
+}
+
+export interface ResolvedQualifiedField {
+  /** Relationship name, also used as the SQL table alias / qualified prefix. */
+  relationshipName: string;
+  relationship: RelationshipDefinition;
+  /** The resolved target dataset instance. */
+  target: AnyDatasetInstance;
+  /** Target dimension name (the allowlist key on the target). */
+  targetDimensionName: string;
+  targetDimension: DimensionDefinition;
+  /** Physical column backing the target dimension. */
+  targetColumn: string;
+  /** The qualified name exactly as referenced, e.g. `customer.country`. */
+  qualifiedName: string;
+}
+
+export type QualifiedFieldResolution =
+  | { resolved: ResolvedQualifiedField; error?: undefined }
+  | { resolved?: undefined; error: string };
+
+/**
+ * Resolves a relationship-qualified field name against a base dataset.
+ *
+ * Returns null when `name` is not qualified (caller handles it as a local
+ * field). Otherwise returns either the resolved to-one target dimension or an
+ * actionable validation error (unknown relationship, multi-hop, `hasMany`,
+ * unknown target dimension, or SQL-backed target dimension).
+ */
+export function resolveQualifiedField(
+  ds: AnyDatasetInstance,
+  name: string,
+): QualifiedFieldResolution | null {
+  const parsed = parseQualifiedField(name);
+  if (!parsed) {
+    return null;
+  }
+
+  const { relationship: relationshipName, field } = parsed;
+  const relationship = ds.relationships[relationshipName];
+  if (!relationship) {
+    const available = Object.keys(ds.relationships);
+    return {
+      error: available.length > 0
+        ? `Unknown relationship "${relationshipName}" in field "${name}" on dataset "${ds.name}". Available relationships: ${available.join(', ')}.`
+        : `Unknown field "${name}": dataset "${ds.name}" declares no relationships.`,
+    };
+  }
+
+  if (field.includes('.')) {
+    return {
+      error: `Multi-hop relationship path "${name}" is not supported. Only a single hop is allowed (e.g. "${relationshipName}.<field>").`,
+    };
+  }
+
+  if (relationship.kind === 'hasMany') {
+    return {
+      error: `Relationship "${relationshipName}" on dataset "${ds.name}" is a hasMany (to-many) relationship and is not queryable, because joining it would fan out and corrupt aggregates. It remains available as metadata only.`,
+    };
+  }
+
+  const target = relationship.target() as AnyDatasetInstance;
+  const targetDimension = target.dimensions[field];
+  if (!targetDimension) {
+    const available = Object.keys(target.dimensions);
+    return {
+      error: `Unknown dimension "${field}" on relationship "${relationshipName}" (target dataset "${target.name}"). Available: ${available.join(', ')}.`,
+    };
+  }
+
+  if (targetDimension.sql) {
+    return {
+      error: `Dimension "${name}" is SQL-backed on target dataset "${target.name}"; SQL-backed dimensions are not yet queryable through relationships.`,
+    };
+  }
+
+  return {
+    resolved: {
+      relationshipName,
+      relationship,
+      target,
+      targetDimensionName: field,
+      targetDimension,
+      targetColumn: targetDimension.column ?? field,
+      qualifiedName: name,
+    },
+  };
+}

--- a/packages/datasets/src/utils/relationship-validation.ts
+++ b/packages/datasets/src/utils/relationship-validation.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared validation for relationship-qualified filters, used by both the
+ * dataset-query and metric-query validators.
+ */
+
+import type {
+  AnyDatasetInstance,
+  ExecutionContext,
+  MetricFilter,
+} from '../types.js';
+import { validateFilterValue } from '../validation.js';
+import { getRuntimeTenantPredicate } from './tenant-runtime.js';
+import { resolveQualifiedField } from './relationship-fields.js';
+
+/**
+ * Validates a relationship-qualified filter (`relationship.field`). Returns an
+ * error message string, or null when the filter is valid.
+ *
+ * Enforces the same tenant rule the base dataset uses: when runtime tenancy is
+ * active and the joined target declares a `tenantKey`, an explicit filter on
+ * that column is rejected (the planner injects the tenant predicate instead).
+ */
+export function validateQualifiedFilter(
+  ds: AnyDatasetInstance,
+  filter: MetricFilter,
+  context?: ExecutionContext,
+): string | null {
+  const resolution = resolveQualifiedField(ds, filter.field);
+  if (!resolution) {
+    return null;
+  }
+  if (!resolution.resolved) {
+    return resolution.error;
+  }
+
+  const { target, targetColumn, targetDimension } = resolution.resolved;
+
+  if (getRuntimeTenantPredicate(context) && target.tenantKey && targetColumn === target.tenantKey) {
+    return `Cannot filter on tenant field "${filter.field}" when runtime tenancy enforcement is active.`;
+  }
+
+  return validateFilterValue(filter, targetDimension.fieldType);
+}

--- a/plans/relationship-aware-semantics-design.md
+++ b/plans/relationship-aware-semantics-design.md
@@ -1,7 +1,23 @@
 # Relationship-Aware Semantics Design
 
 Date: 2026-07-02
-Status: proposed (resolves "Next Work #4" in `datasets-semantic-layer-fix-plan.md`)
+Status: PR 1 landed 2026-07-06 (resolves "Next Work #4" in `datasets-semantic-layer-fix-plan.md`)
+
+## Implementation status
+
+- **PR 1 — DONE (2026-07-06).** Validation (dataset + metric paths), builder-path
+  join planning, `QueryBuilderLike.leftJoin`, `PlanNode.joins` + semantic-planner
+  emission, and the in-memory backend hash join. 19 new unit tests in
+  `packages/datasets/src/relationships-query.test.ts`; full datasets/serve/mcp
+  suites green. `PlanNode.joins` was pulled forward from PR 2 because the
+  in-memory backend consumes it.
+- **PR 2 — TODO.** `@hypequery/clickhouse` `createBackend` translation of
+  `PlanNode.joins` (base columns qualified with `source`, joined with the
+  relationship alias) + live ClickHouse integration specs for joined base,
+  derived, grouped, grained, filtered, and tenant-scoped queries.
+- **PR 3 — TODO.** Catalog/contract `queryable` + `fields`, serve
+  `semantic-input-schema` enums, React field-name types, docs page.
+
 Sources: `packages/datasets/src` (relationships, planners, validation, catalog, contract),
 `packages/clickhouse/src` (query builder joins, semantic backend), `packages/schema/src/compat`,
 `packages/serve/src/semantic/datasets`.


### PR DESCRIPTION
## Summary

Implements **PR 1** of the relationship-aware semantics design ([plans/relationship-aware-semantics-design.md](plans/relationship-aware-semantics-design.md)). `belongsTo` / `hasOne` relationships become executable **one-hop LEFT JOINs** for dimensions, filters, and orderBy, addressed via `relationship.field` names (e.g. `customer.country`). `hasMany` stays metadata-only to avoid fan-out corruption of aggregates.

To-one joins never change the base table's row count, so every existing aggregate stays correct with zero changes to measure semantics.

## What changed

- **Validation** (dataset + metric paths) resolves qualified fields and rejects, with actionable messages: `hasMany` (fan-out), multi-hop paths, unknown relationships/target dimensions, relationship-qualified measures, SQL-backed target dimensions, and explicit filters on a joined target tenant column under runtime tenancy.
- **Semantic backend**: added `PlanNode.joins` + planner emission + an in-memory hash join (LEFT semantics — unmatched base rows survive with `undefined` joined columns). `PlanNode.joins` was pulled forward from PR 2 because the in-memory backend consumes it.
- **Query-builder path**: added `leftJoin` to the `QueryBuilderLike` protocol and threaded column qualification through the planner — base columns qualify with the source table, joined columns use the relationship alias and quoted qualified aliases (``AS `customer.country` ``). Non-join queries are byte-for-byte unchanged.
- **Tenancy**: when a joined target declares a `tenantKey` and runtime tenancy is active, the same predicate is applied to the joined side (defense-in-depth against cross-tenant leakage) on both backends.

## Scope / caveats

- **Library path only for now.** Qualified fields work through `createDatasetClient`, but **not yet through serve's HTTP layer** — serve's input-schema enums reject them until PR 3. A qualified dimension over HTTP will 400.
- **Builder-path SQL is mock-tested, not live-tested.** PR 2 adds the `@hypequery/clickhouse` `createBackend` translation of `PlanNode.joins` + live ClickHouse integration specs, which is where generated join SQL gets validated against a real database.
- PR 3 covers catalog/contract `queryable` flags, serve OpenAPI enums, React field-name types, and docs.

## Testing

- 19 new tests in `packages/datasets/src/relationships-query.test.ts` (validation, in-memory join execution incl. LEFT-join and tenant scoping, builder-path SQL).
- Full datasets suite (162 tests) + type tests + lint green; serve (444 tests) and mcp-server typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)