### PR TITLE
Feat/relationship aware semantics metadata

### DIFF
--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -971,6 +971,26 @@ export class QueryBuilder<
     return this.applyJoin('LEFT', table, leftColumn, rightColumn, alias, on);
   }
 
+  /**
+   * ClickHouse `LEFT ANY JOIN`: like `leftJoin`, but takes at most one matching
+   * right-side row per left row, so duplicate join keys never fan out the
+   * result. Used by the semantic layer for to-one relationship traversal.
+   */
+  leftAnyJoin<TableName extends Extract<keyof Schema, string>, Alias extends string | undefined = undefined>(
+    table: TableName,
+    leftColumn: keyof BaseRow<State>,
+    rightColumn: `${TableName & string}.${keyof Schema[TableName] & string}`,
+    alias?: Alias,
+    on?: JoinConditionInput | JoinConditionInput[],
+  ): QueryBuilder<
+    Schema,
+    Alias extends string
+    ? AddAlias<WidenTables<State, TableName>, Alias, TableName>
+    : WidenTables<State, TableName>
+  > {
+    return this.applyJoin('LEFT ANY', table, leftColumn, rightColumn, alias, on);
+  }
+
   rightJoin<TableName extends Extract<keyof Schema, string>, Alias extends string | undefined = undefined>(
     table: TableName,
     leftColumn: keyof BaseRow<State>,

--- a/packages/clickhouse/src/core/tests/datasets-backend.test.ts
+++ b/packages/clickhouse/src/core/tests/datasets-backend.test.ts
@@ -938,7 +938,7 @@ const TenantOrdersWithCustomer = dataset('tenantOrdersWithCustomer', {
 });
 
 describe('ClickHouse Backend - Relationship Joins', () => {
-  it('emits a LEFT JOIN with qualified base columns and quoted joined aliases', async () => {
+  it('emits a LEFT ANY JOIN with qualified base columns and quoted joined aliases', async () => {
     const { backend, queries } = createTestBackend([]);
     const analytics = createDatasetClient({ backend });
 
@@ -948,7 +948,7 @@ describe('ClickHouse Backend - Relationship Joins', () => {
     });
 
     const sql = queries[0];
-    expect(sql).toContain('LEFT JOIN customers AS customer ON orders.customer_id = customer.id');
+    expect(sql).toContain('LEFT ANY JOIN customers AS customer ON orders.customer_id = customer.id');
     expect(sql).toContain('orders.status AS status');
     expect(sql).toContain('customer.country_code AS `customer.country`');
     expect(sql).toContain('SUM(orders.amount) AS revenue');
@@ -965,7 +965,7 @@ describe('ClickHouse Backend - Relationship Joins', () => {
       filters: [eq('customer.tier', 'enterprise')],
     });
 
-    expect(queries[0]).toContain('LEFT JOIN customers AS customer');
+    expect(queries[0]).toContain('LEFT ANY JOIN customers AS customer');
     expect(queries[0]).toContain('customer.tier = ?');
   });
 
@@ -1033,7 +1033,7 @@ describe('ClickHouse Backend - Relationship Joins', () => {
 
     const sql = queries[0];
     expect(sql).toContain(
-      'LEFT JOIN customers AS customer ON orders.customer_id = customer.id AND customer.tenant_id = ?',
+      'LEFT ANY JOIN customers AS customer ON orders.customer_id = customer.id AND customer.tenant_id = ?',
     );
     expect(sql).toContain('orders.tenant_id = ?');
     expect(sql).not.toContain('WHERE customer.tenant_id = ?');
@@ -1054,7 +1054,7 @@ describe('ClickHouse Backend - Relationship Joins', () => {
     });
 
     const sql = queries[0];
-    expect(sql).toContain('LEFT JOIN customers AS customer');
+    expect(sql).toContain('LEFT ANY JOIN customers AS customer');
     expect(sql).toContain('customer.country_code AS `customer.country`');
     // Outer CTE query references the joined column by its quoted alias.
     expect(sql).toMatch(/SELECT `customer\.country`, .* AS avgOrderValue FROM base/);

--- a/packages/clickhouse/src/core/tests/query-builder.joins.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.joins.test.ts
@@ -128,6 +128,18 @@ describe('QueryBuilder - Joins', () => {
       expect(sql).toBe('SELECT * FROM test_table LEFT JOIN users ON created_by = users.id');
     });
 
+    it('should support LEFT ANY JOIN', () => {
+      const sql = builder
+        .leftAnyJoin(
+          'users',
+          'created_by',
+          'users.id',
+          'user'
+        )
+        .toSQL();
+      expect(sql).toBe('SELECT * FROM test_table LEFT ANY JOIN users AS user ON created_by = user.id');
+    });
+
     it('should support RIGHT JOIN', () => {
       const sql = builder
         .rightJoin(

--- a/packages/clickhouse/src/datasets.ts
+++ b/packages/clickhouse/src/datasets.ts
@@ -70,8 +70,9 @@ function renderLiteral(value: string | number | boolean | null): string {
   if (value === null) return 'NULL';
   if (typeof value === 'number') return String(value);
   if (typeof value === 'boolean') return value ? '1' : '0';
-  // SQL string escaping: single quotes are escaped by doubling them
-  return `'${String(value).replace(/'/g, "''")}'`;
+  // SQL string escaping: backslashes first (ClickHouse treats `\` as an escape
+  // inside string literals), then single quotes doubled.
+  return `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "''")}'`;
 }
 
 /**
@@ -357,10 +358,12 @@ function buildAggregateQuery(queryBuilder: any, plan: Extract<PlanNode, { kind: 
   const qualify = makeColumnQualifier(plan);
   const hasJoins = (plan.joins?.length ?? 0) > 0;
 
-  // Relationship LEFT JOINs (to-one). Base rows survive; joined columns are
+  // Relationship LEFT ANY JOINs (to-one). Base rows survive and at most one
+  // target row matches, so duplicate join keys can never fan out aggregates —
+  // matching the in-memory backend's first-match semantics. Joined columns are
   // addressable as `<relationship>.<column>`.
   for (const join of plan.joins ?? []) {
-    qb = qb.leftJoin(
+    qb = qb.leftAnyJoin(
       join.source,
       `${plan.source}.${join.from}`,
       `${join.source}.${join.to}`,

--- a/packages/clickhouse/src/datasets.ts
+++ b/packages/clickhouse/src/datasets.ts
@@ -25,16 +25,10 @@
  * const analytics = createDatasetClient({ queryBuilder: db });
  * ```
  *
- * Advanced: `createBackend` exposes the database-agnostic SemanticBackend
- * protocol directly. Reach for it when you want a standalone backend instance
- * rather than sharing a query builder.
- * ```ts
- * import { createBackend } from '@hypequery/clickhouse/datasets';
- *
- * const analytics = createDatasetClient({
- *   backend: createBackend({ url, username, password, database }),
- * });
- * ```
+ * Deprecated: `createBackend` exposes the database-agnostic SemanticBackend
+ * protocol directly. That plan/backend path is FROZEN — it receives bug fixes
+ * only, and new semantic features are not guaranteed to be mirrored there.
+ * Use the query-builder path above instead.
  */
 
 import {
@@ -48,6 +42,7 @@ import { createQueryBuilder } from './core/query-builder.js';
 import type { CreateQueryBuilderConfig } from './core/query-builder.js';
 import type { SchemaDefinition } from './core/types/builder-state.js';
 
+/** @deprecated The plan/backend path is frozen; use `createQueryBuilder` with `createDatasetClient({ queryBuilder })`. */
 export type CreateBackendConfig = CreateQueryBuilderConfig;
 
 // =============================================================================
@@ -493,6 +488,10 @@ function buildDerivedSQL(queryBuilder: any, plan: Extract<PlanNode, { kind: 'der
  *
  * Creates a SemanticBackend implementation that translates database-agnostic
  * semantic plans into ClickHouse SQL and executes them.
+ *
+ * @deprecated The plan/backend execution path is frozen (bug fixes only) and
+ * will not gain new features. Share a query builder instead:
+ * `createDatasetClient({ queryBuilder: createQueryBuilder(config) })`.
  *
  * @param config - ClickHouse connection configuration
  * @returns SemanticBackend interface for executing semantic queries

--- a/packages/clickhouse/src/types/base.ts
+++ b/packages/clickhouse/src/types/base.ts
@@ -110,7 +110,7 @@ export interface HavingNode {
   parameters?: ValueNode[];
 }
 
-export type JoinType = 'INNER' | 'LEFT' | 'RIGHT' | 'FULL';
+export type JoinType = 'INNER' | 'LEFT' | 'LEFT ANY' | 'RIGHT' | 'FULL';
 
 export interface JoinConditionInput {
   column: string;

--- a/packages/datasets/src/catalog.test.ts
+++ b/packages/datasets/src/catalog.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { dataset } from './dataset.js';
 import { dimension } from './field.js';
 import { measure } from './measure.js';
-import { belongsTo } from './relationships.js';
+import { belongsTo, hasMany } from './relationships.js';
 import { getDatasetCatalog, getDatasetCatalogs } from './catalog.js';
 
 describe('dataset catalog', () => {
@@ -62,7 +62,18 @@ describe('dataset catalog', () => {
       limits: { maxMeasures: 2 },
       requiresTenant: true,
       supportedGrains: ['day', 'week', 'month', 'quarter', 'year'],
-      orderableFields: ['id', 'customerId', 'status', 'createdAt', 'amount', 'revenue', 'orderCount', 'period'],
+      orderableFields: [
+        'id',
+        'customerId',
+        'status',
+        'createdAt',
+        'amount',
+        'revenue',
+        'orderCount',
+        'customer.id',
+        'customer.country',
+        'period',
+      ],
     });
     expect(catalog.dimensions.status).toMatchObject({
       type: 'string',
@@ -91,7 +102,8 @@ describe('dataset catalog', () => {
       target: 'customers',
       from: 'customerId',
       to: 'id',
-      execution: 'metadata_only',
+      queryable: true,
+      fields: ['customer.id', 'customer.country'],
     });
   });
 
@@ -118,5 +130,28 @@ describe('dataset catalog', () => {
 
     expect(Object.keys(catalogs)).toEqual(['orders', 'customers']);
     expect(catalogs.customers.source).toBe('customers');
+  });
+
+  it('keeps hasMany relationships metadata-only', () => {
+    const LineItems = dataset('line_items', {
+      source: 'line_items',
+      dimensions: {
+        id: dimension.string(),
+        sku: dimension.string(),
+      },
+    });
+    const catalog = getDatasetCatalog(dataset('orders_with_items', {
+      source: 'orders',
+      dimensions: { id: dimension.string() },
+      relationships: {
+        items: hasMany(() => LineItems, { from: 'id', to: 'order_id' }),
+      },
+    }));
+
+    expect(catalog.relationships.items).toMatchObject({
+      queryable: false,
+      fields: [],
+    });
+    expect(catalog.orderableFields).not.toContain('items.sku');
   });
 });

--- a/packages/datasets/src/catalog.ts
+++ b/packages/datasets/src/catalog.ts
@@ -56,7 +56,8 @@ export interface RelationshipCatalogEntry {
   target: string;
   from: string;
   to: string;
-  execution: 'metadata_only';
+  queryable: boolean;
+  fields: string[];
 }
 
 export interface DatasetCatalog {
@@ -134,13 +135,25 @@ function metricToCatalog(metric: MetricHandle): MetricCatalogEntry {
   };
 }
 
-function relationshipToCatalog(relationship: RelationshipDefinition): RelationshipCatalogEntry {
+function relationshipToCatalog(
+  name: string,
+  relationship: RelationshipDefinition,
+): RelationshipCatalogEntry {
+  const queryable = relationship.kind !== 'hasMany';
+  const target = relationship.target() as Partial<AnyDatasetInstance> & { name: string };
+  const fields = queryable
+    ? Object.entries(target.dimensions ?? {})
+        .filter(([, dimension]) => dimension.sql === undefined)
+        .map(([field]) => `${name}.${field}`)
+    : [];
+
   return {
     kind: relationship.kind,
-    target: relationship.target().name,
+    target: target.name,
     from: relationship.from,
     to: relationship.to,
-    execution: 'metadata_only',
+    queryable,
+    fields,
   };
 }
 
@@ -150,6 +163,12 @@ export function getDatasetCatalog(dataset: DatasetCatalogSource): DatasetCatalog
   const metricNames = Object.keys(dataset.metrics ?? {});
   const supportedGrains = dataset.timeKey ? [...SUPPORTED_TIME_GRAINS] : [];
   const maxLimit = dataset.limits?.maxResultSize;
+  const relationships = Object.fromEntries(
+    Object.entries(dataset.relationships).map(([name, relationship]) => [
+      name,
+      relationshipToCatalog(name, relationship),
+    ]),
+  );
 
   return {
     name: dataset.name,
@@ -180,12 +199,7 @@ export function getDatasetCatalog(dataset: DatasetCatalogSource): DatasetCatalog
         filterToCatalog(filter, dataset.dimensions),
       ]),
     ),
-    relationships: Object.fromEntries(
-      Object.entries(dataset.relationships).map(([name, relationship]) => [
-        name,
-        relationshipToCatalog(relationship),
-      ]),
-    ),
+    relationships,
     limits: dataset.limits,
     requiresTenant: !!dataset.tenantKey,
     supportedGrains,
@@ -193,6 +207,7 @@ export function getDatasetCatalog(dataset: DatasetCatalogSource): DatasetCatalog
       ...dimensionNames,
       ...measureNames,
       ...metricNames,
+      ...Object.values(relationships).flatMap(relationship => relationship.fields),
       ...(dataset.timeKey ? ['period'] : []),
     ],
     maxLimit,

--- a/packages/datasets/src/catalog.ts
+++ b/packages/datasets/src/catalog.ts
@@ -9,6 +9,7 @@ import type {
   TimeGrain,
 } from './types.js';
 import { SEMANTIC_FILTER_OPERATORS, SUPPORTED_TIME_GRAINS } from './constants.js';
+import { listQueryableRelationshipFields } from './utils/relationship-fields.js';
 
 export interface DimensionCatalogEntry {
   type: DimensionDefinition['fieldType'];
@@ -139,22 +140,21 @@ function relationshipToCatalog(
   name: string,
   relationship: RelationshipDefinition,
 ): RelationshipCatalogEntry {
-  const queryable = relationship.kind !== 'hasMany';
-  const target = relationship.target() as Partial<AnyDatasetInstance> & { name: string };
-  const fields = queryable
-    ? Object.entries(target.dimensions ?? {})
-        .filter(([, dimension]) => dimension.sql === undefined)
-        .map(([field]) => `${name}.${field}`)
-    : [];
-
   return {
     kind: relationship.kind,
-    target: target.name,
+    target: relationship.target().name,
     from: relationship.from,
     to: relationship.to,
-    queryable,
-    fields,
+    queryable: relationship.kind !== 'hasMany',
+    fields: listQueryableRelationshipFields(name, relationship),
   };
+}
+
+/** All queryable relationship field names (`<relationship>.<dimension>`) a catalog advertises. */
+export function getQueryableRelationshipFields(catalog: DatasetCatalog): string[] {
+  return Object.values(catalog.relationships)
+    .filter(relationship => relationship.queryable)
+    .flatMap(relationship => relationship.fields);
 }
 
 export function getDatasetCatalog(dataset: DatasetCatalogSource): DatasetCatalog {

--- a/packages/datasets/src/contract.test.ts
+++ b/packages/datasets/src/contract.test.ts
@@ -117,6 +117,8 @@ describe('semantic contract — shape', () => {
       target: 'customers',
       from: 'customerId',
       to: 'id',
+      queryable: true,
+      fields: ['customer.country', 'customer.id'],
     });
   });
 

--- a/packages/datasets/src/contract.ts
+++ b/packages/datasets/src/contract.ts
@@ -17,7 +17,7 @@ import { sortedRecord, uniqueSorted } from './utils/canonical-json.js';
  * Version of the semantic contract format. Bump when the serialized shape
  * changes in a way that snapshot consumers must account for.
  */
-export const SEMANTIC_CONTRACT_VERSION = 1;
+export const SEMANTIC_CONTRACT_VERSION = 2;
 
 export interface ContractDimension {
   type: DimensionCatalogEntry['type'];
@@ -63,6 +63,8 @@ export interface ContractRelationship {
   target: string;
   from: string;
   to: string;
+  queryable: boolean;
+  fields: string[];
 }
 
 export interface ContractDataset {
@@ -222,6 +224,8 @@ function relationshipToContract(entry: RelationshipCatalogEntry): ContractRelati
     target: entry.target,
     from: entry.from,
     to: entry.to,
+    queryable: entry.queryable,
+    fields: uniqueSorted(entry.fields),
   };
 }
 

--- a/packages/datasets/src/dataset.ts
+++ b/packages/datasets/src/dataset.ts
@@ -1,9 +1,10 @@
 /**
  * dataset() — creates a typed semantic model over a physical table.
  *
- * Relationships are modeled on the dataset today, but current query execution
- * only supports same-dataset dimensions, measures, and metrics. Joined
- * relationship traversal is not part of the shipped execution surface yet.
+ * Relationships are modeled on the dataset. To-one relationships (`belongsTo`,
+ * `hasOne`) are queryable one hop deep as `<relationship>.<dimension>` and
+ * execute as LEFT JOINs; `hasMany` relationships remain metadata-only to avoid
+ * fan-out corrupting aggregates.
  *
  * @example
  * ```ts
@@ -69,7 +70,7 @@ export function dataset<
   const dimensions = normalizeDimensions(config);
   const measures = normalizeMeasures(config.measures);
   const filters = normalizeFilters(dimensions, config.filters);
-  const relationships = normalizeRelationships(config.relationships);
+  const relationships = normalizeRelationships(config.relationships, config.source);
 
   type ThisDataset = DatasetInstance<TDimensions, TMeasures, TRelationships, TDatasetName>;
   function metric<TName extends string>(

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -230,7 +230,13 @@ export interface MetricQueryEngineOptions {
 export interface CreateDatasetClientOptions {
   /** Query builder factory for executing semantic metric and dataset queries. */
   queryBuilder?: QueryBuilderFactoryInput;
-  /** Semantic backend for executing neutral semantic plans. */
+  /**
+   * Semantic backend for executing neutral semantic plans.
+   *
+   * @deprecated Use `queryBuilder` instead — the query-builder path is
+   * canonical. The plan/backend path is frozen (bug fixes only) and will not
+   * gain new features.
+   */
   backend?: SemanticBackend;
   /**
    * Result-cache defaults for this client. Results are keyed by the canonical

--- a/packages/datasets/src/field.ts
+++ b/packages/datasets/src/field.ts
@@ -19,7 +19,9 @@
 import type { DimensionDefinition, DimensionOptions, FieldType } from './types.js';
 
 function createFieldHelper<T extends FieldType>(fieldType: T) {
-  return (opts?: DimensionOptions): DimensionDefinition<T> => ({
+  return <TOptions extends DimensionOptions | undefined = undefined>(
+    opts?: TOptions,
+  ): DimensionDefinition<T> & (TOptions extends DimensionOptions ? TOptions : object) => ({
     __type: 'field_definition',
     fieldType,
     label: opts?.label,
@@ -28,7 +30,7 @@ function createFieldHelper<T extends FieldType>(fieldType: T) {
     sql: opts?.sql,
     filterable: opts?.filterable,
     groupable: opts?.groupable,
-  });
+  }) as DimensionDefinition<T> & (TOptions extends DimensionOptions ? TOptions : object);
 }
 
 export const dimension = {

--- a/packages/datasets/src/in-memory-backend.ts
+++ b/packages/datasets/src/in-memory-backend.ts
@@ -250,6 +250,11 @@ function serializeMeasures(rows: InMemoryTable, measures: string[]): InMemoryTab
   });
 }
 
+/**
+ * @deprecated The plan/backend execution path is frozen (bug fixes only); this
+ * backend remains as the test harness for that path. New code should use
+ * `createDatasetClient({ queryBuilder })`.
+ */
 export function createInMemoryBackend(tables: InMemoryTables): SemanticBackend {
   function executeAggregate(plan: Extract<PlanNode, { kind: 'aggregate' }>): InMemoryTable {
     const table = tables[plan.source] ?? [];

--- a/packages/datasets/src/index.ts
+++ b/packages/datasets/src/index.ts
@@ -98,6 +98,9 @@ export {
   buildDatasetQuerySignature,
   buildMetricQuerySignature,
 } from './cache/query-signature.js';
+// Plan/backend protocol — FROZEN. Deprecated in favor of the query-builder
+// path (`createDatasetClient({ queryBuilder })`); bug fixes only, no new
+// features. See the deprecation notes on each declaration.
 export { createInMemoryBackend } from './in-memory-backend.js';
 export type { InMemoryTable, InMemoryTables } from './in-memory-backend.js';
 export type {

--- a/packages/datasets/src/index.ts
+++ b/packages/datasets/src/index.ts
@@ -172,6 +172,7 @@ export type {
   DatasetRegistryInstance,
   DatasetFieldNames,
   DatasetDimensionNames,
+  DatasetQueryableDimensions,
   DatasetMeasureNames,
   DatasetOrderableNames,
   DatasetQueryFor,

--- a/packages/datasets/src/index.ts
+++ b/packages/datasets/src/index.ts
@@ -32,7 +32,8 @@ export {
 export { createDatasetRegistry } from './registry.js';
 
 // Catalog
-export { getDatasetCatalog, getDatasetCatalogs } from './catalog.js';
+export { getDatasetCatalog, getDatasetCatalogs, getQueryableRelationshipFields } from './catalog.js';
+export { listQueryableRelationshipFields } from './utils/relationship-fields.js';
 export type {
   DatasetCatalog,
   DatasetCatalogMap,

--- a/packages/datasets/src/query-builder-protocol.ts
+++ b/packages/datasets/src/query-builder-protocol.ts
@@ -33,6 +33,19 @@ export interface QueryBuilderLike {
     on?: QueryBuilderJoinCondition | QueryBuilderJoinCondition[],
   ): QueryBuilderLike;
 
+  /**
+   * Optional single-match LEFT JOIN (ClickHouse `LEFT ANY JOIN`). When a
+   * builder provides it, relationship joins use it so duplicate target join
+   * keys cannot fan out aggregates; otherwise `leftJoin` is used.
+   */
+  leftAnyJoin?(
+    table: string,
+    leftColumn: string,
+    rightColumn: string,
+    alias?: string,
+    on?: QueryBuilderJoinCondition | QueryBuilderJoinCondition[],
+  ): QueryBuilderLike;
+
   // Grouping
   groupBy(columns: string | string[]): QueryBuilderLike;
 

--- a/packages/datasets/src/relationships-query.test.ts
+++ b/packages/datasets/src/relationships-query.test.ts
@@ -185,6 +185,40 @@ const backendClient = (tables: InMemoryTables) => createDatasetClient({ backend:
 // Validation
 // ---------------------------------------------------------------------------
 
+describe('relationship definition validation', () => {
+  it('rejects relationship names that match the dataset source', () => {
+    const Customers = dataset('customers_rel_target', {
+      source: 'customers',
+      dimensions: { id: dimension.string() },
+    });
+    expect(() =>
+      dataset('orders_alias_collision', {
+        source: 'orders',
+        dimensions: { id: dimension.string() },
+        relationships: {
+          orders: belongsTo(() => Customers, { from: 'customer_id', to: 'id' }),
+        },
+      }),
+    ).toThrow(/matches the dataset source/);
+  });
+
+  it('rejects relationship names containing dots', () => {
+    const Customers = dataset('customers_rel_target_2', {
+      source: 'customers',
+      dimensions: { id: dimension.string() },
+    });
+    expect(() =>
+      dataset('orders_dotted_relationship', {
+        source: 'orders',
+        dimensions: { id: dimension.string() },
+        relationships: {
+          'primary.customer': belongsTo(() => Customers, { from: 'customer_id', to: 'id' }),
+        },
+      }),
+    ).toThrow(/cannot contain "\."/);
+  });
+});
+
 describe('relationship-qualified validation', () => {
   it('accepts a to-one qualified dimension', () => {
     const result = validateDatasetQuery(Orders, {

--- a/packages/datasets/src/relationships.ts
+++ b/packages/datasets/src/relationships.ts
@@ -19,11 +19,14 @@
 
 import type { RelationshipDefinition, RelationshipKind } from './types.js';
 
-function createRelationship(
-  kind: RelationshipKind,
-  target: () => { __type: 'dataset'; name: string },
+function createRelationship<
+  TTarget extends { __type: 'dataset'; name: string },
+  TKind extends RelationshipKind,
+>(
+  kind: TKind,
+  target: () => TTarget,
   join: { from: string; to: string },
-): RelationshipDefinition {
+): RelationshipDefinition<TTarget, TKind> {
   return {
     __type: 'relationship',
     kind,
@@ -34,25 +37,25 @@ function createRelationship(
 }
 
 /** Many-to-one relationship (FK on this table). */
-export function belongsTo(
-  target: () => { __type: 'dataset'; name: string },
+export function belongsTo<TTarget extends { __type: 'dataset'; name: string }>(
+  target: () => TTarget,
   join: { from: string; to: string },
-): RelationshipDefinition {
+): RelationshipDefinition<TTarget, 'belongsTo'> {
   return createRelationship('belongsTo', target, join);
 }
 
 /** One-to-many relationship (FK on target table). */
-export function hasMany(
-  target: () => { __type: 'dataset'; name: string },
+export function hasMany<TTarget extends { __type: 'dataset'; name: string }>(
+  target: () => TTarget,
   join: { from: string; to: string },
-): RelationshipDefinition {
+): RelationshipDefinition<TTarget, 'hasMany'> {
   return createRelationship('hasMany', target, join);
 }
 
 /** One-to-one relationship (FK on target table). */
-export function hasOne(
-  target: () => { __type: 'dataset'; name: string },
+export function hasOne<TTarget extends { __type: 'dataset'; name: string }>(
+  target: () => TTarget,
   join: { from: string; to: string },
-): RelationshipDefinition {
+): RelationshipDefinition<TTarget, 'hasOne'> {
   return createRelationship('hasOne', target, join);
 }

--- a/packages/datasets/src/semantic-plan.ts
+++ b/packages/datasets/src/semantic-plan.ts
@@ -1,3 +1,13 @@
+/**
+ * Database-neutral semantic plan protocol (`PlanNode` / `SemanticBackend`).
+ *
+ * FROZEN: this execution path is superseded by the query-builder path —
+ * `createDatasetClient({ queryBuilder })` is the canonical way to execute
+ * semantic queries. The plan/backend protocol receives bug fixes only; new
+ * semantic features land on the query-builder path and are not guaranteed to
+ * be mirrored here.
+ */
+
 import type {
   AggregationType,
   FieldType,
@@ -9,6 +19,7 @@ import type {
 export type SemanticBinaryOperator = 'add' | 'subtract' | 'multiply' | 'divide';
 export type SemanticFunctionName = 'nullIfZero' | 'coalesce' | 'round' | 'floor' | 'ceil';
 
+/** @deprecated Part of the frozen plan/backend protocol; use `createDatasetClient({ queryBuilder })` instead. */
 export type SemanticExpression =
   | { kind: 'ref'; name: string }
   | { kind: 'literal'; value: string | number | boolean | null }
@@ -24,12 +35,14 @@ export type SemanticExpression =
     args: SemanticExpression[];
   };
 
+/** @deprecated Part of the frozen plan/backend protocol; use `createDatasetClient({ queryBuilder })` instead. */
 export interface SemanticDimensionPlan {
   name: string;
   field: string;
   fieldType?: FieldType;
 }
 
+/** @deprecated Part of the frozen plan/backend protocol; use `createDatasetClient({ queryBuilder })` instead. */
 export interface SemanticAggregationPlan {
   name: string;
   aggregation: AggregationType;
@@ -56,6 +69,7 @@ export interface SemanticJoinPlan {
   tenant?: SemanticTenantPredicate;
 }
 
+/** @deprecated Part of the frozen plan/backend protocol; use `createDatasetClient({ queryBuilder })` instead. */
 export interface SemanticGrainPlan {
   field: string;
   unit: TimeGrain;
@@ -64,6 +78,7 @@ export interface SemanticGrainPlan {
   weekStart?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
 }
 
+/** @deprecated Part of the frozen plan/backend protocol; use `createDatasetClient({ queryBuilder })` instead. */
 export type PlanNode =
   | {
     kind: 'aggregate';
@@ -92,6 +107,7 @@ export type PlanNode =
     offset?: number;
   };
 
+/** @deprecated Part of the frozen plan/backend protocol; use `createDatasetClient({ queryBuilder })` instead. */
 export interface SemanticBackendResult<T = Record<string, unknown>> {
   data: T[];
   meta?: {
@@ -101,6 +117,11 @@ export interface SemanticBackendResult<T = Record<string, unknown>> {
   };
 }
 
+/**
+ * @deprecated The plan/backend execution path is frozen (bug fixes only).
+ * Pass a query builder to `createDatasetClient({ queryBuilder })` instead of
+ * implementing a backend.
+ */
 export interface SemanticBackend {
   execute<T = Record<string, unknown>>(plan: PlanNode): Promise<SemanticBackendResult<T>>;
   explain?(plan: PlanNode): Promise<{ sql?: string }>;

--- a/packages/datasets/src/tests/integration/clickhouse-backend.test.ts
+++ b/packages/datasets/src/tests/integration/clickhouse-backend.test.ts
@@ -224,7 +224,7 @@ describe('datasets ClickHouse integration', () => {
       { 'user.userName': 'john_doe', revenue: 36 },
       { 'user.userName': 'bob_jones', revenue: 16.5 },
     ]);
-    expect(result.meta?.sql).toContain('LEFT JOIN users AS user ON orders.user_id = user.id');
+    expect(result.meta?.sql).toContain('LEFT ANY JOIN users AS user ON orders.user_id = user.id');
     expect(result.meta?.sql).toContain('user.user_name AS `user.userName`');
     expect(result.meta?.sql).toContain('SUM(orders.total) AS revenue');
   });
@@ -269,7 +269,7 @@ describe('datasets ClickHouse integration', () => {
     expect(revenueByUser.has('bob_jones')).toBe(false);
     expect(result.data.reduce((total, row) => total + Number(row.revenue), 0)).toBe(144.75);
     expect(result.meta?.sql).toContain(
-      'LEFT JOIN users AS user ON orders.user_id = user.id AND user.status = ?',
+      'LEFT ANY JOIN users AS user ON orders.user_id = user.id AND user.status = ?',
     );
     expect(result.meta?.sql).not.toContain('WHERE user.status = ?');
   });

--- a/packages/datasets/src/tools.test.ts
+++ b/packages/datasets/src/tools.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { dataset } from './dataset.js';
 import { dimension } from './field.js';
 import { measure } from './measure.js';
+import { belongsTo } from './relationships.js';
 import {
   generateDatasetTools,
   toAISDKTools,
@@ -10,6 +11,14 @@ import {
 } from './tools.js';
 
 describe('semantic dataset tools', () => {
+  const Customers = dataset('customers', {
+    source: 'customers',
+    dimensions: {
+      id: dimension.string(),
+      country: dimension.string(),
+    },
+  });
+
   const Orders = dataset('orders', {
     source: 'orders',
     tenantKey: 'tenant_id',
@@ -29,6 +38,9 @@ describe('semantic dataset tools', () => {
         field: 'status',
         operators: ['eq', 'in'],
       },
+    },
+    relationships: {
+      customer: belongsTo(() => Customers, { from: 'customer_id', to: 'id' }),
     },
     limits: {
       maxResultSize: 500,
@@ -61,6 +73,8 @@ describe('semantic dataset tools', () => {
       'status',
       'createdAt',
       'amount',
+      'customer.id',
+      'customer.country',
     ]);
     expect(tool.parameters.properties?.measures.items?.enum).toEqual([
       'revenue',
@@ -106,8 +120,50 @@ describe('semantic dataset tools', () => {
         dataset: 'orders',
         dimensions: ['missing'],
       }),
-    ).rejects.toThrow('Invalid dimensions: missing. Available: status, createdAt, amount.');
+    ).rejects.toThrow('Invalid dimensions: missing. Available: status, createdAt, amount, customer.id, customer.country.');
     expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('accepts queryable relationship fields in generated dataset tools', async () => {
+    const execute = vi.fn(async () => ({
+      data: [{ 'customer.country': 'US', revenue: 42 }],
+    }));
+    const [tool] = generateDatasetTools({
+      datasets: { orders: Orders },
+      analytics: { execute },
+      mode: 'per-dataset',
+    });
+
+    expect(tool.parameters.properties?.dimensions.items?.enum).toEqual([
+      'status',
+      'createdAt',
+      'amount',
+      'customer.id',
+      'customer.country',
+    ]);
+    expect(tool.parameters.properties?.filters.items?.properties?.field.enum).toEqual([
+      'status',
+      'customer.id',
+      'customer.country',
+    ]);
+
+    await tool.execute({
+      dimensions: ['customer.country'],
+      measures: ['revenue'],
+      filters: [{ field: 'customer.country', operator: 'eq', value: 'US' }],
+      orderBy: [{ field: 'customer.country', direction: 'asc' }],
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'orders' }),
+      {
+        dimensions: ['customer.country'],
+        measures: ['revenue'],
+        filters: [{ field: 'customer.country', operator: 'eq', value: 'US' }],
+        orderBy: [{ field: 'customer.country', direction: 'asc' }],
+      },
+      undefined,
+    );
   });
 
   it('generates per-dataset and per-metric tool shapes', () => {
@@ -151,8 +207,43 @@ describe('semantic dataset tools', () => {
       tool.execute({
         orderBy: [{ field: 'revenue', direction: 'desc' }],
       }),
-    ).rejects.toThrow('Invalid orderBy fields: revenue. Available: status, createdAt, amount, totalRevenue, period.');
+    ).rejects.toThrow('Invalid orderBy fields: revenue. Available: status, createdAt, amount, customer.id, customer.country, totalRevenue, period.');
     expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('accepts queryable relationship fields in generated metric tools', async () => {
+    const execute = vi.fn(async () => ({
+      data: [{ 'customer.country': 'US', totalRevenue: 42 }],
+    }));
+    const [tool] = generateDatasetTools({
+      datasets: {
+        orders: {
+          ...Orders,
+          metrics: { totalRevenue },
+        },
+      },
+      analytics: { execute },
+      mode: 'per-metric',
+    });
+
+    expect(tool.parameters.properties?.dimensions.items?.enum).toContain('customer.country');
+    expect(tool.parameters.properties?.orderBy.items?.properties?.field.enum).toContain('customer.country');
+
+    await tool.execute({
+      dimensions: ['customer.country'],
+      filters: [{ field: 'customer.country', operator: 'eq', value: 'US' }],
+      orderBy: [{ field: 'customer.country', direction: 'asc' }],
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      totalRevenue,
+      {
+        dimensions: ['customer.country'],
+        filters: [{ field: 'customer.country', operator: 'eq', value: 'US' }],
+        orderBy: [{ field: 'customer.country', direction: 'asc' }],
+      },
+      undefined,
+    );
   });
 
   it('adapts generated tool metadata for OpenAI, AI SDK, and MCP runtimes', () => {

--- a/packages/datasets/src/tools.ts
+++ b/packages/datasets/src/tools.ts
@@ -10,6 +10,7 @@ import type {
 import {
   getDatasetCatalog,
   getDatasetCatalogs,
+  getQueryableRelationshipFields,
   type DatasetCatalog,
   type DatasetCatalogMap,
   type DatasetCatalogSource,
@@ -107,36 +108,31 @@ function limitSchema(catalogs: DatasetCatalog[]): JsonSchema {
   };
 }
 
-function relationshipFields(catalog: DatasetCatalog): string[] {
-  return Object.values(catalog.relationships)
-    .filter(relationship => relationship.queryable)
-    .flatMap(relationship => relationship.fields);
+/** Field allowlists derived once per catalog when tools are built. */
+interface CatalogFieldLists {
+  dimensions: string[];
+  filters: string[];
 }
 
-function dimensionFields(catalog: DatasetCatalog): string[] {
-  return [
-    ...Object.keys(catalog.dimensions),
-    ...relationshipFields(catalog),
-  ];
-}
-
-function filterFields(catalog: DatasetCatalog): string[] {
-  return [
-    ...Object.keys(catalog.filters),
-    ...relationshipFields(catalog),
-  ];
+function catalogFieldLists(catalog: DatasetCatalog): CatalogFieldLists {
+  const relationshipFields = getQueryableRelationshipFields(catalog);
+  return {
+    dimensions: [...Object.keys(catalog.dimensions), ...relationshipFields],
+    filters: [...Object.keys(catalog.filters), ...relationshipFields],
+  };
 }
 
 function querySchema(catalogs: DatasetCatalog[], includeDataset: boolean): JsonSchema {
+  const fieldLists = catalogs.map(catalogFieldLists);
   const datasetNames = catalogs.map(catalog => catalog.name);
   const dimensionNames = Array.from(
-    new Set(catalogs.flatMap(dimensionFields)),
+    new Set(fieldLists.flatMap(fields => fields.dimensions)),
   );
   const measureNames = Array.from(
     new Set(catalogs.flatMap(catalog => Object.keys(catalog.measures))),
   );
   const filterNames = Array.from(
-    new Set(catalogs.flatMap(filterFields)),
+    new Set(fieldLists.flatMap(fields => fields.filters)),
   );
   const grainNames = Array.from(
     new Set(catalogs.flatMap(catalog => catalog.supportedGrains)),
@@ -270,6 +266,7 @@ function assertAllowedValues(values: string[], allowed: string[], label: string)
 function normalizeDatasetQuery(
   input: Record<string, unknown>,
   catalog: DatasetCatalog,
+  fields: CatalogFieldLists,
   options: { orderableFields?: string[] } = {},
 ): DatasetQuery {
   const dimensions = assertStringArray(input.dimensions, 'dimensions');
@@ -280,9 +277,9 @@ function normalizeDatasetQuery(
   const offset = assertNonNegativeInteger(input.offset, 'offset');
   let by: TimeGrain | undefined;
 
-  assertAllowedValues(dimensions, dimensionFields(catalog), 'dimensions');
+  assertAllowedValues(dimensions, fields.dimensions, 'dimensions');
   assertAllowedValues(measures, Object.keys(catalog.measures), 'measures');
-  assertAllowedValues(filters.map(filter => filter.field), filterFields(catalog), 'filter fields');
+  assertAllowedValues(filters.map(filter => filter.field), fields.filters, 'filter fields');
   assertAllowedValues(
     orderBy.map(order => order.field),
     options.orderableFields ?? catalog.orderableFields,
@@ -344,6 +341,9 @@ function buildCatalogTool(
   includeSql: boolean,
 ): SemanticToolDefinition {
   const catalogList = Object.values(catalogs);
+  const fieldLists = Object.fromEntries(
+    Object.entries(catalogs).map(([name, catalog]) => [name, catalogFieldLists(catalog)]),
+  );
 
   return {
     name: 'query_dataset',
@@ -355,7 +355,7 @@ function buildCatalogTool(
       }
 
       const catalog = catalogs[input.dataset];
-      const query = normalizeDatasetQuery(input, catalog);
+      const query = normalizeDatasetQuery(input, catalog, fieldLists[input.dataset]);
       const result = await analytics.execute(datasets[input.dataset], query, context);
       return redactSql(result, includeSql);
     },
@@ -370,12 +370,13 @@ function buildDatasetTools(
 ): SemanticToolDefinition[] {
   return Object.entries(datasets).map(([datasetName, dataset]) => {
     const catalog = catalogs[datasetName];
+    const fields = catalogFieldLists(catalog);
     return {
       name: `query_${toolNamePart(datasetName)}`,
       description: `Query the ${datasetName} analytics dataset.`,
       parameters: querySchema([catalog], false),
       async execute(input: Record<string, unknown>, context?: ExecutionContext): Promise<unknown> {
-        const query = normalizeDatasetQuery(input, catalog);
+        const query = normalizeDatasetQuery(input, catalog, fields);
         const result = await analytics.execute(dataset, query, context);
         return redactSql(result, includeSql);
       },
@@ -383,7 +384,7 @@ function buildDatasetTools(
   });
 }
 
-function metricQuerySchema(catalog: DatasetCatalog, metricName: string): JsonSchema {
+function metricQuerySchema(catalog: DatasetCatalog, orderableFields: string[]): JsonSchema {
   const schema = querySchema([catalog], false);
   const properties = schema.properties ?? {};
   delete properties.measures;
@@ -392,7 +393,7 @@ function metricQuerySchema(catalog: DatasetCatalog, metricName: string): JsonSch
     items: {
       type: 'object',
       properties: {
-        field: enumSchema([...dimensionFields(catalog), metricName, ...(catalog.timeKey ? ['period'] : [])]),
+        field: enumSchema(orderableFields),
         direction: enumSchema(['asc', 'desc']),
       },
       required: ['field', 'direction'],
@@ -415,20 +416,22 @@ function buildMetricTools(
 
   for (const [datasetName, dataset] of Object.entries(datasets)) {
     const catalog = catalogs[datasetName];
+    const fields = catalogFieldLists(catalog);
     for (const [metricName, metric] of Object.entries(dataset.metrics ?? {})) {
+      const orderableFields = [
+        ...fields.dimensions,
+        metricName,
+        ...(catalog.timeKey ? ['period'] : []),
+      ];
       tools.push({
         name: `query_${toolNamePart(metricName)}`,
         description: `Query the ${metricName} metric from the ${datasetName} dataset.`,
-        parameters: metricQuerySchema(catalog, metricName),
+        parameters: metricQuerySchema(catalog, orderableFields),
         async execute(input: Record<string, unknown>, context?: ExecutionContext): Promise<unknown> {
-          const orderableFields = [
-            ...dimensionFields(catalog),
-            metricName,
-            ...(catalog.timeKey ? ['period'] : []),
-          ];
           const query = normalizeDatasetQuery(
             { ...input, measures: [] },
             catalog,
+            fields,
             { orderableFields },
           );
           const result = await analytics.execute(metric, query, context);

--- a/packages/datasets/src/tools.ts
+++ b/packages/datasets/src/tools.ts
@@ -107,16 +107,36 @@ function limitSchema(catalogs: DatasetCatalog[]): JsonSchema {
   };
 }
 
+function relationshipFields(catalog: DatasetCatalog): string[] {
+  return Object.values(catalog.relationships)
+    .filter(relationship => relationship.queryable)
+    .flatMap(relationship => relationship.fields);
+}
+
+function dimensionFields(catalog: DatasetCatalog): string[] {
+  return [
+    ...Object.keys(catalog.dimensions),
+    ...relationshipFields(catalog),
+  ];
+}
+
+function filterFields(catalog: DatasetCatalog): string[] {
+  return [
+    ...Object.keys(catalog.filters),
+    ...relationshipFields(catalog),
+  ];
+}
+
 function querySchema(catalogs: DatasetCatalog[], includeDataset: boolean): JsonSchema {
   const datasetNames = catalogs.map(catalog => catalog.name);
   const dimensionNames = Array.from(
-    new Set(catalogs.flatMap(catalog => Object.keys(catalog.dimensions))),
+    new Set(catalogs.flatMap(dimensionFields)),
   );
   const measureNames = Array.from(
     new Set(catalogs.flatMap(catalog => Object.keys(catalog.measures))),
   );
   const filterNames = Array.from(
-    new Set(catalogs.flatMap(catalog => Object.keys(catalog.filters))),
+    new Set(catalogs.flatMap(filterFields)),
   );
   const grainNames = Array.from(
     new Set(catalogs.flatMap(catalog => catalog.supportedGrains)),
@@ -260,9 +280,9 @@ function normalizeDatasetQuery(
   const offset = assertNonNegativeInteger(input.offset, 'offset');
   let by: TimeGrain | undefined;
 
-  assertAllowedValues(dimensions, Object.keys(catalog.dimensions), 'dimensions');
+  assertAllowedValues(dimensions, dimensionFields(catalog), 'dimensions');
   assertAllowedValues(measures, Object.keys(catalog.measures), 'measures');
-  assertAllowedValues(filters.map(filter => filter.field), Object.keys(catalog.filters), 'filter fields');
+  assertAllowedValues(filters.map(filter => filter.field), filterFields(catalog), 'filter fields');
   assertAllowedValues(
     orderBy.map(order => order.field),
     options.orderableFields ?? catalog.orderableFields,
@@ -270,7 +290,7 @@ function normalizeDatasetQuery(
   );
 
   for (const filter of filters) {
-    const allowedOperators = catalog.filters[filter.field]?.operators ?? [];
+    const allowedOperators = catalog.filters[filter.field]?.operators ?? [...SEMANTIC_FILTER_OPERATORS];
     if (!allowedOperators.includes(filter.operator)) {
       throw new Error(
         `Invalid filter operator for "${filter.field}": ${filter.operator}. Allowed: ${allowedOperators.join(', ')}.`,
@@ -372,7 +392,7 @@ function metricQuerySchema(catalog: DatasetCatalog, metricName: string): JsonSch
     items: {
       type: 'object',
       properties: {
-        field: enumSchema([...Object.keys(catalog.dimensions), metricName, ...(catalog.timeKey ? ['period'] : [])]),
+        field: enumSchema([...dimensionFields(catalog), metricName, ...(catalog.timeKey ? ['period'] : [])]),
         direction: enumSchema(['asc', 'desc']),
       },
       required: ['field', 'direction'],
@@ -402,7 +422,7 @@ function buildMetricTools(
         parameters: metricQuerySchema(catalog, metricName),
         async execute(input: Record<string, unknown>, context?: ExecutionContext): Promise<unknown> {
           const orderableFields = [
-            ...Object.keys(catalog.dimensions),
+            ...dimensionFields(catalog),
             metricName,
             ...(catalog.timeKey ? ['period'] : []),
           ];

--- a/packages/datasets/src/types.ts
+++ b/packages/datasets/src/types.ts
@@ -34,10 +34,13 @@ export type InferDimensionType<T extends DimensionDefinition> =
 
 export type RelationshipKind = 'belongsTo' | 'hasMany' | 'hasOne';
 
-export interface RelationshipDefinition {
+export interface RelationshipDefinition<
+  TTarget extends { __type: 'dataset'; name: string } = { __type: 'dataset'; name: string },
+  TKind extends RelationshipKind = RelationshipKind,
+> {
   __type: 'relationship';
-  kind: RelationshipKind;
-  target: () => { __type: 'dataset'; name: string };
+  kind: TKind;
+  target: () => TTarget;
   from: string;
   to: string;
 }
@@ -331,9 +334,6 @@ export type AnyDatasetInstance = DatasetInstance<
   string
 >;
 
-export type DatasetFieldNames<TDataset extends DatasetInstance<any, any, any, any>> =
-  keyof TDataset['dimensions'] & string;
-
 type NonNeverStringKeys<T extends Record<string, unknown>> = {
   [K in keyof T]: [T[K]] extends [never] ? never : K;
 }[keyof T] & string;
@@ -346,6 +346,49 @@ type KnownStringKeysOrFallback<T extends Record<string, unknown>> =
   [KnownStringKeys<T>] extends [never]
     ? NonNeverStringKeys<T>
     : KnownStringKeys<T> & NonNeverStringKeys<T>;
+
+type NonSqlDimensionNames<TDimensions extends Record<string, DimensionDefinition>> = {
+  [TName in KnownStringKeysOrFallback<TDimensions>]:
+    TDimensions[TName] extends { sql: string } ? never : TName;
+}[KnownStringKeysOrFallback<TDimensions>];
+
+type QueryableRelationshipDimensionNames<
+  TRelationships extends Record<string, RelationshipDefinition>,
+> = {
+  [TRelationshipName in KnownStringKeys<TRelationships>]:
+    TRelationships[TRelationshipName] extends RelationshipDefinition<
+      infer TTarget,
+      infer TKind
+    >
+      ? TKind extends 'hasMany'
+        ? never
+        : TTarget extends DatasetInstance<infer TDimensions, any, any, any>
+          ? `${TRelationshipName}.${NonSqlDimensionNames<TDimensions>}`
+          : never
+      : never;
+}[KnownStringKeys<TRelationships>];
+
+type DatasetDimensionDefinitionByName<
+  TDataset extends DatasetInstance<any, any, any, any>,
+  TName extends string,
+> = TName extends keyof TDataset['dimensions']
+  ? TDataset['dimensions'][TName]
+  : TName extends `${infer TRelationshipName}.${infer TDimensionName}`
+    ? TRelationshipName extends keyof TDataset['relationships']
+      ? TDataset['relationships'][TRelationshipName] extends RelationshipDefinition<
+          infer TTarget,
+          infer TKind
+        >
+        ? TKind extends 'hasMany'
+          ? never
+          : TTarget extends DatasetInstance<infer TDimensions, any, any, any>
+            ? TDimensionName extends keyof TDimensions
+              ? TDimensions[TDimensionName]
+              : never
+            : never
+        : never
+      : never
+    : never;
 
 // ---------------------------------------------------------------------------
 // Typed query / result helpers for client codegen and React hooks
@@ -362,7 +405,17 @@ type KnownStringKeysOrFallback<T extends Record<string, unknown>> =
 
 /** Dimension names declared by a dataset. */
 export type DatasetDimensionNames<TDataset extends DatasetInstance<any, any, any, any>> =
-  KnownStringKeysOrFallback<TDataset['dimensions']>;
+  | KnownStringKeysOrFallback<TDataset['dimensions']>
+  | QueryableRelationshipDimensionNames<TDataset['relationships']>;
+
+/** Dimension definitions addressable by a one-hop dataset query. */
+export type DatasetQueryableDimensions<TDataset extends DatasetInstance<any, any, any, any>> = {
+  [TName in DatasetDimensionNames<TDataset>]: DatasetDimensionDefinitionByName<TDataset, TName>;
+};
+
+/** Backwards-compatible alias for all queryable dataset dimension names. */
+export type DatasetFieldNames<TDataset extends DatasetInstance<any, any, any, any>> =
+  DatasetDimensionNames<TDataset>;
 
 /** Measure names declared by a dataset. */
 export type DatasetMeasureNames<TDataset extends DatasetInstance<any, any, any, any>> =
@@ -410,7 +463,7 @@ type PeriodSelection<TQuery> = TQuery extends { by: TimeGrain }
 
 /** A broad typed result row for a dataset, independent of projection. */
 export type DatasetRow<TDataset extends DatasetInstance<any, any, any, any>> =
-  & { [K in DatasetDimensionNames<TDataset>]?: InferDimensionType<TDataset['dimensions'][K]> }
+  & { [K in DatasetDimensionNames<TDataset>]?: InferDimensionType<DatasetQueryableDimensions<TDataset>[K]> }
   & { [K in DatasetMeasureNames<TDataset>]?: string }
   & { period?: string };
 
@@ -419,7 +472,7 @@ export type DatasetRowFor<
   TDataset extends DatasetInstance<any, any, any, any>,
   TQuery = DatasetQueryFor<TDataset>,
 > =
-  & { [K in SelectedDimensions<TDataset, TQuery>]?: InferDimensionType<TDataset['dimensions'][K]> }
+  & { [K in SelectedDimensions<TDataset, TQuery>]?: InferDimensionType<DatasetQueryableDimensions<TDataset>[K]> }
   & { [K in SelectedDatasetMeasures<TDataset, TQuery>]?: string }
   & PeriodSelection<TQuery>;
 
@@ -450,7 +503,7 @@ export type MetricRow<
   TDataset extends DatasetInstance<any, any, any, any>,
   TMetricName extends string,
 > =
-  & { [K in DatasetDimensionNames<TDataset>]?: InferDimensionType<TDataset['dimensions'][K]> }
+  & { [K in DatasetDimensionNames<TDataset>]?: InferDimensionType<DatasetQueryableDimensions<TDataset>[K]> }
   & { [K in TMetricName]?: string }
   & { period?: string };
 
@@ -460,7 +513,7 @@ export type MetricRowFor<
   TMetricName extends string,
   TQuery = MetricQueryFor<TDataset, TMetricName>,
 > =
-  & { [K in SelectedDimensions<TDataset, TQuery>]?: InferDimensionType<TDataset['dimensions'][K]> }
+  & { [K in SelectedDimensions<TDataset, TQuery>]?: InferDimensionType<DatasetQueryableDimensions<TDataset>[K]> }
   & { [K in TMetricName]?: string }
   & PeriodSelection<TQuery>;
 

--- a/packages/datasets/src/utils/dataset-normalization.ts
+++ b/packages/datasets/src/utils/dataset-normalization.ts
@@ -45,7 +45,22 @@ export function normalizeMeasures<TMeasures extends Record<string, MeasureDefini
 
 export function normalizeRelationships<TRelationships extends Record<string, RelationshipDefinition>>(
   relationships: TRelationships | undefined,
+  source: string,
 ): TRelationships {
+  for (const name of Object.keys(relationships ?? {})) {
+    if (name === source) {
+      throw new Error(
+        `Invalid relationship "${name}": the name matches the dataset source table, so the join ` +
+        'alias would shadow the base table and produce ambiguous SQL. Rename the relationship.',
+      );
+    }
+    if (name.includes('.')) {
+      throw new Error(
+        `Invalid relationship "${name}": relationship names cannot contain "." because qualified ` +
+        'fields are addressed as "<relationship>.<dimension>".',
+      );
+    }
+  }
   return (relationships ?? {}) as TRelationships;
 }
 

--- a/packages/datasets/src/utils/relationship-builder-plan.ts
+++ b/packages/datasets/src/utils/relationship-builder-plan.ts
@@ -118,6 +118,8 @@ export function resolveQualifiedColumn(
 /**
  * Applies each relationship LEFT JOIN to the builder and, when runtime tenancy
  * is active on a target, scopes the joined rows with the tenant predicate.
+ * Builders that support single-match joins (`leftAnyJoin`, e.g. ClickHouse
+ * `LEFT ANY JOIN`) get them so duplicate target keys cannot fan out aggregates.
  */
 export function applyRelationshipJoins(
   qb: QueryBuilderLike,
@@ -127,7 +129,8 @@ export function applyRelationshipJoins(
     return qb;
   }
   for (const join of ctx.joins) {
-    qb = qb.leftJoin(
+    const applyJoin = qb.leftAnyJoin?.bind(qb) ?? qb.leftJoin.bind(qb);
+    qb = applyJoin(
       join.source,
       `${ctx.baseSource}.${join.from}`,
       `${join.relationship}.${join.to}`,

--- a/packages/datasets/src/utils/relationship-fields.ts
+++ b/packages/datasets/src/utils/relationship-fields.ts
@@ -13,6 +13,26 @@ import type {
   RelationshipDefinition,
 } from '../types.js';
 
+/**
+ * Enumerates the queryable qualified field names (`<name>.<dimension>`) a
+ * relationship contributes, applying the same rules `resolveQualifiedField`
+ * enforces at query time: `hasMany` contributes nothing and SQL-backed target
+ * dimensions are excluded. Keep the two in sync — the catalog, contract, and
+ * generated input schemas all advertise exactly this list.
+ */
+export function listQueryableRelationshipFields(
+  name: string,
+  relationship: RelationshipDefinition,
+): string[] {
+  if (relationship.kind === 'hasMany') {
+    return [];
+  }
+  const target = relationship.target() as Partial<AnyDatasetInstance> | undefined;
+  return Object.entries(target?.dimensions ?? {})
+    .filter(([, dimension]) => !dimension.sql)
+    .map(([field]) => `${name}.${field}`);
+}
+
 export interface ParsedQualifiedField {
   /** The relationship name (prefix before the first dot). */
   relationship: string;

--- a/packages/datasets/type-tests/projection-types.test-d.ts
+++ b/packages/datasets/type-tests/projection-types.test-d.ts
@@ -1,10 +1,13 @@
 import {
   createDatasetClient,
+  belongsTo,
   dataset,
   dimension,
+  hasMany,
   measure,
   type AnyDatasetInstance,
   type DatasetQueryFor,
+  type DatasetDimensionNames,
   type DatasetRow,
   type MetricRow,
 } from '../src/index.js';
@@ -15,6 +18,22 @@ type Equal<A, B> =
   (<T>() => T extends B ? 1 : 2)
     ? true
     : false;
+
+const Customers = dataset('customers', {
+  source: 'customers',
+  dimensions: {
+    country: dimension.string(),
+    tier: dimension.string(),
+    computed: dimension.string({ sql: 'upper(country)' }),
+  },
+});
+
+const Items = dataset('items', {
+  source: 'items',
+  dimensions: {
+    sku: dimension.string(),
+  },
+});
 
 const Orders = dataset('orders', {
   source: 'orders',
@@ -31,6 +50,10 @@ const Orders = dataset('orders', {
     averageOrderValue: measure.avg('amount'),
     smallestOrder: measure.min('amount'),
     largestOrder: measure.max('amount'),
+  },
+  relationships: {
+    customer: belongsTo(() => Customers, { from: 'customer_id', to: 'id' }),
+    items: hasMany(() => Items, { from: 'id', to: 'order_id' }),
   },
 });
 
@@ -67,6 +90,24 @@ async function assertDatasetProjection() {
   void row.orderCount;
   // @ts-expect-error period is only exposed for grained queries
   void row.period;
+}
+
+async function assertRelationshipProjection() {
+  const result = await analytics.execute(Orders, {
+    dimensions: ['customer.country'] as const,
+    measures: ['revenue'] as const,
+    orderBy: [{ field: 'customer.country', direction: 'asc' }] as const,
+  });
+  const row = result.data[0]!;
+
+  type _CustomerCountry = Assert<Equal<typeof row['customer.country'], string | undefined>>;
+
+  type _HasManyExcluded = Assert<
+    Equal<Extract<DatasetDimensionNames<typeof Orders>, 'items.sku'>, never>
+  >;
+  type _SqlDimensionExcluded = Assert<
+    Equal<Extract<DatasetDimensionNames<typeof Orders>, 'customer.computed'>, never>
+  >;
 }
 
 async function assertEveryAggregationEmitsString() {
@@ -160,6 +201,7 @@ function assertBroadRowTypes() {
 }
 
 void assertDatasetProjection;
+void assertRelationshipProjection;
 void assertEveryAggregationEmitsString;
 void assertMeasuresOnlyProjection;
 void assertOmittedMeasuresExposeAllMeasures;

--- a/packages/mcp-server/src/tools/introspect.test.ts
+++ b/packages/mcp-server/src/tools/introspect.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { dataset, dimension, measure } from '@hypequery/datasets';
+import { belongsTo, dataset, dimension, measure } from '@hypequery/datasets';
 import { getDatasetSchemaTool } from './introspect.js';
 
 describe('getDatasetSchemaTool', () => {
@@ -208,6 +208,31 @@ describe('getDatasetSchemaTool', () => {
       aggregation: 'revenue',
       label: 'Total Revenue',
       format: null,
+    });
+  });
+
+  it('advertises queryable relationship fields for real dataset instances', async () => {
+    const Customers = dataset('customers', {
+      source: 'customers',
+      dimensions: {
+        id: dimension.string(),
+        country: dimension.string(),
+      },
+    });
+    const Orders = dataset('orders', {
+      source: 'orders',
+      dimensions: { id: dimension.string() },
+      relationships: {
+        customer: belongsTo(() => Customers, { from: 'customer_id', to: 'id' }),
+      },
+    });
+
+    const result = await getDatasetSchemaTool({ orders: Orders }, { dataset: 'orders' });
+    const schema = JSON.parse(result.content[0].text);
+
+    expect(schema.relationships.customer).toMatchObject({
+      queryable: true,
+      fields: ['customer.id', 'customer.country'],
     });
   });
 

--- a/packages/mcp-server/src/tools/introspect.test.ts
+++ b/packages/mcp-server/src/tools/introspect.test.ts
@@ -236,6 +236,47 @@ describe('getDatasetSchemaTool', () => {
     });
   });
 
+  it('derives queryable relationship metadata for config-shaped datasets', async () => {
+    const datasets = {
+      orders: {
+        dimensions: { id: { fieldType: 'string' } },
+        relationships: {
+          customer: {
+            kind: 'belongsTo',
+            target: () => ({
+              name: 'customers',
+              dimensions: {
+                id: { fieldType: 'string' },
+                country: { fieldType: 'string' },
+                computed: { fieldType: 'string', sql: 'upper(country)' },
+              },
+            }),
+            from: 'customer_id',
+            to: 'id',
+          },
+          items: {
+            kind: 'hasMany',
+            target: () => ({ name: 'line_items', dimensions: { sku: { fieldType: 'string' } } }),
+            from: 'id',
+            to: 'order_id',
+          },
+        },
+      },
+    };
+
+    const result = await getDatasetSchemaTool(datasets as any, { dataset: 'orders' });
+    const schema = JSON.parse(result.content[0].text);
+
+    expect(schema.relationships.customer).toMatchObject({
+      queryable: true,
+      fields: ['customer.id', 'customer.country'],
+    });
+    expect(schema.relationships.items).toMatchObject({
+      queryable: false,
+      fields: [],
+    });
+  });
+
   it('should handle dataset with config structure', async () => {
     const datasets = {
       events: {

--- a/packages/mcp-server/src/tools/introspect.ts
+++ b/packages/mcp-server/src/tools/introspect.ts
@@ -5,7 +5,7 @@
  * named metrics, filters, and relationships.
  */
 
-import { getDatasetCatalog } from '@hypequery/datasets';
+import { getDatasetCatalog, listQueryableRelationshipFields } from '@hypequery/datasets';
 import type {
   DatasetRegistry,
   GetDatasetSchemaArgs,
@@ -168,13 +168,19 @@ export async function getDatasetSchemaTool(
     if (datasetAny.relationships) {
       for (const [name, relationship] of Object.entries(datasetAny.relationships)) {
         const rel = relationship as any;
+        // Raw config relationships don't carry the catalog's computed
+        // queryable/fields metadata; derive it when the shape allows.
+        const kind = rel.type || rel.kind;
+        const hasResolvableTarget = typeof rel.target === 'function';
         const relSchema: RelationshipSchema = {
-          type: rel.type || rel.kind || 'unknown',
-          target: typeof rel.target === 'function' ? rel.target()?.name || '' : rel.target || rel.dataset?.name || '',
+          type: kind || 'unknown',
+          target: hasResolvableTarget ? rel.target()?.name || '' : rel.target || rel.dataset?.name || '',
           from: rel.from,
           to: rel.to,
-          queryable: rel.queryable,
-          fields: rel.fields,
+          queryable: rel.queryable ?? (kind ? kind !== 'hasMany' : undefined),
+          fields: rel.fields ?? (kind && hasResolvableTarget
+            ? listQueryableRelationshipFields(name, { ...rel, kind })
+            : undefined),
           description: rel.description || '',
         };
         schema.relationships[name] = relSchema;

--- a/packages/mcp-server/src/tools/introspect.ts
+++ b/packages/mcp-server/src/tools/introspect.ts
@@ -180,7 +180,7 @@ export async function getDatasetSchemaTool(
           queryable: rel.queryable ?? (kind ? kind !== 'hasMany' : undefined),
           fields: rel.fields ?? (kind && hasResolvableTarget
             ? listQueryableRelationshipFields(name, { ...rel, kind })
-            : undefined),
+            : kind && kind !== 'hasMany' ? [] : undefined),
           description: rel.description || '',
         };
         schema.relationships[name] = relSchema;

--- a/packages/mcp-server/src/tools/introspect.ts
+++ b/packages/mcp-server/src/tools/introspect.ts
@@ -116,7 +116,8 @@ export async function getDatasetSchemaTool(
         target: relationship.target,
         from: relationship.from,
         to: relationship.to,
-        execution: relationship.execution,
+        queryable: relationship.queryable,
+        fields: relationship.fields,
         description: '',
       };
       schema.relationships[name] = relSchema;
@@ -172,7 +173,8 @@ export async function getDatasetSchemaTool(
           target: typeof rel.target === 'function' ? rel.target()?.name || '' : rel.target || rel.dataset?.name || '',
           from: rel.from,
           to: rel.to,
-          execution: rel.execution,
+          queryable: rel.queryable,
+          fields: rel.fields,
           description: rel.description || '',
         };
         schema.relationships[name] = relSchema;

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -147,7 +147,8 @@ export interface RelationshipSchema {
   target: string;
   from?: string;
   to?: string;
-  execution?: string;
+  queryable?: boolean;
+  fields?: string[];
   description: string;
 }
 

--- a/packages/react/type-tests/semantic-infer.test-d.ts
+++ b/packages/react/type-tests/semantic-infer.test-d.ts
@@ -3,7 +3,7 @@ import { createAnalyticsHooks } from '../src/index.js';
 type Api = {
   revenue: {
     input: {
-      dimensions?: readonly ('country' | 'status')[];
+      dimensions?: readonly ('country' | 'status' | 'customer.country')[];
       by?: 'month';
     };
     output: {
@@ -14,6 +14,7 @@ type Api = {
       dimensions: {
         country: { fieldType: 'string' };
         status: { fieldType: 'string' };
+        'customer.country': { fieldType: 'string' };
       };
       measures: {
         revenue: { aggregation: 'sum' };
@@ -24,7 +25,7 @@ type Api = {
   };
   'dataset:orders': {
     input: {
-      dimensions?: readonly ('country' | 'status')[];
+      dimensions?: readonly ('country' | 'status' | 'customer.country')[];
       measures?: readonly ('revenue' | 'orderCount')[];
       by?: 'month';
     };
@@ -36,6 +37,7 @@ type Api = {
       dimensions: {
         country: { fieldType: 'string' };
         status: { fieldType: 'string' };
+        'customer.country': { fieldType: 'string' };
       };
       measures: {
         revenue: { aggregation: 'sum' };
@@ -82,6 +84,14 @@ void groupedRevenue;
 void groupedOrderCount;
 void groupedPeriod;
 
+const relatedDatasetResult = hooks.useDataset('orders', {
+  dimensions: ['customer.country'] as const,
+  measures: ['revenue'] as const,
+});
+const relatedCountry: string | undefined =
+  relatedDatasetResult.data?.data[0]?.['customer.country'];
+void relatedCountry;
+
 // @ts-expect-error unselected dimensions are not exposed
 void groupedDatasetRow?.status;
 
@@ -97,6 +107,13 @@ const metricRevenueAsNumber: number | undefined = metricRow?.revenue;
 void metricRevenueAsNumber;
 void metricRevenue;
 void metricCountry;
+
+const relatedMetricResult = hooks.useMetric('revenue', {
+  dimensions: ['customer.country'] as const,
+});
+const relatedMetricCountry: string | undefined =
+  relatedMetricResult.data?.data[0]?.['customer.country'];
+void relatedMetricCountry;
 
 // @ts-expect-error unknown metric names should be rejected
 hooks.useMetric('missing');

--- a/packages/serve/src/semantic/datasets/serve-integration.test.ts
+++ b/packages/serve/src/semantic/datasets/serve-integration.test.ts
@@ -1947,7 +1947,7 @@ describe("Serve integration — metrics", () => {
         contentHash: string;
         datasets: Record<string, { source: string; dimensions: Record<string, unknown> }>;
       };
-      expect(body.version).toBe(1);
+      expect(body.version).toBe(2);
       expect(body.contentHash).toMatch(/^[a-f0-9]{64}$/);
       expect(body.datasets.orders.source).toBe("orders");
       expect(Object.keys(body.datasets.orders.dimensions)).toContain("country");

--- a/packages/serve/src/semantic/datasets/utils/semantic-input-schema.test.ts
+++ b/packages/serve/src/semantic/datasets/utils/semantic-input-schema.test.ts
@@ -70,4 +70,39 @@ describe('relationship-aware semantic input schemas', () => {
 
     expect(result.success).toBe(true);
   });
+
+  it('does not advertise dimensions as filterable when a dataset opts out of filters', () => {
+    const NoFilters = dataset('orders_no_filters', {
+      source: 'orders',
+      dimensions: { status: dimension.string() },
+      filters: {},
+      relationships: {
+        customer: belongsTo(() => Customers, { from: 'customer_id', to: 'id' }),
+      },
+    });
+    const schema = buildDatasetInputSchema(NoFilters);
+
+    // The runtime validator rejects unqualified filters not declared in
+    // ds.filters, so the schema must not advertise them either.
+    expect(schema.safeParse({
+      filters: [{ field: 'status', operator: 'eq', value: 'x' }],
+    }).success).toBe(false);
+    expect(schema.safeParse({
+      filters: [{ field: 'customer.country', operator: 'eq', value: 'US' }],
+    }).success).toBe(true);
+  });
+
+  it('falls back to plain strings when no filter fields are known', () => {
+    const Bare = dataset('bare', {
+      source: 'bare',
+      dimensions: { id: dimension.string() },
+      filters: {},
+    });
+
+    // Superset-safe: with no known fields the schema stays permissive and the
+    // runtime validator produces the precise error.
+    expect(buildDatasetInputSchema(Bare).safeParse({
+      filters: [{ field: 'anything', operator: 'eq', value: 1 }],
+    }).success).toBe(true);
+  });
 });

--- a/packages/serve/src/semantic/datasets/utils/semantic-input-schema.test.ts
+++ b/packages/serve/src/semantic/datasets/utils/semantic-input-schema.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  belongsTo,
+  dataset,
+  dimension,
+  hasMany,
+  measure,
+} from '@hypequery/datasets';
+import {
+  buildDatasetInputSchema,
+  buildMetricInputSchema,
+} from './semantic-input-schema.js';
+
+const Customers = dataset('customers', {
+  source: 'customers',
+  dimensions: {
+    id: dimension.string(),
+    country: dimension.string(),
+    computed: dimension.string({ sql: 'upper(country)' }),
+  },
+});
+
+const Items = dataset('items', {
+  source: 'items',
+  dimensions: {
+    sku: dimension.string(),
+  },
+});
+
+const Orders = dataset('orders', {
+  source: 'orders',
+  dimensions: {
+    id: dimension.string(),
+    status: dimension.string(),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+  },
+  relationships: {
+    customer: belongsTo(() => Customers, { from: 'customer_id', to: 'id' }),
+    items: hasMany(() => Items, { from: 'id', to: 'order_id' }),
+  },
+});
+
+describe('relationship-aware semantic input schemas', () => {
+  it('accepts queryable relationship fields for dataset queries', () => {
+    const result = buildDatasetInputSchema(Orders).safeParse({
+      dimensions: ['customer.country'],
+      measures: ['revenue'],
+      filters: [{ field: 'customer.country', operator: 'eq', value: 'US' }],
+      orderBy: [{ field: 'customer.country', direction: 'asc' }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('excludes hasMany and SQL-backed target dimensions', () => {
+    const schema = buildDatasetInputSchema(Orders);
+
+    expect(schema.safeParse({ dimensions: ['items.sku'] }).success).toBe(false);
+    expect(schema.safeParse({ dimensions: ['customer.computed'] }).success).toBe(false);
+  });
+
+  it('accepts queryable relationship fields for metric queries', () => {
+    const result = buildMetricInputSchema(Orders, 'revenue').safeParse({
+      dimensions: ['customer.country'],
+      filters: [{ field: 'customer.country', operator: 'eq', value: 'US' }],
+      orderBy: [{ field: 'customer.country', direction: 'asc' }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/serve/src/semantic/datasets/utils/semantic-input-schema.ts
+++ b/packages/serve/src/semantic/datasets/utils/semantic-input-schema.ts
@@ -31,8 +31,18 @@ function grainEnum(catalog: DatasetCatalog): z.ZodTypeAny {
   return fieldEnum(catalog.supportedGrains);
 }
 
+function relationshipFields(catalog: DatasetCatalog): string[] {
+  return Object.values(catalog.relationships)
+    .filter(relationship => relationship.queryable)
+    .flatMap(relationship => relationship.fields);
+}
+
 function filterSchema(catalog: DatasetCatalog) {
-  const fieldNames = Object.keys(catalog.filters);
+  const localFields = Object.keys(catalog.filters);
+  const fieldNames = [
+    ...(localFields.length > 0 ? localFields : Object.keys(catalog.dimensions)),
+    ...relationshipFields(catalog),
+  ];
   return z.object({
     field: fieldEnum(fieldNames),
     operator: z.enum(SEMANTIC_FILTER_OPERATORS),
@@ -59,7 +69,10 @@ function boundedArray(item: z.ZodTypeAny, max?: number) {
  */
 export function buildDatasetInputSchema(ds: AnyDatasetInstance) {
   const catalog = getDatasetCatalog(ds);
-  const dimensionNames = Object.keys(catalog.dimensions);
+  const dimensionNames = [
+    ...Object.keys(catalog.dimensions),
+    ...relationshipFields(catalog),
+  ];
   const measureNames = Object.keys(catalog.measures);
 
   return z.object({
@@ -81,7 +94,10 @@ export function buildDatasetInputSchema(ds: AnyDatasetInstance) {
  */
 export function buildMetricInputSchema(ds: AnyDatasetInstance, metricName: string) {
   const catalog = getDatasetCatalog(ds);
-  const dimensionNames = Object.keys(catalog.dimensions);
+  const dimensionNames = [
+    ...Object.keys(catalog.dimensions),
+    ...relationshipFields(catalog),
+  ];
   const orderableNames = [
     ...dimensionNames,
     metricName,

--- a/packages/serve/src/semantic/datasets/utils/semantic-input-schema.ts
+++ b/packages/serve/src/semantic/datasets/utils/semantic-input-schema.ts
@@ -32,11 +32,7 @@ function grainEnum(catalog: DatasetCatalog): z.ZodTypeAny {
   return fieldEnum(catalog.supportedGrains);
 }
 
-function filterSchema(catalog: DatasetCatalog) {
-  const fieldNames = [
-    ...Object.keys(catalog.filters),
-    ...getQueryableRelationshipFields(catalog),
-  ];
+function filterSchema(fieldNames: string[]) {
   return z.object({
     field: fieldEnum(fieldNames),
     operator: z.enum(SEMANTIC_FILTER_OPERATORS),
@@ -68,11 +64,17 @@ export function buildDatasetInputSchema(ds: AnyDatasetInstance) {
     ...getQueryableRelationshipFields(catalog),
   ];
   const measureNames = Object.keys(catalog.measures);
+  // Dataset runtime (`validateDatasetQueryInput`) rejects any non-relationship
+  // field not in `catalog.filters`, so mirror that exactly (no dimension fallback).
+  const filterFieldNames = [
+    ...Object.keys(catalog.filters),
+    ...getQueryableRelationshipFields(catalog),
+  ];
 
   return z.object({
     dimensions: boundedArray(fieldEnum(dimensionNames), ds.limits?.maxDimensions),
     measures: boundedArray(fieldEnum(measureNames), ds.limits?.maxMeasures),
-    filters: boundedArray(filterSchema(catalog), ds.limits?.maxFilters),
+    filters: boundedArray(filterSchema(filterFieldNames), ds.limits?.maxFilters),
     orderBy: z.array(orderBySchema(catalog.orderableFields)).optional(),
     limit: z.number().int().positive().optional(),
     offset: z.number().int().nonnegative().optional(),
@@ -97,10 +99,18 @@ export function buildMetricInputSchema(ds: AnyDatasetInstance, metricName: strin
     metricName,
     ...(catalog.timeKey ? ['period'] : []),
   ];
+  // Metric runtime (`validateQuery`) falls back to all dimensions as valid
+  // filter fields when the dataset declares no filters — mirror that fallback so
+  // the schema never rejects a local-dimension filter the runtime would accept.
+  const declaredFilters = Object.keys(catalog.filters);
+  const filterFieldNames = [
+    ...(declaredFilters.length > 0 ? declaredFilters : Object.keys(catalog.dimensions)),
+    ...getQueryableRelationshipFields(catalog),
+  ];
 
   return z.object({
     dimensions: boundedArray(fieldEnum(dimensionNames), ds.limits?.maxDimensions),
-    filters: boundedArray(filterSchema(catalog), ds.limits?.maxFilters),
+    filters: boundedArray(filterSchema(filterFieldNames), ds.limits?.maxFilters),
     orderBy: z.array(orderBySchema(orderableNames)).optional(),
     limit: z.number().int().positive().optional(),
     offset: z.number().int().nonnegative().optional(),

--- a/packages/serve/src/semantic/datasets/utils/semantic-input-schema.ts
+++ b/packages/serve/src/semantic/datasets/utils/semantic-input-schema.ts
@@ -14,6 +14,7 @@
 import { z } from 'zod';
 import {
   getDatasetCatalog,
+  getQueryableRelationshipFields,
   SEMANTIC_FILTER_OPERATORS,
   type AnyDatasetInstance,
   type DatasetCatalog,
@@ -31,17 +32,10 @@ function grainEnum(catalog: DatasetCatalog): z.ZodTypeAny {
   return fieldEnum(catalog.supportedGrains);
 }
 
-function relationshipFields(catalog: DatasetCatalog): string[] {
-  return Object.values(catalog.relationships)
-    .filter(relationship => relationship.queryable)
-    .flatMap(relationship => relationship.fields);
-}
-
 function filterSchema(catalog: DatasetCatalog) {
-  const localFields = Object.keys(catalog.filters);
   const fieldNames = [
-    ...(localFields.length > 0 ? localFields : Object.keys(catalog.dimensions)),
-    ...relationshipFields(catalog),
+    ...Object.keys(catalog.filters),
+    ...getQueryableRelationshipFields(catalog),
   ];
   return z.object({
     field: fieldEnum(fieldNames),
@@ -71,7 +65,7 @@ export function buildDatasetInputSchema(ds: AnyDatasetInstance) {
   const catalog = getDatasetCatalog(ds);
   const dimensionNames = [
     ...Object.keys(catalog.dimensions),
-    ...relationshipFields(catalog),
+    ...getQueryableRelationshipFields(catalog),
   ];
   const measureNames = Object.keys(catalog.measures);
 
@@ -96,7 +90,7 @@ export function buildMetricInputSchema(ds: AnyDatasetInstance, metricName: strin
   const catalog = getDatasetCatalog(ds);
   const dimensionNames = [
     ...Object.keys(catalog.dimensions),
-    ...relationshipFields(catalog),
+    ...getQueryableRelationshipFields(catalog),
   ];
   const orderableNames = [
     ...dimensionNames,

--- a/packages/serve/src/types.ts
+++ b/packages/serve/src/types.ts
@@ -2,6 +2,7 @@ import type { ZodType, ZodTypeAny } from "zod";
 import type { ServeQueryLogger, ServeQueryEventCallback } from "./query-logger.js";
 import type {
   DatasetInstance,
+  DatasetQueryableDimensions,
   DatasetQueryFor,
   DatasetQueryResultFor,
   KnownStringKeys,
@@ -259,7 +260,7 @@ interface MetricEndpointSemantic<
 > {
   readonly __hypequerySemantic?: {
     kind: 'metric';
-    dimensions: TDataset['dimensions'];
+    dimensions: DatasetQueryableDimensions<TDataset>;
     measures: TDataset['measures'];
     metricName: TMetricName;
   };
@@ -268,7 +269,7 @@ interface MetricEndpointSemantic<
 interface DatasetEndpointSemantic<TDataset extends DatasetInstance<any, any, any, any>> {
   readonly __hypequerySemantic?: {
     kind: 'dataset';
-    dimensions: TDataset['dimensions'];
+    dimensions: DatasetQueryableDimensions<TDataset>;
     measures: TDataset['measures'];
   };
 }

--- a/packages/serve/type-tests/semantic-hooks.test-d.ts
+++ b/packages/serve/type-tests/semantic-hooks.test-d.ts
@@ -7,7 +7,14 @@
 
 import { createAPI } from '../src/server/create-api.js';
 import type { InferAPIType, InferApiType } from '../src/types.js';
-import { dataset, dimension, measure } from '@hypequery/datasets';
+import { belongsTo, dataset, dimension, measure } from '@hypequery/datasets';
+
+const Customers = dataset('customers', {
+  source: 'customers',
+  dimensions: {
+    country: dimension.string(),
+  },
+});
 
 const Orders = dataset('orders', {
   source: 'orders',
@@ -20,6 +27,9 @@ const Orders = dataset('orders', {
   measures: {
     revenue: measure.sum('amount'),
     orderCount: measure.count('country'),
+  },
+  relationships: {
+    customer: belongsTo(() => Customers, { from: 'customer_id', to: 'id' }),
   },
 });
 
@@ -72,12 +82,18 @@ void ordersMisclassified;
 type OrdersInput = Api['dataset:orders']['input'];
 
 const okDatasetInput: OrdersInput = {
-  dimensions: ['country', 'status', 'amount'],
+  dimensions: ['country', 'status', 'amount', 'customer.country'],
   measures: ['revenue', 'orderCount'],
   orderBy: [{ field: 'revenue', direction: 'desc' }],
   by: 'month',
 };
 void okDatasetInput;
+
+const okRelationshipOrder: OrdersInput = {
+  dimensions: ['customer.country'],
+  orderBy: [{ field: 'customer.country', direction: 'asc' }],
+};
+void okRelationshipOrder;
 
 // @ts-expect-error - unknown dimension name
 const badDatasetDim: OrdersInput = { dimensions: ['nope'] };

--- a/plans/relationship-aware-semantics-design.md
+++ b/plans/relationship-aware-semantics-design.md
@@ -1,7 +1,7 @@
 # Relationship-Aware Semantics Design
 
 Date: 2026-07-02
-Status: PR 1 landed 2026-07-06 (resolves "Next Work #4" in `datasets-semantic-layer-fix-plan.md`)
+Status: Implementation complete across PRs 1–3; documentation tracked separately
 
 ## Implementation status
 
@@ -18,8 +18,10 @@ Status: PR 1 landed 2026-07-06 (resolves "Next Work #4" in `datasets-semantic-la
   builder's alias-inference, which cannot parse quoted dotted aliases. 9 backend
   SQL tests (mock adapter) + 3 live ClickHouse integration cases (joined
   group-by, joined filter, joined tenant scoping).
-- **PR 3 — TODO.** Catalog/contract `queryable` + `fields`, serve
-  `semantic-input-schema` enums, React field-name types, docs page.
+- **PR 3 — DONE (2026-07-09).** Catalog/contract `queryable` + `fields`, serve
+  `semantic-input-schema` enums, React field-name types, and MCP introspection.
+- **PR 4 — TODO.** User-facing relationship documentation and stale semantic
+  package/spec documentation updates.
 
 Sources: `packages/datasets/src` (relationships, planners, validation, catalog, contract),
 `packages/clickhouse/src` (query builder joins, semantic backend), `packages/schema/src/compat`,
@@ -166,6 +168,8 @@ Revisit alongside the SQL-expression lineage work in schema compat.
   template-literal names for to-one relationships. Keep helper types shallow — this
   multiplies name unions and can stress `tsc` (same risk class as production-plan Phase 3).
 - Schema compat: join-column checks already exist; no new checks required for v1.
+- Documentation is intentionally deferred to PR 4 so the metadata/type changes
+  can be reviewed independently.
 
 ### 4. Until v1 lands
 
@@ -179,7 +183,8 @@ generic unknown-field error.
 |----|-------|
 | 1 | Validation + builder-path planning + protocol `leftJoin` + in-memory backend + unit/type tests |
 | 2 | `PlanNode.joins` + ClickHouse backend translation + live integration specs |
-| 3 | Catalog/contract `queryable` + serve enums + React field types + docs page |
+| 3 | Catalog/contract `queryable` + serve enums + React field types + MCP introspection |
+| 4 | User-facing docs page + stale package/spec documentation updates |
 
 ## Non-goals (v1)
 


### PR DESCRIPTION
## Expose queryable relationship metadata, harden the joins path, and freeze the plan/backend surface

### Summary

This is PR 3 of the relationship-aware semantics work ([[design doc](https://claude.ai/epitaxy/plans/relationship-aware-semantics-design.md)](plans/relationship-aware-semantics-design.md)): now that to-one relationship traversal executes end-to-end (PRs 1–2), this PR advertises those fields everywhere metadata is consumed — catalog, contract, serve input schemas, MCP introspection, and the TypeScript row types. It also includes review follow-ups that harden the join execution shipped in PRs 1–2, and deprecates the parallel plan/backend execution path so it no longer carries feature-sync cost.

### 1. Queryable relationship metadata (`0f18c3b`)

- **Catalog & contract:** `RelationshipCatalogEntry` replaces `execution: 'metadata_only'` with `queryable: boolean` and `fields: string[]` (the dotted `<relationship>.<dimension>` names a one-hop query may reference). `SEMANTIC_CONTRACT_VERSION` bumped **1 → 2**.
- **Tool generation & serve schemas:** generated dataset/metric tools and the serve Zod input schemas now accept relationship fields in `dimensions`, `filters`, and `orderBy`, matching what the runtime validators already allow.
- **MCP introspection:** `get_dataset_schema` reports `queryable`/`fields` per relationship.
- **Types:** `DatasetDimensionNames` and the row types (`DatasetRow`, `MetricRow`, etc.) include to-one relationship fields as template-literal names, excluding `hasMany` and SQL-backed target dimensions — so `row['customer.country']` is typed. New `DatasetQueryableDimensions` export; `DatasetFieldNames` kept as a compatible alias.

### 2. Review follow-ups & joins hardening (`f1d38dc`)

Correctness/cleanup from a full-branch review, plus safety fixes to the join execution:

- **`LEFT ANY JOIN` for relationship joins.** Plain `LEFT JOIN` fans out when a `belongsTo`/`hasOne` target key isn't actually unique, silently inflating SUM/COUNT in production while the in-memory backend's first-match semantics made dev/tests look correct. Relationship joins now emit ClickHouse `LEFT ANY JOIN` (new `leftAnyJoin` builder method; optional in the query-builder protocol with a `leftJoin` fallback), so both backends agree and fan-out is impossible. The public `leftJoin` API is unchanged.
- **Single source of truth for queryability rules.** `listQueryableRelationshipFields` (in `utils/relationship-fields.ts`, next to the runtime resolver) now feeds the catalog, and the exported `getQueryableRelationshipFields(catalog)` replaces helpers duplicated across `tools.ts` and serve. Also aligns the catalog's `sql === undefined` check with the resolver's truthy check.
- **Serve filter schema fix:** datasets that opt out with `filters: {}` no longer advertise every dimension as filterable in generated OpenAPI/client types; the schema mirrors declared filters + relationship fields with the documented superset-safe `z.string()` fallback.
- **MCP config-path fix:** config-shaped (non-`DatasetInstance`) datasets now derive `queryable`/`fields` instead of serializing nothing.
- **Definition-time validation:** `dataset()` rejects relationship names that match the source table (the join alias would shadow the base table) or contain dots (unreachable via qualified-field syntax). These configs were already broken at query time; they now fail fast with a clear error.
- **Misc:** tool field allowlists computed once at build time instead of per request; `renderLiteral` escapes backslashes (ClickHouse treats `\` as an escape in string literals — pre-existing, dev-controlled values only).

### 3. Plan/backend path deprecated & frozen (`47854d6`)

`createDatasetClient({ queryBuilder })` is the canonical execution path. `createBackend`, the `backend` client option, `createInMemoryBackend`, and the `PlanNode`/`SemanticBackend` protocol exports are now `@deprecated` with a FROZEN notice: bug fixes only, no new features, new semantic capabilities are not guaranteed to be mirrored there. Annotations only — nothing removed, nothing behaves differently.

### Compatibility notes

- **Contract consumers:** snapshot/diff consumers must account for the v2 relationship shape (`queryable` + `fields` instead of `execution`). No consumers in this repo were pinned to v1.
- **SQL change:** relationship joins render as `LEFT ANY JOIN` instead of `LEFT JOIN`. Results only differ where target join keys were duplicated — cases that previously produced silently inflated aggregates.
- **New throws:** `dataset()` now throws at definition time for relationship names colliding with the source table or containing dots.

### Testing

- Full suites green via turbo for `@hypequery/datasets`, `@hypequery/serve`, `@hypequery/clickhouse` (511 tests), and `@hypequery/mcp`; `test:types` (tsc) clean for datasets, serve, and react.
- New coverage: relationship fields in generated tools and serve schemas, `hasMany`/SQL-backed exclusions, MCP config-path metadata, definition-time name validation, `LEFT ANY JOIN` SQL emission (unit + backend translation).
- ⚠️ The two live-ClickHouse integration assertions were updated to expect `LEFT ANY JOIN` but need a smoke run against a real instance before merge.

Docs are intentionally deferred to PR 4 (user-facing relationship docs + stale spec updates), per the design doc.

🤖 Generated with [[Claude Code](https://claude.com/claude-code)](https://claude.com/claude-code)