### PR TITLE
fix(website-next): light/dark mode now follows live system theme changes

### DIFF
--- a/website-next/src/app/layout.tsx
+++ b/website-next/src/app/layout.tsx
@@ -122,13 +122,6 @@ export default function RootLayout({
           }}
         />
         <Script
-          id="theme-init"
-          strategy="beforeInteractive"
-          dangerouslySetInnerHTML={{
-            __html: '',
-          }}
-        />
-        <Script
           defer
           src="https://cloud.umami.is/script.js"
           data-website-id="a1b133a2-bf0a-4260-9c2c-f76a2a20359f"
@@ -191,7 +184,7 @@ gtag('config', '${gaMeasurementId}');`,
             enableSystem: true,
             disableTransitionOnChange: true,
             storageKey: THEME_STORAGE_KEY,
-            attribute: "class",
+            attribute: ["class", "data-theme"],
           }}
           search={{
             SearchDialog: DefaultSearchDialog,


### PR DESCRIPTION
## Problem

With the theme set to **System**, changing the OS light/dark preference while the site was open didn't update the page — a full refresh was required (reported on the published website-next app).

## Root cause

The theme tokens in `globals.css` match on **two** selectors: `html.light`/`html.dark` *and* `html[data-theme=...]`. But next-themes (via fumadocs `RootProvider`) was configured with `attribute: "class"`, so on a live system-theme change it only flipped the class — `data-theme` stayed frozen at whatever the inline `<head>` script set at page load.

Both CSS blocks have equal specificity and the dark block comes later in the file, so a stale `data-theme="dark"` beat a fresh `class="light"`: the dark→light direction never applied without a refresh.

## Fix

Configure next-themes to manage both attributes:

```tsx
attribute: ["class", "data-theme"],
```

Now `class`, `data-theme`, and `color-scheme` all stay in sync on live system changes. Components using `resolvedTheme` (e.g. `CodeHighlight`) were already reactive and are unaffected.

Also removes a dead, empty `<Script id="theme-init">` block.

## Testing

- `npx tsc --noEmit` passes in `website-next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)