### PR TITLE
fix: harden logging and diagnostics (non-breaking security patches)

### DIFF
--- a/.changeset/secure-r0-containment.md
+++ b/.changeset/secure-r0-containment.md
@@ -1,0 +1,10 @@
+---
+"@hypequery/clickhouse": patch
+"@hypequery/serve": patch
+"@hypequery/cli": patch
+---
+
+Harden logging and diagnostics without changing public APIs: never mark
+authenticated or tenant-aware responses as publicly cacheable, log the
+parameterized SQL template instead of a value-substituted string, and redact
+connection URLs in CLI output and error messages.

--- a/packages/cli/src/commands/generate-datasets.test.ts
+++ b/packages/cli/src/commands/generate-datasets.test.ts
@@ -49,6 +49,7 @@ describe('generate datasets command', () => {
 
   afterEach(() => {
     exitHandler.restore();
+    delete process.env.CLICKHOUSE_URL;
   });
 
   it('derives datasets output from path when provided', async () => {
@@ -80,5 +81,17 @@ describe('generate datasets command', () => {
         excludeTables: ['orders_archive'],
       }),
     );
+  });
+
+  it('redacts credentials from connection diagnostics', async () => {
+    process.env.CLICKHOUSE_URL = 'https://admin:secret@clickhouse.example.com:8443/analytics?token=secret';
+    vi.mocked(detectDb.getTableCount).mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    await expect(generateDatasetsCommand({})).rejects.toThrow();
+
+    expect(mockLogger.indent).toHaveBeenCalledWith(
+      'CLICKHOUSE_URL=https://clickhouse.example.com:8443/analytics',
+    );
+    expect(mockLogger.indent).not.toHaveBeenCalledWith(expect.stringContaining('secret'));
   });
 });

--- a/packages/cli/src/commands/generate-datasets.ts
+++ b/packages/cli/src/commands/generate-datasets.ts
@@ -10,6 +10,7 @@ import ora from 'ora';
 import { logger } from '../utils/logger.js';
 import { getTableCount } from '../utils/detect-database.js';
 import { generateDatasets } from '../generators/dataset-generator.js';
+import { redactConnectionUrl } from '../utils/redact-connection-url.js';
 
 export interface GenerateDatasetsOptions {
   output?: string;
@@ -102,7 +103,9 @@ export async function generateDatasetsCommand(options: GenerateDatasetsOptions =
         logger.indent('• Firewall blocking connection');
         logger.newline();
         logger.info('Check your configuration:');
-        logger.indent('CLICKHOUSE_URL=' + (process.env.CLICKHOUSE_URL || process.env.CLICKHOUSE_HOST || 'not set'));
+        logger.indent('CLICKHOUSE_URL=' + redactConnectionUrl(
+          process.env.CLICKHOUSE_URL || process.env.CLICKHOUSE_HOST,
+        ));
       } else if (error.message.includes('No tables found')) {
         logger.newline();
         logger.info('No tables match the specified criteria');

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -63,6 +63,7 @@ describe('generate command', () => {
   afterEach(() => {
     exitHandler.restore();
     delete process.env.CLICKHOUSE_HOST;
+    delete process.env.CLICKHOUSE_URL;
   });
 
   describe('Happy path', () => {
@@ -157,6 +158,18 @@ describe('generate command', () => {
       expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('ECONNREFUSED'));
       expect(logger.info).toHaveBeenCalledWith('This usually means:');
       expect(logger.indent).toHaveBeenCalledWith('• ClickHouse is not running');
+    });
+
+    it('redacts credentials from connection diagnostics', async () => {
+      process.env.CLICKHOUSE_URL = 'https://admin:secret@clickhouse.example.com:8443/analytics?token=secret';
+      vi.mocked(detectDb.getTableCount).mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+      await expect(generateCommand({})).rejects.toBeInstanceOf(ProcessExitError);
+
+      expect(logger.indent).toHaveBeenCalledWith(
+        'CLICKHOUSE_URL=https://clickhouse.example.com:8443/analytics',
+      );
+      expect(logger.indent).not.toHaveBeenCalledWith(expect.stringContaining('secret'));
     });
 
     it('handles table generation errors', async () => {

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -4,6 +4,7 @@ import { logger } from '../utils/logger.js';
 import { findSchemaFile } from '../utils/find-files.js';
 import { detectDatabase, getTableCount, type DatabaseType } from '../utils/detect-database.js';
 import { getTypeGenerator } from '../generators/index.js';
+import { redactConnectionUrl } from '../utils/redact-connection-url.js';
 
 export interface GenerateOptions {
   output?: string;
@@ -88,7 +89,9 @@ export async function generateCommand(options: GenerateOptions = {}) {
         logger.indent('• Firewall blocking connection');
         logger.newline();
         logger.info('Check your configuration:');
-        logger.indent('CLICKHOUSE_URL=' + (process.env.CLICKHOUSE_URL || process.env.CLICKHOUSE_HOST || 'not set'));
+        logger.indent('CLICKHOUSE_URL=' + redactConnectionUrl(
+          process.env.CLICKHOUSE_URL || process.env.CLICKHOUSE_HOST,
+        ));
         logger.newline();
         logger.info('Docs: https://hypequery.com/docs/troubleshooting#connection-errors');
       } else if (error.message.includes('ETIMEDOUT') || error.message.includes('timeout')) {

--- a/packages/cli/src/utils/redact-connection-url.test.ts
+++ b/packages/cli/src/utils/redact-connection-url.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { redactConnectionUrl } from './redact-connection-url.js';
+
+describe('redactConnectionUrl', () => {
+  it('removes embedded credentials, query parameters, and fragments', () => {
+    expect(redactConnectionUrl(
+      'https://admin:super-secret@clickhouse.example.com:8443/analytics?token=secret#details',
+    )).toBe('https://clickhouse.example.com:8443/analytics');
+  });
+
+  it('keeps a useful bare host for diagnostics', () => {
+    expect(redactConnectionUrl('localhost:8123/analytics')).toBe('localhost:8123/analytics');
+  });
+
+  it('does not echo malformed input', () => {
+    expect(redactConnectionUrl('https://%')).toBe('[configured connection URL]');
+  });
+
+  it('handles missing configuration', () => {
+    expect(redactConnectionUrl(undefined)).toBe('not set');
+  });
+});

--- a/packages/cli/src/utils/redact-connection-url.ts
+++ b/packages/cli/src/utils/redact-connection-url.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns enough endpoint information for diagnostics without exposing URL
+ * userinfo, query parameters, or fragments that may contain credentials.
+ */
+export function redactConnectionUrl(value: string | undefined): string {
+  if (!value) return 'not set';
+
+  const trimmed = value.trim();
+  const hasScheme = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmed);
+
+  try {
+    const url = new URL(hasScheme ? trimmed : `http://${trimmed}`);
+    const pathname = url.pathname === '/' ? '' : url.pathname;
+    return `${hasScheme ? `${url.protocol}//` : ''}${url.host}${pathname}`;
+  } catch {
+    return '[configured connection URL]';
+  }
+}

--- a/packages/clickhouse/src/cli/bin.js
+++ b/packages/clickhouse/src/cli/bin.js
@@ -21,8 +21,13 @@ const colors = {
   cyan: '\x1b[36m'
 };
 
+// Returns enough endpoint information for diagnostics without exposing URL
+// userinfo, query parameters, or fragments that may contain credentials.
+// Keep in sync with packages/cli/src/utils/redact-connection-url.ts.
 function redactConnectionUrl(value) {
-  const trimmed = String(value).trim();
+  if (!value) return 'not set';
+
+  const trimmed = value.trim();
   const hasScheme = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmed);
 
   try {

--- a/packages/clickhouse/src/cli/bin.js
+++ b/packages/clickhouse/src/cli/bin.js
@@ -21,6 +21,19 @@ const colors = {
   cyan: '\x1b[36m'
 };
 
+function redactConnectionUrl(value) {
+  const trimmed = String(value).trim();
+  const hasScheme = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmed);
+
+  try {
+    const url = new URL(hasScheme ? trimmed : `http://${trimmed}`);
+    const pathname = url.pathname === '/' ? '' : url.pathname;
+    return `${hasScheme ? `${url.protocol}//` : ''}${url.host}${pathname}`;
+  } catch {
+    return '[configured connection URL]';
+  }
+}
+
 /**
  * Display a colorful banner with the tool name
  */
@@ -206,7 +219,7 @@ async function main() {
       process.env.NEXT_PUBLIC_CLICKHOUSE_DATABASE ||
       'default';
 
-    console.log(`${colors.dim}Connecting to ClickHouse at ${colors.reset}${colors.bright}${host}${colors.reset}`);
+    console.log(`${colors.dim}Connecting to ClickHouse at ${colors.reset}${colors.bright}${redactConnectionUrl(host)}${colors.reset}`);
     console.log(`${colors.dim}Database: ${colors.reset}${colors.bright}${database}${colors.reset}`);
 
     // Configure connection

--- a/packages/clickhouse/src/core/cache/cache-manager.ts
+++ b/packages/clickhouse/src/core/cache/cache-manager.ts
@@ -4,7 +4,6 @@ import type { CacheEntry, CacheOptions, CacheStatus } from './types.js';
 import { computeCacheKey } from './key.js';
 import { mergeCacheOptions } from './runtime-context.js';
 import { logger } from '../utils/logger.js';
-import { substituteParameters } from '../utils.js';
 
 function isCacheable(options: CacheOptions): boolean {
   const ttl = options.ttlMs ?? 0;
@@ -22,7 +21,7 @@ function deriveTags<Schema extends SchemaDefinition<Schema>, State extends AnyBu
 }
 
 interface CacheHitLogOptions {
-  renderSql: string;
+  sql: string;
   parameters: unknown[];
   status: CacheStatus;
   cacheKey: string;
@@ -33,7 +32,7 @@ interface CacheHitLogOptions {
 }
 
 async function logCacheHit({
-  renderSql,
+  sql,
   parameters,
   status,
   cacheKey,
@@ -44,7 +43,7 @@ async function logCacheHit({
 }: CacheHitLogOptions): Promise<void> {
   const timestamp = Date.now();
   logger.logQuery({
-    query: renderSql,
+    query: sql,
     parameters,
     startTime: timestamp,
     endTime: timestamp,
@@ -82,8 +81,6 @@ export async function executeWithCache<
   const activeProvider = provider;
 
   const { sql, parameters } = builder.toSQLWithParams();
-  const adapter = builder.getAdapter();
-  const renderSql = adapter.render ? adapter.render(sql, parameters) : substituteParameters(sql, parameters);
   const tableName = builder.getTableName();
   const namespace = mergedOptions.namespace || runtime.namespace;
   const queryNode = builder.toQueryNode();
@@ -121,7 +118,7 @@ export async function executeWithCache<
       runtime.stats.staleHits += 1;
     }
     await logCacheHit({
-      renderSql,
+      sql,
       parameters,
       status,
       cacheKey: key,

--- a/packages/clickhouse/src/core/features/executor.ts
+++ b/packages/clickhouse/src/core/features/executor.ts
@@ -29,11 +29,10 @@ export class ExecutorFeature<
     const adapter = this.builder.getAdapter();
     const queryNode = this.builder.toQueryNode();
     const { sql, parameters } = this.toSQLWithParams();
-    const renderSql = adapter.render ? adapter.render(sql, parameters) : substituteParameters(sql, parameters);
 
     const startTime = Date.now();
     logger.logQuery({
-      query: renderSql,
+      query: sql,
       parameters,
       startTime,
       status: 'started',
@@ -49,7 +48,7 @@ export class ExecutorFeature<
       const endTime = Date.now();
 
       logger.logQuery({
-        query: renderSql,
+        query: sql,
         parameters,
         startTime,
         endTime,
@@ -65,7 +64,7 @@ export class ExecutorFeature<
     } catch (error) {
       const endTime = Date.now();
       logger.logQuery({
-        query: renderSql,
+        query: sql,
         parameters,
         startTime,
         endTime,
@@ -83,11 +82,10 @@ export class ExecutorFeature<
     const adapter = this.builder.getAdapter();
     const queryNode = this.builder.toQueryNode();
     const { sql, parameters } = this.toSQLWithParams();
-    const renderSql = adapter.render ? adapter.render(sql, parameters) : substituteParameters(sql, parameters);
 
     const startTime = Date.now();
     logger.logQuery({
-      query: renderSql,
+      query: sql,
       parameters,
       startTime,
       status: 'started'
@@ -103,7 +101,7 @@ export class ExecutorFeature<
 
       const endTime = Date.now();
       logger.logQuery({
-        query: renderSql,
+        query: sql,
         parameters,
         startTime,
         endTime,
@@ -115,7 +113,7 @@ export class ExecutorFeature<
     } catch (error) {
       const endTime = Date.now();
       logger.logQuery({
-        query: renderSql,
+        query: sql,
         parameters,
         startTime,
         endTime,

--- a/packages/serve/src/pipeline.ts
+++ b/packages/serve/src/pipeline.ts
@@ -356,7 +356,7 @@ export const executeEndpoint = async <
           ...(verboseAuthErrors && authErrorInfo?.details ? { auth_error: authErrorInfo.details } : {}),
           endpoint: endpoint.metadata.path,
         },
-        { 'x-request-id': requestId }
+        { 'x-request-id': requestId, 'cache-control': 'no-store' }
       );
     }
 
@@ -389,7 +389,8 @@ export const executeEndpoint = async <
             actual: authzResult.actual,
           }),
           endpoint: endpoint.metadata.path,
-        }
+        },
+        { 'x-request-id': requestId, 'cache-control': 'no-store' }
       );
     }
     const resolvedContext = await resolveContext(contextFactory, request, authContext);
@@ -418,7 +419,7 @@ export const executeEndpoint = async <
         return createErrorResponse(403, 'FORBIDDEN', errorMessage, {
           reason: 'missing_tenant_context',
           tenant_required: true,
-        }, { 'x-request-id': requestId });
+        }, { 'x-request-id': requestId, 'cache-control': 'no-store' });
       }
 
       if (tenantId) {

--- a/packages/serve/src/pipeline.ts
+++ b/packages/serve/src/pipeline.ts
@@ -469,7 +469,12 @@ export const executeEndpoint = async <
       ...(endpoint.defaultHeaders ?? {}),
       'x-request-id': requestId,
     };
-    if (typeof cacheTtlMs === 'number') {
+    // Authenticated and tenant-aware responses must never be shared by an
+    // intermediary cache. Endpoint TTLs only opt public, tenant-independent
+    // responses into shared caching.
+    if (requiresAuth || authContext || activeTenantConfig) {
+      headers['cache-control'] = 'no-store';
+    } else if (typeof cacheTtlMs === 'number') {
       headers['cache-control'] = cacheTtlMs > 0 ? `public, max-age=${Math.floor(cacheTtlMs / 1000)}` : 'no-store';
     }
 

--- a/packages/serve/src/server.test.ts
+++ b/packages/serve/src/server.test.ts
@@ -121,6 +121,71 @@ describe("defineServe", () => {
     expect(authContexts[0]).toEqual({ apiKey: "valid-key" });
   });
 
+  it("never marks authenticated responses as publicly cacheable", async () => {
+    const api = defineServe({
+      queries: {
+        secureMetric: {
+          cacheTtlMs: 60_000,
+          query: async () => ({ ok: true }),
+        },
+      },
+    });
+
+    api.route("/secure-cache", api.queries.secureMetric);
+    api.useAuth(async () => ({ userId: "user-1" }));
+
+    const response = await api.handler(
+      createRequest({ path: "/secure-cache" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers?.["cache-control"]).toBe("no-store");
+  });
+
+  it("never marks tenant-aware responses as publicly cacheable", async () => {
+    const api = defineServe({
+      tenant: {
+        extract: (auth) => auth.tenantId,
+      },
+      queries: {
+        tenantMetric: {
+          cacheTtlMs: 60_000,
+          query: async ({ ctx }) => ({ tenantId: ctx.tenantId }),
+        },
+      },
+    });
+
+    api.route("/tenant-cache", api.queries.tenantMetric);
+    api.useAuth(async () => ({ userId: "user-1", tenantId: "tenant-1" }));
+
+    const response = await api.handler(
+      createRequest({ path: "/tenant-cache" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers?.["cache-control"]).toBe("no-store");
+  });
+
+  it("keeps explicit public caching for unauthenticated tenant-independent responses", async () => {
+    const api = defineServe({
+      queries: {
+        publicMetric: {
+          cacheTtlMs: 60_000,
+          query: async () => ({ ok: true }),
+        },
+      },
+    });
+
+    api.route("/public-cache", api.queries.publicMetric);
+
+    const response = await api.handler(
+      createRequest({ path: "/public-cache" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers?.["cache-control"]).toBe("public, max-age=60");
+  });
+
   it("validates input payloads using endpoint schemas", async () => {
     const received: unknown[] = [];
     const api = defineServe({

--- a/website-next/docs/reference/connection.mdx
+++ b/website-next/docs/reference/connection.mdx
@@ -63,6 +63,15 @@ const db = createQueryBuilder({
 ```
 </CodeBlock>
 
+<Callout type="warn">
+Connecting an end-user browser directly to ClickHouse is not recommended. Any
+credentials shipped to the browser — including values in `NEXT_PUBLIC_*` or
+`VITE_*` variables — are public, so anyone can run whatever that ClickHouse user
+is allowed to. If you do it, restrict the user (read-only, quotas, row
+policies); otherwise keep credentials in server-only variables and have browsers
+call an authenticated server API such as one built with `@hypequery/serve`.
+</Callout>
+
 
 ## Embedded ClickHouse (chDB)
 


### PR DESCRIPTION
## Summary

Ships the **non-breaking subset** of the R0 security-hardening work as a patch bump for `@hypequery/clickhouse`, `@hypequery/serve`, and `@hypequery/cli`. Everything here is either a behavior-preserving security fix or docs — no public API changes, no previously-valid usage broken.

- **serve** — never mark authenticated or tenant-aware responses as publicly cacheable (force `cache-control: no-store`), so an intermediary/CDN can't share protected responses.
- **clickhouse** — log the parameterized SQL template instead of a value-substituted string in the executor and cache paths, keeping query values out of log strings.
- **clickhouse / cli** — redact connection URLs (userinfo/query/fragment) in CLI output and error messages.
- **docs** — `connection.mdx` warns that connecting an end-user browser directly to ClickHouse is not recommended, with an "if you do it, restrict the user" note.

## Deliberately deferred (not in this PR)

These are breaking or minor-level and are intentionally **not** shipped under a patch, to avoid smuggling breaking changes into a patch release:

- CORS credentialed-wildcard rejection (throws on previously-functional config)
- `escapeValue` fail-closed on unsupported positional params
- Logger parameter-value redaction + `includeParameterValues` option
- Removal of `NEXT_PUBLIC_*` / `VITE_*` env-var support

## Testing

- `@hypequery/clickhouse`: 510 unit tests pass; typecheck clean
- `@hypequery/serve`: 451 tests pass; typecheck clean
- `@hypequery/cli`: 31 tests pass; typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)