### PR TITLE
Define tagged ClickHouse value model

### DIFF
--- a/packages/protocol/src/fixtures.test.ts
+++ b/packages/protocol/src/fixtures.test.ts
@@ -16,8 +16,30 @@ interface RejectionFixture {
   sourceUtf8?: string;
   value?: unknown;
   generator?: Record<string, unknown>;
+  declaredClickHouseType?: string;
   error: string;
 }
+
+const STABLE_FAILURE_CODES = [
+  'HQ_VALUE_INVALID_JSON',
+  'HQ_VALUE_DUPLICATE_KEY',
+  'HQ_VALUE_INVALID_UNICODE',
+  'HQ_VALUE_CONTROL_CHARACTER',
+  'HQ_VALUE_NON_FINITE_FLOAT',
+  'HQ_VALUE_NEGATIVE_ZERO',
+  'HQ_VALUE_INTEGER_TAG_REQUIRED',
+  'HQ_VALUE_RAW_COMPOSITE',
+  'HQ_VALUE_UNKNOWN_TAG',
+  'HQ_VALUE_UNKNOWN_TAG_VERSION',
+  'HQ_VALUE_UNKNOWN_FIELD',
+  'HQ_VALUE_INVALID_FORMAT',
+  'HQ_VALUE_OUT_OF_RANGE',
+  'HQ_VALUE_TYPE_MISMATCH',
+  'HQ_VALUE_TOO_DEEP',
+  'HQ_VALUE_TOO_MANY_NODES',
+  'HQ_VALUE_TOO_MANY_ITEMS',
+  'HQ_VALUE_TOO_LARGE',
+] as const;
 
 function readFixture<T>(name: string): T {
   const path = fileURLToPath(new URL(
@@ -51,6 +73,7 @@ function canonicalizeFixtureValue(value: unknown): string {
   if (typeof value === 'object') {
     const object = value as Record<string, unknown>;
     return `{${Object.keys(object)
+      // Default JS string ordering compares UTF-16 code units, as RFC 8785 requires.
       .sort()
       .map((key) => `${JSON.stringify(key)}:${canonicalizeFixtureValue(object[key])}`)
       .join(',')}}`;
@@ -66,6 +89,12 @@ describe('tagged value v1 fixture integrity', () => {
   it('contains unique stable fixture identifiers', () => {
     const ids = [...success, ...rejections].map((fixture) => fixture.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('covers every stable RFC failure code', () => {
+    const coveredCodes = new Set(rejections.map((fixture) => fixture.error));
+
+    expect([...coveredCodes].sort()).toEqual([...STABLE_FAILURE_CODES].sort());
   });
 
   it.each(success)('$id has exact canonical bytes and SHA-256', (fixture) => {
@@ -85,6 +114,14 @@ describe('tagged value v1 fixture integrity', () => {
     expect(composed?.sha256).toBeDefined();
     expect(decomposed?.sha256).toBeDefined();
     expect(composed?.sha256).not.toBe(decomposed?.sha256);
+  });
+
+  it('sorts object keys by UTF-16 code units', () => {
+    const supplementaryKey = '\u{10000}';
+    const bmpKey = '\uE000';
+
+    expect(canonicalizeFixtureValue({ [bmpKey]: 1, [supplementaryKey]: 2 }))
+      .toBe(`{"${supplementaryKey}":2,"${bmpKey}":1}`);
   });
 
   it.each(rejections)('$id declares one input form and a stable error', (fixture) => {

--- a/packages/protocol/src/fixtures.test.ts
+++ b/packages/protocol/src/fixtures.test.ts
@@ -1,0 +1,101 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+interface SuccessFixture {
+  id: string;
+  value: unknown;
+  canonicalHex: string;
+  sha256: string;
+}
+
+interface RejectionFixture {
+  id: string;
+  phase: string;
+  sourceUtf8?: string;
+  value?: unknown;
+  generator?: Record<string, unknown>;
+  error: string;
+}
+
+function readFixture<T>(name: string): T {
+  const path = fileURLToPath(new URL(
+    `../../../specs/security-protocol/fixtures/tagged-values-v1/${name}`,
+    import.meta.url,
+  ));
+
+  return JSON.parse(readFileSync(path, 'utf8')) as T;
+}
+
+// Fixture-integrity helper only. The production JCS implementation belongs to
+// R1A-03 and must not reuse this deliberately small test implementation.
+function canonicalizeFixtureValue(value: unknown): string {
+  if (
+    value === null
+    || typeof value === 'boolean'
+    || typeof value === 'string'
+    || typeof value === 'number'
+  ) {
+    const encoded = JSON.stringify(value);
+    if (encoded === undefined) {
+      throw new TypeError('Fixture contains a non-JSON scalar');
+    }
+    return encoded;
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalizeFixtureValue).join(',')}]`;
+  }
+
+  if (typeof value === 'object') {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalizeFixtureValue(object[key])}`)
+      .join(',')}}`;
+  }
+
+  throw new TypeError('Fixture contains a non-JSON value');
+}
+
+describe('tagged value v1 fixture integrity', () => {
+  const success = readFixture<SuccessFixture[]>('success.json');
+  const rejections = readFixture<RejectionFixture[]>('rejections.json');
+
+  it('contains unique stable fixture identifiers', () => {
+    const ids = [...success, ...rejections].map((fixture) => fixture.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it.each(success)('$id has exact canonical bytes and SHA-256', (fixture) => {
+    const canonical = canonicalizeFixtureValue(fixture.value);
+    const canonicalBytes = Buffer.from(canonical, 'utf8');
+
+    expect(canonicalBytes.toString('hex')).toBe(fixture.canonicalHex);
+    expect(createHash('sha256').update(canonicalBytes).digest('hex'))
+      .toBe(fixture.sha256);
+    expect(JSON.parse(canonicalBytes.toString('utf8'))).toEqual(fixture.value);
+  });
+
+  it('proves Unicode normalization is not performed', () => {
+    const composed = success.find((fixture) => fixture.id === 'unicode-composed');
+    const decomposed = success.find((fixture) => fixture.id === 'unicode-decomposed');
+
+    expect(composed?.sha256).toBeDefined();
+    expect(decomposed?.sha256).toBeDefined();
+    expect(composed?.sha256).not.toBe(decomposed?.sha256);
+  });
+
+  it.each(rejections)('$id declares one input form and a stable error', (fixture) => {
+    const inputs = [
+      fixture.sourceUtf8 !== undefined,
+      fixture.value !== undefined,
+      fixture.generator !== undefined,
+    ].filter(Boolean);
+
+    expect(inputs).toHaveLength(1);
+    expect(fixture.error).toMatch(/^HQ_VALUE_[A-Z0-9_]+$/);
+    expect(fixture.phase).toMatch(/^(parse|unicode|model|limits)$/);
+  });
+});

--- a/specs/security-protocol/README.md
+++ b/specs/security-protocol/README.md
@@ -40,8 +40,8 @@ a bug. Implementations must not silently establish competing protocol rules.
   validation failures.
 - `rfc/`: proposals that are not normative until accepted.
 
-Only `decisions/` exists in the scaffold. Empty directories will be introduced
-with the first artifact that needs them.
+The tagged-value proposal and its draft fixtures now live in `rfc/` and
+`fixtures/`. Empty directories are introduced only with their first artifact.
 
 ## Boundaries
 

--- a/specs/security-protocol/fixtures/tagged-values-v1/README.md
+++ b/specs/security-protocol/fixtures/tagged-values-v1/README.md
@@ -1,0 +1,31 @@
+# Tagged value version 1 fixtures
+
+These draft language-neutral fixtures accompany RFC 0001. They become
+normative when the RFC is accepted.
+
+## Success manifest
+
+Each entry in `success.json` contains:
+
+- `id`: stable fixture identifier;
+- `value`: the parsed canonical value before JCS;
+- `canonicalHex`: exact RFC 8785 canonical UTF-8 bytes as lowercase hex;
+- `sha256`: lowercase SHA-256 of those exact bytes.
+
+The hash is a fixture integrity check, not a deployment digest or cache key.
+
+## Rejection manifest
+
+Entries in `rejections.json` use one of:
+
+- `sourceUtf8`: exact JSON source presented to a duplicate-aware parser;
+- `value`: an already parsed value presented to model validation;
+- `generator`: a deterministic boundary case that would be wasteful to store
+  expanded.
+
+`error` is the required stable failure code. `phase` identifies the earliest
+stage that must reject the input. A consumer may reject earlier only when it
+returns the same code and does not partially execute or hash the value.
+
+Fixture runners must not pass `sourceUtf8` through an ordinary JSON dictionary
+parser before duplicate-key detection.

--- a/specs/security-protocol/fixtures/tagged-values-v1/README.md
+++ b/specs/security-protocol/fixtures/tagged-values-v1/README.md
@@ -23,6 +23,19 @@ Entries in `rejections.json` use one of:
 - `generator`: a deterministic boundary case that would be wasteful to store
   expanded.
 
+`declaredClickHouseType`, when present, supplies the containing schema type
+needed to validate integer-tag requirements and exact tag/type compatibility.
+
+Generators expand as follows:
+
+- `non-finite-float`: creates the host-language non-finite number named by
+  `value` (`NaN`, `Infinity`, or `-Infinity`) after JSON parsing;
+- `nested-array`: wraps `leaf` in the tagged array form `depth` times;
+- `array`: creates one tagged array containing `items` copies of `value`;
+- `array-tree`: creates one tagged array containing `branches` tagged arrays,
+  each containing `itemsPerBranch` copies of `value`;
+- `repeat-string`: concatenates `count` copies of the UTF-8 string `utf8`.
+
 `error` is the required stable failure code. `phase` identifies the earliest
 stage that must reject the input. A consumer may reject earlier only when it
 returns the same code and does not partially execute or hash the value.

--- a/specs/security-protocol/fixtures/tagged-values-v1/rejections.json
+++ b/specs/security-protocol/fixtures/tagged-values-v1/rejections.json
@@ -1,0 +1,239 @@
+[
+  {
+    "id": "duplicate-object-key",
+    "phase": "parse",
+    "sourceUtf8": "{\"a\":1,\"a\":2}",
+    "error": "HQ_VALUE_DUPLICATE_KEY"
+  },
+  {
+    "id": "invalid-json-nan",
+    "phase": "parse",
+    "sourceUtf8": "NaN",
+    "error": "HQ_VALUE_INVALID_JSON"
+  },
+  {
+    "id": "invalid-json-infinity",
+    "phase": "parse",
+    "sourceUtf8": "Infinity",
+    "error": "HQ_VALUE_INVALID_JSON"
+  },
+  {
+    "id": "lone-high-surrogate",
+    "phase": "unicode",
+    "sourceUtf8": "\"\\ud800\"",
+    "error": "HQ_VALUE_INVALID_UNICODE"
+  },
+  {
+    "id": "control-character-null",
+    "phase": "model",
+    "sourceUtf8": "\"\\u0000\"",
+    "error": "HQ_VALUE_CONTROL_CHARACTER"
+  },
+  {
+    "id": "negative-zero",
+    "phase": "model",
+    "sourceUtf8": "-0",
+    "error": "HQ_VALUE_NEGATIVE_ZERO"
+  },
+  {
+    "id": "raw-array",
+    "phase": "model",
+    "value": [true, false],
+    "error": "HQ_VALUE_RAW_COMPOSITE"
+  },
+  {
+    "id": "unknown-tag-version",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "integer",
+        "version": 2,
+        "bits": 8,
+        "signed": true,
+        "value": "1"
+      }
+    },
+    "error": "HQ_VALUE_UNKNOWN_TAG_VERSION"
+  },
+  {
+    "id": "unknown-tag-field",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "integer",
+        "version": 1,
+        "bits": 8,
+        "signed": true,
+        "value": "1",
+        "extra": true
+      }
+    },
+    "error": "HQ_VALUE_UNKNOWN_FIELD"
+  },
+  {
+    "id": "integer-leading-zero",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "integer",
+        "version": 1,
+        "bits": 8,
+        "signed": false,
+        "value": "01"
+      }
+    },
+    "error": "HQ_VALUE_INVALID_FORMAT"
+  },
+  {
+    "id": "signed-int8-overflow",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "integer",
+        "version": 1,
+        "bits": 8,
+        "signed": true,
+        "value": "128"
+      }
+    },
+    "error": "HQ_VALUE_OUT_OF_RANGE"
+  },
+  {
+    "id": "decimal-negative-zero",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "decimal",
+        "version": 1,
+        "precision": 9,
+        "scale": 2,
+        "coefficient": "-0"
+      }
+    },
+    "error": "HQ_VALUE_INVALID_FORMAT"
+  },
+  {
+    "id": "decimal-scale-exceeds-precision",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "decimal",
+        "version": 1,
+        "precision": 2,
+        "scale": 3,
+        "coefficient": "1"
+      }
+    },
+    "error": "HQ_VALUE_OUT_OF_RANGE"
+  },
+  {
+    "id": "invalid-date",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "date",
+        "version": 1,
+        "clickhouseType": "Date",
+        "value": "2025-02-29"
+      }
+    },
+    "error": "HQ_VALUE_INVALID_FORMAT"
+  },
+  {
+    "id": "date-out-of-range",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "date",
+        "version": 1,
+        "clickhouseType": "Date",
+        "value": "1900-01-01"
+      }
+    },
+    "error": "HQ_VALUE_OUT_OF_RANGE"
+  },
+  {
+    "id": "datetime-missing-timezone",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "datetime",
+        "version": 1,
+        "clickhouseType": "DateTime64",
+        "precision": 3,
+        "timezone": "Europe/Madrid",
+        "value": "2026-07-13T14:30:45.123"
+      }
+    },
+    "error": "HQ_VALUE_INVALID_FORMAT"
+  },
+  {
+    "id": "uuid-uppercase",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "uuid",
+        "version": 1,
+        "value": "01890F3E-7B7B-7CC2-98C4-DC0C0C07398F"
+      }
+    },
+    "error": "HQ_VALUE_INVALID_FORMAT"
+  },
+  {
+    "id": "bytes-padding",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "bytes",
+        "version": 1,
+        "encoding": "base64url",
+        "value": "AA=="
+      }
+    },
+    "error": "HQ_VALUE_INVALID_FORMAT"
+  },
+  {
+    "id": "enum8-code-overflow",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "enum",
+        "version": 1,
+        "bits": 8,
+        "code": 128,
+        "label": "overflow"
+      }
+    },
+    "error": "HQ_VALUE_OUT_OF_RANGE"
+  },
+  {
+    "id": "composite-depth-17",
+    "phase": "limits",
+    "generator": {
+      "type": "nested-array",
+      "depth": 17,
+      "leaf": null
+    },
+    "error": "HQ_VALUE_TOO_DEEP"
+  },
+  {
+    "id": "array-items-1001",
+    "phase": "limits",
+    "generator": {
+      "type": "array",
+      "items": 1001,
+      "value": null
+    },
+    "error": "HQ_VALUE_TOO_MANY_ITEMS"
+  },
+  {
+    "id": "string-bytes-65537",
+    "phase": "limits",
+    "generator": {
+      "type": "repeat-string",
+      "utf8": "a",
+      "count": 65537
+    },
+    "error": "HQ_VALUE_TOO_LARGE"
+  }
+]

--- a/specs/security-protocol/fixtures/tagged-values-v1/rejections.json
+++ b/specs/security-protocol/fixtures/tagged-values-v1/rejections.json
@@ -36,10 +36,37 @@
     "error": "HQ_VALUE_NEGATIVE_ZERO"
   },
   {
+    "id": "non-finite-float-model-value",
+    "phase": "model",
+    "generator": {
+      "type": "non-finite-float",
+      "value": "NaN"
+    },
+    "error": "HQ_VALUE_NON_FINITE_FLOAT"
+  },
+  {
+    "id": "safe-integer-requires-tag",
+    "phase": "model",
+    "value": 42,
+    "declaredClickHouseType": "Int64",
+    "error": "HQ_VALUE_INTEGER_TAG_REQUIRED"
+  },
+  {
     "id": "raw-array",
     "phase": "model",
     "value": [true, false],
     "error": "HQ_VALUE_RAW_COMPOSITE"
+  },
+  {
+    "id": "unknown-tag-type",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "blob",
+        "version": 1
+      }
+    },
+    "error": "HQ_VALUE_UNKNOWN_TAG"
   },
   {
     "id": "unknown-tag-version",
@@ -99,6 +126,21 @@
     "error": "HQ_VALUE_OUT_OF_RANGE"
   },
   {
+    "id": "integer-declared-type-mismatch",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "integer",
+        "version": 1,
+        "bits": 8,
+        "signed": false,
+        "value": "1"
+      }
+    },
+    "declaredClickHouseType": "Int8",
+    "error": "HQ_VALUE_TYPE_MISMATCH"
+  },
+  {
     "id": "decimal-negative-zero",
     "phase": "model",
     "value": {
@@ -153,7 +195,7 @@
     "error": "HQ_VALUE_OUT_OF_RANGE"
   },
   {
-    "id": "datetime-missing-timezone",
+    "id": "datetime-value-missing-z",
     "phase": "model",
     "value": {
       "$hypequery": {
@@ -225,6 +267,17 @@
       "value": null
     },
     "error": "HQ_VALUE_TOO_MANY_ITEMS"
+  },
+  {
+    "id": "value-nodes-10001",
+    "phase": "limits",
+    "generator": {
+      "type": "array-tree",
+      "branches": 10,
+      "itemsPerBranch": 999,
+      "value": null
+    },
+    "error": "HQ_VALUE_TOO_MANY_NODES"
   },
   {
     "id": "string-bytes-65537",

--- a/specs/security-protocol/fixtures/tagged-values-v1/success.json
+++ b/specs/security-protocol/fixtures/tagged-values-v1/success.json
@@ -1,0 +1,262 @@
+[
+  {
+    "id": "native-null",
+    "value": null,
+    "canonicalHex": "6e756c6c",
+    "sha256": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b"
+  },
+  {
+    "id": "native-boolean",
+    "value": true,
+    "canonicalHex": "74727565",
+    "sha256": "b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b"
+  },
+  {
+    "id": "unicode-composed",
+    "value": "café",
+    "canonicalHex": "22636166c3a922",
+    "sha256": "28380feb8724d669bc8d4cf5b5a5bb1adbdc61b81ebd06f3fabc567b4f3b0fc5"
+  },
+  {
+    "id": "unicode-decomposed",
+    "value": "café",
+    "canonicalHex": "2263616665cc8122",
+    "sha256": "c7d7e72b8ad0dd91beb4044a4bb17c6c8a9672cc620c4c76e6584f3525d400d1"
+  },
+  {
+    "id": "native-float",
+    "value": 1.5,
+    "canonicalHex": "312e35",
+    "sha256": "9f29a130438b81170b92a42650f9a94291ecad60bd47af2a3886e75f7f728725"
+  },
+  {
+    "id": "int64-min",
+    "value": {
+      "$hypequery": {
+        "type": "integer",
+        "version": 1,
+        "bits": 64,
+        "signed": true,
+        "value": "-9223372036854775808"
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b2262697473223a36342c227369676e6564223a747275652c2274797065223a22696e7465676572222c2276616c7565223a222d39323233333732303336383534373735383038222c2276657273696f6e223a317d7d",
+    "sha256": "c8bb49d00e73358cedf6f24b1743a7f496c401220187df7465f23e50e8dc64b5"
+  },
+  {
+    "id": "uint256-max",
+    "value": {
+      "$hypequery": {
+        "type": "integer",
+        "version": 1,
+        "bits": 256,
+        "signed": false,
+        "value": "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b2262697473223a3235362c227369676e6564223a66616c73652c2274797065223a22696e7465676572222c2276616c7565223a22313135373932303839323337333136313935343233353730393835303038363837393037383533323639393834363635363430353634303339343537353834303037393133313239363339393335222c2276657273696f6e223a317d7d",
+    "sha256": "180e2834c8c0cdd64b3d33dc11fccd18e74a4728dc724e9f15289ab0e0152211"
+  },
+  {
+    "id": "decimal-fixed-scale",
+    "value": {
+      "$hypequery": {
+        "type": "decimal",
+        "version": 1,
+        "precision": 18,
+        "scale": 4,
+        "coefficient": "-123450"
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b22636f656666696369656e74223a222d313233343530222c22707265636973696f6e223a31382c227363616c65223a342c2274797065223a22646563696d616c222c2276657273696f6e223a317d7d",
+    "sha256": "266fc8aae1490982ece30bc2bf7be16f16534cc1bcb128359c8a22fbeb63cd19"
+  },
+  {
+    "id": "date-max",
+    "value": {
+      "$hypequery": {
+        "type": "date",
+        "version": 1,
+        "clickhouseType": "Date",
+        "value": "2149-06-06"
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b22636c69636b686f75736554797065223a2244617465222c2274797065223a2264617465222c2276616c7565223a22323134392d30362d3036222c2276657273696f6e223a317d7d",
+    "sha256": "ff28f4d6d0980ab8cf06091ba029d3c16dae7b00daf4f94be59ab1d3279e5ac4"
+  },
+  {
+    "id": "date32-min",
+    "value": {
+      "$hypequery": {
+        "type": "date",
+        "version": 1,
+        "clickhouseType": "Date32",
+        "value": "1900-01-01"
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b22636c69636b686f75736554797065223a22446174653332222c2274797065223a2264617465222c2276616c7565223a22313930302d30312d3031222c2276657273696f6e223a317d7d",
+    "sha256": "1ca0cd2f2e53bb9fcd511f66762a84f69a5273fd6b69cf486a4f68ec328a7929"
+  },
+  {
+    "id": "datetime-max",
+    "value": {
+      "$hypequery": {
+        "type": "datetime",
+        "version": 1,
+        "clickhouseType": "DateTime",
+        "precision": 0,
+        "timezone": "UTC",
+        "value": "2106-02-07T06:28:15Z"
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b22636c69636b686f75736554797065223a224461746554696d65222c22707265636973696f6e223a302c2274696d657a6f6e65223a22555443222c2274797065223a226461746574696d65222c2276616c7565223a22323130362d30322d30375430363a32383a31355a222c2276657273696f6e223a317d7d",
+    "sha256": "00e8edb27e1019e09f8461d7859d155a6ab2a18cd8b9840ad3b4abfe1833b6c7"
+  },
+  {
+    "id": "datetime64-nanoseconds",
+    "value": {
+      "$hypequery": {
+        "type": "datetime",
+        "version": 1,
+        "clickhouseType": "DateTime64",
+        "precision": 9,
+        "timezone": "Europe/Madrid",
+        "value": "2026-07-13T14:30:45.123456789Z"
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b22636c69636b686f75736554797065223a224461746554696d653634222c22707265636973696f6e223a392c2274696d657a6f6e65223a224575726f70652f4d6164726964222c2274797065223a226461746574696d65222c2276616c7565223a22323032362d30372d31335431343a33303a34352e3132333435363738395a222c2276657273696f6e223a317d7d",
+    "sha256": "6bfb8ff31d75046b95ef5b6bc1632509a3718db6128d37c39aaf68b2bc339055"
+  },
+  {
+    "id": "uuid",
+    "value": {
+      "$hypequery": {
+        "type": "uuid",
+        "version": 1,
+        "value": "01890f3e-7b7b-7cc2-98c4-dc0c0c07398f"
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b2274797065223a2275756964222c2276616c7565223a2230313839306633652d376237622d376363322d393863342d646330633063303733393866222c2276657273696f6e223a317d7d",
+    "sha256": "2ade363f45d84acf17aa30a5f87b06dbcd7f80d8562139e5515ad1be2b90402d"
+  },
+  {
+    "id": "bytes",
+    "value": {
+      "$hypequery": {
+        "type": "bytes",
+        "version": 1,
+        "encoding": "base64url",
+        "value": "AP8Q"
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b22656e636f64696e67223a2262617365363475726c222c2274797065223a226279746573222c2276616c7565223a2241503851222c2276657273696f6e223a317d7d",
+    "sha256": "1892849ed1e884ab585c7173ce82e4cb3928c784ed1ced60b22004a1f9c7b907"
+  },
+  {
+    "id": "enum8",
+    "value": {
+      "$hypequery": {
+        "type": "enum",
+        "version": 1,
+        "bits": 8,
+        "code": -1,
+        "label": "unknown"
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b2262697473223a382c22636f6465223a2d312c226c6162656c223a22756e6b6e6f776e222c2274797065223a22656e756d222c2276657273696f6e223a317d7d",
+    "sha256": "6b1f0e98475f260329c58169ca1729904032118586ba2e606bd6ce42c37ae250"
+  },
+  {
+    "id": "array",
+    "value": {
+      "$hypequery": {
+        "type": "array",
+        "version": 1,
+        "values": [
+          {
+            "$hypequery": {
+              "type": "integer",
+              "version": 1,
+              "bits": 8,
+              "signed": true,
+              "value": "1"
+            }
+          },
+          {
+            "$hypequery": {
+              "type": "integer",
+              "version": 1,
+              "bits": 8,
+              "signed": true,
+              "value": "2"
+            }
+          },
+          null
+        ]
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b2274797065223a226172726179222c2276616c756573223a5b7b2224687970657175657279223a7b2262697473223a382c227369676e6564223a747275652c2274797065223a22696e7465676572222c2276616c7565223a2231222c2276657273696f6e223a317d7d2c7b2224687970657175657279223a7b2262697473223a382c227369676e6564223a747275652c2274797065223a22696e7465676572222c2276616c7565223a2232222c2276657273696f6e223a317d7d2c6e756c6c5d2c2276657273696f6e223a317d7d",
+    "sha256": "c5cd6992f14dce9f651382721df22cc83bef1ceccdb5f76622b97a3a4c1480e7"
+  },
+  {
+    "id": "tuple",
+    "value": {
+      "$hypequery": {
+        "type": "tuple",
+        "version": 1,
+        "values": [
+          "EMEA",
+          true,
+          {
+            "$hypequery": {
+              "type": "decimal",
+              "version": 1,
+              "precision": 9,
+              "scale": 2,
+              "coefficient": "12345"
+            }
+          }
+        ]
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b2274797065223a227475706c65222c2276616c756573223a5b22454d4541222c747275652c7b2224687970657175657279223a7b22636f656666696369656e74223a223132333435222c22707265636973696f6e223a392c227363616c65223a322c2274797065223a22646563696d616c222c2276657273696f6e223a317d7d5d2c2276657273696f6e223a317d7d",
+    "sha256": "0d5fd05377a8ea454b0494c17bc41d0d23750798a51ce677ea83aca943d219eb"
+  },
+  {
+    "id": "map-ordered-duplicate-keys",
+    "value": {
+      "$hypequery": {
+        "type": "map",
+        "version": 1,
+        "entries": [
+          [
+            "region",
+            {
+              "$hypequery": {
+                "type": "integer",
+                "version": 1,
+                "bits": 8,
+                "signed": false,
+                "value": "1"
+              }
+            }
+          ],
+          [
+            "region",
+            {
+              "$hypequery": {
+                "type": "integer",
+                "version": 1,
+                "bits": 8,
+                "signed": false,
+                "value": "2"
+              }
+            }
+          ]
+        ]
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b22656e7472696573223a5b5b22726567696f6e222c7b2224687970657175657279223a7b2262697473223a382c227369676e6564223a66616c73652c2274797065223a22696e7465676572222c2276616c7565223a2231222c2276657273696f6e223a317d7d5d2c5b22726567696f6e222c7b2224687970657175657279223a7b2262697473223a382c227369676e6564223a66616c73652c2274797065223a22696e7465676572222c2276616c7565223a2232222c2276657273696f6e223a317d7d5d5d2c2274797065223a226d6170222c2276657273696f6e223a317d7d",
+    "sha256": "9cb2c26100b18e84f1a6974424ddd600ef8a0a7d113420bb882e61e9fa690f41"
+  }
+]

--- a/specs/security-protocol/rfc/0001-tagged-clickhouse-value-model.md
+++ b/specs/security-protocol/rfc/0001-tagged-clickhouse-value-model.md
@@ -1,0 +1,421 @@
+# RFC 0001: Tagged ClickHouse value model
+
+- Status: Proposed
+- Created: 2026-07-13
+- Target extension version: 1
+- Owners: Hypequery maintainers
+
+## Summary
+
+Hypequery canonical artifacts use RFC 8785 JSON Canonicalization Scheme (JCS)
+without modification. Values that cannot be represented safely and
+unambiguously by interoperable JSON use strict, versioned Hypequery tags before
+JCS is applied.
+
+This RFC defines the value layer only. Parameter names, complete ClickHouse
+type expressions, sensitivity classes, bundle envelopes, query digest domains,
+and cache-key derivation are defined by later contracts. Those contracts pair a
+canonical value with its declared logical and ClickHouse types and must reject a
+mismatch.
+
+## Goals
+
+- Produce byte-identical canonical values in TypeScript and Python.
+- Preserve integer, decimal, temporal, UUID, byte, enum, and composite meaning
+  without host-language conversion rules.
+- Reject ambiguous, lossy, oversized, or executable input before hashing or
+  query compilation.
+- Keep the representation public and independently implementable.
+
+## Non-goals
+
+- Changing or extending the JCS algorithm.
+- Parsing arbitrary ClickHouse type strings or SQL.
+- Defining driver wire encodings.
+- Supporting every ClickHouse data type in version 1.
+- Serializing callbacks, classes, proxies, custom objects, or host-language
+  objects through methods such as `toJSON`.
+
+## Terminology
+
+- **Parsed value:** a duplicate-aware I-JSON parse result before Hypequery
+  model validation.
+- **Canonical value:** a parsed value that satisfies this RFC.
+- **Tagged value:** an object with exactly one `$hypequery` member whose value
+  is a strict tag payload.
+- **Canonical bytes:** UTF-8 bytes emitted by RFC 8785 over a canonical value.
+- **Value hash:** lowercase hexadecimal SHA-256 of canonical bytes. Fixture
+  value hashes are conformance aids, not deployment digests or cache keys.
+
+The key words MUST, MUST NOT, REQUIRED, SHOULD, SHOULD NOT, and MAY are to be
+interpreted as described by BCP 14.
+
+## Processing order
+
+An implementation MUST perform these stages in order:
+
+1. Enforce the encoded-byte limit while reading input.
+2. Parse JSON while detecting duplicate object keys at every depth.
+3. Validate I-JSON strings and numbers without invoking custom serializers.
+4. Validate the native or tagged Hypequery value, including exact fields,
+   ranges, collection limits, and declared type compatibility.
+5. Apply RFC 8785 JCS without modifying strings or the value tree.
+6. Encode the JCS result as UTF-8.
+7. Hash the canonical bytes only in the domain defined by the containing
+   artifact contract.
+
+Rejecting duplicate keys after an ordinary dictionary parse is non-conformant
+because the parser may already have discarded one of the values.
+
+## Native I-JSON values
+
+The following values use native JSON representations:
+
+- `null` for the logical null value;
+- `true` and `false` for booleans;
+- JSON strings for Unicode text;
+- JSON numbers for finite binary floating-point values only.
+
+Strings MUST contain valid Unicode scalar values, MUST be preserved without
+Unicode normalization, and MUST NOT contain C0 control characters U+0000
+through U+001F or U+007F. Quotes, backslashes, comment-looking text, and other
+ordinary Unicode remain data.
+
+Native JSON numbers are floating-point values. NaN, positive or negative
+Infinity, and lexical negative zero are forbidden. An integer-valued JSON token
+does not become an integer: integer semantics require the integer tag below.
+The declared containing type decides whether a finite native number is
+`Float32` or `Float64` and validates any additional range or rounding policy.
+
+Strict tag metadata such as `version`, `bits`, `precision`, `scale`, and enum
+`code` uses bounded native JSON integers because each field's integer meaning
+and range are fixed by its tag schema. The integer-tag requirement applies to
+semantic values, not to these closed-schema metadata fields.
+
+Raw JSON arrays and application-created objects are not canonical values. They
+must be represented by the array, tuple, or map tags. Objects belonging to the
+containing artifact schema are outside this value union and are validated by
+that schema.
+
+## Tag envelope
+
+A tagged value has this shape:
+
+```json
+{
+  "$hypequery": {
+    "type": "integer",
+    "version": 1
+  }
+}
+```
+
+The outer object MUST contain exactly `$hypequery`. The payload MUST contain
+exactly the fields defined for its tag. Unknown fields, unknown types, and
+unknown versions fail closed. Version 1 payloads use the integer JSON number
+`1`; a string or floating representation is invalid.
+
+The tag is a data-model extension, not a JCS extension. It is validated into an
+ordinary I-JSON tree and then canonicalized normally.
+
+## Version 1 tag registry
+
+### Integer
+
+```json
+{
+  "$hypequery": {
+    "bits": 64,
+    "signed": false,
+    "type": "integer",
+    "value": "18446744073709551615",
+    "version": 1
+  }
+}
+```
+
+- `bits` MUST be one of `8`, `16`, `32`, `64`, `128`, or `256`.
+- `signed` MUST be a JSON boolean.
+- `value` MUST be canonical base-10: `0` or an optional `-` followed by a
+  non-zero digit and remaining digits.
+- `+`, leading zeroes, whitespace, exponents, decimal points, and `-0` are
+  forbidden.
+- The value MUST fit the signed or unsigned range for `bits`.
+- The containing ClickHouse type MUST be the corresponding `IntN` or `UIntN`.
+
+All integers use this tag, including integers within the I-JSON safe range.
+This prevents a security-sensitive integer from being confused with a binary
+floating-point number.
+
+### Decimal
+
+```json
+{
+  "$hypequery": {
+    "coefficient": "-123450",
+    "precision": 18,
+    "scale": 4,
+    "type": "decimal",
+    "version": 1
+  }
+}
+```
+
+The represented value is `coefficient × 10^-scale`.
+
+- `precision` MUST be an integer from `1` through `76`.
+- `scale` MUST be an integer from `0` through `precision`.
+- `coefficient` follows the canonical integer string rules, including no
+  negative zero.
+- The coefficient MUST contain no more than `precision` decimal digits,
+  excluding its sign.
+- The tag never accepts a binary float as a decimal source.
+- The containing Decimal type MUST have the same precision and scale. Alias
+  forms such as `Decimal64(S)` are normalized by the later type contract before
+  comparison.
+
+Trailing fractional zeroes are preserved through the coefficient and declared
+scale. For example Decimal(9, 4) value `12.3400` has coefficient `123400`.
+
+### Date
+
+```json
+{
+  "$hypequery": {
+    "clickhouseType": "Date",
+    "type": "date",
+    "value": "2026-07-13",
+    "version": 1
+  }
+}
+```
+
+- `clickhouseType` MUST be `Date` or `Date32`.
+- `value` MUST be a real proleptic-Gregorian date in `YYYY-MM-DD` form.
+- `Date` values MUST be within `1970-01-01` through `2149-06-06`.
+- `Date32` values MUST be within `1900-01-01` through `2299-12-31`.
+- Host locale and timezone do not participate in parsing.
+
+### Datetime
+
+```json
+{
+  "$hypequery": {
+    "clickhouseType": "DateTime64",
+    "precision": 3,
+    "timezone": "Europe/Madrid",
+    "type": "datetime",
+    "value": "2026-07-13T14:30:45.123Z",
+    "version": 1
+  }
+}
+```
+
+- `clickhouseType` MUST be `DateTime` or `DateTime64`.
+- `precision` MUST be `0` for `DateTime` and an integer from `0` through `9`
+  for `DateTime64`.
+- `timezone` MUST be the explicit canonical IANA timezone name selected by the
+  containing schema. `UTC` is valid. Fixed-offset labels and local-process
+  defaults are forbidden.
+- `value` MUST be an RFC 3339 UTC instant ending in uppercase `Z`.
+- The fractional part MUST be absent at precision `0` and contain exactly
+  `precision` digits otherwise. Inputs with offsets are normalized to this UTC
+  form before the tag is constructed.
+- The instant MUST fit the declared ClickHouse type and precision. In
+  particular, `DateTime64(9)` has a narrower upper bound than lower precisions.
+
+The timezone is type policy and display/parse context; the canonical `value`
+identifies the instant. No implementation may infer a missing timezone.
+
+### UUID
+
+```json
+{
+  "$hypequery": {
+    "type": "uuid",
+    "value": "01890f3e-7b7b-7cc2-98c4-dc0c0c07398f",
+    "version": 1
+  }
+}
+```
+
+The value MUST use lowercase hexadecimal canonical UUID text with the
+`8-4-4-4-12` grouping. Braces, uppercase, missing hyphens, and host-specific
+UUID string forms are forbidden. All UUID versions are representable; version
+policy belongs to the containing schema.
+
+### Bytes
+
+```json
+{
+  "$hypequery": {
+    "encoding": "base64url",
+    "type": "bytes",
+    "value": "AP8Q",
+    "version": 1
+  }
+}
+```
+
+Bytes use RFC 4648 base64url without `=` padding. The empty byte string is the
+empty JSON string. Standard base64 characters `+` and `/`, whitespace,
+non-minimal encodings, and padding are forbidden. The containing type decides
+whether the bytes target `String`, `FixedString(N)`, or another allowed type and
+validates its length.
+
+### Enum
+
+```json
+{
+  "$hypequery": {
+    "bits": 8,
+    "code": -1,
+    "label": "unknown",
+    "type": "enum",
+    "version": 1
+  }
+}
+```
+
+- `bits` MUST be `8` or `16`.
+- `code` MUST be a native JSON integer in the corresponding signed range.
+- `label` follows the native string rules.
+- Both label and code MUST match one member of the declared `Enum8` or `Enum16`
+  type. Carrying both makes an enum-definition drift observable.
+
+### Array
+
+```json
+{
+  "$hypequery": {
+    "type": "array",
+    "values": [true, false, null],
+    "version": 1
+  }
+}
+```
+
+`values` is an ordered JSON array of canonical values. Order is semantic and is
+never sorted. The containing `Array(T)` type validates element compatibility.
+
+### Tuple
+
+```json
+{
+  "$hypequery": {
+    "type": "tuple",
+    "values": ["EMEA", true],
+    "version": 1
+  }
+}
+```
+
+`values` is an ordered JSON array of canonical values. Positional and named
+tuple type declarations are outside the value and MUST match its arity and
+members.
+
+### Map
+
+```json
+{
+  "$hypequery": {
+    "entries": [
+      ["region", "EMEA"],
+      ["region", "fallback"]
+    ],
+    "type": "map",
+    "version": 1
+  }
+}
+```
+
+`entries` is an ordered array of two-element `[key, value]` arrays. Order is
+semantic and duplicate map keys are preserved because ClickHouse Map is
+represented as `Array(Tuple(K, V))` and permits duplicate keys. This does not
+relax the prohibition on duplicate JSON object property names. The containing
+`Map(K, V)` type validates both members of every entry.
+
+## Absolute version 1 limits
+
+These limits apply before product-specific policy. A product MAY advertise a
+lower limit but MUST NOT accept a larger value under extension version 1.
+
+| Limit | Maximum |
+| --- | ---: |
+| Encoded input for one canonical value | 1,048,576 bytes |
+| Canonical UTF-8 for one canonical value | 1,048,576 bytes |
+| Tagged composite nesting depth | 16 |
+| Total value nodes | 10,000 |
+| Values in one array or tuple | 1,000 |
+| Entries in one map | 1,000 |
+| UTF-8 bytes in one string or enum label | 65,536 |
+| Decoded bytes in one bytes value | 65,536 |
+| Decimal precision | 76 |
+
+Depth is `0` for a native scalar or scalar tag. Entering an array, tuple, or map
+adds one; each map key and value is traversed at that depth. Node count includes
+every scalar, scalar tag, composite tag, map key, and map value.
+
+Implementations MUST check limits during parsing/validation rather than first
+allocating an unbounded host-language object.
+
+## Stable failure codes
+
+Version 1 conformance fixtures use these minimum codes:
+
+- `HQ_VALUE_INVALID_JSON`
+- `HQ_VALUE_DUPLICATE_KEY`
+- `HQ_VALUE_INVALID_UNICODE`
+- `HQ_VALUE_CONTROL_CHARACTER`
+- `HQ_VALUE_NON_FINITE_FLOAT`
+- `HQ_VALUE_NEGATIVE_ZERO`
+- `HQ_VALUE_INTEGER_TAG_REQUIRED`
+- `HQ_VALUE_RAW_COMPOSITE`
+- `HQ_VALUE_UNKNOWN_TAG`
+- `HQ_VALUE_UNKNOWN_TAG_VERSION`
+- `HQ_VALUE_UNKNOWN_FIELD`
+- `HQ_VALUE_INVALID_FORMAT`
+- `HQ_VALUE_OUT_OF_RANGE`
+- `HQ_VALUE_TYPE_MISMATCH`
+- `HQ_VALUE_TOO_DEEP`
+- `HQ_VALUE_TOO_MANY_NODES`
+- `HQ_VALUE_TOO_MANY_ITEMS`
+- `HQ_VALUE_TOO_LARGE`
+
+Products may attach safe source locations and expected types, but these codes
+and their meaning are part of the frozen value contract.
+
+## Security considerations
+
+- Validation must inspect plain data and must not invoke getters, proxies,
+  `toJSON`, Python dunder conversion, or custom serializers.
+- A rendered/debug representation is never executable SQL.
+- Unknown tags and fields fail closed to prevent downgrade-by-interpretation.
+- Duplicate-key detection occurs before normal object construction.
+- Limits are enforced before hashing and before driver conversion.
+- Canonical bytes may contain sensitive values and must not be logged. Raw
+  SHA-256 value hashes are not suitable shared cache keys; the cache contract
+  uses domain-separated HMAC with a project/environment secret.
+
+## Compatibility
+
+Changing a tag's fields, accepted lexical forms, meaning, limits, or canonical
+preimage requires a new extension/core protocol version. Adding a new tag also
+requires an explicit version compatibility decision; version 1 consumers do
+not ignore unknown tags.
+
+Package SemVer does not select this extension version. Containing artifacts
+carry their protocol and schema versions explicitly.
+
+## References
+
+- [RFC 8785: JSON Canonicalization Scheme](https://www.rfc-editor.org/rfc/rfc8785)
+- [RFC 7493: The I-JSON Message Format](https://www.rfc-editor.org/rfc/rfc7493)
+- [RFC 3339: Date and Time on the Internet](https://www.rfc-editor.org/rfc/rfc3339)
+- [RFC 4648: Base-N Encodings](https://www.rfc-editor.org/rfc/rfc4648)
+- [ClickHouse Date](https://clickhouse.com/docs/sql-reference/data-types/date)
+- [ClickHouse Date32](https://clickhouse.com/docs/sql-reference/data-types/date32)
+- [ClickHouse DateTime](https://clickhouse.com/docs/sql-reference/data-types/datetime)
+- [ClickHouse DateTime64](https://clickhouse.com/docs/sql-reference/data-types/datetime64)
+- [ClickHouse Decimal](https://clickhouse.com/docs/sql-reference/data-types/decimal)
+- [ClickHouse Map](https://clickhouse.com/docs/sql-reference/data-types/map)


### PR DESCRIPTION
## What changed

- propose the RFC 8785/JCS-based version 1 tagged ClickHouse value model
- define exact native and tagged representations for integers, decimals, dates, datetimes, UUIDs, bytes, enums, arrays, tuples, and maps
- preserve ClickHouse Map ordering and duplicate-key semantics without relaxing duplicate JSON object-key rejection
- define absolute byte, depth, node, and collection limits plus stable failure codes
- add language-neutral canonical byte/SHA-256 success fixtures and rejection fixtures
- add fixture-integrity tests without exposing a runtime codec yet

## Why

TypeScript, Python, CLI, Studio, and Cloud need byte-identical artifact identity without relying on host-language number, date, UUID, or serialization defaults. This RFC fixes the value preimage before the production TypeScript encoder/decoder is implemented.

## User and developer impact

This is additive protocol design work and changes no existing package runtime behavior. The RFC remains `Proposed` until review. Self-hosted execution is unchanged.

## Stack

- Depends on #274 (`codex/protocol-scaffold`)
- This PR intentionally targets that branch so its diff contains only R1A-02

## Validation

- `pnpm --filter @hypequery/protocol lint`
- `pnpm --filter @hypequery/protocol types`
- `pnpm --filter @hypequery/protocol build`
- `pnpm --filter @hypequery/protocol test` — 43 tests passed
- `git diff --check`