### PR TITLE
Translate relationship joins in the ClickHouse semantic backend (PR 2)

### DIFF
--- a/packages/clickhouse/src/core/dialects/clickhouse-dialect.ts
+++ b/packages/clickhouse/src/core/dialects/clickhouse-dialect.ts
@@ -23,7 +23,9 @@ export class ClickHouseDialect implements SqlDialect {
     }
 
     if (query.joins?.length) {
-      parts.push(this.formatter.formatJoins(query));
+      const compiled = this.formatter.compileJoins(query);
+      parts.push(compiled.query);
+      parameters.push(...compiled.parameters);
     }
 
     if (query.prewhere) {

--- a/packages/clickhouse/src/core/features/joins.ts
+++ b/packages/clickhouse/src/core/features/joins.ts
@@ -1,6 +1,48 @@
 import type { BuilderState, SchemaDefinition } from '../types/builder-state.js';
 import { QueryBuilder } from '../query-builder.js';
-import { JoinType, type SelectQueryNode } from '../../types/index.js';
+import {
+  JoinType,
+  type ConditionValueNode,
+  type ExprNode,
+  type JoinConditionInput,
+  type SelectQueryNode,
+  type ValueNode,
+} from '../../types/index.js';
+
+function wrapConditionValue(operator: JoinConditionInput['operator'], value: unknown): ConditionValueNode {
+  if (operator === 'inSubquery' || operator === 'globalInSubquery' || operator === 'inTable' || operator === 'globalInTable') {
+    return String(value);
+  }
+  if (operator === 'between') {
+    const range = value as unknown[];
+    return [
+      { kind: 'value', value: range[0] },
+      { kind: 'value', value: range[1] },
+    ];
+  }
+  if (operator === 'inTuple' || operator === 'globalInTuple') {
+    return (value as unknown[][]).map(tuple =>
+      tuple.map(tupleValue => ({ kind: 'value' as const, value: tupleValue }))
+    );
+  }
+  if (operator === 'in' || operator === 'notIn' || operator === 'globalIn' || operator === 'globalNotIn') {
+    return (value as unknown[]).map(item => ({ kind: 'value' as const, value: item }));
+  }
+  return { kind: 'value', value } satisfies ValueNode;
+}
+
+function buildOnExpression(conditions: JoinConditionInput | JoinConditionInput[]): ExprNode {
+  const conditionList = Array.isArray(conditions) ? conditions : [conditions];
+  const expressions: ExprNode[] = conditionList.map(condition => ({
+    kind: 'condition',
+    column: condition.column,
+    operator: condition.operator,
+    value: wrapConditionValue(condition.operator, condition.value),
+  }));
+  return expressions.length === 1
+    ? expressions[0]
+    : { kind: 'logical', operator: 'AND', conditions: expressions };
+}
 
 export class JoinFeature<
   Schema extends SchemaDefinition<Schema>,
@@ -14,7 +56,8 @@ export class JoinFeature<
     leftColumn: string,
     rightColumn: `${TableName & string}.${keyof Schema[TableName] & string}`,
     alias?: string,
-    leftSource?: string
+    leftSource?: string,
+    on?: JoinConditionInput | JoinConditionInput[],
   ): SelectQueryNode<State['output'], Schema> {
     const query = this.builder.getQueryNode();
     const renderedRightColumn = alias
@@ -32,6 +75,7 @@ export class JoinFeature<
           leftSource,
           rightColumn: renderedRightColumn,
           alias,
+          on: on ? buildOnExpression(on) : undefined,
         }
       ]
     };

--- a/packages/clickhouse/src/core/formatters/sql-formatter.ts
+++ b/packages/clickhouse/src/core/formatters/sql-formatter.ts
@@ -203,18 +203,26 @@ export class SQLFormatter {
     }
   }
 
-  formatJoins(query: SelectQueryNode<any, any>): string {
-    if (!query.joins?.length) return '';
+  compileJoins(query: SelectQueryNode<any, any>): CompiledQuery {
+    if (!query.joins?.length) return { query: '', parameters: [] };
 
-    return query.joins.map(join => {
+    return this.combineCompiledWithSeparator(query.joins.map(join => {
       const tableClause = join.alias
         ? `${join.table} AS ${join.alias}`
         : join.table;
       const leftColumn = join.leftSource && !join.leftColumn.includes('.')
         ? `${join.leftSource}.${join.leftColumn}`
         : join.leftColumn;
-      return `${join.type} JOIN ${tableClause} ON ${leftColumn} = ${join.rightColumn}`;
-    }).join(' ');
+      const extra = this.compileExpr(join.on);
+      return {
+        query: `${join.type} JOIN ${tableClause} ON ${leftColumn} = ${join.rightColumn}${extra.query ? ` AND ${extra.query}` : ''}`,
+        parameters: extra.parameters,
+      };
+    }), ' ');
+  }
+
+  formatJoins(query: SelectQueryNode<any, any>): string {
+    return this.compileJoins(query).query;
   }
 
   formatCtes(query: SelectQueryNode<any, any>): string {

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -8,6 +8,7 @@ import {
   OperatorValueMap,
   OrderDirection,
   JoinType,
+  type JoinConditionInput,
   type SelectQueryNode,
 } from '../types/index.js';
 import { AnySchema, ColumnType } from '../types/schema.js';
@@ -959,14 +960,15 @@ export class QueryBuilder<
     table: TableName,
     leftColumn: keyof BaseRow<State>,
     rightColumn: `${TableName & string}.${keyof Schema[TableName] & string}`,
-    alias?: Alias
+    alias?: Alias,
+    on?: JoinConditionInput | JoinConditionInput[],
   ): QueryBuilder<
     Schema,
     Alias extends string
     ? AddAlias<WidenTables<State, TableName>, Alias, TableName>
     : WidenTables<State, TableName>
   > {
-    return this.applyJoin('LEFT', table, leftColumn, rightColumn, alias);
+    return this.applyJoin('LEFT', table, leftColumn, rightColumn, alias, on);
   }
 
   rightJoin<TableName extends Extract<keyof Schema, string>, Alias extends string | undefined = undefined>(
@@ -1002,7 +1004,8 @@ export class QueryBuilder<
     table: TableName,
     leftColumn: keyof BaseRow<State>,
     rightColumn: `${TableName & string}.${keyof Schema[TableName] & string}`,
-    alias?: Alias
+    alias?: Alias,
+    on?: JoinConditionInput | JoinConditionInput[],
   ): QueryBuilder<
     Schema,
     Alias extends string
@@ -1020,7 +1023,7 @@ export class QueryBuilder<
 
     const nextState = this.withAliasesState<NextState>(nextAliases);
 
-    const nextConfig = this.joins.addJoin(type, table, String(leftColumn), rightColumn, alias);
+    const nextConfig = this.joins.addJoin(type, table, String(leftColumn), rightColumn, alias, undefined, on);
     return this.transition<NextState>(nextState, nextConfig);
   }
 

--- a/packages/clickhouse/src/core/query-node.ts
+++ b/packages/clickhouse/src/core/query-node.ts
@@ -77,7 +77,9 @@ export function createSelectQueryNode<TOutput, TSchema>(
     offset: config.offset,
     distinct: config.distinct,
     orderBy: config.orderBy ? config.orderBy.map(item => ({ ...item })) : undefined,
-    joins: config.joins ? config.joins.map(item => ({ ...item })) : undefined,
+    joins: config.joins
+      ? config.joins.map(item => ({ ...item, on: cloneExprNode(item.on) }))
+      : undefined,
     ctes: config.ctes ? config.ctes.map(item => ({ ...item })) : undefined,
     unionQueries: config.unionQueries ? [...config.unionQueries] : undefined,
     settings: config.settings ? { ...config.settings } : undefined,

--- a/packages/clickhouse/src/core/tests/datasets-backend.test.ts
+++ b/packages/clickhouse/src/core/tests/datasets-backend.test.ts
@@ -4,6 +4,7 @@ import {
   dataset,
   dimension,
   measure,
+  belongsTo,
   eq,
   neq,
   gt,
@@ -877,6 +878,200 @@ describe('ClickHouse Backend - Edge Cases', () => {
 // =============================================================================
 // SQL Generation via explain()
 // =============================================================================
+
+// =============================================================================
+// Relationship Join Fixtures + Tests
+// =============================================================================
+
+const Customers = dataset('customers', {
+  source: 'customers',
+  dimensions: {
+    id: dimension.string(),
+    country: dimension.string({ column: 'country_code' }),
+    tier: dimension.string(),
+  },
+});
+
+const OrdersWithCustomer = dataset('ordersWithCustomer', {
+  source: 'orders',
+  timeKey: 'created_at',
+  dimensions: {
+    id: dimension.string(),
+    status: dimension.string(),
+    amount: dimension.number(),
+    createdAt: dimension.timestamp({ column: 'created_at' }),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+    orderCount: measure.count('id'),
+    completedRevenue: measure.sum('amount', { filters: [eq('status', 'completed')] }),
+  },
+  relationships: {
+    customer: belongsTo(() => Customers, { from: 'customer_id', to: 'id' }),
+  },
+});
+
+const TenantCustomers = dataset('tenantCustomers', {
+  source: 'customers',
+  tenantKey: 'tenant_id',
+  dimensions: {
+    id: dimension.string(),
+    country: dimension.string({ column: 'country_code' }),
+    tenantId: dimension.string({ column: 'tenant_id' }),
+  },
+});
+
+const TenantOrdersWithCustomer = dataset('tenantOrdersWithCustomer', {
+  source: 'orders',
+  tenantKey: 'tenant_id',
+  dimensions: {
+    id: dimension.string(),
+    amount: dimension.number(),
+    tenantId: dimension.string({ column: 'tenant_id' }),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+  },
+  relationships: {
+    customer: belongsTo(() => TenantCustomers, { from: 'customer_id', to: 'id' }),
+  },
+});
+
+describe('ClickHouse Backend - Relationship Joins', () => {
+  it('emits a LEFT JOIN with qualified base columns and quoted joined aliases', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(OrdersWithCustomer, {
+      dimensions: ['status', 'customer.country'],
+      measures: ['revenue'],
+    });
+
+    const sql = queries[0];
+    expect(sql).toContain('LEFT JOIN customers AS customer ON orders.customer_id = customer.id');
+    expect(sql).toContain('orders.status AS status');
+    expect(sql).toContain('customer.country_code AS `customer.country`');
+    expect(sql).toContain('SUM(orders.amount) AS revenue');
+    expect(sql).toContain('GROUP BY status, `customer.country`');
+  });
+
+  it('filters on a joined dimension', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(OrdersWithCustomer, {
+      dimensions: ['status'],
+      measures: ['revenue'],
+      filters: [eq('customer.tier', 'enterprise')],
+    });
+
+    expect(queries[0]).toContain('LEFT JOIN customers AS customer');
+    expect(queries[0]).toContain('customer.tier = ?');
+  });
+
+  it('qualifies base filters with the source when joins are in scope', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(OrdersWithCustomer, {
+      dimensions: ['customer.country'],
+      measures: ['revenue'],
+      filters: [gt('amount', 100)],
+    });
+
+    expect(queries[0]).toContain('orders.amount > ?');
+  });
+
+  it('qualifies filtered-measure conditions across a join', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(OrdersWithCustomer, {
+      dimensions: ['customer.country'],
+      measures: ['completedRevenue'],
+    });
+
+    expect(queries[0]).toContain("SUM(if((orders.status = 'completed'), orders.amount, 0)) AS completedRevenue");
+  });
+
+  it('qualifies the grain field across a join', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+    const revenue = OrdersWithCustomer.metric('revenue', { measure: 'revenue' });
+
+    await analytics.execute(revenue, {
+      dimensions: ['customer.country'],
+      by: 'month',
+    });
+
+    expect(queries[0]).toContain('toStartOfMonth(orders.created_at) AS period');
+    expect(queries[0]).toContain('customer.country_code AS `customer.country`');
+  });
+
+  it('orders by a joined dimension using its quoted alias', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(OrdersWithCustomer, {
+      dimensions: ['customer.country'],
+      measures: ['revenue'],
+      orderBy: [{ field: 'customer.country', direction: 'asc' }],
+    });
+
+    expect(queries[0]).toContain('ORDER BY `customer.country` ASC');
+  });
+
+  it('scopes the joined target by tenant under runtime tenancy', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(
+      TenantOrdersWithCustomer,
+      { dimensions: ['customer.country'], measures: ['revenue'] },
+      { runtime: { tenant: { id: 'tenant_123' } } },
+    );
+
+    const sql = queries[0];
+    expect(sql).toContain('LEFT JOIN customers AS customer ON orders.customer_id = customer.id');
+    expect(sql).toContain('orders.tenant_id = ?');
+    expect(sql).toContain('customer.tenant_id = ?');
+  });
+
+  it('supports derived metrics over a joined dimension', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+    const revenue = OrdersWithCustomer.metric('revenue', { measure: 'revenue' });
+    const orderCount = OrdersWithCustomer.metric('orderCount', { measure: 'orderCount' });
+    const avgOrderValue = OrdersWithCustomer.metric('avgOrderValue', {
+      uses: { rev: revenue, cnt: orderCount },
+      formula: ({ rev, cnt }) => divide(rev, nullIfZero(cnt)),
+    });
+
+    await analytics.execute(avgOrderValue, {
+      dimensions: ['customer.country'],
+    });
+
+    const sql = queries[0];
+    expect(sql).toContain('LEFT JOIN customers AS customer');
+    expect(sql).toContain('customer.country_code AS `customer.country`');
+    // Outer CTE query references the joined column by its quoted alias.
+    expect(sql).toMatch(/SELECT `customer\.country`, .* AS avgOrderValue FROM base/);
+  });
+
+  it('leaves non-join queries unqualified (no regression)', async () => {
+    const { backend, queries } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+
+    await analytics.execute(OrdersWithCustomer, {
+      dimensions: ['status'],
+      measures: ['revenue'],
+    });
+
+    expect(queries[0]).toContain('SELECT status, SUM(amount) AS revenue FROM orders');
+    expect(queries[0]).not.toContain('LEFT JOIN');
+    expect(queries[0]).not.toContain('orders.status');
+  });
+});
 
 describe('ClickHouse Backend - SQL Generation via Explain', () => {
   it('backend supports explain() to generate SQL without execution', async () => {

--- a/packages/clickhouse/src/core/tests/datasets-backend.test.ts
+++ b/packages/clickhouse/src/core/tests/datasets-backend.test.ts
@@ -1032,9 +1032,11 @@ describe('ClickHouse Backend - Relationship Joins', () => {
     );
 
     const sql = queries[0];
-    expect(sql).toContain('LEFT JOIN customers AS customer ON orders.customer_id = customer.id');
+    expect(sql).toContain(
+      'LEFT JOIN customers AS customer ON orders.customer_id = customer.id AND customer.tenant_id = ?',
+    );
     expect(sql).toContain('orders.tenant_id = ?');
-    expect(sql).toContain('customer.tenant_id = ?');
+    expect(sql).not.toContain('WHERE customer.tenant_id = ?');
   });
 
   it('supports derived metrics over a joined dimension', async () => {

--- a/packages/clickhouse/src/core/tests/query-builder.joins.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.joins.test.ts
@@ -29,6 +29,21 @@ describe('QueryBuilder - Joins', () => {
       expect(sql).toBe('SELECT * FROM test_table INNER JOIN users AS u1 ON created_by = u1.id INNER JOIN users AS u2 ON updated_by = u2.id');
     });
 
+    it('should parameterize additional LEFT JOIN conditions', () => {
+      const { sql, parameters } = builder
+        .leftJoin('users', 'created_by', 'users.id', 'user', {
+          column: 'user.status',
+          operator: 'eq',
+          value: 'active',
+        })
+        .toSQLWithParams();
+
+      expect(sql).toBe(
+        'SELECT * FROM test_table LEFT JOIN users AS user ON created_by = user.id AND user.status = ?',
+      );
+      expect(parameters).toEqual(['active']);
+    });
+
     it('should maintain types when joining on same column name', () => {
       const _query = builder
         .select(['id'])

--- a/packages/clickhouse/src/core/utils/query-config-compat.ts
+++ b/packages/clickhouse/src/core/utils/query-config-compat.ts
@@ -46,6 +46,7 @@ export type LegacyQueryConfig<T> = {
     leftColumn: string;
     rightColumn: string;
     alias?: string;
+    on?: ExprNode;
   }>;
   parameters?: any[];
   ctes?: string[];
@@ -201,8 +202,10 @@ export function toLegacyQueryConfig<T, Schema>(
       leftColumn: join.leftColumn,
       rightColumn: join.rightColumn,
       alias: join.alias,
+      on: join.on,
     })),
     parameters: [
+      ...(queryNode.joins?.flatMap(join => collectExprParameters(join.on)) || []),
       ...collectExprParameters(queryNode.prewhere),
       ...collectExprParameters(queryNode.where),
       ...(queryNode.having?.flatMap(item => item.parameters?.map(unwrapValueNode) || []) || []),

--- a/packages/clickhouse/src/datasets.ts
+++ b/packages/clickhouse/src/datasets.ts
@@ -83,13 +83,53 @@ function renderGrain(field: string, unit: keyof typeof GRAIN_FUNCTIONS): string 
 }
 
 /**
+ * Backtick-quotes a ClickHouse identifier, doubling any embedded backticks.
+ */
+function quoteIdentifier(identifier: string): string {
+  return `\`${identifier.replace(/`/g, '``')}\``;
+}
+
+/**
+ * Quotes a name only when it is relationship-qualified (contains a dot), so
+ * joined column aliases like `customer.country` render as `` `customer.country` ``.
+ */
+function quoteQualified(name: string): string {
+  return name.includes('.') ? quoteIdentifier(name) : name;
+}
+
+/** Maps a plan field to its SQL reference. See {@link makeColumnQualifier}. */
+type ColumnQualifier = (field: string) => string;
+
+/**
+ * Builds a column qualifier for an aggregate plan. When the plan has joins,
+ * base columns are table-qualified with the plan source (`orders.status`) while
+ * columns already qualified by a relationship alias (`customer.country`) are
+ * left untouched. Without joins the field passes through unchanged so non-join
+ * SQL is byte-for-byte identical.
+ */
+function makeColumnQualifier(plan: Extract<PlanNode, { kind: 'aggregate' }>): ColumnQualifier {
+  const joins = plan.joins ?? [];
+  if (joins.length === 0) {
+    return (field) => field;
+  }
+  const relationships = new Set(joins.map((join) => join.relationship));
+  return (field) => {
+    const dot = field.indexOf('.');
+    if (dot !== -1 && relationships.has(field.slice(0, dot))) {
+      return field;
+    }
+    return `${plan.source}.${field}`;
+  };
+}
+
+/**
  * Filter Rendering - Applies filters using query builder WHERE clauses
  * This is the preferred method when working with the query builder
  */
-function applyFilters(builder: any, filters: MetricFilter[]): any {
+function applyFilters(builder: any, filters: MetricFilter[], qualify: ColumnQualifier = (field) => field): any {
   let qb = builder;
   for (const filter of filters) {
-    qb = qb.where(filter.field, filter.operator, filter.value);
+    qb = qb.where(qualify(filter.field), filter.operator, filter.value);
   }
   return qb;
 }
@@ -121,8 +161,9 @@ function renderFilterValue(value: unknown): string {
  * Filter Condition Rendering - Converts filter to SQL WHERE clause string
  * Used for filtered aggregations (IF conditions) where query builder can't be used
  */
-function renderFilterCondition(filter: MetricFilter): string {
-  const { field, operator, value } = filter;
+function renderFilterCondition(filter: MetricFilter, qualify: ColumnQualifier = (field) => field): string {
+  const { operator, value } = filter;
+  const field = qualify(filter.field);
 
   switch (operator) {
     case 'eq':
@@ -166,21 +207,23 @@ function renderFilterCondition(filter: MetricFilter): string {
  */
 function renderFilteredAggregationField(
   aggregation: Extract<PlanNode, { kind: 'aggregate' }>['aggregations'][number],
+  qualify: ColumnQualifier = (field) => field,
 ): string {
+  const field = qualify(aggregation.field);
   if (!aggregation.filters?.length) {
-    return aggregation.field;
+    return field;
   }
 
   // Combine multiple filters with AND
   const condition = aggregation.filters
-    .map(renderFilterCondition)
+    .map((filter) => renderFilterCondition(filter, qualify))
     .map((part) => `(${part})`)
     .join(' AND ');
 
   // Use appropriate fallback: 0 for SUM, NULL for others
   const fallback = aggregation.aggregation === 'sum' ? '0' : 'NULL';
 
-  return `if(${condition}, ${aggregation.field}, ${fallback})`;
+  return `if(${condition}, ${field}, ${fallback})`;
 }
 
 /**
@@ -246,11 +289,15 @@ function renderExpression(expression: SemanticExpression): string {
  * Apply Aggregations
  * Translates semantic aggregations to query builder method calls
  */
-function applyAggregations(builder: any, plan: Extract<PlanNode, { kind: 'aggregate' }>): any {
+function applyAggregations(
+  builder: any,
+  plan: Extract<PlanNode, { kind: 'aggregate' }>,
+  qualify: ColumnQualifier = (field) => field,
+): any {
   let qb = builder;
 
   for (const aggregation of plan.aggregations) {
-    const field = renderFilteredAggregationField(aggregation);
+    const field = renderFilteredAggregationField(aggregation, qualify);
     const { name, aggregation: aggType } = aggregation;
 
     switch (aggType) {
@@ -285,9 +332,9 @@ function applyAggregations(builder: any, plan: Extract<PlanNode, { kind: 'aggreg
 function appendOrderLimitOffset(builder: any, plan: Pick<PlanNode, 'orderBy' | 'limit' | 'offset'>): any {
   let qb = builder;
 
-  // Order by
+  // Order by (qualified fields reference their quoted joined alias)
   for (const order of plan.orderBy ?? []) {
-    qb = qb.orderBy(order.field, order.direction.toUpperCase());
+    qb = qb.orderBy(quoteQualified(order.field), order.direction.toUpperCase());
   }
 
   // Pagination
@@ -307,6 +354,23 @@ function appendOrderLimitOffset(builder: any, plan: Pick<PlanNode, 'orderBy' | '
  */
 function buildAggregateQuery(queryBuilder: any, plan: Extract<PlanNode, { kind: 'aggregate' }>): any {
   let qb = queryBuilder.table(plan.source);
+  const qualify = makeColumnQualifier(plan);
+  const hasJoins = (plan.joins?.length ?? 0) > 0;
+
+  // Relationship LEFT JOINs (to-one). Base rows survive; joined columns are
+  // addressable as `<relationship>.<column>`.
+  for (const join of plan.joins ?? []) {
+    qb = qb.leftJoin(
+      join.source,
+      `${plan.source}.${join.from}`,
+      `${join.source}.${join.to}`,
+      join.relationship,
+    );
+    // Defense in depth: scope the joined target by tenant when active.
+    if (join.tenant) {
+      qb = qb.where(`${join.relationship}.${join.tenant.field}`, join.tenant.operator, join.tenant.value);
+    }
+  }
 
   // Build SELECT and GROUP BY for dimensions
   const selectParts: string[] = [];
@@ -314,18 +378,25 @@ function buildAggregateQuery(queryBuilder: any, plan: Extract<PlanNode, { kind: 
 
   // Time grain (period column)
   if (plan.grain) {
-    const grainSql = renderGrain(plan.grain.field, plan.grain.unit);
+    const grainSql = renderGrain(qualify(plan.grain.field), plan.grain.unit);
     selectParts.push(`${grainSql} AS ${plan.grain.output}`);
     groupByParts.push(plan.grain.output);
   }
 
-  // Dimensions
+  // Dimensions. With joins in scope every selection is qualified and aliased so
+  // grouping can reference the (quoted) alias unambiguously.
   for (const dimension of plan.dimensions) {
-    const columnSql = dimension.field === dimension.name
-      ? dimension.name
-      : `${dimension.field} AS ${dimension.name}`;
-    selectParts.push(columnSql);
-    groupByParts.push(dimension.name);
+    if (hasJoins) {
+      const alias = quoteQualified(dimension.name);
+      selectParts.push(`${qualify(dimension.field)} AS ${alias}`);
+      groupByParts.push(alias);
+    } else {
+      const columnSql = dimension.field === dimension.name
+        ? dimension.name
+        : `${dimension.field} AS ${dimension.name}`;
+      selectParts.push(columnSql);
+      groupByParts.push(dimension.name);
+    }
   }
 
   // Apply SELECT clause
@@ -333,21 +404,24 @@ function buildAggregateQuery(queryBuilder: any, plan: Extract<PlanNode, { kind: 
     qb = qb.select(selectParts);
   }
 
-  // Apply aggregations (measures)
-  qb = applyAggregations(qb, plan);
-
-  // Apply GROUP BY
+  // Apply GROUP BY before aggregations so the builder does not auto-infer it
+  // from the SELECT list. Inference re-derives group keys from the selection
+  // strings and cannot parse quoted, dotted joined aliases; setting it
+  // explicitly first keeps `GROUP BY status, \`customer.country\`` correct.
   if (groupByParts.length > 0) {
     qb = qb.groupBy(groupByParts);
   }
 
+  // Apply aggregations (measures)
+  qb = applyAggregations(qb, plan, qualify);
+
   // Apply tenant filter (auto-injected)
   if (plan.tenant) {
-    qb = qb.where(plan.tenant.field, plan.tenant.operator, plan.tenant.value);
+    qb = qb.where(qualify(plan.tenant.field), plan.tenant.operator, plan.tenant.value);
   }
 
   // Apply user filters
-  qb = applyFilters(qb, plan.filters);
+  qb = applyFilters(qb, plan.filters, qualify);
 
   // Apply order/limit/offset
   return appendOrderLimitOffset(qb, plan);
@@ -369,10 +443,11 @@ function buildDerivedSQL(queryBuilder: any, plan: Extract<PlanNode, { kind: 'der
   const inputQuery = buildAggregateQuery(queryBuilder, plan.input);
   const { sql, parameters } = inputQuery.toSQLWithParams();
 
-  // Passthrough columns (grain + dimensions)
+  // Passthrough columns (grain + dimensions). Joined dimensions surface from
+  // the CTE under their quoted qualified alias.
   const passthrough = [
     ...(plan.input.grain ? [plan.input.grain.output] : []),
-    ...plan.input.dimensions.map((dim) => dim.name),
+    ...plan.input.dimensions.map((dim) => quoteQualified(dim.name)),
   ];
 
   // Derived metric calculations
@@ -387,7 +462,7 @@ function buildDerivedSQL(queryBuilder: any, plan: Extract<PlanNode, { kind: 'der
   // ORDER BY
   if (plan.orderBy?.length) {
     const orderClauses = plan.orderBy.map(
-      (order) => `${order.field} ${order.direction.toUpperCase()}`
+      (order) => `${quoteQualified(order.field)} ${order.direction.toUpperCase()}`
     );
     outerSql += ` ORDER BY ${orderClauses.join(', ')}`;
   }

--- a/packages/clickhouse/src/datasets.ts
+++ b/packages/clickhouse/src/datasets.ts
@@ -365,11 +365,14 @@ function buildAggregateQuery(queryBuilder: any, plan: Extract<PlanNode, { kind: 
       `${plan.source}.${join.from}`,
       `${join.source}.${join.to}`,
       join.relationship,
+      join.tenant
+        ? {
+          column: `${join.relationship}.${join.tenant.field}`,
+          operator: join.tenant.operator,
+          value: join.tenant.value,
+        }
+        : undefined,
     );
-    // Defense in depth: scope the joined target by tenant when active.
-    if (join.tenant) {
-      qb = qb.where(`${join.relationship}.${join.tenant.field}`, join.tenant.operator, join.tenant.value);
-    }
   }
 
   // Build SELECT and GROUP BY for dimensions

--- a/packages/clickhouse/src/types/base.ts
+++ b/packages/clickhouse/src/types/base.ts
@@ -112,6 +112,12 @@ export interface HavingNode {
 
 export type JoinType = 'INNER' | 'LEFT' | 'RIGHT' | 'FULL';
 
+export interface JoinConditionInput {
+  column: string;
+  operator: FilterOperator;
+  value: unknown;
+}
+
 export interface JoinNode {
   kind: 'join';
   type: JoinType;
@@ -120,6 +126,7 @@ export interface JoinNode {
   leftSource?: string;
   rightColumn: string;
   alias?: string;
+  on?: ExprNode;
 }
 
 export interface OrderByItemNode {

--- a/packages/datasets/src/query-builder-protocol.ts
+++ b/packages/datasets/src/query-builder-protocol.ts
@@ -30,6 +30,7 @@ export interface QueryBuilderLike {
     leftColumn: string,
     rightColumn: string,
     alias?: string,
+    on?: QueryBuilderJoinCondition | QueryBuilderJoinCondition[],
   ): QueryBuilderLike;
 
   // Grouping
@@ -43,6 +44,12 @@ export interface QueryBuilderLike {
   // Terminal operations
   toSQLWithParams(): { sql: string; parameters: unknown[] };
   execute<T = Record<string, unknown>>(): Promise<T[]>;
+}
+
+export interface QueryBuilderJoinCondition {
+  column: string;
+  operator: string;
+  value: unknown;
 }
 
 /** A query builder factory (what `createQueryBuilder(config)` returns). */

--- a/packages/datasets/src/relationships-query.test.ts
+++ b/packages/datasets/src/relationships-query.test.ts
@@ -147,9 +147,13 @@ function createJoinMockBuilderFactory(): QueryBuilderFactoryLike {
         state.where.push(`${column} ${op} ?`);
         return builder;
       },
-      leftJoin: (joinTable, leftColumn, rightColumn, alias) => {
+      leftJoin: (joinTable, leftColumn, rightColumn, alias, on) => {
         const tableClause = alias ? `${joinTable} AS ${alias}` : joinTable;
-        state.joins.push(`LEFT JOIN ${tableClause} ON ${leftColumn} = ${rightColumn}`);
+        const conditions = on ? (Array.isArray(on) ? on : [on]) : [];
+        const extra = conditions
+          .map(condition => ` AND ${condition.column} ${condition.operator === 'eq' ? '=' : condition.operator} ?`)
+          .join('');
+        state.joins.push(`LEFT JOIN ${tableClause} ON ${leftColumn} = ${rightColumn}${extra}`);
         return builder;
       },
       groupBy: (args) => {
@@ -448,9 +452,11 @@ describe('relationship joins on the query-builder path', () => {
       { dimensions: ['customer.country'], measures: ['revenue'] },
       context,
     );
-    expect(sql).toContain('LEFT JOIN tenant_customers AS customer ON tenant_orders.customer_id = customer.id');
+    expect(sql).toContain(
+      'LEFT JOIN tenant_customers AS customer ON tenant_orders.customer_id = customer.id AND customer.tenant_id = ?',
+    );
     expect(sql).toContain('tenant_orders.tenant_id = ?');
-    expect(sql).toContain('customer.tenant_id = ?');
+    expect(sql).not.toContain('WHERE customer.tenant_id = ?');
   });
 
   it('leaves non-join queries unqualified (no regression)', () => {

--- a/packages/datasets/src/tests/integration/clickhouse-backend.test.ts
+++ b/packages/datasets/src/tests/integration/clickhouse-backend.test.ts
@@ -260,14 +260,17 @@ describe('datasets ClickHouse integration', () => {
       { runtime: { tenant: { id: 'active' } } },
     );
 
-    // Only active users survive the join; bob_jones (inactive) must not leak.
+    // The inactive user must not leak, but its base order must survive the LEFT JOIN.
     const revenueByUser = new Map(
       result.data.map((row) => [row['user.userName'], row.revenue]),
     );
     expect(revenueByUser.get('jane_smith')).toBe(92.25);
     expect(revenueByUser.get('john_doe')).toBe(36);
     expect(revenueByUser.has('bob_jones')).toBe(false);
-    expect(result.meta?.sql).toContain('LEFT JOIN users AS user ON orders.user_id = user.id');
-    expect(result.meta?.sql).toContain('user.status = ?');
+    expect(result.data.reduce((total, row) => total + Number(row.revenue), 0)).toBe(144.75);
+    expect(result.meta?.sql).toContain(
+      'LEFT JOIN users AS user ON orders.user_id = user.id AND user.status = ?',
+    );
+    expect(result.meta?.sql).not.toContain('WHERE user.status = ?');
   });
 });

--- a/packages/datasets/src/tests/integration/clickhouse-backend.test.ts
+++ b/packages/datasets/src/tests/integration/clickhouse-backend.test.ts
@@ -6,6 +6,7 @@ import { dataset } from '../../dataset.js';
 import { dimension } from '../../field.js';
 import { divide, nullIfZero, round } from '../../formulas.js';
 import { measure } from '../../measure.js';
+import { belongsTo } from '../../relationships.js';
 import { eq, gt } from '../../query-helpers.js';
 import {
   TEST_CONNECTION_CONFIG,
@@ -44,6 +45,51 @@ const TenantOrders = dataset('tenantOrders', {
   measures: {
     revenue: measure.sum('total'),
     orderCount: measure.count('id'),
+  },
+});
+
+const Users = dataset('users', {
+  source: 'users',
+  dimensions: {
+    id: dimension.number(),
+    userName: dimension.string({ column: 'user_name' }),
+    email: dimension.string(),
+    status: dimension.string(),
+  },
+});
+
+const OrdersWithUser = dataset('ordersWithUser', {
+  source: 'orders',
+  timeKey: 'created_at',
+  dimensions: Orders.dimensions,
+  measures: {
+    revenue: measure.sum('total'),
+    orderCount: measure.count('id'),
+  },
+  relationships: {
+    user: belongsTo(() => Users, { from: 'user_id', to: 'id' }),
+  },
+});
+
+// Target dataset with a tenantKey, to exercise defense-in-depth join scoping.
+const TenantUsers = dataset('tenantUsers', {
+  source: 'users',
+  tenantKey: 'status',
+  dimensions: {
+    id: dimension.number(),
+    userName: dimension.string({ column: 'user_name' }),
+    status: dimension.string(),
+  },
+});
+
+const OrdersWithTenantUser = dataset('ordersWithTenantUser', {
+  source: 'orders',
+  dimensions: Orders.dimensions,
+  measures: {
+    revenue: measure.sum('total'),
+  },
+  relationships: {
+    user: belongsTo(() => TenantUsers, { from: 'user_id', to: 'id' }),
   },
 });
 
@@ -161,5 +207,67 @@ describe('datasets ClickHouse integration', () => {
       tenant: 'completed',
     });
     expect(result.meta?.sql).toContain('WHERE status = ?');
+  });
+
+  it('groups a base measure by a to-one joined dimension', async () => {
+    const analytics = createClient();
+
+    const result = await analytics.execute(OrdersWithUser, {
+      dimensions: ['user.userName'],
+      measures: ['revenue'],
+      orderBy: [{ field: 'revenue', direction: 'desc' }],
+    });
+
+    // Every order maps to a user, so no LEFT JOIN misses here.
+    expect(result.data).toEqual([
+      { 'user.userName': 'jane_smith', revenue: 92.25 },
+      { 'user.userName': 'john_doe', revenue: 36 },
+      { 'user.userName': 'bob_jones', revenue: 16.5 },
+    ]);
+    expect(result.meta?.sql).toContain('LEFT JOIN users AS user ON orders.user_id = user.id');
+    expect(result.meta?.sql).toContain('user.user_name AS `user.userName`');
+    expect(result.meta?.sql).toContain('SUM(orders.total) AS revenue');
+  });
+
+  it('filters a base measure by a joined dimension', async () => {
+    const analytics = createClient();
+
+    const result = await analytics.execute(OrdersWithUser, {
+      dimensions: ['status'],
+      measures: ['revenue'],
+      filters: [eq('user.status', 'active')],
+      orderBy: [{ field: 'revenue', direction: 'desc' }],
+    });
+
+    // Active users (john_doe, jane_smith) own orders 1-4; bob_jones' order is excluded.
+    expect(result.data).toEqual([
+      { status: 'completed', revenue: 66 },
+      { status: 'pending', revenue: 62.25 },
+    ]);
+    expect(result.meta?.sql).toContain('user.status = ?');
+  });
+
+  it('scopes the joined target by tenant (defense in depth)', async () => {
+    const analytics = createClient();
+
+    const result = await analytics.execute(
+      OrdersWithTenantUser,
+      {
+        dimensions: ['user.userName'],
+        measures: ['revenue'],
+        orderBy: [{ field: 'revenue', direction: 'desc' }],
+      },
+      { runtime: { tenant: { id: 'active' } } },
+    );
+
+    // Only active users survive the join; bob_jones (inactive) must not leak.
+    const revenueByUser = new Map(
+      result.data.map((row) => [row['user.userName'], row.revenue]),
+    );
+    expect(revenueByUser.get('jane_smith')).toBe(92.25);
+    expect(revenueByUser.get('john_doe')).toBe(36);
+    expect(revenueByUser.has('bob_jones')).toBe(false);
+    expect(result.meta?.sql).toContain('LEFT JOIN users AS user ON orders.user_id = user.id');
+    expect(result.meta?.sql).toContain('user.status = ?');
   });
 });

--- a/packages/datasets/src/utils/relationship-builder-plan.ts
+++ b/packages/datasets/src/utils/relationship-builder-plan.ts
@@ -132,22 +132,14 @@ export function applyRelationshipJoins(
       `${ctx.baseSource}.${join.from}`,
       `${join.relationship}.${join.to}`,
       join.relationship,
+      join.tenant
+        ? {
+          column: `${join.relationship}.${join.tenant.field}`,
+          operator: join.tenant.operator,
+          value: join.tenant.value,
+        }
+        : undefined,
     );
-    if (join.tenant) {
-      // NOTE: applying the tenant predicate in WHERE (rather than the JOIN ON
-      // clause) turns this LEFT JOIN into an effective INNER JOIN — base rows
-      // whose FK matches a different tenant, or no target at all, are dropped
-      // instead of surviving with undefined joined columns (as the in-memory
-      // backend does). Correct LEFT semantics require an ON-clause predicate,
-      // which needs `leftJoin` to carry extra conditions; that lands with the
-      // @hypequery/clickhouse join changes in PR 2. Until then this over-filters
-      // (safe: it never leaks cross-tenant rows).
-      qb = qb.where(
-        `${join.relationship}.${join.tenant.field}`,
-        join.tenant.operator,
-        join.tenant.value,
-      );
-    }
   }
   return qb;
 }

--- a/plans/relationship-aware-semantics-design.md
+++ b/plans/relationship-aware-semantics-design.md
@@ -11,10 +11,13 @@ Status: PR 1 landed 2026-07-06 (resolves "Next Work #4" in `datasets-semantic-la
   `packages/datasets/src/relationships-query.test.ts`; full datasets/serve/mcp
   suites green. `PlanNode.joins` was pulled forward from PR 2 because the
   in-memory backend consumes it.
-- **PR 2 — TODO.** `@hypequery/clickhouse` `createBackend` translation of
-  `PlanNode.joins` (base columns qualified with `source`, joined with the
-  relationship alias) + live ClickHouse integration specs for joined base,
-  derived, grouped, grained, filtered, and tenant-scoped queries.
+- **PR 2 — DONE (2026-07-06).** `@hypequery/clickhouse` `createBackend`
+  translates `PlanNode.joins` into LEFT JOINs (base columns qualified with
+  `source`, joined columns kept relationship-qualified and aliased to their
+  quoted qualified name). GROUP BY is applied before aggregations to bypass the
+  builder's alias-inference, which cannot parse quoted dotted aliases. 9 backend
+  SQL tests (mock adapter) + 3 live ClickHouse integration cases (joined
+  group-by, joined filter, joined tenant scoping).
 - **PR 3 — TODO.** Catalog/contract `queryable` + `fields`, serve
   `semantic-input-schema` enums, React field-name types, docs page.
 


### PR DESCRIPTION
## Summary

**PR 2** of relationship-aware semantics ([design](plans/relationship-aware-semantics-design.md)). Stacked on #258 — base is `claude/eloquent-panini-4842a0`, so review after PR 1.

PR 1 made to-one relationships executable through validation, planning, the in-memory backend, and the query-builder path. This PR completes the **semantic-backend** path: `@hypequery/clickhouse`'s `createBackend` now translates `PlanNode.joins` into real ClickHouse LEFT JOIN SQL.

## What changed (`packages/clickhouse/src/datasets.ts`)

- `buildAggregateQuery` emits `leftJoin` per `plan.joins`, aliasing the target with the relationship name. Base columns are table-qualified with the plan source (`orders.status`); joined columns keep their relationship-qualified form (`customer.country_code`) and are aliased to their backtick-quoted qualified name (``AS `customer.country` ``).
- **GROUP BY is applied before aggregations.** The builder auto-infers GROUP BY from the SELECT list when it's unset, and its alias-extraction regex can't parse a quoted, dotted alias — so it would emit the full `expr AS alias` string as a group key. Setting GROUP BY explicitly first bypasses inference. Non-join SQL is byte-for-byte unchanged.
- Filters, filtered-measure `if(...)` conditions, the grain field, tenant predicates, and derived-CTE passthrough/orderBy all qualify and quote consistently.
- Joined targets that declare a `tenantKey` are scoped with the runtime tenant predicate (defense in depth).

## Testing

- **9 new backend SQL tests** in `datasets-backend.test.ts` via the mock adapter (CI-runnable, no live DB): LEFT JOIN shape, qualified base columns, quoted joined aliases, joined filter, base-filter qualification, filtered-measure qualification, grain qualification, joined orderBy, joined tenant scoping, and a no-regression check.
- **3 live ClickHouse integration cases** in `clickhouse-backend.test.ts` (joined group-by, joined filter, joined tenant scoping) against the seeded `users`/`orders` tables.
- Full clickhouse suite green (509 unit + 9 new); datasets type tests green; lint clean.

## Caveats

- The **live integration cases were written from the seed data but not executed locally** (no Docker in the authoring environment) — they run in CI with the ClickHouse harness. The GROUP BY inference bug was caught by the real builder in the mock-adapter tests, which exercise the actual query-builder SQL generation.
- Serve HTTP enums (PR 3) still reject qualified fields; this PR is backend/library execution only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)