### PR TITLE
docs: relationship documentation and release changeset

### DIFF
--- a/.changeset/hip-moons-shake.md
+++ b/.changeset/hip-moons-shake.md
@@ -1,0 +1,16 @@
+---
+"@hypequery/datasets": minor
+"@hypequery/clickhouse": minor
+"@hypequery/serve": minor
+"@hypequery/mcp": minor
+---
+
+Relationship-aware semantics: to-one relationships are now queryable end to end, and every metadata surface advertises them.
+
+**Querying (`@hypequery/datasets`, `@hypequery/clickhouse`):** dataset and metric queries can select, filter, and order by to-one related fields one hop deep (`dimensions: ['customer.country']`). Traversal executes as a ClickHouse `LEFT ANY JOIN` (new `leftAnyJoin` query-builder method), so base rows survive, duplicate target join keys can never fan out aggregates, and production matches the in-memory backend's first-match semantics. When runtime tenancy is active, joined targets with a `tenantKey` are scoped inside the join condition. `hasMany` remains metadata-only, and result row types include qualified fields (`row['customer.country']` is typed).
+
+**Metadata:** the catalog and semantic contract expose `queryable` and `fields` per relationship (replacing `execution: 'metadata_only'`; `SEMANTIC_CONTRACT_VERSION` is now 2). Generated agent tools, Serve's Zod/OpenAPI input schemas, and MCP `get_dataset_schema` all advertise the same qualified field names the validators accept — including for config-shaped datasets in MCP. Serve no longer advertises dimensions as filterable when a dataset explicitly declares `filters: {}`.
+
+**Validation:** `dataset()` now rejects relationship names that match the dataset's source table (the join alias would shadow the base table) or contain dots — both configurations previously failed confusingly at query time.
+
+**Deprecations (no removals, no behavior changes):** the plan/backend execution path is frozen in favor of `createDatasetClient({ queryBuilder })`. `createBackend`, the `backend` client option, `createInMemoryBackend`, and the `PlanNode`/`SemanticBackend` protocol exports are `@deprecated` and receive bug fixes only.

--- a/website-next/docs/datasets/catalog.mdx
+++ b/website-next/docs/datasets/catalog.mdx
@@ -15,7 +15,7 @@ Catalog metadata includes:
 - measures and their aggregation metadata
 - attached named metrics
 - filters, allowed operators, and filter value types
-- relationship metadata and current execution support
+- relationship metadata, including whether each relationship is queryable and the qualified field names it contributes
 - dataset limits, maximum result limit, supported time grains, and orderable fields
 
 ## Dataset catalog
@@ -78,6 +78,8 @@ The returned object is plain JSON-compatible metadata.
 }
 ```
 </CodeBlock>
+
+Relationship entries carry `queryable` and `fields` — the qualified `<relationship>.<dimension>` names a one-hop query may reference. To-one relationships (`belongsTo`, `hasOne`) are queryable; `hasMany` entries report `queryable: false` with an empty field list. See [Relationships](/docs/datasets/relationships) for the query semantics.
 
 When a filter definition does not specify `operators`, the catalog exposes the default semantic operators from `SEMANTIC_FILTER_OPERATORS`:
 

--- a/website-next/docs/datasets/defining-datasets.mdx
+++ b/website-next/docs/datasets/defining-datasets.mdx
@@ -64,4 +64,4 @@ A dataset can include:
 - `relationships`
 - `limits`
 
-See [Dimensions](/docs/datasets/dimensions), [Measures](/docs/datasets/measures), and [Metrics](/docs/datasets/metrics) for the main building blocks.
+See [Dimensions](/docs/datasets/dimensions), [Measures](/docs/datasets/measures), [Metrics](/docs/datasets/metrics), and [Relationships](/docs/datasets/relationships) for the main building blocks.

--- a/website-next/docs/datasets/relationships.mdx
+++ b/website-next/docs/datasets/relationships.mdx
@@ -1,0 +1,133 @@
+---
+title: Relationships
+description: Model links between datasets and query to-one related fields one hop deep.
+---
+
+import { CodeBlock } from 'fumadocs-ui/components/codeblock';
+
+Relationships model how one dataset links to another. To-one relationships (`belongsTo`, `hasOne`) are queryable: dataset and metric queries can select, filter, and order by fields on the related dataset one hop deep, and hypequery executes the join for you. To-many relationships (`hasMany`) are metadata only.
+
+## Defining relationships
+
+Declare relationships in the dataset config. The target is a lazy reference (`() => Dataset`) so datasets can reference each other without import-order problems. `from` is the join column on this dataset's table; `to` is the join column on the target's table.
+
+<CodeBlock>
+```typescript
+import { dataset, dimension, measure, belongsTo, hasMany } from '@hypequery/datasets';
+
+const Customers = dataset('customers', {
+  source: 'customers',
+  dimensions: {
+    id: dimension.string(),
+    country: dimension.string(),
+    tier: dimension.string(),
+  },
+});
+
+const LineItems = dataset('line_items', {
+  source: 'line_items',
+  dimensions: {
+    id: dimension.string(),
+    sku: dimension.string(),
+  },
+});
+
+const Orders = dataset('orders', {
+  source: 'orders',
+  dimensions: {
+    id: dimension.string(),
+    status: dimension.string(),
+    amount: dimension.number(),
+  },
+  measures: {
+    revenue: measure.sum('amount'),
+  },
+  relationships: {
+    customer: belongsTo(() => Customers, { from: 'customer_id', to: 'id' }),
+    items: hasMany(() => LineItems, { from: 'id', to: 'order_id' }),
+  },
+});
+```
+</CodeBlock>
+
+The three helpers describe where the foreign key lives:
+
+- `belongsTo` — many-to-one; the FK is on this table (`orders.customer_id → customers.id`).
+- `hasOne` — one-to-one; the FK is on the target table.
+- `hasMany` — one-to-many; the FK is on the target table. Metadata only — see below.
+
+## Querying related fields
+
+Reference to-one related dimensions as `<relationship>.<dimension>` anywhere a dimension name is accepted: `dimensions`, `filters`, and `orderBy`, in both dataset and metric queries.
+
+<CodeBlock>
+```typescript
+const result = await analytics.execute(Orders, {
+  dimensions: ['customer.country'],
+  measures: ['revenue'],
+  filters: [{ field: 'customer.tier', operator: 'eq', value: 'enterprise' }],
+  orderBy: [{ field: 'customer.country', direction: 'asc' }],
+});
+
+// Rows are typed: result.data[0]['customer.country'] is string | undefined
+```
+</CodeBlock>
+
+Result rows key joined columns by their qualified name (`'customer.country'`), and the row types include them, so projections stay fully typed end to end — including through Serve endpoints and the React hooks.
+
+## Join semantics
+
+Relationship traversal executes as a ClickHouse `LEFT ANY JOIN` (first match), aliased by the relationship name:
+
+- Base rows always survive. An order with no matching customer keeps its measures; its joined columns are `NULL`.
+- At most one target row matches per base row, so duplicate join keys on the target can never fan out and inflate aggregates. The in-memory backend applies the same first-match rule.
+- Filtering on a joined column excludes base rows without a match (the standard SQL behavior: `NULL` fails the comparison).
+
+Queries that reference no relationship fields generate exactly the same SQL as before relationships existed — there is no cost until you traverse.
+
+## Rules and limits
+
+Validation rejects, with a specific error message:
+
+- **More than one hop.** `customer.region.name` is not supported; only `<relationship>.<dimension>`.
+- **`hasMany` traversal.** Joining a to-many relationship would fan out rows and corrupt aggregates, so `hasMany` stays metadata only.
+- **SQL-backed target dimensions.** Dimensions defined with a raw `sql` expression on the target are not yet queryable through a relationship.
+- **Measures across relationships.** Measures aggregate the base dataset only.
+- **Ordering by an unselected joined field.** As with local dimensions, a qualified `orderBy` field must also be selected as a dimension.
+
+At definition time, `dataset()` rejects relationship names that collide with the dataset's own `source` table (the join alias would shadow the base table) or contain a dot.
+
+## Multi-tenancy
+
+When runtime tenant enforcement is active and the target dataset declares a `tenantKey`, the tenant predicate is applied to the joined table **inside the join condition**. Rows from other tenants are never joined — they surface as `NULL`s rather than leaking values — and base-table scoping continues to apply as usual. Explicitly filtering on the target's tenant column is rejected while enforcement is active, same as on the base dataset.
+
+## Metadata
+
+The [catalog](/docs/datasets/catalog) and the versioned semantic contract expose relationship metadata, so tools and agents can discover what is traversable:
+
+<CodeBlock>
+```json
+{
+  "relationships": {
+    "customer": {
+      "kind": "belongsTo",
+      "target": "customers",
+      "from": "customer_id",
+      "to": "id",
+      "queryable": true,
+      "fields": ["customer.id", "customer.country", "customer.tier"]
+    },
+    "items": {
+      "kind": "hasMany",
+      "target": "line_items",
+      "from": "id",
+      "to": "order_id",
+      "queryable": false,
+      "fields": []
+    }
+  }
+}
+```
+</CodeBlock>
+
+`fields` lists the qualified names a query may reference. The same list flows into [generated tools](/docs/datasets/tool-generation) (enum schemas for agents), Serve's OpenAPI input schemas, and MCP's `get_dataset_schema`, so every surface advertises exactly what the validators accept.

--- a/website-next/docs/datasets/tool-generation.mdx
+++ b/website-next/docs/datasets/tool-generation.mdx
@@ -35,7 +35,7 @@ const openaiTools = toOpenAITools(tools);
 ```
 </CodeBlock>
 
-The generated schema includes enums derived from the dataset catalog.
+The generated schema includes enums derived from the dataset catalog. Queryable [relationship fields](/docs/datasets/relationships) (for example `customer.country`) appear in the dimension, filter, and order enums alongside local dimensions.
 
 <CodeBlock>
 ```json

--- a/website-next/docs/mcp/tools.mdx
+++ b/website-next/docs/mcp/tools.mdx
@@ -40,7 +40,7 @@ Example response:
 
 ## `get_dataset_schema`
 
-Returns metadata for one dataset, including dimensions, measures, named metrics, filters, tenant key, time key, limits, and relationship metadata when present.
+Returns metadata for one dataset, including dimensions, measures, named metrics, filters, tenant key, time key, limits, and relationship metadata when present. Relationship entries include `queryable` and `fields`, so agents can discover which related fields (for example `customer.country`) a query may reference. See [Relationships](/docs/datasets/relationships).
 
 <CodeBlock>
 ```json

--- a/website-next/docs/meta.json
+++ b/website-next/docs/meta.json
@@ -28,6 +28,7 @@
     "datasets/metrics",
     "datasets/filters",
     "datasets/time-grains",
+    "datasets/relationships",
     "datasets/execution",
     "datasets/caching",
     "datasets/multi-tenancy",


### PR DESCRIPTION
## Summary
Final piece of the relationship-aware semantics work (design doc): user-facing documentation for querying to-one relationships, refreshes of the metadata docs that still described the old execution: 'metadata_only' world, and the changeset covering the whole feature for release.

## New documentation
docs/datasets/relationships (added to the sidebar between Time Grains and Execution) — the complete guide to the feature:

Defining belongsTo / hasOne / hasMany with lazy targets and from/to join columns
Querying related fields one hop deep (dimensions: ['customer.country']) in dimensions, filters, and orderBy, with typed result rows
Join semantics: LEFT ANY JOIN, base rows always survive, duplicate target keys can't fan out aggregates, filters on joined columns exclude unmatched rows
Validation rules: single hop only, hasMany is metadata-only, SQL-backed target dimensions excluded, measures aggregate the base dataset only, and the definition-time name checks
Multi-tenancy: tenant predicates applied inside the join condition, so other-tenant rows surface as NULLs rather than leaking
The queryable/fields metadata shape and where it flows (catalog, contract, generated tools, Serve OpenAPI, MCP)
Refreshed pages

Catalog — "relationship metadata and current execution support" now describes queryable/fields, with a short section on relationship entries linking to the new page

MCP tools — get_dataset_schema documents the new relationship metadata agents can use for discovery
Tool generation — notes that relationship fields appear in the generated dimension/filter/order enums

Defining datasets — links Relationships alongside Dimensions/Measures/Metrics
The site docs had no stale createBackend-as-recommended or "metadata only" claims, so no further cleanup was needed.

## Changeset
One changeset with minor bumps for @hypequery/datasets, @hypequery/clickhouse, @hypequery/serve, and @hypequery/mcp, summarizing for the changelog: relationship querying end to end, LEFT ANY JOIN / leftAnyJoin, contract v2 (queryable + fields), the serve filter-schema fix, the new dataset() name validation, and the plan/backend deprecations (frozen, no removals). Verified with changeset status — all four packages resolve to minor.

## Testing
Docs site: MDX compilation and TypeScript pass (next build compiles clean; the build's later failure is the blog's pre-existing BLOB_READ_WRITE_TOKEN environment requirement, unrelated to this change)
npx changeset status validates the release plan