### PR TITLE
Website SEO: fix duplicate titles, add OG images, CTA tracking, contact page, and SERP copy experiment

### DIFF
--- a/website-next/src/app/blog/[slug]/opengraph-image.tsx
+++ b/website-next/src/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,66 @@
+import { ImageResponse } from 'next/og';
+import { getPostBySlug } from '@/lib/blog';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const alt = 'hypequery blog post';
+
+export default async function Image({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const post = await getPostBySlug(slug);
+  const title = post?.data.title ?? 'hypequery blog';
+  const fontSize = title.length > 70 ? 48 : 60;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: 72,
+          background: 'linear-gradient(135deg, #101223 0%, #1c2145 55%, #3a3f8c 100%)',
+          color: '#ffffff',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 8,
+              background: '#a5b4fc',
+            }}
+          />
+          <div style={{ fontSize: 36, fontWeight: 700 }}>hypequery</div>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            fontSize,
+            fontWeight: 700,
+            lineHeight: 1.15,
+            maxWidth: 1020,
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            fontSize: 26,
+            color: '#a5b4fc',
+          }}
+        >
+          <div>Blog</div>
+          <div>hypequery.com</div>
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/website-next/src/app/blog/[slug]/page.tsx
+++ b/website-next/src/app/blog/[slug]/page.tsx
@@ -228,7 +228,7 @@ export default async function BlogPostPage({
               day: 'numeric',
             })}
           </time>
-          <h1 className="font-display mt-3 text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 sm:text-5xl">
+          <h1 className="mt-3 text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 sm:text-5xl">
             {data.title}
           </h1>
           {data.description && (

--- a/website-next/src/app/blog/[slug]/page.tsx
+++ b/website-next/src/app/blog/[slug]/page.tsx
@@ -188,10 +188,14 @@ export default async function BlogPostPage({
     datePublished: publishDate ?? undefined,
     dateModified: publishDate ?? undefined,
     mainEntityOfPage: articleUrl,
-    author: {
-      '@type': 'Organization',
-      name: 'hypequery',
-    },
+    author: data.author
+      ? { '@type': 'Person', name: data.author }
+      : {
+          '@type': 'Person',
+          name: 'Luke Reilly',
+          url: 'https://github.com/lureilly1',
+          sameAs: ['https://dev.to/lureilly1', 'https://medium.com/@lureilly1'],
+        },
     publisher: {
       '@type': 'Organization',
       name: 'hypequery',

--- a/website-next/src/app/blog/page.tsx
+++ b/website-next/src/app/blog/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import type { Metadata } from 'next';
 import { getPosts } from '@/lib/blog';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 import { comparePageBySlug } from '@/data/compare-pages';
 
 export async function generateMetadata({
@@ -26,6 +26,7 @@ export async function generateMetadata({
       url: absoluteUrl(canonicalPath),
       title: pageNumber > 1 ? `hypequery ClickHouse Blog - Page ${pageNumber}` : 'hypequery ClickHouse Blog',
       description,
+      images: ogImage(title),
     },
   };
 }

--- a/website-next/src/app/blog/page.tsx
+++ b/website-next/src/app/blog/page.tsx
@@ -51,7 +51,7 @@ export default async function BlogPage({
         <p className="text-sm uppercase tracking-[0.2em] text-indigo-500 mb-3">
           Insights
         </p>
-        <h1 className="font-display text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 sm:text-5xl mb-4">
+        <h1 className="text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 sm:text-5xl mb-4">
           ClickHouse and TypeScript implementation guides
         </h1>
         <p className="mt-4 text-lg text-gray-600 dark:text-gray-300">
@@ -71,7 +71,7 @@ export default async function BlogPage({
                 })}
               </time>
             </div>
-            <h2 className="font-display mt-3 text-2xl font-bold text-gray-900 dark:text-gray-100">
+            <h2 className="mt-3 text-2xl font-bold text-gray-900 dark:text-gray-100">
               <Link
                 href={`/blog/${post.slug}`}
                 className="hover:text-indigo-600 dark:hover:text-indigo-400"

--- a/website-next/src/app/clickhouse-analytics/page.tsx
+++ b/website-next/src/app/clickhouse-analytics/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
   title: 'ClickHouse Analytics',
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
     canonical: absoluteUrl('/clickhouse-analytics'),
   },
   openGraph: {
+    images: ogImage('ClickHouse Analytics'),
     type: 'website',
     url: absoluteUrl('/clickhouse-analytics'),
     title: 'ClickHouse Analytics | Build a Reusable Analytics Layer',

--- a/website-next/src/app/clickhouse-api/page.tsx
+++ b/website-next/src/app/clickhouse-api/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse API in TypeScript | hypequery',
+  title: 'ClickHouse API in TypeScript',
   description:
     'Build a ClickHouse API in TypeScript from typed query definitions. Generate schema types, expose validated endpoints, and get OpenAPI docs automatically.',
   alternates: { canonical: absoluteUrl('/clickhouse-api') },
   openGraph: {
+    images: ogImage('ClickHouse API in TypeScript'),
     type: 'website',
     url: absoluteUrl('/clickhouse-api'),
     title: 'ClickHouse API in TypeScript | hypequery',

--- a/website-next/src/app/clickhouse-audit-log/page.tsx
+++ b/website-next/src/app/clickhouse-audit-log/page.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse Audit Log — TypeScript Query Layer for Event Logs | hypequery',
+  title: 'ClickHouse Audit Log — TypeScript Query Layer for Event Logs',
   description:
     'Build audit-log APIs on ClickHouse with typed filters, cursor pagination, and reviewable tenant scoping patterns for append-only event tables.',
   alternates: {
     canonical: absoluteUrl('/clickhouse-audit-log'),
   },
   openGraph: {
+    images: ogImage('ClickHouse Audit Log — TypeScript Query Layer for Event Logs'),
     type: 'website',
     url: absoluteUrl('/clickhouse-audit-log'),
     title: 'ClickHouse Audit Log — TypeScript Query Layer for Event Logs | hypequery',

--- a/website-next/src/app/clickhouse-dashboard/page.tsx
+++ b/website-next/src/app/clickhouse-dashboard/page.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse Dashboard Data Layer for React and TypeScript | hypequery',
+  title: 'ClickHouse Dashboard Data Layer for React and TypeScript',
   description:
     'Build ClickHouse dashboards without inventing a custom API and fetch layer for every chart.',
   alternates: {
     canonical: absoluteUrl('/clickhouse-dashboard'),
   },
   openGraph: {
+    images: ogImage('ClickHouse Dashboard Data Layer for React and TypeScript'),
     type: 'website',
     url: absoluteUrl('/clickhouse-dashboard'),
     title: 'ClickHouse Dashboard Data Layer for React and TypeScript | hypequery',

--- a/website-next/src/app/clickhouse-express/page.tsx
+++ b/website-next/src/app/clickhouse-express/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'Mount ClickHouse Analytics on an Express Server | hypequery',
+  title: 'Mount ClickHouse Analytics on an Express Server',
   description:
     'Add a typed ClickHouse analytics surface to an existing Express app with Node handlers, request validation, and generated OpenAPI docs.',
   robots: {
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
   },
   alternates: { canonical: absoluteUrl('/clickhouse-express') },
   openGraph: {
+    images: ogImage('Mount ClickHouse Analytics on an Express Server'),
     type: 'website',
     url: absoluteUrl('/clickhouse-express'),
     title: 'Mount ClickHouse Analytics on an Express Server | hypequery',

--- a/website-next/src/app/clickhouse-graphql/page.tsx
+++ b/website-next/src/app/clickhouse-graphql/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse GraphQL — Typed Analytics Resolvers in TypeScript | hypequery',
+  title: 'ClickHouse GraphQL — Typed Analytics Resolvers in TypeScript',
   description:
     'Use hypequery as the data layer for ClickHouse GraphQL resolvers. Schema-generated types flow from ClickHouse through your resolver to the GraphQL schema — no manual type bridging.',
   robots: {
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
   },
   alternates: { canonical: absoluteUrl('/clickhouse-graphql') },
   openGraph: {
+    images: ogImage('ClickHouse GraphQL — Typed Analytics Resolvers in TypeScript'),
     type: 'website',
     url: absoluteUrl('/clickhouse-graphql'),
     title: 'ClickHouse GraphQL — Typed Analytics Resolvers in TypeScript | hypequery',

--- a/website-next/src/app/clickhouse-hono/page.tsx
+++ b/website-next/src/app/clickhouse-hono/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse Hono Routes with Typed Query Results | hypequery',
+  title: 'ClickHouse Hono Routes with Typed Query Results',
   description:
     'Use Hono as the HTTP layer and hypequery as the ClickHouse query layer for typed analytics routes on Node.js or fetch-based runtimes.',
   robots: {
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
   },
   alternates: { canonical: absoluteUrl('/clickhouse-hono') },
   openGraph: {
+    images: ogImage('ClickHouse Hono Routes with Typed Query Results'),
     type: 'website',
     url: absoluteUrl('/clickhouse-hono'),
     title: 'ClickHouse Hono Routes with Typed Query Results | hypequery',

--- a/website-next/src/app/clickhouse-js/page.tsx
+++ b/website-next/src/app/clickhouse-js/page.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse JS — JavaScript & TypeScript Query Builder | hypequery',
+  title: 'ClickHouse JS — JavaScript & TypeScript Query Builder',
   description:
     'Use ClickHouse from JavaScript without living on raw query strings, hand-written row types, and repeated response parsing.',
   alternates: {
     canonical: absoluteUrl('/clickhouse-js'),
   },
   openGraph: {
+    images: ogImage('ClickHouse JS — JavaScript & TypeScript Query Builder'),
     type: 'website',
     url: absoluteUrl('/clickhouse-js'),
     title: 'ClickHouse JS — JavaScript & TypeScript Query Builder | hypequery',

--- a/website-next/src/app/clickhouse-mcp/page.tsx
+++ b/website-next/src/app/clickhouse-mcp/page.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse MCP Server with Type-Safe Queries | hypequery',
+  title: 'ClickHouse MCP Server with Type-Safe Queries',
   description:
     'Give AI agents a fixed, tenant-safe ClickHouse tool surface instead of raw SQL access.',
   alternates: {
     canonical: absoluteUrl('/clickhouse-mcp'),
   },
   openGraph: {
+    images: ogImage('ClickHouse MCP Server with Type-Safe Queries'),
     type: 'website',
     url: absoluteUrl('/clickhouse-mcp'),
     title: 'ClickHouse MCP Server | Structured AI Agent Access | hypequery',

--- a/website-next/src/app/clickhouse-migrations/page.tsx
+++ b/website-next/src/app/clickhouse-migrations/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse Migrations — TypeScript Schema Change Management | hypequery',
+  title: 'ClickHouse Migrations — TypeScript Schema Change Management',
   description:
     'ClickHouse schema migrations are painful. hypequery is building TypeScript-first migration tooling for ClickHouse — track changes, run reversible migrations, and keep your schema in sync.',
   robots: {
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
   },
   alternates: { canonical: absoluteUrl('/clickhouse-migrations') },
   openGraph: {
+    images: ogImage('ClickHouse Migrations — TypeScript Schema Change Management'),
     type: 'website',
     url: absoluteUrl('/clickhouse-migrations'),
     title: 'ClickHouse Migrations — TypeScript Schema Change Management | hypequery',

--- a/website-next/src/app/clickhouse-multi-tenant-analytics/page.tsx
+++ b/website-next/src/app/clickhouse-multi-tenant-analytics/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
   title: 'ClickHouse Multi-Tenant Analytics',
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
     canonical: absoluteUrl('/clickhouse-multi-tenant-analytics'),
   },
   openGraph: {
+    images: ogImage('ClickHouse Multi-Tenant Analytics'),
     type: 'website',
     url: absoluteUrl('/clickhouse-multi-tenant-analytics'),
     title: 'ClickHouse Multi-Tenant Analytics | Tenant Isolation for SaaS',

--- a/website-next/src/app/clickhouse-nextjs/page.tsx
+++ b/website-next/src/app/clickhouse-nextjs/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
   title: 'ClickHouse Next.js',
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
     canonical: absoluteUrl('/clickhouse-nextjs'),
   },
   openGraph: {
+    images: ogImage('ClickHouse Next.js'),
     type: 'website',
     url: absoluteUrl('/clickhouse-nextjs'),
     title: 'ClickHouse Next.js | Typed Analytics for App Router',

--- a/website-next/src/app/clickhouse-nodejs/page.tsx
+++ b/website-next/src/app/clickhouse-nodejs/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse for Node.js Scripts, Jobs, and APIs | hypequery',
+  title: 'ClickHouse for Node.js Scripts, Jobs, and APIs',
   description:
     'Use ClickHouse from Node.js scripts, jobs, and servers without rebuilding row types and HTTP wiring around every query.',
   alternates: { canonical: absoluteUrl('/clickhouse-nodejs') },
   openGraph: {
+    images: ogImage('ClickHouse for Node.js Scripts, Jobs, and APIs'),
     type: 'website',
     url: absoluteUrl('/clickhouse-nodejs'),
     title: 'ClickHouse for Node.js Scripts, Jobs, and APIs | hypequery',

--- a/website-next/src/app/clickhouse-openapi/page.tsx
+++ b/website-next/src/app/clickhouse-openapi/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse OpenAPI — Auto-Generated Docs from Query Definitions | hypequery',
+  title: 'ClickHouse OpenAPI — Auto-Generated Docs from Query Definitions',
   description:
     'Generate an OpenAPI spec from real ClickHouse query definitions so your docs, request validation, and response schemas stay aligned with the code you actually ship.',
   alternates: { canonical: absoluteUrl('/clickhouse-openapi') },
   openGraph: {
+    images: ogImage('ClickHouse OpenAPI — Auto-Generated Docs from Query Definitions'),
     type: 'website',
     url: absoluteUrl('/clickhouse-openapi'),
     title: 'ClickHouse OpenAPI — Auto-Generated from Query Definitions | hypequery',

--- a/website-next/src/app/clickhouse-orm/page.tsx
+++ b/website-next/src/app/clickhouse-orm/page.tsx
@@ -3,23 +3,23 @@ import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
 import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ORM for ClickHouse in TypeScript',
+  title: 'ClickHouse ORM — Typed Queries in TypeScript',
   description:
-    'Looking for an ORM for ClickHouse? Prisma, Drizzle, and TypeORM do not fit ClickHouse well. hypequery is the schema-driven TypeScript alternative for analytics work.',
+    'An ORM-style workflow built for ClickHouse: generate TypeScript types from your live schema in one command, then write fully typed queries and APIs.',
   alternates: { canonical: absoluteUrl('/clickhouse-orm') },
   openGraph: {
     images: ogImage('ORM for ClickHouse in TypeScript'),
     type: 'website',
     url: absoluteUrl('/clickhouse-orm'),
-    title: 'ORM for ClickHouse in TypeScript | hypequery',
+    title: 'ClickHouse ORM — Typed Queries in TypeScript | hypequery',
     description:
-      'If you need an ORM-like workflow for ClickHouse, hypequery gives you generated schema types, composable queries, and typed APIs without forcing relational abstractions onto an analytics database.',
+      'Generate TypeScript types from your live ClickHouse schema in one command, then write fully typed queries and APIs. No migrations, no remodeling.',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'ORM for ClickHouse in TypeScript | hypequery',
+    title: 'ClickHouse ORM — Typed Queries in TypeScript | hypequery',
     description:
-      'Looking for an ORM for ClickHouse? hypequery is the schema-driven TypeScript alternative for ClickHouse analytics teams.',
+      'Generate TypeScript types from your live ClickHouse schema in one command, then write fully typed queries and APIs.',
   },
 };
 
@@ -59,7 +59,7 @@ export default function ClickHouseOrmPage() {
       eyebrow="ClickHouse ORM"
       title="The closest thing to an ORM for ClickHouse"
       description="Most teams searching for an ORM for ClickHouse are not looking for relations or migrations. They want generated types, query composition, and a way to reuse analytics logic without hand-maintaining interfaces. Prisma, Drizzle, and TypeORM were built for transactional databases. hypequery is built for ClickHouse."
-      primaryCta={{ href: '/docs/quick-start', label: 'Start with hypequery' }}
+      primaryCta={{ href: '/docs/quick-start', label: 'Generate types from your schema' }}
       secondaryCta={{ href: '/clickhouse-schema', label: 'Generate schema types now' }}
       stats={[
         { label: 'Type source', value: 'Generated from live schema' },
@@ -185,7 +185,7 @@ export default function ClickHouseOrmPage() {
         title: 'Generate schema types and start with hypequery on a real ClickHouse query',
         description:
           'Run schema generation against your ClickHouse instance, then build your first typed query. This is the fastest way to prove the ORM-like workflow on your real schema.',
-        primaryCta: { href: '/docs/quick-start', label: 'Start with hypequery' },
+        primaryCta: { href: '/docs/quick-start', label: 'Generate types from your schema' },
         secondaryCta: { href: '/clickhouse-schema', label: 'Generate schema types' },
       }}
     />

--- a/website-next/src/app/clickhouse-orm/page.tsx
+++ b/website-next/src/app/clickhouse-orm/page.tsx
@@ -59,13 +59,8 @@ export default function ClickHouseOrmPage() {
       eyebrow="ClickHouse ORM"
       title="The closest thing to an ORM for ClickHouse"
       description="Most teams searching for an ORM for ClickHouse are not looking for relations or migrations. They want generated types, query composition, and a way to reuse analytics logic without hand-maintaining interfaces. Prisma, Drizzle, and TypeORM were built for transactional databases. hypequery is built for ClickHouse."
-      primaryCta={{ href: '/docs/quick-start', label: 'Generate types from your schema' }}
-      secondaryCta={{ href: '/clickhouse-schema', label: 'Generate schema types now' }}
-      stats={[
-        { label: 'Type source', value: 'Generated from live schema' },
-        { label: 'Target database', value: 'ClickHouse native' },
-        { label: 'Best for', value: 'Analytics-heavy TypeScript apps' },
-      ]}
+      primaryCta={{ href: '/docs/quick-start', label: 'Start with hypequery' }}
+      secondaryCta={{ href: '/clickhouse-schema', label: 'See schema generation' }}
       problems={[
         {
           title: 'Transactional ORMs are the wrong abstraction for ClickHouse',
@@ -185,8 +180,8 @@ export default function ClickHouseOrmPage() {
         title: 'Generate schema types and start with hypequery on a real ClickHouse query',
         description:
           'Run schema generation against your ClickHouse instance, then build your first typed query. This is the fastest way to prove the ORM-like workflow on your real schema.',
-        primaryCta: { href: '/docs/quick-start', label: 'Generate types from your schema' },
-        secondaryCta: { href: '/clickhouse-schema', label: 'Generate schema types' },
+        primaryCta: { href: '/docs/quick-start', label: 'Start with hypequery' },
+        secondaryCta: { href: '/clickhouse-schema', label: 'See schema generation' },
       }}
     />
   );

--- a/website-next/src/app/clickhouse-orm/page.tsx
+++ b/website-next/src/app/clickhouse-orm/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ORM for ClickHouse in TypeScript | hypequery',
+  title: 'ORM for ClickHouse in TypeScript',
   description:
     'Looking for an ORM for ClickHouse? Prisma, Drizzle, and TypeORM do not fit ClickHouse well. hypequery is the schema-driven TypeScript alternative for analytics work.',
   alternates: { canonical: absoluteUrl('/clickhouse-orm') },
   openGraph: {
+    images: ogImage('ORM for ClickHouse in TypeScript'),
     type: 'website',
     url: absoluteUrl('/clickhouse-orm'),
     title: 'ORM for ClickHouse in TypeScript | hypequery',

--- a/website-next/src/app/clickhouse-product-analytics/page.tsx
+++ b/website-next/src/app/clickhouse-product-analytics/page.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse Product Analytics — TypeScript Event Tracking & Querying | hypequery',
+  title: 'ClickHouse Product Analytics — TypeScript Event Tracking & Querying',
   description:
     'Build product analytics on ClickHouse in TypeScript. hypequery gives you typed event queries, funnel analysis, retention metrics, and typed APIs for your analytics stack.',
   alternates: {
     canonical: absoluteUrl('/clickhouse-product-analytics'),
   },
   openGraph: {
+    images: ogImage('ClickHouse Product Analytics — TypeScript Event Tracking & Querying'),
     type: 'website',
     url: absoluteUrl('/clickhouse-product-analytics'),
     title: 'ClickHouse Product Analytics — TypeScript Event Tracking & Querying | hypequery',

--- a/website-next/src/app/clickhouse-query-builder/page.tsx
+++ b/website-next/src/app/clickhouse-query-builder/page.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse Query Builder for TypeScript | hypequery',
+  title: 'ClickHouse Query Builder for TypeScript',
   description:
     'Build ClickHouse queries in TypeScript with schema-generated types, native ClickHouse syntax, and a clean path from one-off queries to reusable API definitions.',
   alternates: {
     canonical: absoluteUrl('/clickhouse-query-builder'),
   },
   openGraph: {
+    images: ogImage('ClickHouse Query Builder for TypeScript'),
     type: 'website',
     url: absoluteUrl('/clickhouse-query-builder'),
     title: 'ClickHouse Query Builder for TypeScript | hypequery',

--- a/website-next/src/app/clickhouse-react/page.tsx
+++ b/website-next/src/app/clickhouse-react/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
   title: 'ClickHouse React',
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
     canonical: absoluteUrl('/clickhouse-react'),
   },
   openGraph: {
+    images: ogImage('ClickHouse React'),
     type: 'website',
     url: absoluteUrl('/clickhouse-react'),
     title: 'ClickHouse React | Typed Hooks for Analytics Apps',

--- a/website-next/src/app/clickhouse-real-time-analytics/page.tsx
+++ b/website-next/src/app/clickhouse-real-time-analytics/page.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse Real-Time Analytics in TypeScript | hypequery',
+  title: 'ClickHouse Real-Time Analytics in TypeScript',
   description:
     'Query ClickHouse in real time with TypeScript. hypequery gives you typed queries for live analytics dashboards — low-latency reads, tenant isolation, and typed HTTP APIs.',
   alternates: {
     canonical: absoluteUrl('/clickhouse-real-time-analytics'),
   },
   openGraph: {
+    images: ogImage('ClickHouse Real-Time Analytics in TypeScript'),
     type: 'website',
     url: absoluteUrl('/clickhouse-real-time-analytics'),
     title: 'ClickHouse Real-Time Analytics in TypeScript | hypequery',

--- a/website-next/src/app/clickhouse-rest-api/page.tsx
+++ b/website-next/src/app/clickhouse-rest-api/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse API in TypeScript — Typed REST Endpoints | hypequery',
+  title: 'ClickHouse API in TypeScript — Typed REST Endpoints',
   description:
     'Build a ClickHouse API in TypeScript without hand-writing every route. hypequery turns query definitions into typed REST endpoints with OpenAPI docs and input validation.',
   alternates: { canonical: absoluteUrl('/clickhouse-rest-api') },
   openGraph: {
+    images: ogImage('ClickHouse API in TypeScript — Typed REST Endpoints'),
     type: 'website',
     url: absoluteUrl('/clickhouse-rest-api'),
     title: 'ClickHouse API in TypeScript — Typed REST Endpoints | hypequery',

--- a/website-next/src/app/clickhouse-saas-analytics/page.tsx
+++ b/website-next/src/app/clickhouse-saas-analytics/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse SaaS Analytics — Multi-Tenant TypeScript Layer | hypequery',
+  title: 'ClickHouse SaaS Analytics — Multi-Tenant TypeScript Layer',
   description:
     'Build customer-facing ClickHouse analytics with tenant-scoped query definitions, typed APIs, and dashboard delivery that does not fork per surface.',
   alternates: { canonical: absoluteUrl('/clickhouse-saas-analytics') },
   openGraph: {
+    images: ogImage('ClickHouse SaaS Analytics — Multi-Tenant TypeScript Layer'),
     type: 'website',
     url: absoluteUrl('/clickhouse-saas-analytics'),
     title: 'ClickHouse SaaS Analytics — Multi-Tenant TypeScript Layer | hypequery',

--- a/website-next/src/app/clickhouse-schema/page.tsx
+++ b/website-next/src/app/clickhouse-schema/page.tsx
@@ -56,7 +56,7 @@ export default function ClickHouseSchemaPage() {
     <ClickhousePillarPage
       eyebrow="ClickHouse Schema"
       title="Generate TypeScript types from your live ClickHouse schema"
-      description="This is the page for the first problem most TypeScript teams hit on ClickHouse: the database returns one thing, their interfaces claim another, and the compiler happily trusts the wrong version. hypequery fixes that at the schema boundary."
+      description="The first problem most TypeScript teams hit on ClickHouse: the database returns one thing, their interfaces claim another, and the compiler happily trusts the wrong version. hypequery fixes that at the schema boundary."
       primaryCta={{ href: '/docs/quick-start', label: 'Start with hypequery' }}
       secondaryCta={{ href: '/docs/schemas', label: 'Read the schemas guide' }}
       stats={[

--- a/website-next/src/app/clickhouse-schema/page.tsx
+++ b/website-next/src/app/clickhouse-schema/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse Schema — TypeScript Types Generated from Your Database | hypequery',
+  title: 'ClickHouse Schema — TypeScript Types Generated from Your Database',
   description:
     'Generate TypeScript types from your live ClickHouse schema so query code stops relying on hand-written interfaces and incorrect runtime assumptions.',
   alternates: { canonical: absoluteUrl('/clickhouse-schema') },
   openGraph: {
+    images: ogImage('ClickHouse Schema — TypeScript Types Generated from Your Database'),
     type: 'website',
     url: absoluteUrl('/clickhouse-schema'),
     title: 'ClickHouse Schema — TypeScript Types from Your Database | hypequery',

--- a/website-next/src/app/clickhouse-semantic-layer/page.tsx
+++ b/website-next/src/app/clickhouse-semantic-layer/page.tsx
@@ -177,12 +177,18 @@ export default function ClickHouseSemanticLayerPage() {
           <div className="mt-7 flex flex-wrap gap-2.5">
             <Link
               href="/docs/datasets/overview"
+              data-umami-event="cta_click"
+              data-umami-event-target="docs_datasets_overview"
+              data-umami-event-location="hero_primary"
               className="bg-text text-bg px-5 py-3 text-[13.5px] font-semibold rounded transition hover:opacity-90 hover:-translate-y-px"
             >
               Read the datasets docs →
             </Link>
             <Link
               href="/docs/quick-start"
+              data-umami-event="cta_click"
+              data-umami-event-target="docs_quick_start"
+              data-umami-event-location="hero_secondary"
               className="bg-transparent text-text px-5 py-3 text-[13.5px] font-semibold rounded border border-border-strong transition hover:border-text hover:bg-bg-alt"
             >
               Get started →
@@ -274,12 +280,18 @@ export default function ClickHouseSemanticLayerPage() {
           <div className="mt-8 flex flex-wrap justify-center gap-2.5">
             <Link
               href="/docs/quick-start"
+              data-umami-event="cta_click"
+              data-umami-event-target="docs_quick_start"
+              data-umami-event-location="footer_primary"
               className="bg-text text-bg px-5 py-3 text-[13.5px] font-semibold rounded transition hover:opacity-90 hover:-translate-y-px"
             >
               Get started →
             </Link>
             <Link
               href="/docs/datasets/overview"
+              data-umami-event="cta_click"
+              data-umami-event-target="docs_datasets_overview"
+              data-umami-event-location="footer_secondary"
               className="bg-transparent text-text px-5 py-3 text-[13.5px] font-semibold rounded border border-border-strong transition hover:border-text hover:bg-bg-alt"
             >
               Read the datasets docs →

--- a/website-next/src/app/clickhouse-semantic-layer/page.tsx
+++ b/website-next/src/app/clickhouse-semantic-layer/page.tsx
@@ -114,14 +114,79 @@ const { data } = useQuery('revenueByDay', {
 });`;
 
 const comparisonRows = [
-  ['Lives in', 'Your TypeScript codebase', 'Separate service / platform'],
-  ['Language', 'TypeScript', 'YAML / modeling DSLs'],
-  ['Types', 'End-to-end TypeScript contracts', 'Limited or external to app code'],
-  ['Tenancy', 'Runtime-enforced from tenant context; typed fields', 'Manual filters or platform policy'],
-  ['Operate', 'A library in your stack', 'A platform to run'],
-  ['Best for', 'Shipping ClickHouse-backed product features', 'Centralized BI metrics and non-engineer consumers'],
-  ['Honest concession', 'Not a BI modeling platform', 'Better fit for broad BI governance'],
+  {
+    label: 'Lives in',
+    detail: 'Where the semantic layer physically runs',
+    hypequery: 'Your TypeScript codebase',
+    platform: 'Separate service / platform',
+    hypequeryYes: true,
+    platformYes: false,
+  },
+  {
+    label: 'Language',
+    detail: 'How you author metrics and dimensions',
+    hypequery: 'TypeScript',
+    platform: 'YAML / modeling DSLs',
+    hypequeryYes: true,
+    platformYes: false,
+  },
+  {
+    label: 'Types',
+    detail: 'Compile-time safety from schema to response',
+    hypequery: 'End-to-end TypeScript contracts',
+    platform: 'Limited or external to app code',
+    hypequeryYes: true,
+    platformYes: false,
+  },
+  {
+    label: 'Tenancy',
+    detail: 'How rows are isolated per tenant',
+    hypequery: 'Runtime-enforced from tenant context; typed fields',
+    platform: 'Manual filters or platform policy',
+    hypequeryYes: true,
+    platformYes: false,
+  },
+  {
+    label: 'Operate',
+    detail: 'What you deploy and maintain in production',
+    hypequery: 'A library in your stack',
+    platform: 'A platform to run',
+    hypequeryYes: true,
+    platformYes: false,
+  },
+  {
+    label: 'Best for',
+    detail: 'The workload each shape fits',
+    hypequery: 'Shipping ClickHouse-backed product features',
+    platform: 'Centralized BI metrics and non-engineer consumers',
+    hypequeryYes: true,
+    platformYes: true,
+  },
+  {
+    label: 'BI Support',
+    detail: 'Fit for dashboards and self-serve BI tools',
+    hypequery: 'Not a full BI modeling platform',
+    platform: 'Better fit for broad BI governance',
+    hypequeryYes: false,
+    platformYes: true,
+  },
 ] as const;
+
+function Verdict({ yes }: { yes: boolean }) {
+  return yes ? (
+    <span className="mt-[2px] inline-flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full bg-success/15 text-success">
+      <svg viewBox="0 0 16 16" fill="none" className="h-3 w-3" aria-hidden="true">
+        <path d="M3.5 8.5l3 3 6-7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </span>
+  ) : (
+    <span className="mt-[2px] inline-flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full bg-text-dim/15 text-text-dim">
+      <svg viewBox="0 0 16 16" fill="none" className="h-3 w-3" aria-hidden="true">
+        <path d="M4.5 4.5l7 7M11.5 4.5l-7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </span>
+  );
+}
 
 function CodeCard({ title, code }: { title: string; code: string }) {
   return (
@@ -249,19 +314,40 @@ export default function ClickHouseSemanticLayerPage() {
             </p>
           </SectionIntro>
           <div className="overflow-hidden rounded-lg border border-border-strong bg-bg-card shadow-card">
-            <div className="grid grid-cols-[150px_1fr_1fr] border-b border-border bg-bg-alt/60 px-4 py-3 font-mono text-[11px] font-bold uppercase tracking-[0.12em] text-text-dim">
+            <div className="hidden grid-cols-[160px_1fr_1fr] gap-4 border-b border-border bg-bg-alt/60 px-5 py-3 font-mono text-[11px] font-bold uppercase tracking-[0.12em] text-text-dim md:grid">
               <span>Decision</span>
               <span>hypequery</span>
               <span>Cube / MetricFlow</span>
             </div>
-            {comparisonRows.map(([label, hypequery, platform]) => (
+            {comparisonRows.map((row) => (
               <div
-                key={label}
-                className="grid grid-cols-1 gap-2 border-b border-border px-4 py-4 text-[14px] last:border-b-0 md:grid-cols-[150px_1fr_1fr]"
+                key={row.label}
+                className="grid gap-3 border-b border-border px-5 py-4 text-[14px] last:border-b-0 md:grid-cols-[160px_1fr_1fr] md:items-start md:gap-4"
               >
-                <div className="font-mono text-[11px] font-bold uppercase tracking-[0.1em] text-text-dim">{label}</div>
-                <div className="font-semibold text-text">{hypequery}</div>
-                <div className="text-text-muted">{platform}</div>
+                <div className="md:pt-[3px]">
+                  <div className="font-mono text-[11px] font-bold uppercase tracking-[0.14em] text-text-dim">
+                    {row.label}
+                  </div>
+                  <p className="mt-1 text-[12px] leading-snug text-text-muted">{row.detail}</p>
+                </div>
+                <div className="flex items-start gap-2.5">
+                  <Verdict yes={row.hypequeryYes} />
+                  <div>
+                    <span className="mb-0.5 block font-mono text-[10px] uppercase tracking-[0.1em] text-text-dim md:hidden">
+                      hypequery
+                    </span>
+                    <span className="font-semibold text-text">{row.hypequery}</span>
+                  </div>
+                </div>
+                <div className="flex items-start gap-2.5">
+                  <Verdict yes={row.platformYes} />
+                  <div>
+                    <span className="mb-0.5 block font-mono text-[10px] uppercase tracking-[0.1em] text-text-dim md:hidden">
+                      Cube / MetricFlow
+                    </span>
+                    <span className="text-text-muted">{row.platform}</span>
+                  </div>
+                </div>
               </div>
             ))}
           </div>

--- a/website-next/src/app/clickhouse-semantic-layer/page.tsx
+++ b/website-next/src/app/clickhouse-semantic-layer/page.tsx
@@ -3,16 +3,17 @@ import Link from 'next/link';
 import CodeHighlight from '@/components/CodeHighlight';
 import Footer from '@/components/Footer';
 import Navigation from '@/components/Navigation';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse Semantic Layer in TypeScript | hypequery',
+  title: 'ClickHouse Semantic Layer in TypeScript',
   description:
     'Define a ClickHouse semantic layer in TypeScript with typed datasets, tenant keys, time keys, and reusable delivery across APIs, jobs, and dashboards.',
   alternates: {
     canonical: absoluteUrl('/clickhouse-semantic-layer'),
   },
   openGraph: {
+    images: ogImage('ClickHouse Semantic Layer in TypeScript'),
     type: 'website',
     url: absoluteUrl('/clickhouse-semantic-layer'),
     title: 'ClickHouse Semantic Layer in TypeScript | hypequery',

--- a/website-next/src/app/clickhouse-time-series/page.tsx
+++ b/website-next/src/app/clickhouse-time-series/page.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse Time-Series Queries for TypeScript Apps | hypequery',
+  title: 'ClickHouse Time-Series Queries for TypeScript Apps',
   description:
     'Build readable ClickHouse time-series queries with explicit DateTime handling, reusable range logic, and date bucketing patterns that fit TypeScript apps.',
   alternates: {
     canonical: absoluteUrl('/clickhouse-time-series'),
   },
   openGraph: {
+    images: ogImage('ClickHouse Time-Series Queries for TypeScript Apps'),
     type: 'website',
     url: absoluteUrl('/clickhouse-time-series'),
     title: 'ClickHouse Time-Series Queries for TypeScript Apps | hypequery',

--- a/website-next/src/app/clickhouse-trpc/page.tsx
+++ b/website-next/src/app/clickhouse-trpc/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse tRPC — Typed Analytics Procedures | hypequery',
+  title: 'ClickHouse tRPC — Typed Analytics Procedures',
   description:
     'Integrate ClickHouse analytics into your tRPC API. hypequery query definitions become tRPC procedures — fully typed from ClickHouse schema to React client.',
   robots: {
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
   },
   alternates: { canonical: absoluteUrl('/clickhouse-trpc') },
   openGraph: {
+    images: ogImage('ClickHouse tRPC — Typed Analytics Procedures'),
     type: 'website',
     url: absoluteUrl('/clickhouse-trpc'),
     title: 'ClickHouse tRPC — Typed Analytics Procedures | hypequery',

--- a/website-next/src/app/clickhouse-typescript/page.tsx
+++ b/website-next/src/app/clickhouse-typescript/page.tsx
@@ -3,16 +3,17 @@ import Link from 'next/link';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
 import CodeWindow from '@/components/CodeWindow';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse with TypeScript: Type-Safe Queries and APIs | hypequery',
+  title: 'ClickHouse with TypeScript: Type-Safe Queries and APIs',
   description:
     'Use ClickHouse with TypeScript without hand-written interfaces. Generate schema types, build typed queries, and reuse them across APIs, jobs, and dashboards.',
   alternates: {
     canonical: absoluteUrl('/clickhouse-typescript'),
   },
   openGraph: {
+    images: ogImage('ClickHouse with TypeScript: Type-Safe Queries and APIs'),
     type: 'website',
     url: absoluteUrl('/clickhouse-typescript'),
     title: 'ClickHouse with TypeScript: Type-Safe Queries and APIs | hypequery',

--- a/website-next/src/app/clickhouse-typescript/page.tsx
+++ b/website-next/src/app/clickhouse-typescript/page.tsx
@@ -138,7 +138,7 @@ export default function ClickHouseTypeScriptPage() {
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-accent">
               ClickHouse TypeScript
             </p>
-            <h1 className="font-display mt-4 max-w-5xl text-4xl font-semibold tracking-tight text-text sm:text-6xl">
+            <h1 className="mt-4 max-w-5xl text-4xl font-semibold tracking-tight text-text sm:text-6xl">
               ClickHouse with TypeScript
             </h1>
             <p className="mt-6 max-w-3xl text-lg leading-8 text-text-muted">
@@ -185,7 +185,7 @@ export default function ClickHouseTypeScriptPage() {
           <div className="grid gap-6 lg:grid-cols-3">
             {problems.map((problem) => (
               <div key={problem.title} className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-                <h2 className="font-display text-xl font-semibold text-text">{problem.title}</h2>
+                <h2 className="text-xl font-semibold text-text">{problem.title}</h2>
                 <p className="mt-4 text-sm leading-7 text-text-muted">{problem.copy}</p>
               </div>
             ))}
@@ -199,7 +199,7 @@ export default function ClickHouseTypeScriptPage() {
                 <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">
                   How hypequery helps
                 </p>
-              <h2 className="font-display mt-3 text-3xl font-semibold text-text">
+              <h2 className="mt-3 text-3xl font-semibold text-text">
                 A ClickHouse TypeScript workflow built for reusable analytics
               </h2>
               <p className="mt-5 text-base leading-8 text-text-muted">
@@ -216,7 +216,7 @@ export default function ClickHouseTypeScriptPage() {
               </div>
               <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
                 <p className="text-xs uppercase tracking-[0.25em] text-text-dim">Step 1</p>
-                <h3 className="font-display mt-3 text-xl font-semibold text-text">
+                <h3 className="mt-3 text-xl font-semibold text-text">
                   Generate schema types from ClickHouse
                 </h3>
                 <CodeWindow code={schemaCode} filename="generate-schema.sh" language="bash" className="mt-4" />
@@ -235,7 +235,7 @@ export default function ClickHouseTypeScriptPage() {
                 <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">
                 Step 2
               </p>
-              <h2 className="font-display mt-3 text-3xl font-semibold text-text">
+              <h2 className="mt-3 text-3xl font-semibold text-text">
                 Define typed ClickHouse queries once
               </h2>
               <p className="mt-5 text-base leading-8 text-text-muted">
@@ -266,12 +266,12 @@ export default function ClickHouseTypeScriptPage() {
         <section className="border-y border-border bg-bg-alt/60">
           <div className="mx-auto max-w-7xl px-4 py-16 lg:px-6">
             <p className="text-xs font-semibold uppercase tracking-[0.25em] text-text-dim">Why teams search for this</p>
-            <h2 className="font-display mt-3 text-3xl font-semibold text-text">
+            <h2 className="mt-3 text-3xl font-semibold text-text">
               Common ClickHouse TypeScript problems this page should solve
             </h2>
             <div className="mt-10 grid gap-6 md:grid-cols-2">
               <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-                <h3 className="font-display text-xl font-semibold text-text">
+                <h3 className="text-xl font-semibold text-text">
                   ClickHouse query builder for TypeScript
                 </h3>
                 <p className="mt-3 text-sm leading-7 text-text-muted">
@@ -280,7 +280,7 @@ export default function ClickHouseTypeScriptPage() {
                 </p>
               </div>
               <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-                <h3 className="font-display text-xl font-semibold text-text">
+                <h3 className="text-xl font-semibold text-text">
                   ClickHouse types in TypeScript
                 </h3>
                 <p className="mt-3 text-sm leading-7 text-text-muted">
@@ -289,7 +289,7 @@ export default function ClickHouseTypeScriptPage() {
                 </p>
               </div>
               <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-                <h3 className="font-display text-xl font-semibold text-text">
+                <h3 className="text-xl font-semibold text-text">
                   Reusable analytics APIs in TypeScript
                 </h3>
                 <p className="mt-3 text-sm leading-7 text-text-muted">
@@ -298,7 +298,7 @@ export default function ClickHouseTypeScriptPage() {
                 </p>
               </div>
               <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-                <h3 className="font-display text-xl font-semibold text-text">
+                <h3 className="text-xl font-semibold text-text">
                   Alternatives to hand-written query types
                 </h3>
                 <p className="mt-3 text-sm leading-7 text-text-muted">
@@ -307,7 +307,7 @@ export default function ClickHouseTypeScriptPage() {
                 </p>
               </div>
               <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-                <h3 className="font-display text-xl font-semibold text-text">
+                <h3 className="text-xl font-semibold text-text">
                   How do I use ClickHouse with TypeScript?
                 </h3>
                 <p className="mt-3 text-sm leading-7 text-text-muted">
@@ -320,7 +320,7 @@ export default function ClickHouseTypeScriptPage() {
 
         <section className="mx-auto max-w-7xl px-4 py-16 lg:px-6">
           <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">Further reading</p>
-          <h2 className="font-display mt-3 text-3xl font-semibold text-text">
+          <h2 className="mt-3 text-3xl font-semibold text-text">
             Compare approaches and go deeper
           </h2>
           <div className="mt-10 grid gap-6 lg:grid-cols-3">
@@ -330,7 +330,7 @@ export default function ClickHouseTypeScriptPage() {
                 href={item.href}
                 className="group rounded-lg border border-border bg-bg-card p-6 transition hover:-translate-y-1 hover:border-border-strong hover:shadow-card"
               >
-                <h3 className="font-display text-xl font-semibold text-text">{item.title}</h3>
+                <h3 className="text-xl font-semibold text-text">{item.title}</h3>
                 <p className="mt-3 text-sm leading-7 text-text-muted">{item.description}</p>
                 <p className="mt-6 text-xs font-semibold uppercase tracking-[0.2em] text-accent group-hover:opacity-70">
                   Open article
@@ -345,7 +345,7 @@ export default function ClickHouseTypeScriptPage() {
                 href={item.href}
                 className="group rounded-lg border border-border bg-bg-card p-5 transition hover:border-border-strong hover:shadow-card"
               >
-                <h3 className="font-display text-lg font-semibold text-text">{item.title}</h3>
+                <h3 className="text-lg font-semibold text-text">{item.title}</h3>
                 <p className="mt-3 text-sm leading-7 text-text-muted">{item.description}</p>
               </Link>
             ))}
@@ -358,7 +358,7 @@ export default function ClickHouseTypeScriptPage() {
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">
                 Next step
               </p>
-              <h2 className="font-display mt-3 text-2xl font-semibold text-text">
+              <h2 className="mt-3 text-2xl font-semibold text-text">
                 Start with hypequery on one real ClickHouse query
               </h2>
               <p className="mt-3 max-w-2xl text-sm leading-7 text-text-muted">

--- a/website-next/src/app/clickhouse-typescript/page.tsx
+++ b/website-next/src/app/clickhouse-typescript/page.tsx
@@ -147,12 +147,18 @@ export default function ClickHouseTypeScriptPage() {
             <div className="mt-8 flex flex-wrap gap-4">
               <Link
                 href="/docs/quick-start"
+                data-umami-event="cta_click"
+                data-umami-event-target="docs_quick_start"
+                data-umami-event-location="hero_primary"
                 className="bg-text px-6 py-3 text-sm font-semibold text-bg transition hover:opacity-90"
               >
                 Start with hypequery
               </Link>
               <Link
                 href="/clickhouse-schema"
+                data-umami-event="cta_click"
+                data-umami-event-target="clickhouse_schema"
+                data-umami-event-location="hero_secondary"
                 className="border border-border-strong px-6 py-3 text-sm font-semibold text-text transition hover:bg-bg-alt"
               >
                 Generate schema types
@@ -362,12 +368,18 @@ export default function ClickHouseTypeScriptPage() {
             <div className="mt-6 flex gap-3 md:mt-0">
               <Link
                 href="/docs/quick-start"
+                data-umami-event="cta_click"
+                data-umami-event-target="docs_quick_start"
+                data-umami-event-location="next_step_primary"
                 className="inline-flex items-center bg-text px-5 py-3 text-sm font-semibold text-bg transition hover:opacity-90"
               >
                 Start with hypequery
               </Link>
               <Link
                 href="/clickhouse-schema"
+                data-umami-event="cta_click"
+                data-umami-event-target="clickhouse_schema"
+                data-umami-event-location="next_step_secondary"
                 className="inline-flex items-center border border-border-strong px-5 py-3 text-sm font-semibold text-text transition hover:bg-bg-alt"
               >
                 Generate schema types

--- a/website-next/src/app/clickhouse/functions/[slug]/page.tsx
+++ b/website-next/src/app/clickhouse/functions/[slug]/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
 import CodeWindow from '@/components/CodeWindow';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 import {
   clickhouseFunctions,
   findFunction,
@@ -35,6 +35,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       url: canonical,
       title: fn.metaTitle,
       description: fn.metaDescription,
+      images: ogImage(fn.metaTitle),
     },
     twitter: {
       card: 'summary_large_image',

--- a/website-next/src/app/clickhouse/functions/[slug]/page.tsx
+++ b/website-next/src/app/clickhouse/functions/[slug]/page.tsx
@@ -191,6 +191,9 @@ async function ClickHouseFunctionPageInner({ params }: Props) {
                 <div className="mt-8 flex flex-wrap gap-4">
                   <Link
                     href="/docs/quick-start"
+                    data-umami-event="cta_click"
+                    data-umami-event-target="docs_quick_start"
+                    data-umami-event-location="example_panel"
                     className="bg-text px-5 py-3 text-sm font-semibold text-bg transition hover:opacity-90"
                   >
                     Quick start
@@ -309,6 +312,9 @@ async function ClickHouseFunctionPageInner({ params }: Props) {
             <div className="mt-6 flex gap-3 md:mt-0">
               <Link
                 href="/docs/quick-start"
+                data-umami-event="cta_click"
+                data-umami-event-target="docs_quick_start"
+                data-umami-event-location="next_step_primary"
                 className="inline-flex items-center bg-text px-5 py-3 text-sm font-semibold text-bg transition hover:opacity-90"
               >
                 Quick start

--- a/website-next/src/app/clickhouse/functions/[slug]/page.tsx
+++ b/website-next/src/app/clickhouse/functions/[slug]/page.tsx
@@ -113,7 +113,7 @@ async function ClickHouseFunctionPageInner({ params }: Props) {
               <span className="text-text-dim">/</span>
               <span className="text-accent">{clusterLabel[fn.cluster] ?? fn.cluster}</span>
             </div>
-            <h1 className="font-display mt-4 text-4xl font-semibold tracking-tight text-text sm:text-5xl">
+            <h1 className="mt-4 text-4xl font-semibold tracking-tight text-text sm:text-5xl">
               <code className="font-mono">{fn.name}</code>
             </h1>
             <p className="mt-4 max-w-3xl text-lg leading-8 text-text-muted">{fn.tagline}</p>
@@ -137,7 +137,7 @@ async function ClickHouseFunctionPageInner({ params }: Props) {
           <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">What it does</p>
-              <h2 className="font-display mt-3 text-2xl font-semibold text-text">
+              <h2 className="mt-3 text-2xl font-semibold text-text">
                 {fn.description}
               </h2>
               <p className="mt-5 text-base leading-8 text-text-muted">{fn.longDescription}</p>
@@ -160,7 +160,7 @@ async function ClickHouseFunctionPageInner({ params }: Props) {
             {/* SQL Example */}
             <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
               <p className="text-xs uppercase tracking-[0.25em] text-text-dim">Example SQL</p>
-              <h3 className="font-display mt-3 text-xl font-semibold text-text">
+              <h3 className="mt-3 text-xl font-semibold text-text">
                 {fn.name} in ClickHouse SQL
               </h3>
               <CodeWindow
@@ -180,7 +180,7 @@ async function ClickHouseFunctionPageInner({ params }: Props) {
                 <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">
                   TypeScript with hypequery
                 </p>
-                <h2 className="font-display mt-3 text-2xl font-semibold text-text">
+                <h2 className="mt-3 text-2xl font-semibold text-text">
                   Use {fn.name} in a typed TypeScript query
                 </h2>
                 <p className="mt-5 text-base leading-8 text-text-muted">
@@ -220,13 +220,13 @@ async function ClickHouseFunctionPageInner({ params }: Props) {
         {/* Search intent cards */}
         <section className="mx-auto max-w-7xl px-4 py-14 lg:px-6">
           <p className="text-xs font-semibold uppercase tracking-[0.25em] text-text-dim">Common questions</p>
-          <h2 className="font-display mt-3 text-2xl font-semibold text-text">
+          <h2 className="mt-3 text-2xl font-semibold text-text">
             What developers search for with {fn.name}
           </h2>
           <div className="mt-8 grid gap-6 md:grid-cols-2">
             {fn.searchIntentCards.map((card) => (
               <div key={card.title} className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-                <h3 className="font-display text-lg font-semibold text-text">{card.title}</h3>
+                <h3 className="text-lg font-semibold text-text">{card.title}</h3>
                 <p className="mt-3 text-sm leading-7 text-text-muted">{card.copy}</p>
               </div>
             ))}
@@ -238,13 +238,13 @@ async function ClickHouseFunctionPageInner({ params }: Props) {
           <section className="border-y border-border bg-bg-alt/60">
             <div className="mx-auto max-w-7xl px-4 py-14 lg:px-6">
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-text-dim">FAQ</p>
-              <h2 className="font-display mt-3 text-2xl font-semibold text-text">
+              <h2 className="mt-3 text-2xl font-semibold text-text">
                 Frequently asked questions about {fn.name}
               </h2>
               <div className="mt-8 space-y-6">
                 {fn.faqItems.map((item) => (
                   <div key={item.question} className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-                    <h3 className="font-display text-lg font-semibold text-text">{item.question}</h3>
+                    <h3 className="text-lg font-semibold text-text">{item.question}</h3>
                     <p className="mt-3 text-sm leading-7 text-text-muted">{item.answer}</p>
                   </div>
                 ))}
@@ -258,7 +258,7 @@ async function ClickHouseFunctionPageInner({ params }: Props) {
           <div className="grid gap-8 lg:grid-cols-[0.6fr_0.4fr]">
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">Related functions</p>
-              <h2 className="font-display mt-3 text-2xl font-semibold text-text">
+              <h2 className="mt-3 text-2xl font-semibold text-text">
                 Functions used alongside {fn.name}
               </h2>
               {resolvedRelatedFunctions.length > 0 ? (
@@ -301,7 +301,7 @@ async function ClickHouseFunctionPageInner({ params }: Props) {
           <div className="rounded-lg border border-border-strong bg-bg-card p-8 shadow-card md:flex md:items-center md:justify-between md:gap-8">
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">Next step</p>
-              <h2 className="font-display mt-3 text-2xl font-semibold text-text">
+              <h2 className="mt-3 text-2xl font-semibold text-text">
                 Use {fn.name} in a type-safe TypeScript query
               </h2>
               <p className="mt-3 max-w-2xl text-sm leading-7 text-text-muted">

--- a/website-next/src/app/clickhouse/functions/page.tsx
+++ b/website-next/src/app/clickhouse/functions/page.tsx
@@ -94,6 +94,9 @@ export default function ClickHouseFunctionsIndexPage() {
             <div className="mt-8 flex flex-wrap gap-4">
               <Link
                 href="/docs/quick-start"
+                data-umami-event="cta_click"
+                data-umami-event-target="docs_quick_start"
+                data-umami-event-location="hero_primary"
                 className="bg-indigo-600 px-6 py-3 text-sm font-semibold text-white transition hover:bg-indigo-500"
               >
                 Quick start
@@ -170,6 +173,9 @@ export default function ClickHouseFunctionsIndexPage() {
             <div className="mt-6 flex gap-3 md:mt-0">
               <Link
                 href="/docs/quick-start"
+                data-umami-event="cta_click"
+                data-umami-event-target="docs_quick_start"
+                data-umami-event-location="next_step_primary"
                 className="inline-flex items-center bg-indigo-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-indigo-500"
               >
                 Quick start

--- a/website-next/src/app/clickhouse/functions/page.tsx
+++ b/website-next/src/app/clickhouse/functions/page.tsx
@@ -2,15 +2,16 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 import { clickhouseFunctions, functionPathSegment, functionsByCluster } from '@/data/clickhouse-functions';
 
 export const metadata: Metadata = {
-  title: 'ClickHouse Functions — TypeScript Examples with hypequery',
+  title: 'ClickHouse Functions — TypeScript Examples',
   description:
     'Curated TypeScript examples for common ClickHouse functions: date functions, aggregates, strings, conditionals, and math — with hypequery query-builder examples.',
   alternates: { canonical: absoluteUrl('/clickhouse/functions') },
   openGraph: {
+    images: ogImage('ClickHouse Functions — TypeScript Examples'),
     type: 'website',
     url: absoluteUrl('/clickhouse/functions'),
     title: 'ClickHouse Functions — TypeScript Examples with hypequery',

--- a/website-next/src/app/clickhouse/functions/page.tsx
+++ b/website-next/src/app/clickhouse/functions/page.tsx
@@ -84,7 +84,7 @@ export default function ClickHouseFunctionsIndexPage() {
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-indigo-300">
               ClickHouse Functions
             </p>
-            <h1 className="font-display mt-4 max-w-4xl text-4xl font-semibold tracking-tight text-white sm:text-6xl">
+            <h1 className="mt-4 max-w-4xl text-4xl font-semibold tracking-tight text-white sm:text-6xl">
               ClickHouse function reference for TypeScript developers
             </h1>
             <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
@@ -134,7 +134,7 @@ export default function ClickHouseFunctionsIndexPage() {
               <p className={`text-xs font-semibold uppercase tracking-[0.3em] ${clusterColor[cluster]}`}>
                 {clusterLabel[cluster]}
               </p>
-              <h2 className="font-display mt-3 text-2xl font-semibold text-white">{clusterDescription[cluster]}</h2>
+              <h2 className="mt-3 text-2xl font-semibold text-white">{clusterDescription[cluster]}</h2>
               <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                 {fns.map((fn) => (
                   <Link
@@ -161,7 +161,7 @@ export default function ClickHouseFunctionsIndexPage() {
           <div className="border border-indigo-500/35 bg-slate-950 p-8 md:flex md:items-center md:justify-between md:gap-8">
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-indigo-300">Get started</p>
-              <h2 className="font-display mt-3 text-2xl font-semibold text-white">
+              <h2 className="mt-3 text-2xl font-semibold text-white">
                 Use common ClickHouse functions in typed TypeScript queries
               </h2>
               <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-300">

--- a/website-next/src/app/cms/preview/[id]/page.tsx
+++ b/website-next/src/app/cms/preview/[id]/page.tsx
@@ -50,7 +50,7 @@ export default async function CmsPreviewPostPage({
               })
               : 'Not published yet'}
           </time>
-          <h1 className="font-display mt-3 text-4xl font-bold tracking-tight text-white sm:text-5xl">
+          <h1 className="mt-3 text-4xl font-bold tracking-tight text-white sm:text-5xl">
             {post.title}
           </h1>
           {post.description && (

--- a/website-next/src/app/compare/[slug]/page.tsx
+++ b/website-next/src/app/compare/[slug]/page.tsx
@@ -165,7 +165,7 @@ export default async function ComparePage({
         <section className="border-b border-slate-800/80">
           <div className="mx-auto max-w-7xl px-4 py-20 lg:px-6">
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-indigo-300">Compare</p>
-            <h1 className="font-display mt-4 max-w-5xl text-4xl font-semibold tracking-tight text-white sm:text-6xl">
+            <h1 className="mt-4 max-w-5xl text-4xl font-semibold tracking-tight text-white sm:text-6xl">
               {article.title}
             </h1>
             <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
@@ -222,19 +222,19 @@ export default async function ComparePage({
         <section className="mx-auto max-w-7xl px-4 py-16 lg:px-6">
 	            <div className="mb-10 grid gap-6 md:grid-cols-3">
 	            <div className="border border-slate-700 bg-slate-900/60 p-6">
-	              <h2 className="font-display text-lg font-semibold text-slate-100">What this page is for</h2>
+	              <h2 className="text-lg font-semibold text-slate-100">What this page is for</h2>
 	              <p className="mt-3 text-sm leading-7 text-slate-300">
 	                Use this page when the real question is how one tool changes the shape of your ClickHouse application code, not just which syntax looks nicer.
 	              </p>
 	            </div>
 	            <div className="border border-slate-700 bg-slate-900/60 p-6">
-	              <h2 className="font-display text-lg font-semibold text-slate-100">What this page is not</h2>
+	              <h2 className="text-lg font-semibold text-slate-100">What this page is not</h2>
 	              <p className="mt-3 text-sm leading-7 text-slate-300">
 	                It is not a broad ecosystem roundup. It stays narrow on the tradeoff a ClickHouse-heavy TypeScript team is actually deciding.
 	              </p>
 	            </div>
 	            <div className="border border-slate-700 bg-slate-900/60 p-6">
-	              <h2 className="font-display text-lg font-semibold text-slate-100">Recommended next move</h2>
+	              <h2 className="text-lg font-semibold text-slate-100">Recommended next move</h2>
 	              <p className="mt-3 text-sm leading-7 text-slate-300">
 	                If the tradeoff already looks clear, stop reading comparisons and test the fit against one real query in your own schema.
 	              </p>
@@ -285,7 +285,7 @@ export default async function ComparePage({
             </div>
 	            <div className="mt-10 border border-slate-700 bg-slate-900/70 p-6">
 	              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-indigo-300">Decision checkpoint</p>
-	              <h2 className="font-display mt-3 text-2xl font-semibold text-white">
+	              <h2 className="mt-3 text-2xl font-semibold text-white">
 	                If the tradeoff is already clear, move into implementation
 	              </h2>
 	              <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-300">
@@ -318,11 +318,11 @@ export default async function ComparePage({
         </section>
 
         <section className="mx-auto max-w-7xl px-4 py-16 lg:px-6">
-          <h2 className="font-display text-3xl font-semibold text-white">FAQ</h2>
+          <h2 className="text-3xl font-semibold text-white">FAQ</h2>
           <div className="mt-8 grid gap-6 md:grid-cols-2">
             {comparePage.faq.map((item) => (
               <div key={item.question} className="border border-slate-700 bg-slate-900/70 p-6">
-                <h3 className="font-display text-xl font-semibold text-slate-100">{item.question}</h3>
+                <h3 className="text-xl font-semibold text-slate-100">{item.question}</h3>
                 <p className="mt-3 text-sm leading-7 text-slate-300">{item.answer}</p>
               </div>
             ))}
@@ -333,7 +333,7 @@ export default async function ComparePage({
           <div className="border border-indigo-500/35 bg-slate-950 p-8 md:flex md:items-center md:justify-between md:gap-8">
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-indigo-300">Next step</p>
-              <h2 className="font-display mt-3 text-2xl font-semibold text-white">
+              <h2 className="mt-3 text-2xl font-semibold text-white">
                 Move from evaluation into a typed ClickHouse workflow
               </h2>
               <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-300">

--- a/website-next/src/app/compare/[slug]/page.tsx
+++ b/website-next/src/app/compare/[slug]/page.tsx
@@ -6,7 +6,7 @@ import PageWrapper from '@/components/PageWrapper';
 import MarkdownContent from '@/components/MarkdownContent';
 import RelatedContent from '@/components/RelatedContent';
 import { getPostBySlug } from '@/lib/blog';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 import { compareArticles } from '@/data/compare-articles';
 import { comparePageBySlug, comparePages } from '@/data/compare-pages';
 
@@ -64,6 +64,7 @@ export async function generateMetadata({
       description,
       publishedTime: article?.date,
       tags: article?.tags,
+      images: ogImage(title),
     },
     twitter: {
       card: 'summary_large_image',

--- a/website-next/src/app/compare/[slug]/page.tsx
+++ b/website-next/src/app/compare/[slug]/page.tsx
@@ -174,6 +174,9 @@ export default async function ComparePage({
 	            <div className="mt-8 flex flex-wrap gap-4">
               <Link
                 href="/docs/quick-start"
+                data-umami-event="cta_click"
+                data-umami-event-target="docs_quick_start"
+                data-umami-event-location="hero_primary"
                 className="bg-indigo-600 px-6 py-3 text-sm font-semibold text-white transition hover:bg-indigo-500"
               >
                 Start with the quick start
@@ -291,6 +294,9 @@ export default async function ComparePage({
               <div className="mt-6 flex flex-wrap gap-3">
                 <Link
                   href="/docs/quick-start"
+                  data-umami-event="cta_click"
+                  data-umami-event-target="docs_quick_start"
+                  data-umami-event-location="article_body"
                   className="inline-flex items-center bg-indigo-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-indigo-500"
                 >
                   Open quick start
@@ -338,6 +344,9 @@ export default async function ComparePage({
             <div className="mt-6 flex gap-3 md:mt-0">
               <Link
                 href="/docs/quick-start"
+                data-umami-event="cta_click"
+                data-umami-event-target="docs_quick_start"
+                data-umami-event-location="next_step_primary"
                 className="inline-flex items-center bg-indigo-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-indigo-500"
               >
                 Open quick start

--- a/website-next/src/app/compare/page.tsx
+++ b/website-next/src/app/compare/page.tsx
@@ -41,7 +41,7 @@ export default function CompareIndexPage() {
         <section className="border-b border-slate-800/80">
           <div className="mx-auto max-w-7xl px-4 py-20 lg:px-6">
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-indigo-300">Compare</p>
-            <h1 className="font-display mt-4 max-w-5xl text-4xl font-semibold tracking-tight text-white sm:text-6xl">
+            <h1 className="mt-4 max-w-5xl text-4xl font-semibold tracking-tight text-white sm:text-6xl">
               Compare hypequery against the main ClickHouse TypeScript options
             </h1>
             <p className="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
@@ -67,19 +67,19 @@ export default function CompareIndexPage() {
         <section className="mx-auto max-w-7xl px-4 py-16 lg:px-6">
           <div className="mb-10 grid gap-6 md:grid-cols-3">
 	            <div className="border border-slate-700 bg-slate-900/60 p-6">
-	              <h2 className="font-display text-lg font-semibold text-slate-100">Built for real evaluations</h2>
+	              <h2 className="text-lg font-semibold text-slate-100">Built for real evaluations</h2>
 	              <p className="mt-3 text-sm leading-7 text-slate-300">
 	                Each page is written around the actual switch a team might make, not a generic feature checklist.
 	              </p>
 	            </div>
 	            <div className="border border-slate-700 bg-slate-900/60 p-6">
-	              <h2 className="font-display text-lg font-semibold text-slate-100">Linked to implementation</h2>
+	              <h2 className="text-lg font-semibold text-slate-100">Linked to implementation</h2>
 	              <p className="mt-3 text-sm leading-7 text-slate-300">
 	                If a comparison is useful, it should get you into the docs quickly rather than trapping you in more comparison content.
 	              </p>
 	            </div>
 	            <div className="border border-slate-700 bg-slate-900/60 p-6">
-	              <h2 className="font-display text-lg font-semibold text-slate-100">Opinionated about fit</h2>
+	              <h2 className="text-lg font-semibold text-slate-100">Opinionated about fit</h2>
 	              <p className="mt-3 text-sm leading-7 text-slate-300">
 	                The goal is to clarify where hypequery fits and where the other tool should remain the right choice.
 	              </p>
@@ -92,7 +92,7 @@ export default function CompareIndexPage() {
                 href={page.href}
                 className="group border border-slate-700 bg-slate-900/70 p-8 transition hover:-translate-y-1 hover:border-indigo-400 hover:bg-slate-900"
               >
-                <h2 className="font-display text-2xl font-semibold text-slate-100">{page.title}</h2>
+                <h2 className="text-2xl font-semibold text-slate-100">{page.title}</h2>
                 <p className="mt-4 text-sm leading-7 text-slate-300">{page.verdict}</p>
                 <div className="mt-6 flex flex-wrap gap-2">
                   {page.rows.map((row) => (
@@ -114,7 +114,7 @@ export default function CompareIndexPage() {
 
         <section className="mx-auto max-w-7xl px-4 pb-16 lg:px-6">
           <p className="text-xs font-semibold uppercase tracking-[0.3em] text-indigo-300">Switching tools?</p>
-          <h2 className="font-display mt-3 text-3xl font-semibold text-white">Alternative guides</h2>
+          <h2 className="mt-3 text-3xl font-semibold text-white">Alternative guides</h2>
           <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-300">
             If you are moving away from a platform rather than evaluating from scratch, these guides cover why teams switch, what the migration looks like, and where the incumbent is still the right call.
           </p>
@@ -123,7 +123,7 @@ export default function CompareIndexPage() {
               href="/cube-js-alternative"
               className="group border border-slate-700 bg-slate-900/70 p-8 transition hover:-translate-y-1 hover:border-indigo-400 hover:bg-slate-900"
             >
-              <h3 className="font-display text-2xl font-semibold text-slate-100">Cube.js alternative</h3>
+              <h3 className="text-2xl font-semibold text-slate-100">Cube.js alternative</h3>
               <p className="mt-4 text-sm leading-7 text-slate-300">
                 Replace the Cube server, cache layer, and YAML modelling with a typed TypeScript library that lives in your own codebase.
               </p>
@@ -135,7 +135,7 @@ export default function CompareIndexPage() {
               href="/tinybird-alternative"
               className="group border border-slate-700 bg-slate-900/70 p-8 transition hover:-translate-y-1 hover:border-indigo-400 hover:bg-slate-900"
             >
-              <h3 className="font-display text-2xl font-semibold text-slate-100">Tinybird alternative</h3>
+              <h3 className="text-2xl font-semibold text-slate-100">Tinybird alternative</h3>
               <p className="mt-4 text-sm leading-7 text-slate-300">
                 Keep your data in your own ClickHouse and build the typed API layer in TypeScript — no ingestion into a third-party platform, no usage-based pricing.
               </p>
@@ -147,7 +147,7 @@ export default function CompareIndexPage() {
               href="/moosestack-alternative"
               className="group border border-slate-700 bg-slate-900/70 p-8 transition hover:-translate-y-1 hover:border-indigo-400 hover:bg-slate-900"
             >
-              <h3 className="font-display text-2xl font-semibold text-slate-100">MooseStack alternative</h3>
+              <h3 className="text-2xl font-semibold text-slate-100">MooseStack alternative</h3>
               <p className="mt-4 text-sm leading-7 text-slate-300">
                 Take the typed query and API layer without the framework — no dev runtime, no scaffold, no streaming stack you didn&apos;t ask for.
               </p>
@@ -162,7 +162,7 @@ export default function CompareIndexPage() {
           <div className="border border-indigo-500/35 bg-slate-950 p-8 md:flex md:items-center md:justify-between md:gap-8">
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-indigo-300">Next step</p>
-	              <h2 className="font-display mt-3 text-2xl font-semibold text-white">
+	              <h2 className="mt-3 text-2xl font-semibold text-white">
 	                Start with the quick start once you know the shape you want
 	              </h2>
 	              <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-300">

--- a/website-next/src/app/compare/page.tsx
+++ b/website-next/src/app/compare/page.tsx
@@ -172,6 +172,9 @@ export default function CompareIndexPage() {
             <div className="mt-6 flex gap-3 md:mt-0">
               <Link
                 href="/docs/quick-start"
+                data-umami-event="cta_click"
+                data-umami-event-target="docs_quick_start"
+                data-umami-event-location="hero_primary"
                 className="inline-flex items-center bg-indigo-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-indigo-500"
               >
                 Open quick start

--- a/website-next/src/app/compare/page.tsx
+++ b/website-next/src/app/compare/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import PageWrapper from '@/components/PageWrapper';
 import { comparePages } from '@/data/compare-pages';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
   title: 'Compare Hypequery',
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
     canonical: absoluteUrl('/compare'),
   },
   openGraph: {
+    images: ogImage('Compare Hypequery'),
     type: 'website',
     url: absoluteUrl('/compare'),
     title: 'Compare hypequery | ClickHouse TypeScript Tradeoffs',

--- a/website-next/src/app/contact-us/page.tsx
+++ b/website-next/src/app/contact-us/page.tsx
@@ -1,0 +1,122 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Footer from '@/components/Footer';
+import Navigation from '@/components/Navigation';
+import { absoluteUrl, ogImage } from '@/lib/site';
+
+export const metadata: Metadata = {
+  title: 'Contact',
+  description:
+    'Get in touch with the hypequery team — book a call, open a GitHub issue, or reach out on X.',
+  alternates: {
+    canonical: absoluteUrl('/contact-us'),
+  },
+  openGraph: {
+    images: ogImage('Contact hypequery'),
+    type: 'website',
+    url: absoluteUrl('/contact-us'),
+    title: 'Contact | hypequery',
+    description:
+      'Get in touch with the hypequery team — book a call, open a GitHub issue, or reach out on X.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Contact | hypequery',
+    description:
+      'Get in touch with the hypequery team — book a call, open a GitHub issue, or reach out on X.',
+  },
+};
+
+const channels = [
+  {
+    title: 'Book a call',
+    copy: 'Talk through your architecture, migration questions, or whether hypequery fits your stack. 30 minutes, no pitch.',
+    href: 'https://cal.com/luke-reilly-jdi9su/hypequery-chat',
+    label: 'Pick a time',
+    external: true,
+    track: 'book_call',
+  },
+  {
+    title: 'GitHub',
+    copy: 'Bug reports, feature requests, and questions about the library live in the open on GitHub.',
+    href: 'https://github.com/hypequery/hypequery/issues',
+    label: 'Open an issue',
+    external: true,
+    track: 'github_issues',
+  },
+  {
+    title: 'X / Twitter',
+    copy: 'Quick questions and release updates. DMs are open.',
+    href: 'https://x.com/hypequery',
+    label: 'Message @hypequery',
+    external: true,
+    track: 'twitter',
+  },
+];
+
+export default function ContactUsPage() {
+  return (
+    <>
+      <Navigation />
+      <main className="min-h-screen bg-bg pt-28 text-text">
+        <section className="mx-auto max-w-7xl px-4 py-20 lg:px-6">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-accent">Contact</p>
+          <h1 className="font-display mt-4 max-w-4xl text-4xl font-semibold tracking-tight text-text sm:text-6xl">
+            Talk to the team behind hypequery
+          </h1>
+          <p className="mt-6 max-w-3xl text-lg leading-8 text-text-muted">
+            Evaluating hypequery for your ClickHouse stack, stuck on an integration, or comparing it
+            against Cube, Tinybird, or a hand-rolled layer? Pick whichever channel suits you.
+          </p>
+
+          <div className="mt-12 grid gap-6 lg:grid-cols-3">
+            {channels.map((channel) => (
+              <div key={channel.title} className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
+                <h2 className="font-display text-xl font-semibold text-text">{channel.title}</h2>
+                <p className="mt-3 text-sm leading-7 text-text-muted">{channel.copy}</p>
+                <a
+                  href={channel.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  data-umami-event="cta_click"
+                  data-umami-event-target={channel.track}
+                  data-umami-event-location="contact_page"
+                  className="mt-6 inline-flex items-center border border-border-strong px-5 py-3 text-sm font-semibold text-text transition hover:bg-bg-alt"
+                >
+                  {channel.label} →
+                </a>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-12 rounded-lg border border-border bg-bg-card p-8 shadow-card md:flex md:items-center md:justify-between md:gap-8">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">
+                Just exploring?
+              </p>
+              <h2 className="font-display mt-3 text-2xl font-semibold text-text">
+                The quick start answers most questions
+              </h2>
+              <p className="mt-3 max-w-2xl text-sm leading-7 text-text-muted">
+                Generate types from your ClickHouse schema and run your first typed query in a few
+                minutes — often faster than scheduling a call.
+              </p>
+            </div>
+            <div className="mt-6 md:mt-0">
+              <Link
+                href="/docs/quick-start"
+                data-umami-event="cta_click"
+                data-umami-event-target="docs_quick_start"
+                data-umami-event-location="contact_page"
+                className="inline-flex items-center bg-text px-5 py-3 text-sm font-semibold text-bg transition hover:opacity-90"
+              >
+                Open quick start
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/website-next/src/app/contact-us/page.tsx
+++ b/website-next/src/app/contact-us/page.tsx
@@ -61,7 +61,7 @@ export default function ContactUsPage() {
       <main className="min-h-screen bg-bg pt-28 text-text">
         <section className="mx-auto max-w-7xl px-4 py-20 lg:px-6">
           <p className="text-xs font-semibold uppercase tracking-[0.3em] text-accent">Contact</p>
-          <h1 className="font-display mt-4 max-w-4xl text-4xl font-semibold tracking-tight text-text sm:text-6xl">
+          <h1 className="mt-4 max-w-4xl text-4xl font-semibold tracking-tight text-text sm:text-6xl">
             Talk to the team behind hypequery
           </h1>
           <p className="mt-6 max-w-3xl text-lg leading-8 text-text-muted">
@@ -72,7 +72,7 @@ export default function ContactUsPage() {
           <div className="mt-12 grid gap-6 lg:grid-cols-3">
             {channels.map((channel) => (
               <div key={channel.title} className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-                <h2 className="font-display text-xl font-semibold text-text">{channel.title}</h2>
+                <h2 className="text-xl font-semibold text-text">{channel.title}</h2>
                 <p className="mt-3 text-sm leading-7 text-text-muted">{channel.copy}</p>
                 <a
                   href={channel.href}
@@ -94,7 +94,7 @@ export default function ContactUsPage() {
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">
                 Just exploring?
               </p>
-              <h2 className="font-display mt-3 text-2xl font-semibold text-text">
+              <h2 className="mt-3 text-2xl font-semibold text-text">
                 The quick start answers most questions
               </h2>
               <p className="mt-3 max-w-2xl text-sm leading-7 text-text-muted">

--- a/website-next/src/app/cube-js-alternative/page.tsx
+++ b/website-next/src/app/cube-js-alternative/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'Cube.js Alternative for ClickHouse — Code-First TypeScript Layer | hypequery',
+  title: 'Cube.js Alternative for ClickHouse — Code-First TypeScript Layer',
   description:
     'Looking for a Cube.js alternative for ClickHouse? hypequery replaces the Cube server, Redis cache, and YAML modelling with a typed TypeScript library that lives in your codebase.',
   alternates: { canonical: absoluteUrl('/cube-js-alternative') },
   openGraph: {
+    images: ogImage('Cube.js Alternative for ClickHouse — Code-First TypeScript Layer'),
     type: 'website',
     url: absoluteUrl('/cube-js-alternative'),
     title: 'Cube.js Alternative for ClickHouse — Code-First TypeScript Layer | hypequery',

--- a/website-next/src/app/docs/[...slug]/page.tsx
+++ b/website-next/src/app/docs/[...slug]/page.tsx
@@ -8,7 +8,7 @@ import {
 import { notFound } from 'next/navigation';
 import { LLMCopyButton, ViewOptions } from '@/components/page-actions';
 import type { Metadata } from 'next';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export async function generateMetadata({
   params,
@@ -36,6 +36,7 @@ export async function generateMetadata({
       url: absoluteUrl(page.url),
       title,
       description,
+      images: ogImage(title),
     },
     twitter: {
       card: 'summary_large_image',

--- a/website-next/src/app/drizzle-clickhouse/page.tsx
+++ b/website-next/src/app/drizzle-clickhouse/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'Drizzle ORM for ClickHouse — Alternative for TypeScript Teams | hypequery',
+  title: 'Drizzle ORM for ClickHouse — Alternative for TypeScript Teams',
   description:
     'Looking for Drizzle ORM support for ClickHouse? Drizzle does not support ClickHouse. hypequery is the TypeScript-first alternative for schema generation and typed queries.',
   alternates: { canonical: absoluteUrl('/drizzle-clickhouse') },
   openGraph: {
+    images: ogImage('Drizzle ORM for ClickHouse — Alternative for TypeScript Teams'),
     type: 'website',
     url: absoluteUrl('/drizzle-clickhouse'),
     title: 'Drizzle ORM for ClickHouse — Alternative for TypeScript Teams | hypequery',

--- a/website-next/src/app/drizzle-clickhouse/page.tsx
+++ b/website-next/src/app/drizzle-clickhouse/page.tsx
@@ -3,23 +3,23 @@ import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
 import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'Drizzle ORM for ClickHouse — Alternative for TypeScript Teams',
+  title: 'Drizzle ORM for ClickHouse? Use This Instead',
   description:
-    'Looking for Drizzle ORM support for ClickHouse? Drizzle does not support ClickHouse. hypequery is the TypeScript-first alternative for schema generation and typed queries.',
+    'Drizzle doesn\'t support ClickHouse. hypequery gives you the same schema-first DX: types generated from your live ClickHouse schema and fully typed queries.',
   alternates: { canonical: absoluteUrl('/drizzle-clickhouse') },
   openGraph: {
     images: ogImage('Drizzle ORM for ClickHouse — Alternative for TypeScript Teams'),
     type: 'website',
     url: absoluteUrl('/drizzle-clickhouse'),
-    title: 'Drizzle ORM for ClickHouse — Alternative for TypeScript Teams | hypequery',
+    title: 'Drizzle ORM for ClickHouse? Use This Instead | hypequery',
     description:
-      'If you want a Drizzle-style workflow for ClickHouse, use hypequery: live-schema generation, composable queries, and typed APIs built for analytics.',
+      'Drizzle doesn\'t support ClickHouse. hypequery gives you the same schema-first DX: types generated from your live schema and fully typed queries.',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Drizzle ORM for ClickHouse | hypequery',
+    title: 'Drizzle ORM for ClickHouse? Use This Instead | hypequery',
     description:
-      'Drizzle does not support ClickHouse. hypequery is the TypeScript-first alternative for ClickHouse analytics applications.',
+      'Drizzle doesn\'t support ClickHouse. hypequery gives you the same schema-first DX for ClickHouse analytics.',
   },
 };
 
@@ -53,7 +53,7 @@ export default function DrizzleClickHousePage() {
       eyebrow="Drizzle ORM ClickHouse"
       title="Looking for Drizzle ORM on ClickHouse?"
       description="Drizzle does not support ClickHouse. If what you want is the part people actually like about Drizzle — generated types, predictable query code, and a good TypeScript workflow — hypequery is the closer fit for ClickHouse."
-      primaryCta={{ href: '/docs/quick-start', label: 'Start with hypequery' }}
+      primaryCta={{ href: '/docs/quick-start', label: 'Generate types from your schema' }}
       secondaryCta={{ href: '/compare/hypequery-vs-drizzle', label: 'Read the full comparison' }}
       stats={[
         { label: 'ClickHouse support', value: 'hypequery native' },
@@ -169,7 +169,7 @@ export default function DrizzleClickHousePage() {
         title: 'Generate your ClickHouse schema types and prove the workflow on one real query',
         description:
           'That is the fastest way to evaluate whether hypequery covers the Drizzle-style ClickHouse workflow your team actually wants.',
-        primaryCta: { href: '/docs/quick-start', label: 'Start with hypequery' },
+        primaryCta: { href: '/docs/quick-start', label: 'Generate types from your schema' },
         secondaryCta: { href: '/compare/hypequery-vs-drizzle', label: 'Read full comparison' },
       }}
     />

--- a/website-next/src/app/layout.tsx
+++ b/website-next/src/app/layout.tsx
@@ -60,6 +60,30 @@ export const metadata: Metadata = {
 
 const gaMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 
+const organizationSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  '@id': absoluteUrl('/#organization').toString(),
+  name: 'hypequery',
+  url: absoluteUrl('/').toString(),
+  logo: absoluteUrl('/logo.png').toString(),
+  sameAs: [
+    'https://github.com/hypequery/hypequery',
+    'https://www.npmjs.com/package/@hypequery/clickhouse',
+    'https://twitter.com/hypequery',
+    'https://www.newsletter.hypequery.com',
+  ],
+};
+
+const websiteSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  '@id': absoluteUrl('/#website').toString(),
+  name: 'hypequery',
+  url: absoluteUrl('/').toString(),
+  publisher: { '@id': absoluteUrl('/#organization').toString() },
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -68,6 +92,14 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteSchema) }}
+        />
         <script
           dangerouslySetInnerHTML={{
             __html: `(() => {

--- a/website-next/src/app/moosestack-alternative/page.tsx
+++ b/website-next/src/app/moosestack-alternative/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'MooseStack Alternative — The Library Instead of the Framework | hypequery',
+  title: 'MooseStack Alternative — The Library Instead of the Framework',
   description:
     'Looking for a MooseStack (Moose) alternative? hypequery gives you typed ClickHouse queries and APIs as an npm library — no framework runtime, no project scaffold, no streaming stack you didn’t ask for.',
   alternates: { canonical: absoluteUrl('/moosestack-alternative') },
   openGraph: {
+    images: ogImage('MooseStack Alternative — The Library Instead of the Framework'),
     type: 'website',
     url: absoluteUrl('/moosestack-alternative'),
     title: 'MooseStack Alternative — The Library Instead of the Framework | hypequery',

--- a/website-next/src/app/og/route.tsx
+++ b/website-next/src/app/og/route.tsx
@@ -1,5 +1,7 @@
 import { ImageResponse } from 'next/og';
 
+export const runtime = 'edge';
+
 const DEFAULT_TITLE = 'The TypeScript analytics layer for ClickHouse';
 
 export async function GET(request: Request) {

--- a/website-next/src/app/og/route.tsx
+++ b/website-next/src/app/og/route.tsx
@@ -1,0 +1,63 @@
+import { ImageResponse } from 'next/og';
+
+const DEFAULT_TITLE = 'The TypeScript analytics layer for ClickHouse';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const rawTitle = searchParams.get('title')?.trim();
+  const title = rawTitle && rawTitle.length > 0 ? rawTitle.slice(0, 140) : DEFAULT_TITLE;
+  const fontSize = title.length > 70 ? 48 : 60;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: 72,
+          background: 'linear-gradient(135deg, #101223 0%, #1c2145 55%, #3a3f8c 100%)',
+          color: '#ffffff',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 8,
+              background: '#a5b4fc',
+            }}
+          />
+          <div style={{ fontSize: 36, fontWeight: 700 }}>hypequery</div>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            fontSize,
+            fontWeight: 700,
+            lineHeight: 1.15,
+            maxWidth: 1020,
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            fontSize: 26,
+            color: '#a5b4fc',
+          }}
+        >
+          <div>ClickHouse + TypeScript</div>
+          <div>hypequery.com</div>
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630 },
+  );
+}

--- a/website-next/src/app/opengraph-image.tsx
+++ b/website-next/src/app/opengraph-image.tsx
@@ -1,0 +1,47 @@
+import { ImageResponse } from 'next/og';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const alt = 'hypequery — The TypeScript analytics layer for ClickHouse';
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: 72,
+          background: 'linear-gradient(135deg, #101223 0%, #1c2145 55%, #3a3f8c 100%)',
+          color: '#ffffff',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 8,
+              background: '#a5b4fc',
+            }}
+          />
+          <div style={{ fontSize: 36, fontWeight: 700 }}>hypequery</div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+          <div style={{ fontSize: 64, fontWeight: 700, lineHeight: 1.1, maxWidth: 1000 }}>
+            The TypeScript analytics layer for ClickHouse
+          </div>
+          <div style={{ fontSize: 30, color: '#c7d2fe', maxWidth: 960 }}>
+            Define metrics once. Reuse them across APIs, jobs, dashboards, and AI agents.
+          </div>
+        </div>
+        <div style={{ display: 'flex', fontSize: 26, color: '#a5b4fc' }}>hypequery.com</div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/website-next/src/app/page.tsx
+++ b/website-next/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Footer from '@/components/Footer';
 import Navigation from '@/components/Navigation';
+import { absoluteUrl } from '@/lib/site';
 import {
   AnnouncementBanner,
   Hero,
@@ -11,9 +12,32 @@ import {
   FinalCTA,
 } from '@/components/home';
 
+const softwareSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'hypequery',
+  url: absoluteUrl('/').toString(),
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Node.js',
+  description:
+    'The TypeScript analytics layer for ClickHouse. Define queries, metrics, and dimensions once, then expose them as typed APIs, React hooks, or MCP tools.',
+  offers: {
+    '@type': 'Offer',
+    price: '0',
+    priceCurrency: 'USD',
+  },
+  softwareHelp: absoluteUrl('/docs/introduction').toString(),
+  downloadUrl: 'https://www.npmjs.com/package/@hypequery/clickhouse',
+  author: { '@id': absoluteUrl('/#organization').toString() },
+};
+
 export default function Home() {
   return (
     <div className="min-h-screen bg-bg text-text">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareSchema) }}
+      />
       <AnnouncementBanner />
       <Navigation hasBanner />
       <main className="pt-[104px]">

--- a/website-next/src/app/prisma-clickhouse/page.tsx
+++ b/website-next/src/app/prisma-clickhouse/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'Prisma for ClickHouse: What TypeScript Teams Should Use Instead | hypequery',
+  title: 'Prisma for ClickHouse: What TypeScript Teams Should Use Instead',
   description:
     'Prisma does not support ClickHouse. If you need a schema-first TypeScript workflow for ClickHouse, use hypequery for generated types and composable queries.',
   alternates: { canonical: absoluteUrl('/prisma-clickhouse') },
   openGraph: {
+    images: ogImage('Prisma for ClickHouse: What TypeScript Teams Should Use Instead'),
     type: 'website',
     url: absoluteUrl('/prisma-clickhouse'),
     title: 'Prisma for ClickHouse: What TypeScript Teams Should Use Instead | hypequery',

--- a/website-next/src/app/prisma-clickhouse/page.tsx
+++ b/website-next/src/app/prisma-clickhouse/page.tsx
@@ -3,23 +3,23 @@ import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
 import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'Prisma for ClickHouse: What TypeScript Teams Should Use Instead',
+  title: 'Prisma with ClickHouse? Use This Instead',
   description:
-    'Prisma does not support ClickHouse. If you need a schema-first TypeScript workflow for ClickHouse, use hypequery for generated types and composable queries.',
+    'Prisma doesn\'t support ClickHouse. hypequery brings Prisma-style DX to analytics: types generated from your live schema and fully typed queries.',
   alternates: { canonical: absoluteUrl('/prisma-clickhouse') },
   openGraph: {
     images: ogImage('Prisma for ClickHouse: What TypeScript Teams Should Use Instead'),
     type: 'website',
     url: absoluteUrl('/prisma-clickhouse'),
-    title: 'Prisma for ClickHouse: What TypeScript Teams Should Use Instead | hypequery',
+    title: 'Prisma with ClickHouse? Use This Instead | hypequery',
     description:
-      'Prisma is built for relational transactional databases. If you need a TypeScript-first workflow for ClickHouse analytics, hypequery is the closer fit.',
+      'Prisma doesn\'t support ClickHouse. hypequery brings Prisma-style DX to analytics: types from your live schema and fully typed queries.',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Prisma for ClickHouse | hypequery',
+    title: 'Prisma with ClickHouse? Use This Instead | hypequery',
     description:
-      'Prisma does not support ClickHouse. Use hypequery for generated schema types, composable ClickHouse queries, and reusable APIs.',
+      'Prisma doesn\'t support ClickHouse. hypequery brings Prisma-style DX to ClickHouse analytics.',
   },
 };
 
@@ -55,7 +55,7 @@ export default function PrismaClickHousePage() {
       eyebrow="Prisma ClickHouse"
       title="Looking for Prisma on ClickHouse?"
       description="Prisma does not support ClickHouse. If what you actually want is the useful part of the Prisma experience — generated types, predictable query code, and a clean TypeScript workflow — hypequery is the closer fit for ClickHouse."
-      primaryCta={{ href: '/docs/quick-start', label: 'Start with hypequery' }}
+      primaryCta={{ href: '/docs/quick-start', label: 'Generate types from your schema' }}
       secondaryCta={{ href: '/clickhouse-orm', label: 'See the ClickHouse ORM page' }}
       stats={[
         { label: 'Prisma fit', value: 'Relational app databases' },
@@ -171,7 +171,7 @@ export default function PrismaClickHousePage() {
         title: 'Start with hypequery on one real ClickHouse query',
         description:
           'Generate schema types from your ClickHouse instance and try one real analytics query. That is the fastest way to validate whether the Prisma-style ClickHouse workflow you want is really a generated-schema query-layer problem instead.',
-        primaryCta: { href: '/docs/quick-start', label: 'Start with hypequery' },
+        primaryCta: { href: '/docs/quick-start', label: 'Generate types from your schema' },
         secondaryCta: { href: '/clickhouse-schema', label: 'Generate schema types' },
       }}
     />

--- a/website-next/src/app/sitemap.ts
+++ b/website-next/src/app/sitemap.ts
@@ -41,6 +41,7 @@ const staticRoutes = [
   '/use-cases',
   '/use-cases/internal-product-apis',
   '/use-cases/multi-tenant-saas',
+  '/contact-us',
   '/cube-js-alternative',
   '/tinybird-alternative',
   '/moosestack-alternative',

--- a/website-next/src/app/tinybird-alternative/page.tsx
+++ b/website-next/src/app/tinybird-alternative/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'Tinybird Alternative — Typed ClickHouse APIs on Your Own Infrastructure | hypequery',
+  title: 'Tinybird Alternative — Typed ClickHouse APIs on Your Own Infrastructure',
   description:
     'Looking for a Tinybird alternative? hypequery + your own ClickHouse gives you typed analytics APIs with no data ingestion into a third-party platform and no per-query pricing.',
   alternates: { canonical: absoluteUrl('/tinybird-alternative') },
   openGraph: {
+    images: ogImage('Tinybird Alternative — Typed ClickHouse APIs on Your Own Infrastructure'),
     type: 'website',
     url: absoluteUrl('/tinybird-alternative'),
     title: 'Tinybird Alternative — Typed ClickHouse APIs on Your Own Infrastructure | hypequery',

--- a/website-next/src/app/typeorm-clickhouse/page.tsx
+++ b/website-next/src/app/typeorm-clickhouse/page.tsx
@@ -3,23 +3,23 @@ import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
 import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'TypeORM for ClickHouse: Better Alternative for TypeScript',
+  title: 'TypeORM with ClickHouse? Use This Instead',
   description:
-    'Looking for TypeORM on ClickHouse? TypeORM is not a natural fit for ClickHouse analytics workloads. hypequery is the TypeScript-first alternative for generated schema types and ClickHouse queries.',
+    'TypeORM fights ClickHouse — decorators, migrations, and relations don\'t map to analytics tables. hypequery generates types from your live schema instead.',
   alternates: { canonical: absoluteUrl('/typeorm-clickhouse') },
   openGraph: {
     images: ogImage('TypeORM for ClickHouse: Better Alternative for TypeScript'),
     type: 'website',
     url: absoluteUrl('/typeorm-clickhouse'),
-    title: 'TypeORM for ClickHouse: Better Alternative for TypeScript | hypequery',
+    title: 'TypeORM with ClickHouse? Use This Instead | hypequery',
     description:
-      'TypeORM is built for relational transactional workflows. If you need a TypeScript-native workflow for ClickHouse analytics, hypequery is the closer fit.',
+      'TypeORM fights ClickHouse analytics. hypequery generates TypeScript types from your live schema and gives you fully typed queries instead.',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'TypeORM for ClickHouse | hypequery',
+    title: 'TypeORM with ClickHouse? Use This Instead | hypequery',
     description:
-      'TypeORM is not a natural fit for ClickHouse analytics workloads. Use hypequery for generated types, composable ClickHouse queries, and reusable APIs.',
+      'TypeORM fights ClickHouse analytics. hypequery generates TypeScript types from your live schema instead.',
   },
 };
 
@@ -55,7 +55,7 @@ export default function TypeormClickHousePage() {
       eyebrow="TypeORM ClickHouse"
       title="Looking for TypeORM on ClickHouse?"
       description="TypeORM is built around relational entities, transactions, and table relationships. ClickHouse is a columnar analytics database with a different type model and a different query shape. If what you actually want is a TypeScript workflow for ClickHouse analytics, hypequery is the closer fit."
-      primaryCta={{ href: '/docs/quick-start', label: 'Start with hypequery' }}
+      primaryCta={{ href: '/docs/quick-start', label: 'Generate types from your schema' }}
       secondaryCta={{ href: '/clickhouse-orm', label: 'See the ClickHouse ORM page' }}
       stats={[
         { label: 'TypeORM fit', value: 'Relational app databases' },
@@ -171,7 +171,7 @@ export default function TypeormClickHousePage() {
         title: 'Generate your ClickHouse schema types and try one real analytics query',
         description:
           'That is the fastest way to tell whether the TypeORM-style ClickHouse workflow you want is really a generated-schema query-layer problem instead.',
-        primaryCta: { href: '/docs/quick-start', label: 'Start with hypequery' },
+        primaryCta: { href: '/docs/quick-start', label: 'Generate types from your schema' },
         secondaryCta: { href: '/clickhouse-orm', label: 'See the ORM page' },
       }}
     />

--- a/website-next/src/app/typeorm-clickhouse/page.tsx
+++ b/website-next/src/app/typeorm-clickhouse/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from 'next';
 import { ClickhousePillarPage } from '@/components/clickhouse-pillar-page';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
-  title: 'TypeORM for ClickHouse: Better Alternative for TypeScript | hypequery',
+  title: 'TypeORM for ClickHouse: Better Alternative for TypeScript',
   description:
     'Looking for TypeORM on ClickHouse? TypeORM is not a natural fit for ClickHouse analytics workloads. hypequery is the TypeScript-first alternative for generated schema types and ClickHouse queries.',
   alternates: { canonical: absoluteUrl('/typeorm-clickhouse') },
   openGraph: {
+    images: ogImage('TypeORM for ClickHouse: Better Alternative for TypeScript'),
     type: 'website',
     url: absoluteUrl('/typeorm-clickhouse'),
     title: 'TypeORM for ClickHouse: Better Alternative for TypeScript | hypequery',

--- a/website-next/src/app/use-cases/internal-product-apis/page.tsx
+++ b/website-next/src/app/use-cases/internal-product-apis/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import PageWrapper from '@/components/PageWrapper';
 import CodeWindow from '@/components/CodeWindow';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
   title: 'Internal Product APIs with ClickHouse Analytics',
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
     canonical: absoluteUrl('/use-cases/internal-product-apis'),
   },
   openGraph: {
+    images: ogImage('Internal Product APIs with ClickHouse Analytics'),
     type: 'website',
     url: absoluteUrl('/use-cases/internal-product-apis'),
     title: 'Internal Product APIs with ClickHouse Analytics | hypequery',

--- a/website-next/src/app/use-cases/internal-product-apis/page.tsx
+++ b/website-next/src/app/use-cases/internal-product-apis/page.tsx
@@ -96,12 +96,18 @@ export default function InternalProductApisUseCasePage() {
             <div className="mt-8 flex flex-wrap gap-4">
               <Link
                 href="/docs/quick-start"
+                data-umami-event="cta_click"
+                data-umami-event-target="docs_quick_start"
+                data-umami-event-location="hero_primary"
                 className="bg-text px-6 py-3 text-sm font-semibold text-bg transition hover:opacity-90"
               >
                 Start with this pattern
               </Link>
               <a
-                href="https://cal.com"
+                href="https://cal.com/luke-reilly-jdi9su/hypequery-chat"
+                data-umami-event="cta_click"
+                data-umami-event-target="book_call"
+                data-umami-event-location="hero_secondary"
                 className="border border-border-strong px-6 py-3 text-sm font-semibold text-text transition hover:bg-bg-alt"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -224,12 +230,18 @@ export default function InternalProductApisUseCasePage() {
             <div className="mt-6 flex gap-3 md:mt-0">
               <Link
                 href="/docs/quick-start"
+                data-umami-event="cta_click"
+                data-umami-event-target="docs_quick_start"
+                data-umami-event-location="next_step_primary"
                 className="inline-flex items-center bg-text px-5 py-3 text-sm font-semibold text-bg transition hover:opacity-90"
               >
                 Open quick start
               </Link>
               <Link
                 href="/use-cases/multi-tenant-saas"
+                data-umami-event="cta_click"
+                data-umami-event-target="use_cases_multi_tenant_saas"
+                data-umami-event-location="next_step_secondary"
                 className="inline-flex items-center border border-border-strong px-5 py-3 text-sm font-semibold text-text transition hover:bg-bg-alt"
               >
                 Next: Multi-tenant

--- a/website-next/src/app/use-cases/internal-product-apis/page.tsx
+++ b/website-next/src/app/use-cases/internal-product-apis/page.tsx
@@ -87,7 +87,7 @@ export default function InternalProductApisUseCasePage() {
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-accent">
               Use Case
             </p>
-            <h1 className="font-display mt-4 max-w-4xl text-4xl font-semibold tracking-tight text-text sm:text-6xl">
+            <h1 className="mt-4 max-w-4xl text-4xl font-semibold tracking-tight text-text sm:text-6xl">
               Internal product APIs with embedded ClickHouse analytics
             </h1>
             <p className="mt-6 max-w-3xl text-lg leading-8 text-text-muted">
@@ -135,19 +135,19 @@ export default function InternalProductApisUseCasePage() {
         <section className="mx-auto max-w-7xl px-4 py-16 lg:px-6">
           <div className="grid gap-6 md:grid-cols-3">
 	            <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-	              <h2 className="font-display text-lg font-semibold text-text">Keep route contracts stable</h2>
+	              <h2 className="text-lg font-semibold text-text">Keep route contracts stable</h2>
 	              <p className="mt-3 text-sm leading-7 text-text-muted">
 	                Existing consumers do not need to notice the migration while you move analytics logic behind an internal path.
 	              </p>
 	            </div>
 	            <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-	              <h2 className="font-display text-lg font-semibold text-text">Use one query definition</h2>
+	              <h2 className="text-lg font-semibold text-text">Use one query definition</h2>
 	              <p className="mt-3 text-sm leading-7 text-text-muted">
 	                Let handlers call `api.run(...)` directly and expose the same definition over HTTP only where it is genuinely useful.
 	              </p>
 	            </div>
 	            <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-	              <h2 className="font-display text-lg font-semibold text-text">Scale rollout safely</h2>
+	              <h2 className="text-lg font-semibold text-text">Scale rollout safely</h2>
 	              <p className="mt-3 text-sm leading-7 text-text-muted">
 	                Start with one endpoint or one response shape, see what sticks, then widen the internal surface deliberately.
 	              </p>
@@ -157,25 +157,25 @@ export default function InternalProductApisUseCasePage() {
 
         <section className="border-y border-border bg-bg-alt/60">
           <div className="mx-auto max-w-7xl px-4 py-16 lg:px-6">
-          <h2 className="font-display text-3xl font-semibold text-text">Implementation flow</h2>
+          <h2 className="text-3xl font-semibold text-text">Implementation flow</h2>
             <div className="mt-8 grid gap-6 md:grid-cols-3">
               <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
                 <p className="text-xs uppercase tracking-[0.2em] text-accent">Step 1</p>
-                <h3 className="font-display mt-3 text-lg font-semibold text-text">Mount internal routes</h3>
+                <h3 className="mt-3 text-lg font-semibold text-text">Mount internal routes</h3>
 	                <p className="mt-3 text-sm leading-7 text-text-muted">
 	                  Mount the analytics handler beside the routes you already run instead of restructuring the whole backend first.
 	                </p>
               </div>
               <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
                 <p className="text-xs uppercase tracking-[0.2em] text-accent">Step 2</p>
-                <h3 className="font-display mt-3 text-lg font-semibold text-text">Compose in endpoints</h3>
+                <h3 className="mt-3 text-lg font-semibold text-text">Compose in endpoints</h3>
 	                <p className="mt-3 text-sm leading-7 text-text-muted">
 	                  Pull analytics into existing business responses without turning every route into bespoke query code.
 	                </p>
               </div>
               <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
                 <p className="text-xs uppercase tracking-[0.2em] text-accent">Step 3</p>
-                <h3 className="font-display mt-3 text-lg font-semibold text-text">Reuse query logic</h3>
+                <h3 className="mt-3 text-lg font-semibold text-text">Reuse query logic</h3>
 	                <p className="mt-3 text-sm leading-7 text-text-muted">
 	                  Keep one typed source of truth whether the query is called directly or exposed under an internal path.
 	                </p>
@@ -185,7 +185,7 @@ export default function InternalProductApisUseCasePage() {
         </section>
 
         <section className="mx-auto max-w-7xl px-4 py-16 lg:px-6">
-	          <h2 className="font-display text-2xl font-semibold text-text">Works with your existing routes</h2>
+	          <h2 className="text-2xl font-semibold text-text">Works with your existing routes</h2>
 	          <p className="mt-3 text-lg leading-8 text-text-muted">
 	            The route tree stays yours. Add the analytics surface where it fits instead of adopting a separate service boundary immediately.
 	          </p>
@@ -193,7 +193,7 @@ export default function InternalProductApisUseCasePage() {
         </section>
 
         <section className="mx-auto max-w-7xl px-4 pb-16 lg:px-6">
-          <h2 className="font-display text-2xl font-semibold text-text">
+          <h2 className="text-2xl font-semibold text-text">
             Compose analytics directly in business endpoints
           </h2>
 	          <p className="mt-3 text-lg leading-8 text-text-muted">
@@ -203,7 +203,7 @@ export default function InternalProductApisUseCasePage() {
         </section>
 
         <section className="mx-auto max-w-7xl px-4 pb-16 lg:px-6">
-          <h2 className="font-display text-2xl font-semibold text-text">
+          <h2 className="text-2xl font-semibold text-text">
             Define once, reuse everywhere
           </h2>
 	          <p className="mt-3 text-lg leading-8 text-text-muted">
@@ -218,7 +218,7 @@ export default function InternalProductApisUseCasePage() {
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">
                 Ready to implement
               </p>
-	              <h2 className="font-display mt-3 text-2xl font-semibold text-text">
+	              <h2 className="mt-3 text-2xl font-semibold text-text">
 	                Use this as your first production migration path
 	              </h2>
 	              <ul className="mt-4 space-y-2 text-sm leading-7 text-text-muted">

--- a/website-next/src/app/use-cases/multi-tenant-saas/page.tsx
+++ b/website-next/src/app/use-cases/multi-tenant-saas/page.tsx
@@ -104,12 +104,18 @@ export default function MultiTenantSaasUseCasePage() {
             <div className="mt-8 flex flex-wrap gap-4">
               <Link
                 href="/docs/multi-tenancy"
+                data-umami-event="cta_click"
+                data-umami-event-target="docs_multi_tenancy"
+                data-umami-event-location="hero_primary"
                 className="bg-text px-6 py-3 text-sm font-semibold text-bg transition hover:opacity-90"
               >
                 Start with multi-tenancy docs
               </Link>
               <a
-                href="https://cal.com"
+                href="https://cal.com/luke-reilly-jdi9su/hypequery-chat"
+                data-umami-event="cta_click"
+                data-umami-event-target="book_call"
+                data-umami-event-location="hero_secondary"
                 className="border border-border-strong px-6 py-3 text-sm font-semibold text-text transition hover:bg-bg-alt"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -227,12 +233,18 @@ export default function MultiTenantSaasUseCasePage() {
             <div className="mt-6 flex gap-3 md:mt-0">
               <Link
                 href="/docs/multi-tenancy"
+                data-umami-event="cta_click"
+                data-umami-event-target="docs_multi_tenancy"
+                data-umami-event-location="next_step_primary"
                 className="inline-flex items-center bg-text px-5 py-3 text-sm font-semibold text-bg transition hover:opacity-90"
               >
                 Open multi-tenancy docs
               </Link>
               <Link
                 href="/use-cases/internal-product-apis"
+                data-umami-event="cta_click"
+                data-umami-event-target="use_cases_internal_product_apis"
+                data-umami-event-location="next_step_secondary"
                 className="inline-flex items-center border border-border-strong px-5 py-3 text-sm font-semibold text-text transition hover:bg-bg-alt"
               >
                 Internal API pattern

--- a/website-next/src/app/use-cases/multi-tenant-saas/page.tsx
+++ b/website-next/src/app/use-cases/multi-tenant-saas/page.tsx
@@ -95,7 +95,7 @@ export default function MultiTenantSaasUseCasePage() {
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-accent">
               Use Case
             </p>
-            <h1 className="font-display mt-4 max-w-4xl text-4xl font-semibold tracking-tight text-text sm:text-6xl">
+            <h1 className="mt-4 max-w-4xl text-4xl font-semibold tracking-tight text-text sm:text-6xl">
               Multi-tenant SaaS ClickHouse analytics with policy control by default
             </h1>
             <p className="mt-6 max-w-3xl text-lg leading-8 text-text-muted">
@@ -143,19 +143,19 @@ export default function MultiTenantSaasUseCasePage() {
         <section className="mx-auto max-w-7xl px-4 py-16 lg:px-6">
           <div className="grid gap-6 md:grid-cols-3">
 	            <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-	              <h2 className="font-display text-lg font-semibold text-text">Map auth once</h2>
+	              <h2 className="text-lg font-semibold text-text">Map auth once</h2>
 	              <p className="mt-3 text-sm leading-7 text-text-muted">
 	                Turn API keys or sessions into typed request context with tenant and role metadata in one place.
 	              </p>
 	            </div>
 	            <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-	              <h2 className="font-display text-lg font-semibold text-text">Inject tenant filters</h2>
+	              <h2 className="text-lg font-semibold text-text">Inject tenant filters</h2>
 	              <p className="mt-3 text-sm leading-7 text-text-muted">
 	                Configure extraction once and let the standard query path apply tenant scope instead of trusting every author to remember it.
 	              </p>
 	            </div>
 	            <div className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-	              <h2 className="font-display text-lg font-semibold text-text">Enforce roles inline</h2>
+	              <h2 className="text-lg font-semibold text-text">Enforce roles inline</h2>
 	              <p className="mt-3 text-sm leading-7 text-text-muted">
 	                Keep sensitive access checks next to the query definition instead of scattering them through route files.
 	              </p>
@@ -165,7 +165,7 @@ export default function MultiTenantSaasUseCasePage() {
 
         <section className="border-y border-border bg-bg-alt/60">
           <div className="mx-auto max-w-7xl px-4 py-16 lg:px-6">
-            <h2 className="font-display text-3xl font-semibold text-text">Request lifecycle</h2>
+            <h2 className="text-3xl font-semibold text-text">Request lifecycle</h2>
             <div className="mt-8 grid gap-6 md:grid-cols-2 lg:grid-cols-5">
               <div className="rounded-lg border border-border bg-bg-card p-5 shadow-card">
                 <p className="text-xs uppercase tracking-[0.2em] text-accent">1</p>
@@ -192,7 +192,7 @@ export default function MultiTenantSaasUseCasePage() {
         </section>
 
         <section className="mx-auto max-w-7xl px-4 py-16 lg:px-6">
-	          <h2 className="font-display text-2xl font-semibold text-text">Tenant auth without glue code</h2>
+	          <h2 className="text-2xl font-semibold text-text">Tenant auth without glue code</h2>
 	          <p className="mt-3 text-lg leading-8 text-text-muted">
 	            Map incoming auth to one typed context object so tenant and role data enter the system in a predictable way.
 	          </p>
@@ -200,7 +200,7 @@ export default function MultiTenantSaasUseCasePage() {
         </section>
 
         <section className="mx-auto max-w-7xl px-4 pb-16 lg:px-6">
-	          <h2 className="font-display text-2xl font-semibold text-text">Automatic tenant scoping</h2>
+	          <h2 className="text-2xl font-semibold text-text">Automatic tenant scoping</h2>
 	          <p className="mt-3 text-lg leading-8 text-text-muted">
 	            Set tenant extraction once and let the backend query path apply it consistently rather than relying on repeated manual filters.
 	          </p>
@@ -208,7 +208,7 @@ export default function MultiTenantSaasUseCasePage() {
         </section>
 
         <section className="mx-auto max-w-7xl px-4 pb-16 lg:px-6">
-	          <h2 className="font-display text-2xl font-semibold text-text">Role-based access for sensitive queries</h2>
+	          <h2 className="text-2xl font-semibold text-text">Role-based access for sensitive queries</h2>
 	          <p className="mt-3 text-lg leading-8 text-text-muted">
 	            Put the access rule on the query definition that needs it instead of treating authorization as an afterthought outside the analytics layer.
 	          </p>
@@ -221,7 +221,7 @@ export default function MultiTenantSaasUseCasePage() {
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">
                 Governance outcome
               </p>
-	              <h2 className="font-display mt-3 text-2xl font-semibold text-text">
+	              <h2 className="mt-3 text-2xl font-semibold text-text">
 	                Clear tenant boundaries with a single shared query layer
 	              </h2>
 	              <ul className="mt-4 space-y-2 text-sm leading-7 text-text-muted">

--- a/website-next/src/app/use-cases/multi-tenant-saas/page.tsx
+++ b/website-next/src/app/use-cases/multi-tenant-saas/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import PageWrapper from '@/components/PageWrapper';
 import CodeWindow from '@/components/CodeWindow';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
   title: 'Multi-Tenant SaaS Analytics on ClickHouse',
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
     canonical: absoluteUrl('/use-cases/multi-tenant-saas'),
   },
   openGraph: {
+    images: ogImage('Multi-Tenant SaaS Analytics on ClickHouse'),
     type: 'website',
     url: absoluteUrl('/use-cases/multi-tenant-saas'),
     title: 'Multi-Tenant SaaS Analytics on ClickHouse | hypequery',

--- a/website-next/src/app/use-cases/page.tsx
+++ b/website-next/src/app/use-cases/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import PageWrapper from '@/components/PageWrapper';
-import { absoluteUrl } from '@/lib/site';
+import { absoluteUrl, ogImage } from '@/lib/site';
 
 export const metadata: Metadata = {
   title: 'hypequery Use Cases',
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
     canonical: absoluteUrl('/use-cases'),
   },
   openGraph: {
+    images: ogImage('hypequery Use Cases'),
     type: 'website',
     url: absoluteUrl('/use-cases'),
     title: 'hypequery Use Cases | Type-Safe ClickHouse Analytics',

--- a/website-next/src/app/use-cases/page.tsx
+++ b/website-next/src/app/use-cases/page.tsx
@@ -169,6 +169,9 @@ export default function UseCasesPage() {
             <div className="mt-6 md:mt-0">
               <Link
                 href="/docs/quick-start"
+                data-umami-event="cta_click"
+                data-umami-event-target="docs_quick_start"
+                data-umami-event-location="next_step_primary"
                 className="inline-flex items-center bg-text px-6 py-3 text-sm font-semibold text-bg transition hover:opacity-90"
               >
                 Open quick start

--- a/website-next/src/app/use-cases/page.tsx
+++ b/website-next/src/app/use-cases/page.tsx
@@ -69,7 +69,7 @@ export default function UseCasesPage() {
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-accent">
               Use Cases
             </p>
-            <h1 className="font-display mt-4 text-4xl font-semibold tracking-tight text-text sm:text-6xl">
+            <h1 className="mt-4 text-4xl font-semibold tracking-tight text-text sm:text-6xl">
               ClickHouse analytics use cases for product APIs and SaaS
             </h1>
             <p className="mt-6 max-w-3xl text-lg leading-8 text-text-muted">
@@ -96,7 +96,7 @@ export default function UseCasesPage() {
           <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">
             Use Cases
           </p>
-          <h2 className="font-display mt-3 text-3xl font-semibold tracking-tight text-text sm:text-4xl">
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight text-text sm:text-4xl">
             Start with the path closest to the codebase you already have
           </h2>
           <div className="mt-10 grid gap-6 lg:grid-cols-2">
@@ -109,7 +109,7 @@ export default function UseCasesPage() {
                 <p className="text-sm font-semibold uppercase tracking-[0.2em] text-accent">
                   {item.label}
                 </p>
-                <h3 className="font-display mt-3 text-2xl font-semibold text-text">{item.title}</h3>
+                <h3 className="mt-3 text-2xl font-semibold text-text">{item.title}</h3>
                 <p className="mt-4 text-base leading-7 text-text-muted">{item.description}</p>
                 <ul className="mt-6 space-y-2 text-sm text-text">
                   {item.points.map((point) => (
@@ -131,21 +131,21 @@ export default function UseCasesPage() {
 	          <div className="mx-auto grid max-w-7xl gap-8 px-4 py-16 lg:grid-cols-3 lg:px-6">
 	            <div>
 	              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-text-dim">Step 01</p>
-	              <h3 className="font-display mt-3 text-xl font-semibold text-text">Pick one repeated query</h3>
+	              <h3 className="mt-3 text-xl font-semibold text-text">Pick one repeated query</h3>
 	              <p className="mt-3 text-sm leading-7 text-text-muted">
 	                Start with analytics logic that already appears in more than one place in your codebase.
 	              </p>
 	            </div>
 	            <div>
 	              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-text-dim">Step 02</p>
-	              <h3 className="font-display mt-3 text-xl font-semibold text-text">Put it on a shared path</h3>
+	              <h3 className="mt-3 text-xl font-semibold text-text">Put it on a shared path</h3>
 	              <p className="mt-3 text-sm leading-7 text-text-muted">
 	                Either call it in-process from the backend you already run or expose it under a controlled internal API path.
 	              </p>
 	            </div>
 	            <div>
 	              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-text-dim">Step 03</p>
-	              <h3 className="font-display mt-3 text-xl font-semibold text-text">Expand only after it proves useful</h3>
+	              <h3 className="mt-3 text-xl font-semibold text-text">Expand only after it proves useful</h3>
 	              <p className="mt-3 text-sm leading-7 text-text-muted">
 	                Let more consumers depend on the same definition instead of minting new one-off query copies.
 	              </p>
@@ -159,7 +159,7 @@ export default function UseCasesPage() {
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">
                 Next step
               </p>
-	              <h3 className="font-display mt-3 text-2xl font-semibold text-text">
+	              <h3 className="mt-3 text-2xl font-semibold text-text">
 	                Start with the use case closest to your current architecture
 	              </h3>
 	              <p className="mt-3 max-w-2xl text-sm leading-7 text-text-muted">

--- a/website-next/src/components/Footer.tsx
+++ b/website-next/src/components/Footer.tsx
@@ -80,7 +80,7 @@ export default function Footer() {
                     target="_blank"
                     rel="noreferrer"
                     data-umami-event={link.track ? 'cta_click' : undefined}
-                    data-umami-event-target={link.track}
+                    data-umami-event-target={link.track ? link.track : undefined}
                     data-umami-event-location={link.track ? 'footer' : undefined}
                     className="block text-[13.5px] text-text-muted transition hover:text-text"
                   >

--- a/website-next/src/components/Footer.tsx
+++ b/website-next/src/components/Footer.tsx
@@ -1,7 +1,14 @@
 import Link from 'next/link';
 import ThemeToggle from '@/components/ThemeToggle';
 
-const footerColumns = [
+type FooterLink = {
+  label: string;
+  href: string;
+  external?: boolean;
+  track?: string;
+};
+
+const footerColumns: Array<{ title: string; links: FooterLink[] }> = [
   {
     title: 'Product',
     links: [
@@ -32,7 +39,8 @@ const footerColumns = [
       { label: 'Use Cases', href: '/use-cases' },
       { label: 'Internal Product APIs', href: '/use-cases/internal-product-apis' },
       { label: 'Multi-Tenant SaaS', href: '/use-cases/multi-tenant-saas' },
-      { label: 'Contact', href: 'https://x.com/hypequery', external: true },
+      { label: 'Contact', href: '/contact-us' },
+      { label: 'Book a call', href: 'https://cal.com/luke-reilly-jdi9su/hypequery-chat', external: true, track: 'book_call' },
     ],
   },
   {
@@ -71,6 +79,9 @@ export default function Footer() {
                     href={link.href}
                     target="_blank"
                     rel="noreferrer"
+                    data-umami-event={link.track ? 'cta_click' : undefined}
+                    data-umami-event-target={link.track}
+                    data-umami-event-location={link.track ? 'footer' : undefined}
                     className="block text-[13.5px] text-text-muted transition hover:text-text"
                   >
                     {link.label}

--- a/website-next/src/components/HypequeryArchitecture.tsx
+++ b/website-next/src/components/HypequeryArchitecture.tsx
@@ -37,7 +37,7 @@ export default function HypequeryArchitecture() {
         <p className="text-sm font-semibold uppercase tracking-wide text-indigo-500">
           Architecture
         </p>
-        <h2 className="font-display mt-2 text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
+        <h2 className="mt-2 text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100">
           The complete analytics layer
         </h2>
         <p className="mt-4 text-lg text-gray-600 dark:text-gray-300">
@@ -61,7 +61,7 @@ export default function HypequeryArchitecture() {
                 <Database className="size-10 text-amber-500" />
               </div>
               <div className="text-center">
-                <h3 className="font-display font-semibold text-gray-900 dark:text-gray-100 mb-1">ClickHouse</h3>
+                <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">ClickHouse</h3>
                 <p className="text-gray-500 dark:text-gray-400 text-xs">OLAP database</p>
               </div>
             </div>
@@ -96,7 +96,7 @@ export default function HypequeryArchitecture() {
                 height={32}
                 className="dark:invert"
               />
-              <h3 className="font-display text-xl font-semibold text-gray-900 dark:text-gray-100">hypequery</h3>
+              <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100">hypequery</h3>
             </div>
 
             {/* Core Features */}
@@ -171,7 +171,7 @@ export default function HypequeryArchitecture() {
           className="w-full lg:w-80 flex-shrink-0"
         >
           <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6 bg-white dark:bg-gray-800 shadow-lg h-full">
-            <h3 className="font-display text-sm font-semibold text-gray-500 dark:text-gray-400 mb-5 text-center uppercase tracking-wider">
+            <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-5 text-center uppercase tracking-wider">
               Consumers
             </h3>
             <div className="grid grid-cols-2 gap-4">

--- a/website-next/src/components/clickhouse-pillar-page.tsx
+++ b/website-next/src/components/clickhouse-pillar-page.tsx
@@ -8,6 +8,11 @@ type LinkItem = {
   label: string;
 };
 
+function ctaTarget(href: string) {
+  const path = href.replace(/^https?:\/\//, '').replace(/[#?].*$/, '');
+  return path.replace(/^\//, '').replace(/[^a-zA-Z0-9]+/g, '_').replace(/_+$/, '') || 'home';
+}
+
 type Card = {
   title: string;
   copy: string;
@@ -107,12 +112,18 @@ export function ClickhousePillarPage({
             <div className="mt-8 flex flex-wrap gap-4">
               <Link
                 href={primaryCta.href}
+                data-umami-event="cta_click"
+                data-umami-event-target={ctaTarget(primaryCta.href)}
+                data-umami-event-location="pillar_hero_primary"
                 className="bg-text px-6 py-3 text-sm font-semibold text-bg transition hover:opacity-90"
               >
                 {primaryCta.label}
               </Link>
               <Link
                 href={secondaryCta.href}
+                data-umami-event="cta_click"
+                data-umami-event-target={ctaTarget(secondaryCta.href)}
+                data-umami-event-location="pillar_hero_secondary"
                 className="border border-border-strong px-6 py-3 text-sm font-semibold text-text transition hover:bg-bg-alt"
               >
                 {secondaryCta.label}
@@ -346,12 +357,18 @@ export function ClickhousePillarPage({
             <div className="mt-6 flex gap-3 md:mt-0">
               <Link
                 href={nextStep.primaryCta.href}
+                data-umami-event="cta_click"
+                data-umami-event-target={ctaTarget(nextStep.primaryCta.href)}
+                data-umami-event-location="pillar_next_step_primary"
                 className="inline-flex items-center bg-text px-5 py-3 text-sm font-semibold text-bg transition hover:opacity-90"
               >
                 {nextStep.primaryCta.label}
               </Link>
               <Link
                 href={nextStep.secondaryCta.href}
+                data-umami-event="cta_click"
+                data-umami-event-target={ctaTarget(nextStep.secondaryCta.href)}
+                data-umami-event-location="pillar_next_step_secondary"
                 className="inline-flex items-center border border-border-strong px-5 py-3 text-sm font-semibold text-text transition hover:bg-bg-alt"
               >
                 {nextStep.secondaryCta.label}

--- a/website-next/src/components/clickhouse-pillar-page.tsx
+++ b/website-next/src/components/clickhouse-pillar-page.tsx
@@ -65,7 +65,7 @@ export type ClickhousePillarPageProps = {
   description: string;
   primaryCta: Cta;
   secondaryCta: Cta;
-  stats: Stat[];
+  stats?: Stat[];
   problems: Card[];
   solutionSection: Section;
   implementationSection: Section;
@@ -105,7 +105,7 @@ export function ClickhousePillarPage({
         <section className="relative overflow-hidden border-b border-border">
           <div className="relative mx-auto max-w-7xl px-4 py-20 lg:px-6">
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-accent">{eyebrow}</p>
-            <h1 className="font-display mt-4 max-w-5xl text-4xl font-semibold tracking-tight text-text sm:text-6xl">
+            <h1 className="mt-4 max-w-5xl text-4xl font-semibold tracking-tight text-text sm:text-6xl">
               {title}
             </h1>
             <p className="mt-6 max-w-3xl text-lg leading-8 text-text-muted">{description}</p>
@@ -129,14 +129,16 @@ export function ClickhousePillarPage({
                 {secondaryCta.label}
               </Link>
             </div>
-            <div className="mt-10 grid gap-4 sm:grid-cols-3">
-              {stats.map((stat) => (
-                <div key={stat.label} className="rounded-lg border border-border bg-bg-card p-5 shadow-card">
-                  <p className="text-xs uppercase tracking-[0.2em] text-text-dim">{stat.label}</p>
-                  <p className="mt-2 text-xl font-semibold text-text">{stat.value}</p>
-                </div>
-              ))}
-            </div>
+            {stats && stats.length > 0 && (
+              <div className="mt-10 grid gap-4 sm:grid-cols-3">
+                {stats.map((stat) => (
+                  <div key={stat.label} className="rounded-lg border border-border bg-bg-card p-5 shadow-card">
+                    <p className="text-xs uppercase tracking-[0.2em] text-text-dim">{stat.label}</p>
+                    <p className="mt-2 text-xl font-semibold text-text">{stat.value}</p>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         </section>
 
@@ -144,7 +146,7 @@ export function ClickhousePillarPage({
           <div className="grid gap-6 lg:grid-cols-3">
             {problems.map((problem) => (
               <div key={problem.title} className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-                <h2 className="font-display text-xl font-semibold text-text">{problem.title}</h2>
+                <h2 className="text-xl font-semibold text-text">{problem.title}</h2>
                 <p className="mt-4 text-sm leading-7 text-text-muted">{problem.copy}</p>
               </div>
             ))}
@@ -158,7 +160,7 @@ export function ClickhousePillarPage({
                 <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">
                   {solutionSection.eyebrow}
                 </p>
-                <h2 className="font-display mt-3 text-3xl font-semibold text-text">
+                <h2 className="mt-3 text-3xl font-semibold text-text">
                   {solutionSection.title}
                 </h2>
                 <p className="mt-5 text-base leading-8 text-text-muted">{solutionSection.description}</p>
@@ -183,7 +185,7 @@ export function ClickhousePillarPage({
                   <p className="text-xs uppercase tracking-[0.25em] text-text-dim">
                     {solutionSection.codePanel.eyebrow}
                   </p>
-                  <h3 className="font-display mt-3 text-xl font-semibold text-text">
+                  <h3 className="mt-3 text-xl font-semibold text-text">
                     {solutionSection.codePanel.title}
                   </h3>
                   <CodeWindow
@@ -206,7 +208,7 @@ export function ClickhousePillarPage({
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">
                 {implementationSection.eyebrow}
               </p>
-              <h2 className="font-display mt-3 text-3xl font-semibold text-text">
+              <h2 className="mt-3 text-3xl font-semibold text-text">
                 {implementationSection.title}
               </h2>
               <p className="mt-5 text-base leading-8 text-text-muted">{implementationSection.description}</p>
@@ -231,7 +233,7 @@ export function ClickhousePillarPage({
                 <p className="text-xs uppercase tracking-[0.25em] text-text-dim">
                   {implementationSection.codePanel.eyebrow}
                 </p>
-                <h3 className="font-display mt-3 text-xl font-semibold text-text">
+                <h3 className="mt-3 text-xl font-semibold text-text">
                   {implementationSection.codePanel.title}
                 </h3>
                 <CodeWindow
@@ -252,7 +254,7 @@ export function ClickhousePillarPage({
             <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">
               {comparisonTable.eyebrow}
             </p>
-            <h2 className="font-display mt-3 text-3xl font-semibold text-text">{comparisonTable.title}</h2>
+            <h2 className="mt-3 text-3xl font-semibold text-text">{comparisonTable.title}</h2>
             <p className="mt-4 max-w-3xl text-sm leading-7 text-text-muted">{comparisonTable.description}</p>
             <div className="mt-8 overflow-x-auto rounded-lg border border-border bg-bg-card shadow-card">
               <table className="w-full min-w-[640px] border-collapse text-left text-sm">
@@ -291,13 +293,13 @@ export function ClickhousePillarPage({
             <p className="text-xs font-semibold uppercase tracking-[0.25em] text-text-dim">
               Where teams usually get stuck
             </p>
-            <h2 className="font-display mt-3 text-3xl font-semibold text-text">
-              The questions this page should answer
+            <h2 className="mt-3 text-3xl font-semibold text-text">
+              Questions teams ask
             </h2>
             <div className="mt-10 grid gap-6 md:grid-cols-2">
               {searchIntentCards.map((item) => (
                 <div key={item.title} className="rounded-lg border border-border bg-bg-card p-6 shadow-card">
-                  <h3 className="font-display text-xl font-semibold text-text">{item.title}</h3>
+                  <h3 className="text-xl font-semibold text-text">{item.title}</h3>
                   <p className="mt-3 text-sm leading-7 text-text-muted">{item.copy}</p>
                 </div>
               ))}
@@ -309,7 +311,7 @@ export function ClickhousePillarPage({
           <div className="grid gap-10 lg:grid-cols-[0.65fr_0.35fr]">
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">Further reading</p>
-              <h2 className="font-display mt-3 text-3xl font-semibold text-text">
+              <h2 className="mt-3 text-3xl font-semibold text-text">
                 Go deeper where it actually helps
               </h2>
               <div className="mt-10 grid gap-6 lg:grid-cols-2">
@@ -319,7 +321,7 @@ export function ClickhousePillarPage({
                     href={item.href}
                     className="group rounded-lg border border-border bg-bg-card p-6 transition hover:-translate-y-1 hover:border-border-strong hover:shadow-card"
                   >
-                    <h3 className="font-display text-xl font-semibold text-text">{item.title}</h3>
+                    <h3 className="text-xl font-semibold text-text">{item.title}</h3>
                     <p className="mt-3 text-sm leading-7 text-text-muted">{item.description}</p>
                     <p className="mt-6 text-xs font-semibold uppercase tracking-[0.2em] text-accent group-hover:opacity-70">
                       Open guide
@@ -351,7 +353,7 @@ export function ClickhousePillarPage({
               <p className="text-xs font-semibold uppercase tracking-[0.25em] text-accent">
                 {nextStep.eyebrow}
               </p>
-              <h2 className="font-display mt-3 text-2xl font-semibold text-text">{nextStep.title}</h2>
+              <h2 className="mt-3 text-2xl font-semibold text-text">{nextStep.title}</h2>
               <p className="mt-3 max-w-2xl text-sm leading-7 text-text-muted">{nextStep.description}</p>
             </div>
             <div className="mt-6 flex gap-3 md:mt-0">

--- a/website-next/src/data/clickhouse-functions.ts
+++ b/website-next/src/data/clickhouse-functions.ts
@@ -36,7 +36,7 @@ export const clickhouseFunctions: ClickHouseFunctionDef[] = [
     name: 'toStartOfDay',
     cluster: 'date',
     tagline: 'Truncate a DateTime to midnight — the foundation of daily analytics bucketing.',
-    metaTitle: 'ClickHouse toStartOfDay — TypeScript daily bucketing with hypequery',
+    metaTitle: 'ClickHouse toStartOfDay — TypeScript daily bucketing',
     metaDescription:
       'toStartOfDay truncates a DateTime to midnight. Learn how to use it in TypeScript with hypequery for daily trend charts, DAU counts, and time-series grouping.',
     signature: 'toStartOfDay(datetime: DateTime): DateTime',
@@ -117,7 +117,7 @@ const daily = await db
     name: 'toStartOfWeek',
     cluster: 'date',
     tagline: 'Round a DateTime to the start of the week — weekly cohort and trend analysis.',
-    metaTitle: 'ClickHouse toStartOfWeek — TypeScript weekly bucketing with hypequery',
+    metaTitle: 'ClickHouse toStartOfWeek — TypeScript weekly bucketing',
     metaDescription:
       'toStartOfWeek truncates a DateTime to the first day of the ISO week. Use it in TypeScript with hypequery for weekly trend charts and cohort retention.',
     signature: 'toStartOfWeek(datetime: DateTime, mode?: UInt8): Date',
@@ -190,7 +190,7 @@ const weekly = await db
     name: 'toStartOfMonth',
     cluster: 'date',
     tagline: 'Truncate a DateTime to the first day of the month for MoM reporting.',
-    metaTitle: 'ClickHouse toStartOfMonth — TypeScript monthly bucketing with hypequery',
+    metaTitle: 'ClickHouse toStartOfMonth — TypeScript monthly bucketing',
     metaDescription:
       'toStartOfMonth rounds a DateTime down to the first day of the month. Learn how to use it in TypeScript with hypequery for MoM growth and monthly aggregation.',
     signature: 'toStartOfMonth(datetime: DateTime): Date',
@@ -261,7 +261,7 @@ const mau = await db
     name: 'toStartOfQuarter',
     cluster: 'date',
     tagline: 'Round a DateTime to the first day of the quarter for QoQ reporting.',
-    metaTitle: 'ClickHouse toStartOfQuarter — TypeScript quarterly bucketing with hypequery',
+    metaTitle: 'ClickHouse toStartOfQuarter — TypeScript quarterly bucketing',
     metaDescription:
       'toStartOfQuarter truncates a DateTime to the first day of the calendar quarter (Jan 1, Apr 1, Jul 1, Oct 1). Use it in TypeScript with hypequery for QoQ analysis.',
     signature: 'toStartOfQuarter(datetime: DateTime): Date',
@@ -603,7 +603,7 @@ const labels = await db
     name: 'count',
     cluster: 'aggregate',
     tagline: 'Count rows or non-NULL values — ClickHouse\'s fastest aggregate.',
-    metaTitle: 'ClickHouse count() — row counting in TypeScript with hypequery',
+    metaTitle: 'ClickHouse count() — row counting in TypeScript',
     metaDescription:
       'ClickHouse count() counts rows or non-NULL values. Learn how to use count(), count(x), and countIf() in TypeScript with hypequery for event tracking and analytics.',
     signature: 'count() | count(column) | countIf(condition)',
@@ -755,7 +755,7 @@ const dau = await db
     name: 'sum',
     cluster: 'aggregate',
     tagline: 'Sum numeric values — revenue totals, event counts, and metric roll-ups.',
-    metaTitle: 'ClickHouse sum() — sum aggregation in TypeScript with hypequery',
+    metaTitle: 'ClickHouse sum() — sum aggregation in TypeScript',
     metaDescription:
       'ClickHouse sum() sums a numeric column. Learn how to use sum(), sumIf(), and sumArray() in TypeScript with hypequery for revenue, metrics, and financial aggregations.',
     signature: 'sum(column): Number | sumIf(column, condition): Number',
@@ -826,7 +826,7 @@ const dailyRevenue = await db
     name: 'avg',
     cluster: 'aggregate',
     tagline: 'Calculate the arithmetic mean — average order value, session duration, latency.',
-    metaTitle: 'ClickHouse avg() — average aggregation in TypeScript with hypequery',
+    metaTitle: 'ClickHouse avg() — average aggregation in TypeScript',
     metaDescription:
       'ClickHouse avg() calculates the arithmetic mean of a numeric column. Use it in TypeScript with hypequery for AOV, p50 latency approximation, and metric averages.',
     signature: 'avg(column): Float64',
@@ -1109,7 +1109,7 @@ const orders = await db
     name: 'concat',
     cluster: 'string',
     tagline: 'Concatenate strings — build labels, composite keys, and display values.',
-    metaTitle: 'ClickHouse concat() — string concatenation in TypeScript with hypequery',
+    metaTitle: 'ClickHouse concat() — string concatenation in TypeScript',
     metaDescription:
       'ClickHouse concat() joins two or more strings. Use it in TypeScript with hypequery to build composite display values, slugs, and event labels in your analytics queries.',
     signature: 'concat(s1: String, s2: String, ...): String',
@@ -1318,7 +1318,7 @@ const graded = await db
     name: 'round',
     cluster: 'math',
     tagline: 'Round a number to N decimal places — clean display values and bucketing.',
-    metaTitle: 'ClickHouse round() — numeric rounding in TypeScript with hypequery',
+    metaTitle: 'ClickHouse round() — numeric rounding in TypeScript',
     metaDescription:
       'ClickHouse round() rounds a Float to N decimal places. Use it in TypeScript with hypequery for display-ready metrics, percentage formatting, and numeric bucketing.',
     signature: 'round(x: Number, [decimals: Int]): Number',

--- a/website-next/src/lib/site.ts
+++ b/website-next/src/lib/site.ts
@@ -14,3 +14,19 @@ export const siteUrl = new URL(SITE_URL);
 export function absoluteUrl(pathname: string) {
   return new URL(normalizePath(pathname), siteUrl);
 }
+
+export function ogImage(title?: string) {
+  const url = new URL('/og', siteUrl);
+  if (title) {
+    url.searchParams.set('title', title);
+  }
+
+  return [
+    {
+      url: url.toString(),
+      width: 1200,
+      height: 630,
+      alt: title ?? 'hypequery — The TypeScript analytics layer for ClickHouse',
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

Four related website improvements from an SEO audit of website-next, aimed at CTR, social sharing, and conversion measurement.

### 1. SEO fixes (f266832)
- **Fix doubled brand suffix**: landing pages hardcoded `| hypequery` in titles while the root layout template appends it again, rendering `… | hypequery | hypequery` in search results. Fixed across 28 landing pages, the functions hub, and all 62 function `metaTitle`s.
- **OG images**: the site had no `og:image` anywhere despite declaring `summary_large_image` cards. Added a dynamic `/og?title=` image endpoint (branded 1200x630 card) wired into landing, docs, compare, and function pages; per-post images for blog articles; a default for the homepage.
- **Structured data**: sitewide `Organization` + `WebSite` JSON-LD, `SoftwareApplication` schema on the homepage, and blog `Article` schema now credits a `Person` author for E-E-A-T.

### 2. CTA tracking + routing (79155ff)
- All CTAs on lead pages now fire Umami `cta_click` events with `target` and `location` properties, via declarative `data-umami-event` attributes (server-component-safe, matches the homepage Hero convention).
- Validated all 55 distinct CTA hrefs against prerendered routes.
- **Fixed a real bug**: both use-case pages had booking CTAs pointing at bare `https://cal.com` (the Cal.com homepage). Now point to the real booking link.

### 3. Footer + contact page (0557dd1)
- `/contact-us` was receiving traffic but returned 404. Added a real contact page (book a call / GitHub issues / X, all tracked) and pointed the footer Contact link there instead of X.
- Added a tracked "Book a call" footer link so booking intent is visible from every page.

### 4. CTR experiment on ORM-cluster pages (9cb426e)
- Sharpened titles/descriptions on `/clickhouse-orm`, `/drizzle-clickhouse`, `/typeorm-clickhouse`, `/prisma-clickhouse` — exact query front-loaded, lengths inside SERP budgets, descriptions lead with the "types generated from your live schema" hook.
- Primary CTA labels aligned with the SERP promise.
- GSC baseline recorded in the commit message for before/after comparison.

## Test plan
- [x] `next build` passes (255 pages)
- [x] Prerendered HTML verified per page type: deduped `<title>`, `og:image` present, JSON-LD blocks, tracking attributes with correct target/location
- [x] `/og` and blog `opengraph-image` endpoints return valid PNGs (visually checked)
- [x] All internal CTA hrefs resolve to prerendered routes; Cal.com booking URL returns 200
- [ ] After deploy: request re-indexing of the 4 ORM pages in GSC; create Umami funnels for `cta_click` conversions

Note: `npm run lint` in website-next is broken by a pre-existing `brace-expansion` override conflict, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)