### PR TITLE
Add public protocol package scaffold

### DIFF
--- a/.changeset/public-protocol-scaffold.md
+++ b/.changeset/public-protocol-scaffold.md
@@ -1,0 +1,6 @@
+---
+"@hypequery/protocol": minor
+---
+
+Add the public protocol package scaffold and document ownership, versioning,
+compatibility, and export boundaries for portable Hypequery artifacts.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
           "@hypequery/serve": patch
           "@hypequery/cli": patch
           "@hypequery/mcp": patch
+          "@hypequery/protocol": patch
           "@hypequery/react": patch
           "@hypequery/schema": patch
           ---
@@ -138,6 +139,8 @@ jobs:
               packages/cli/CHANGELOG.md \
               packages/mcp-server/package.json \
               packages/mcp-server/CHANGELOG.md \
+              packages/protocol/package.json \
+              packages/protocol/CHANGELOG.md \
               packages/react/package.json \
               packages/react/CHANGELOG.md \
               packages/schema/package.json \

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ If this saves you from hand-writing ClickHouse types, a ⭐ helps other TypeScri
 - `@hypequery/serve`: code-first runtime for query contracts, HTTP routes, docs, and adapters
 - `@hypequery/react`: thin TanStack Query hooks for hypequery APIs
 - `@hypequery/mcp`: MCP server for exposing governed analytics tools to agents
+- `@hypequery/protocol`: public, language-neutral contracts and TypeScript reference implementation for portable artifacts
 - `@hypequery/schema`: ClickHouse schema definitions, migrations, and dataset compatibility checks
 - `@hypequery/cli`: scaffolding, schema generation, and local dev tooling
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "packages/clickhouse",
     "packages/datasets",
     "packages/mcp-server",
+    "packages/protocol",
     "packages/react",
     "packages/schema",
     "packages/serve",

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @hypequery/protocol

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -1,0 +1,35 @@
+# @hypequery/protocol
+
+Public contracts and the TypeScript reference implementation for portable
+Hypequery artifacts.
+
+## Current status
+
+This package is an intentionally empty public scaffold. It does not yet define
+a stable protocol or an executable deployment bundle. Runtime exports will be
+added incrementally after their language-neutral specifications and conformance
+fixtures are accepted.
+
+The normative source is
+[`specs/security-protocol`](../../specs/security-protocol/README.md).
+
+## Intended scope
+
+The package will contain deterministic, framework-independent implementations
+of accepted protocol rules, including strict validation, canonical encoding,
+digest calculation, identifiers, portable AST structures, artifact envelopes,
+and compatibility checks.
+
+It will not connect to ClickHouse, execute queries, load project source, access
+credentials or the environment, perform network or filesystem I/O, implement
+authentication or tenancy, or contain CLI, HTTP, UI, and Cloud operations.
+
+Self-hosted Serve continues to run project source directly. Deployment bundles
+are required only by Cloud deployment and may be generated ephemerally for
+Studio compatibility and security diagnostics.
+
+## Public API
+
+Only the root package export is public. Deep imports from `src` or `dist` are
+unsupported. Package SemVer and protocol/artifact versions are separate; an
+installed npm version never determines an artifact's identity.

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -33,3 +33,10 @@ Studio compatibility and security diagnostics.
 Only the root package export is public. Deep imports from `src` or `dist` are
 unsupported. Package SemVer and protocol/artifact versions are separate; an
 installed npm version never determines an artifact's identity.
+
+## Runtime compatibility
+
+This package is ESM-only. Consumers must load it with `import`; CommonJS
+`require()` and a dual ESM/CommonJS build are intentionally out of scope.
+Older tools that ignore the package `exports` map and attempt to require the
+`main` entry may fail with `ERR_REQUIRE_ESM`.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@hypequery/protocol",
+  "version": "0.0.0",
+  "description": "Public contracts and TypeScript reference implementation for portable Hypequery artifacts",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "dev": "tsc --project tsconfig.json --watch",
+    "lint": "eslint --ext .ts \"src/**/*.ts\"",
+    "test": "vitest run",
+    "types": "tsc --project tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.6"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hypequery/hypequery.git",
+    "directory": "packages/protocol"
+  },
+  "homepage": "https://github.com/hypequery/hypequery/tree/main/packages/protocol",
+  "bugs": {
+    "url": "https://github.com/hypequery/hypequery/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -22,7 +22,7 @@
     "dev": "tsc --project tsconfig.json --watch",
     "lint": "eslint --ext .ts \"src/**/*.ts\"",
     "test": "vitest run",
-    "types": "tsc --project tsconfig.json --noEmit"
+    "types": "tsc --project tsconfig.json --noEmit && tsc --project tsconfig.test.json"
   },
   "devDependencies": {
     "typescript": "^5.7.3",

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import * as protocol from './index.js';
+
+describe('@hypequery/protocol scaffold', () => {
+  it('does not expose a protocol before its normative contracts are accepted', () => {
+    expect(Object.keys(protocol)).toEqual([]);
+  });
+});

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Public TypeScript reference implementation for the Hypequery protocol.
+ *
+ * The scaffold intentionally exports no runtime contract. Each future export
+ * must implement an accepted specification and ship with normative fixtures.
+ * See `specs/security-protocol/` in the repository.
+ */
+export {};

--- a/packages/protocol/tsconfig.json
+++ b/packages/protocol/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts"
+  ]
+}

--- a/packages/protocol/tsconfig.test.json
+++ b/packages/protocol/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/protocol/vitest.config.ts
+++ b/packages/protocol/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/packages/protocol/vitest.config.ts
+++ b/packages/protocol/vitest.config.ts
@@ -4,5 +4,8 @@ export default defineConfig({
   test: {
     include: ['src/**/*.test.ts'],
     environment: 'node',
+    typecheck: {
+      tsconfig: './tsconfig.test.json',
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,6 +421,15 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  packages/protocol:
+    devDependencies:
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/react:
     devDependencies:
       '@hypequery/datasets':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,5 +6,6 @@ packages:
   - 'packages/datasets'
   - 'packages/serve'
   - 'packages/mcp-server'
+  - 'packages/protocol'
   - 'packages/tsconfig'
   - 'examples/*'

--- a/specs/security-protocol/README.md
+++ b/specs/security-protocol/README.md
@@ -1,0 +1,61 @@
+# Hypequery security protocol
+
+This directory is the public, language-neutral source of truth for the
+contracts shared by Hypequery authoring tools, deployment tooling, runtimes,
+Studio, and Cloud.
+
+The protocol exists so that independently implemented components can agree on
+the meaning, validation, canonical bytes, and identity of an artifact. It does
+not make deployment bundles mandatory for self-hosted Serve. Self-hosted Serve
+continues to execute project source within its existing trust model.
+
+## Status
+
+The protocol is under active design and has no stable wire version yet. The
+initial `@hypequery/protocol` package is deliberately an empty public scaffold.
+Normative schemas and runtime exports are added only by reviewed follow-up
+decisions with conformance fixtures.
+
+Do not treat a draft document or the npm package version as an executable
+artifact version.
+
+## Authority
+
+The sources have the following roles:
+
+1. Documents in this directory define the normative, language-neutral rules.
+2. Language-neutral fixtures prove canonical success and failure behavior.
+3. `@hypequery/protocol` is the TypeScript reference implementation.
+4. Other language implementations, including Python, implement the same public
+   rules and must pass the same fixtures.
+
+If an implementation and the normative specification disagree, the mismatch is
+a bug. Implementations must not silently establish competing protocol rules.
+
+## Planned layout
+
+- `decisions/`: accepted architecture and governance decisions.
+- `schemas/`: versioned normative schemas and their compatibility rules.
+- `fixtures/`: language-neutral canonical inputs, outputs, hashes, and expected
+  validation failures.
+- `rfc/`: proposals that are not normative until accepted.
+
+Only `decisions/` exists in the scaffold. Empty directories will be introduced
+with the first artifact that needs them.
+
+## Boundaries
+
+The protocol may define:
+
+- canonical typed values and artifact identity;
+- safe identifier and portable expression structures;
+- discovery, deployment bundle, and runtime-reference envelopes;
+- compiled-query, error, event, and diagnostic contracts;
+- compatibility, limits, and validation failure codes.
+
+The protocol must not contain credentials, runtime secrets, customer callbacks,
+database connections, HTTP handlers, authentication implementations, tenant
+resolution, billing logic, or Cloud control-plane behavior.
+
+See [Decision 0001](./decisions/0001-protocol-ownership-and-versioning.md) for
+ownership and versioning policy.

--- a/specs/security-protocol/decisions/0001-protocol-ownership-and-versioning.md
+++ b/specs/security-protocol/decisions/0001-protocol-ownership-and-versioning.md
@@ -1,0 +1,99 @@
+# Decision 0001: Protocol ownership and versioning
+
+- Status: Accepted
+- Date: 2026-07-13
+- Owners: Hypequery maintainers
+
+## Context
+
+Datasets, ClickHouse, Serve, the CLI, Studio, Python, and Cloud need to exchange
+portable artifacts without assigning different meanings to the same bytes.
+Duplicating canonical encoding, validation, identifier rules, or artifact
+schemas inside each product package would make cross-language identity and
+security behavior drift.
+
+The shared contract also forms part of the deployed security boundary. Users
+must be able to inspect it, implement it independently, and reproduce the
+validation and hashing performed by hosted services.
+
+## Decision
+
+The normative protocol specification and conformance fixtures are maintained
+publicly under `specs/security-protocol/` in this Apache-2.0 repository.
+
+The public `@hypequery/protocol` package is the TypeScript reference
+implementation. It contains only deterministic contract primitives: types,
+strict parsers and validators, canonical encoders and decoders, digest helpers,
+and version compatibility checks that implement accepted specifications.
+
+Product packages consume these primitives but do not redefine them. A Python
+implementation does not depend on Node; it implements the same normative rules
+and must pass the shared language-neutral fixtures.
+
+The protocol package does not own SQL execution, database connections,
+authentication, tenant resolution, HTTP routing, UI behavior, deployment
+operations, or Cloud control-plane logic.
+
+## Version domains
+
+Four versions have different jobs and must not be conflated:
+
+1. **Package version:** npm SemVer for `@hypequery/protocol` implementation
+   releases. It describes library compatibility, not artifact identity.
+2. **Core protocol version:** identifies frozen rules whose interpretation
+   affects canonical bytes, hashes, deployment acceptance, parameter typing, or
+   identifier meaning. An incompatible change requires a new core version and
+   hash domain.
+3. **Artifact schema version:** discovery documents, deployment bundles, runtime
+   configuration references, events, errors, and diagnostics evolve under
+   their own explicitly declared schemas. One artifact cannot infer its version
+   from another artifact or from the installed npm version.
+4. **Implementation version:** product and language package versions are useful
+   diagnostics but never substitute for an artifact's declared versions.
+
+No stable core or artifact schema version is assigned by this scaffold.
+
+## Compatibility policy
+
+- Parsers fail closed on unknown core versions and unknown security-relevant
+  fields. They never guess a newer interpretation.
+- Frozen-core changes require an explicit new core version, canonical fixtures,
+  migration notes, and compatibility tests.
+- Evolvable metadata may add fields only where its schema explicitly defines
+  forward behavior. Security meaning cannot change through an additive field.
+- A producer must emit one declared version. A consumer must report the
+  unsupported version and required upgrade without partially executing it.
+- Canonical fixtures are normative. Every supported language must produce the
+  same bytes and hashes and the same stable failure codes.
+- Pre-stable `0.x` npm releases may change library APIs, but they may not
+  silently reinterpret an already published artifact version.
+
+## Public export policy
+
+- Only exports declared by `packages/protocol/package.json` are public.
+- The root export is the initial and preferred public surface. Internal source
+  paths are not supported API.
+- Runtime exports require an accepted normative document and matching fixtures.
+- Framework adapters and product conveniences belong in their owning packages,
+  even when they consume protocol types.
+- The initial scaffold intentionally has no runtime exports and defines no
+  executable artifact schema.
+
+## Self-hosting and open-core boundary
+
+The protocol and its reference implementation remain public. Bundles are a
+Cloud deployment boundary and may be used for Studio diagnostics; they are not
+a mandatory intermediate for self-hosted Serve. Trusted raw SQL and custom
+handlers remain available under the existing self-hosted trust model.
+
+Cloud may charge for managed deployment, isolation, secrets, operations,
+scaling, and support. It must not make the public artifact semantics or the
+ability to validate a bundle proprietary.
+
+## Consequences
+
+- Protocol changes require deliberate review and conformance evidence.
+- TypeScript and Python can evolve independently without semantic drift.
+- CLI and Studio can diagnose Cloud compatibility locally.
+- Cloud can revalidate uploads instead of trusting producer behavior.
+- The package remains smaller than the products that consume it.


### PR DESCRIPTION
## What changed

- establish `specs/security-protocol/` as the public, language-neutral source of truth
- add the protocol ownership, versioning, compatibility, export, and self-hosting ADR
- scaffold the public Apache-2.0 `@hypequery/protocol` TypeScript reference package
- integrate the package with pnpm, Turbo, CI, canary publishing, and Changesets
- keep the initial runtime surface intentionally empty until normative schemas and fixtures are accepted

## Why

Cloud deployment, Studio, CLI, TypeScript, and Python need one inspectable contract for artifact meaning, canonical identity, and compatibility. This prevents each product package from independently redefining security-sensitive protocol behavior while preserving direct-source self-hosting.

## User and developer impact

No existing runtime behavior changes and no major package bump is required. The package is prepared for an initial `0.1.0` public release. Self-hosted Serve continues to execute project source directly; bundles remain a Cloud deployment and optional Studio diagnostics boundary.

## Validation

- `pnpm turbo run build --filter='@hypequery/*'`
- `pnpm lint`
- `pnpm types`
- `pnpm test`
- `pnpm install --frozen-lockfile --offline`
- `git diff --check`