### PR TITLE
Add canonical protocol value codec

### DIFF
--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -5,20 +5,21 @@ Hypequery artifacts.
 
 ## Current status
 
-This package is an intentionally empty public scaffold. It does not yet define
-a stable protocol or an executable deployment bundle. Runtime exports will be
-added incrementally after their language-neutral specifications and conformance
-fixtures are accepted.
+This package now contains the proposed version 1 tagged ClickHouse value codec.
+The API remains pre-stable while the language-neutral specification and
+conformance fixtures are reviewed. It does not yet define an executable
+deployment bundle or a stable Cloud protocol.
 
 The normative source is
 [`specs/security-protocol`](../../specs/security-protocol/README.md).
 
-## Intended scope
+## Scope
 
-The package will contain deterministic, framework-independent implementations
-of accepted protocol rules, including strict validation, canonical encoding,
-digest calculation, identifiers, portable AST structures, artifact envelopes,
-and compatibility checks.
+The package contains deterministic, framework-independent implementations of
+accepted protocol rules. The current implementation provides strict tagged
+value validation, RFC 8785 canonical encoding, duplicate-aware decoding, and a
+raw SHA-256 conformance digest. Identifiers, portable AST structures, artifact
+envelopes, and compatibility checks will follow in separate changes.
 
 It will not connect to ClickHouse, execute queries, load project source, access
 credentials or the environment, perform network or filesystem I/O, implement
@@ -33,6 +34,18 @@ Studio compatibility and security diagnostics.
 Only the root package export is public. Deep imports from `src` or `dist` are
 unsupported. Package SemVer and protocol/artifact versions are separate; an
 installed npm version never determines an artifact's identity.
+
+The proposed tagged-value surface exports:
+
+- `validateCanonicalValue`
+- `encodeCanonicalValue` and `encodeCanonicalValueToString`
+- `decodeCanonicalValue`
+- `hashCanonicalValue`
+- `ProtocolValueError` and stable error-code types
+- tagged-value, option, and limit types
+
+The raw conformance digest is not a deployment identity or shared cache key.
+Those domains require separate, versioned, domain-separated contracts.
 
 ## Runtime compatibility
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -17,6 +17,9 @@
     "dist",
     "README.md"
   ],
+  "dependencies": {
+    "@noble/hashes": "^1.8.0"
+  },
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "dev": "tsc --project tsconfig.json --watch",

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -2,7 +2,15 @@ import { describe, expect, it } from 'vitest';
 import * as protocol from './index.js';
 
 describe('@hypequery/protocol scaffold', () => {
-  it('does not expose a protocol before its normative contracts are accepted', () => {
-    expect(Object.keys(protocol)).toEqual([]);
+  it('exports only the reviewed canonical value surface', () => {
+    expect(Object.keys(protocol).sort()).toEqual([
+      'DEFAULT_CANONICAL_VALUE_LIMITS',
+      'ProtocolValueError',
+      'decodeCanonicalValue',
+      'encodeCanonicalValue',
+      'encodeCanonicalValueToString',
+      'hashCanonicalValue',
+      'validateCanonicalValue',
+    ]);
   });
 });

--- a/packages/protocol/src/values/codec.test.ts
+++ b/packages/protocol/src/values/codec.test.ts
@@ -1,0 +1,197 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  ProtocolValueError,
+  decodeCanonicalValue,
+  encodeCanonicalValue,
+  encodeCanonicalValueToString,
+  hashCanonicalValue,
+  validateCanonicalValue,
+} from './index.js';
+
+interface SuccessFixture {
+  id: string;
+  value: unknown;
+  canonicalHex: string;
+  sha256: string;
+}
+
+interface RejectionFixture {
+  id: string;
+  sourceUtf8?: string;
+  value?: unknown;
+  generator?: {
+    type: string;
+    depth?: number;
+    leaf?: unknown;
+    items?: number;
+    value?: unknown;
+    utf8?: string;
+    count?: number;
+  };
+  error: string;
+}
+
+function readFixture<T>(name: string): T {
+  const path = fileURLToPath(new URL(
+    `../../../../specs/security-protocol/fixtures/tagged-values-v1/${name}`,
+    import.meta.url,
+  ));
+  return JSON.parse(readFileSync(path, 'utf8')) as T;
+}
+
+function arrayValue(values: unknown[]): unknown {
+  return { $hypequery: { type: 'array', version: 1, values } };
+}
+
+function generateRejection(generator: NonNullable<RejectionFixture['generator']>): unknown {
+  switch (generator.type) {
+    case 'nested-array': {
+      let value = generator.leaf;
+      for (let depth = 0; depth < (generator.depth ?? 0); depth += 1) {
+        value = arrayValue([value]);
+      }
+      return value;
+    }
+    case 'array': return arrayValue(
+      Array.from({ length: generator.items ?? 0 }, () => generator.value),
+    );
+    case 'repeat-string': return (generator.utf8 ?? '').repeat(generator.count ?? 0);
+    default: throw new Error(`Unknown fixture generator: ${generator.type}`);
+  }
+}
+
+function expectProtocolError(action: () => unknown, code: string): void {
+  try {
+    action();
+    throw new Error('Expected protocol operation to fail');
+  } catch (error) {
+    expect(error).toBeInstanceOf(ProtocolValueError);
+    expect((error as ProtocolValueError).code).toBe(code);
+    expect((error as Error).message).not.toContain('region');
+  }
+}
+
+describe('canonical value codec', () => {
+  const success = readFixture<SuccessFixture[]>('success.json');
+  const rejections = readFixture<RejectionFixture[]>('rejections.json');
+
+  it.each(success)('$id matches canonical bytes, hash, and decode fixtures', (fixture) => {
+    const bytes = encodeCanonicalValue(fixture.value);
+    expect(Buffer.from(bytes).toString('hex')).toBe(fixture.canonicalHex);
+    expect(encodeCanonicalValueToString(fixture.value))
+      .toBe(Buffer.from(fixture.canonicalHex, 'hex').toString('utf8'));
+    expect(hashCanonicalValue(fixture.value)).toBe(fixture.sha256);
+    expect(decodeCanonicalValue(bytes)).toEqual(fixture.value);
+  });
+
+  it.each(rejections)('rejects $id with its stable code', (fixture) => {
+    const action = fixture.sourceUtf8 !== undefined
+      ? () => decodeCanonicalValue(fixture.sourceUtf8 as string)
+      : () => validateCanonicalValue(
+        fixture.generator ? generateRejection(fixture.generator) : fixture.value,
+      );
+    expectProtocolError(action, fixture.error);
+  });
+
+  it('returns a detached deeply frozen snapshot', () => {
+    const input = arrayValue(['original']) as {
+      $hypequery: { values: string[] };
+    };
+    const value = validateCanonicalValue(input) as {
+      readonly $hypequery: { readonly values: readonly string[] };
+    };
+
+    input.$hypequery.values[0] = 'changed';
+    expect(value.$hypequery.values[0]).toBe('original');
+    expect(Object.isFrozen(value)).toBe(true);
+    expect(Object.isFrozen(value.$hypequery)).toBe(true);
+    expect(Object.isFrozen(value.$hypequery.values)).toBe(true);
+  });
+
+  it('never invokes getters or toJSON', () => {
+    let getterCalls = 0;
+    let toJsonCalls = 0;
+    const getterInput = Object.defineProperty({}, '$hypequery', {
+      enumerable: true,
+      get() {
+        getterCalls += 1;
+        return { type: 'uuid', version: 1, value: '01890f3e-7b7b-7cc2-98c4-dc0c0c07398f' };
+      },
+    });
+    const serializerInput = {
+      toJSON() {
+        toJsonCalls += 1;
+        return null;
+      },
+    };
+
+    expectProtocolError(
+      () => validateCanonicalValue(getterInput),
+      'HQ_VALUE_UNSAFE_OBJECT',
+    );
+    expectProtocolError(
+      () => validateCanonicalValue(serializerInput),
+      'HQ_VALUE_UNSAFE_OBJECT',
+    );
+    expect(getterCalls).toBe(0);
+    expect(toJsonCalls).toBe(0);
+  });
+
+  it('snapshots proxy data without invoking value get traps', () => {
+    let getCalls = 0;
+    const input = new Proxy(
+      { $hypequery: { type: 'integer', version: 1, bits: 8, signed: true, value: '1' } },
+      {
+        get(target, property, receiver) {
+          getCalls += 1;
+          return Reflect.get(target, property, receiver);
+        },
+      },
+    );
+
+    expect(encodeCanonicalValueToString(input)).toContain('integer');
+    expect(getCalls).toBe(0);
+  });
+
+  it('rejects sparse arrays, symbols, custom prototypes, and cycles', () => {
+    const sparse = arrayValue(new Array(1));
+    const symbol = arrayValue([null]) as Record<PropertyKey, unknown>;
+    symbol[Symbol('hidden')] = true;
+    const custom = Object.create({ inherited: true }) as Record<string, unknown>;
+    custom.$hypequery = { type: 'array', version: 1, values: [] };
+    const cyclic = arrayValue([]) as { $hypequery: { values: unknown[] } };
+    cyclic.$hypequery.values.push(cyclic);
+
+    expectProtocolError(() => validateCanonicalValue(sparse), 'HQ_VALUE_INVALID_FORMAT');
+    expectProtocolError(() => validateCanonicalValue(symbol), 'HQ_VALUE_UNSAFE_OBJECT');
+    expectProtocolError(() => validateCanonicalValue(custom), 'HQ_VALUE_UNSAFE_OBJECT');
+    expectProtocolError(() => validateCanonicalValue(cyclic), 'HQ_VALUE_INVALID_FORMAT');
+  });
+
+  it('supports lower product limits but rejects attempts to raise protocol limits', () => {
+    expectProtocolError(
+      () => validateCanonicalValue('12345', { limits: { maxStringBytes: 4 } }),
+      'HQ_VALUE_TOO_LARGE',
+    );
+    expect(() => validateCanonicalValue(null, { limits: { maxDepth: 17 } }))
+      .toThrow(RangeError);
+  });
+
+  it('rejects duplicate keys at nested depths before object construction', () => {
+    expectProtocolError(
+      () => decodeCanonicalValue(
+        '{"$hypequery":{"type":"tuple","version":1,"values":[{"a":1,"a":2}]}}',
+      ),
+      'HQ_VALUE_DUPLICATE_KEY',
+    );
+  });
+
+  it('rejects invalid UTF-8 byte input', () => {
+    expectProtocolError(
+      () => decodeCanonicalValue(Uint8Array.from([0xc3, 0x28])),
+      'HQ_VALUE_INVALID_UNICODE',
+    );
+  });
+});

--- a/packages/protocol/src/values/codec.test.ts
+++ b/packages/protocol/src/values/codec.test.ts
@@ -131,6 +131,18 @@ describe('canonical value codec', () => {
     expect(Object.isFrozen(value.$hypequery.values)).toBe(true);
   });
 
+  it('deeply freezes trees produced by the duplicate-aware decoder', () => {
+    const value = decodeCanonicalValue(
+      '{"$hypequery":{"type":"array","version":1,"values":["original"]}}',
+    ) as {
+      readonly $hypequery: { readonly values: readonly string[] };
+    };
+
+    expect(Object.isFrozen(value)).toBe(true);
+    expect(Object.isFrozen(value.$hypequery)).toBe(true);
+    expect(Object.isFrozen(value.$hypequery.values)).toBe(true);
+  });
+
   it('never invokes getters or toJSON', () => {
     let getterCalls = 0;
     let toJsonCalls = 0;
@@ -213,6 +225,17 @@ describe('canonical value codec', () => {
     expectProtocolError(
       () => decodeCanonicalValue(Uint8Array.from([0xc3, 0x28])),
       'HQ_VALUE_INVALID_UNICODE',
+    );
+  });
+
+  it('enforces input byte limits for obvious and multibyte string overflows', () => {
+    expectProtocolError(
+      () => decodeCanonicalValue('"aa"', { limits: { maxInputBytes: 3 } }),
+      'HQ_VALUE_TOO_LARGE',
+    );
+    expectProtocolError(
+      () => decodeCanonicalValue('"é"', { limits: { maxInputBytes: 3 } }),
+      'HQ_VALUE_TOO_LARGE',
     );
   });
 });

--- a/packages/protocol/src/values/codec.test.ts
+++ b/packages/protocol/src/values/codec.test.ts
@@ -29,7 +29,10 @@ interface RejectionFixture {
     value?: unknown;
     utf8?: string;
     count?: number;
+    branches?: number;
+    itemsPerBranch?: number;
   };
+  declaredClickHouseType?: string;
   error: string;
 }
 
@@ -57,6 +60,23 @@ function generateRejection(generator: NonNullable<RejectionFixture['generator']>
     case 'array': return arrayValue(
       Array.from({ length: generator.items ?? 0 }, () => generator.value),
     );
+    case 'array-tree': return arrayValue(
+      Array.from(
+        { length: generator.branches ?? 0 },
+        () => arrayValue(
+          Array.from(
+            { length: generator.itemsPerBranch ?? 0 },
+            () => generator.value,
+          ),
+        ),
+      ),
+    );
+    case 'non-finite-float': {
+      if (generator.value === 'NaN') return Number.NaN;
+      if (generator.value === 'Infinity') return Number.POSITIVE_INFINITY;
+      if (generator.value === '-Infinity') return Number.NEGATIVE_INFINITY;
+      throw new Error(`Unknown non-finite float: ${String(generator.value)}`);
+    }
     case 'repeat-string': return (generator.utf8 ?? '').repeat(generator.count ?? 0);
     default: throw new Error(`Unknown fixture generator: ${generator.type}`);
   }
@@ -91,6 +111,7 @@ describe('canonical value codec', () => {
       ? () => decodeCanonicalValue(fixture.sourceUtf8 as string)
       : () => validateCanonicalValue(
         fixture.generator ? generateRejection(fixture.generator) : fixture.value,
+        { declaredClickHouseType: fixture.declaredClickHouseType },
       );
     expectProtocolError(action, fixture.error);
   });

--- a/packages/protocol/src/values/codec.ts
+++ b/packages/protocol/src/values/codec.ts
@@ -14,7 +14,10 @@ function prepare(
   options: CanonicalValueOptions,
 ): { value: CanonicalValue; canonical: string; bytes: Uint8Array } {
   const limits = resolveLimits(options);
-  const value = validateCanonicalValue(input, { limits });
+  const value = validateCanonicalValue(input, {
+    limits,
+    declaredClickHouseType: options.declaredClickHouseType,
+  });
   const canonical = serializeJcs(value);
   const bytes = textEncoder.encode(canonical);
   if (bytes.byteLength > limits.maxCanonicalBytes) {
@@ -49,7 +52,10 @@ export function decodeCanonicalValue(
 ): CanonicalValue {
   const limits = resolveLimits(options);
   const parsed = parseDuplicateAwareJson(input, limits);
-  return validateCanonicalValue(parsed, { limits });
+  return validateCanonicalValue(parsed, {
+    limits,
+    declaredClickHouseType: options.declaredClickHouseType,
+  });
 }
 
 /** Raw conformance hash only; deployment and cache domains are specified later. */

--- a/packages/protocol/src/values/codec.ts
+++ b/packages/protocol/src/values/codec.ts
@@ -5,7 +5,10 @@ import { serializeJcs } from './jcs.js';
 import { resolveLimits } from './limits.js';
 import { parseDuplicateAwareJson } from './parser.js';
 import type { CanonicalValue, CanonicalValueOptions } from './types.js';
-import { validateCanonicalValue } from './validate.js';
+import {
+  validateCanonicalValueWithLimits,
+  validateParsedCanonicalValue,
+} from './validate.js';
 
 const textEncoder = new TextEncoder();
 
@@ -14,10 +17,11 @@ function prepare(
   options: CanonicalValueOptions,
 ): { value: CanonicalValue; canonical: string; bytes: Uint8Array } {
   const limits = resolveLimits(options);
-  const value = validateCanonicalValue(input, {
+  const value = validateCanonicalValueWithLimits(
+    input,
     limits,
-    declaredClickHouseType: options.declaredClickHouseType,
-  });
+    options.declaredClickHouseType,
+  );
   const canonical = serializeJcs(value);
   const bytes = textEncoder.encode(canonical);
   if (bytes.byteLength > limits.maxCanonicalBytes) {
@@ -52,10 +56,11 @@ export function decodeCanonicalValue(
 ): CanonicalValue {
   const limits = resolveLimits(options);
   const parsed = parseDuplicateAwareJson(input, limits);
-  return validateCanonicalValue(parsed, {
+  return validateParsedCanonicalValue(
+    parsed,
     limits,
-    declaredClickHouseType: options.declaredClickHouseType,
-  });
+    options.declaredClickHouseType,
+  );
 }
 
 /** Raw conformance hash only; deployment and cache domains are specified later. */

--- a/packages/protocol/src/values/codec.ts
+++ b/packages/protocol/src/values/codec.ts
@@ -1,0 +1,61 @@
+import { sha256 } from '@noble/hashes/sha2';
+import { bytesToHex } from '@noble/hashes/utils';
+import { valueError } from './errors.js';
+import { serializeJcs } from './jcs.js';
+import { resolveLimits } from './limits.js';
+import { parseDuplicateAwareJson } from './parser.js';
+import type { CanonicalValue, CanonicalValueOptions } from './types.js';
+import { validateCanonicalValue } from './validate.js';
+
+const textEncoder = new TextEncoder();
+
+function prepare(
+  input: unknown,
+  options: CanonicalValueOptions,
+): { value: CanonicalValue; canonical: string; bytes: Uint8Array } {
+  const limits = resolveLimits(options);
+  const value = validateCanonicalValue(input, { limits });
+  const canonical = serializeJcs(value);
+  const bytes = textEncoder.encode(canonical);
+  if (bytes.byteLength > limits.maxCanonicalBytes) {
+    valueError('HQ_VALUE_TOO_LARGE');
+  }
+  return { value, canonical, bytes };
+}
+
+/** Validates plain data and returns exact RFC 8785 canonical UTF-8 bytes. */
+export function encodeCanonicalValue(
+  input: unknown,
+  options: CanonicalValueOptions = {},
+): Uint8Array {
+  return prepare(input, options).bytes;
+}
+
+/** String form of the exact bytes returned by `encodeCanonicalValue`. */
+export function encodeCanonicalValueToString(
+  input: unknown,
+  options: CanonicalValueOptions = {},
+): string {
+  return prepare(input, options).canonical;
+}
+
+/**
+ * Parses duplicate-aware UTF-8/JSON and returns a validated, deeply frozen
+ * canonical value. Input need not already use canonical object-key ordering.
+ */
+export function decodeCanonicalValue(
+  input: string | Uint8Array,
+  options: CanonicalValueOptions = {},
+): CanonicalValue {
+  const limits = resolveLimits(options);
+  const parsed = parseDuplicateAwareJson(input, limits);
+  return validateCanonicalValue(parsed, { limits });
+}
+
+/** Raw conformance hash only; deployment and cache domains are specified later. */
+export function hashCanonicalValue(
+  input: unknown,
+  options: CanonicalValueOptions = {},
+): string {
+  return bytesToHex(sha256(prepare(input, options).bytes));
+}

--- a/packages/protocol/src/values/errors.ts
+++ b/packages/protocol/src/values/errors.ts
@@ -1,0 +1,39 @@
+export type ProtocolValueErrorCode =
+  | 'HQ_VALUE_INVALID_JSON'
+  | 'HQ_VALUE_DUPLICATE_KEY'
+  | 'HQ_VALUE_INVALID_UNICODE'
+  | 'HQ_VALUE_CONTROL_CHARACTER'
+  | 'HQ_VALUE_NON_FINITE_FLOAT'
+  | 'HQ_VALUE_NEGATIVE_ZERO'
+  | 'HQ_VALUE_INTEGER_TAG_REQUIRED'
+  | 'HQ_VALUE_RAW_COMPOSITE'
+  | 'HQ_VALUE_UNKNOWN_TAG'
+  | 'HQ_VALUE_UNKNOWN_TAG_VERSION'
+  | 'HQ_VALUE_UNKNOWN_FIELD'
+  | 'HQ_VALUE_INVALID_FORMAT'
+  | 'HQ_VALUE_OUT_OF_RANGE'
+  | 'HQ_VALUE_TYPE_MISMATCH'
+  | 'HQ_VALUE_TOO_DEEP'
+  | 'HQ_VALUE_TOO_MANY_NODES'
+  | 'HQ_VALUE_TOO_MANY_ITEMS'
+  | 'HQ_VALUE_TOO_LARGE'
+  | 'HQ_VALUE_UNSAFE_OBJECT';
+
+export class ProtocolValueError extends TypeError {
+  readonly code: ProtocolValueErrorCode;
+  readonly path: string;
+
+  constructor(code: ProtocolValueErrorCode, path = '$') {
+    super(`${code} at ${path}`);
+    this.name = 'ProtocolValueError';
+    this.code = code;
+    this.path = path;
+  }
+}
+
+export function valueError(
+  code: ProtocolValueErrorCode,
+  path = '$',
+): never {
+  throw new ProtocolValueError(code, path);
+}

--- a/packages/protocol/src/values/index.ts
+++ b/packages/protocol/src/values/index.ts
@@ -1,13 +1,13 @@
 export {
-  DEFAULT_CANONICAL_VALUE_LIMITS,
-  ProtocolValueError,
   decodeCanonicalValue,
   encodeCanonicalValue,
   encodeCanonicalValueToString,
   hashCanonicalValue,
-  validateCanonicalValue,
-} from './values/index.js';
-
+} from './codec.js';
+export { ProtocolValueError } from './errors.js';
+export type { ProtocolValueErrorCode } from './errors.js';
+export { DEFAULT_CANONICAL_VALUE_LIMITS } from './limits.js';
+export { validateCanonicalValue } from './validate.js';
 export type {
   ArrayTaggedValue,
   BytesTaggedValue,
@@ -20,8 +20,7 @@ export type {
   EnumTaggedValue,
   IntegerTaggedValue,
   MapTaggedValue,
-  ProtocolValueErrorCode,
   TaggedValue,
   TupleTaggedValue,
   UuidTaggedValue,
-} from './values/index.js';
+} from './types.js';

--- a/packages/protocol/src/values/jcs.ts
+++ b/packages/protocol/src/values/jcs.ts
@@ -1,0 +1,25 @@
+import { valueError } from './errors.js';
+
+export function serializeJcs(value: unknown): string {
+  if (
+    value === null
+    || typeof value === 'boolean'
+    || typeof value === 'string'
+    || typeof value === 'number'
+  ) {
+    const encoded = JSON.stringify(value);
+    if (encoded === undefined) valueError('HQ_VALUE_INVALID_FORMAT');
+    return encoded;
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(serializeJcs).join(',')}]`;
+  }
+  if (typeof value === 'object') {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${serializeJcs(object[key])}`)
+      .join(',')}}`;
+  }
+  valueError('HQ_VALUE_INVALID_FORMAT');
+}

--- a/packages/protocol/src/values/limits.ts
+++ b/packages/protocol/src/values/limits.ts
@@ -1,0 +1,42 @@
+import type { CanonicalValueLimits, CanonicalValueOptions } from './types.js';
+
+type MutableCanonicalValueLimits = {
+  -readonly [Key in keyof CanonicalValueLimits]: CanonicalValueLimits[Key];
+};
+
+export const DEFAULT_CANONICAL_VALUE_LIMITS: Readonly<CanonicalValueLimits> = Object.freeze({
+  maxInputBytes: 1_048_576,
+  maxCanonicalBytes: 1_048_576,
+  maxDepth: 16,
+  maxNodes: 10_000,
+  maxCollectionItems: 1_000,
+  maxStringBytes: 65_536,
+  maxDecodedBytes: 65_536,
+});
+
+export function resolveLimits(
+  options: CanonicalValueOptions = {},
+): Readonly<CanonicalValueLimits> {
+  const resolved: MutableCanonicalValueLimits = { ...DEFAULT_CANONICAL_VALUE_LIMITS };
+
+  if (!options.limits) {
+    return resolved;
+  }
+
+  for (const key of Object.keys(options.limits) as (keyof CanonicalValueLimits)[]) {
+    const value = options.limits[key];
+    if (
+      value === undefined
+      || !Number.isSafeInteger(value)
+      || value < 1
+      || value > DEFAULT_CANONICAL_VALUE_LIMITS[key]
+    ) {
+      throw new RangeError(
+        `${key} must be a positive integer no greater than the protocol v1 maximum`,
+      );
+    }
+    resolved[key] = value;
+  }
+
+  return Object.freeze(resolved);
+}

--- a/packages/protocol/src/values/parser.ts
+++ b/packages/protocol/src/values/parser.ts
@@ -1,6 +1,8 @@
 import { valueError } from './errors.js';
 import type { CanonicalValueLimits } from './types.js';
 
+const textEncoder = new TextEncoder();
+
 class DuplicateAwareJsonParser {
   private index = 0;
   private syntaxNodes = 0;
@@ -249,8 +251,11 @@ export function parseDuplicateAwareJson(
   let byteLength: number;
 
   if (typeof input === 'string') {
+    if (input.length > limits.maxInputBytes) {
+      valueError('HQ_VALUE_TOO_LARGE');
+    }
     source = input;
-    byteLength = new TextEncoder().encode(input).byteLength;
+    byteLength = textEncoder.encode(input).byteLength;
   } else if (input instanceof Uint8Array) {
     byteLength = input.byteLength;
     try {

--- a/packages/protocol/src/values/parser.ts
+++ b/packages/protocol/src/values/parser.ts
@@ -1,0 +1,273 @@
+import { valueError } from './errors.js';
+import type { CanonicalValueLimits } from './types.js';
+
+class DuplicateAwareJsonParser {
+  private index = 0;
+  private syntaxNodes = 0;
+
+  constructor(
+    private readonly source: string,
+    private readonly limits: Readonly<CanonicalValueLimits>,
+  ) {}
+
+  parse(): unknown {
+    this.skipWhitespace();
+    const value = this.parseValue(0);
+    this.skipWhitespace();
+    if (this.index !== this.source.length) {
+      valueError('HQ_VALUE_INVALID_JSON');
+    }
+    return value;
+  }
+
+  private parseValue(depth: number): unknown {
+    this.syntaxNodes += 1;
+    if (this.syntaxNodes > this.limits.maxNodes * 16) {
+      valueError('HQ_VALUE_TOO_MANY_NODES');
+    }
+    if (depth > this.limits.maxDepth * 4 + 8) {
+      valueError('HQ_VALUE_TOO_DEEP');
+    }
+
+    const token = this.source[this.index];
+    if (token === '"') return this.parseString();
+    if (token === '{') return this.parseObject(depth + 1);
+    if (token === '[') return this.parseArray(depth + 1);
+    if (token === 't') return this.parseLiteral('true', true);
+    if (token === 'f') return this.parseLiteral('false', false);
+    if (token === 'n') return this.parseLiteral('null', null);
+    if (token === '-' || (token !== undefined && token >= '0' && token <= '9')) {
+      return this.parseNumber();
+    }
+    valueError('HQ_VALUE_INVALID_JSON');
+  }
+
+  private parseLiteral<T>(source: string, value: T): T {
+    if (this.source.slice(this.index, this.index + source.length) !== source) {
+      valueError('HQ_VALUE_INVALID_JSON');
+    }
+    this.index += source.length;
+    return value;
+  }
+
+  private parseObject(depth: number): Record<string, unknown> {
+    this.index += 1;
+    this.skipWhitespace();
+    const result = Object.create(null) as Record<string, unknown>;
+    const keys = new Set<string>();
+
+    if (this.source[this.index] === '}') {
+      this.index += 1;
+      return result;
+    }
+
+    while (true) {
+      if (this.source[this.index] !== '"') {
+        valueError('HQ_VALUE_INVALID_JSON');
+      }
+      const key = this.parseString();
+      if (keys.has(key)) {
+        valueError('HQ_VALUE_DUPLICATE_KEY');
+      }
+      keys.add(key);
+      this.skipWhitespace();
+      if (this.source[this.index] !== ':') {
+        valueError('HQ_VALUE_INVALID_JSON');
+      }
+      this.index += 1;
+      this.skipWhitespace();
+      const value = this.parseValue(depth);
+      Object.defineProperty(result, key, {
+        value,
+        enumerable: true,
+        configurable: false,
+        writable: false,
+      });
+      this.skipWhitespace();
+
+      const separator = this.source[this.index];
+      if (separator === '}') {
+        this.index += 1;
+        return result;
+      }
+      if (separator !== ',') {
+        valueError('HQ_VALUE_INVALID_JSON');
+      }
+      this.index += 1;
+      this.skipWhitespace();
+    }
+  }
+
+  private parseArray(depth: number): unknown[] {
+    this.index += 1;
+    this.skipWhitespace();
+    const result: unknown[] = [];
+
+    if (this.source[this.index] === ']') {
+      this.index += 1;
+      return result;
+    }
+
+    while (true) {
+      result.push(this.parseValue(depth));
+      this.skipWhitespace();
+      const separator = this.source[this.index];
+      if (separator === ']') {
+        this.index += 1;
+        return result;
+      }
+      if (separator !== ',') {
+        valueError('HQ_VALUE_INVALID_JSON');
+      }
+      this.index += 1;
+      this.skipWhitespace();
+    }
+  }
+
+  private parseString(): string {
+    this.index += 1;
+    let result = '';
+
+    while (this.index < this.source.length) {
+      const character = this.source[this.index];
+      if (character === '"') {
+        this.index += 1;
+        return result;
+      }
+      if (character === '\\') {
+        this.index += 1;
+        result += this.parseEscape();
+        continue;
+      }
+
+      const code = this.source.charCodeAt(this.index);
+      if (code <= 0x1f) {
+        valueError('HQ_VALUE_INVALID_JSON');
+      }
+      if (code >= 0xd800 && code <= 0xdbff) {
+        const low = this.source.charCodeAt(this.index + 1);
+        if (low < 0xdc00 || low > 0xdfff) {
+          valueError('HQ_VALUE_INVALID_UNICODE');
+        }
+        result += character + this.source[this.index + 1];
+        this.index += 2;
+        continue;
+      }
+      if (code >= 0xdc00 && code <= 0xdfff) {
+        valueError('HQ_VALUE_INVALID_UNICODE');
+      }
+      result += character;
+      this.index += 1;
+    }
+
+    valueError('HQ_VALUE_INVALID_JSON');
+  }
+
+  private parseEscape(): string {
+    const escape = this.source[this.index];
+    this.index += 1;
+    const simple: Record<string, string> = {
+      '"': '"',
+      '\\': '\\',
+      '/': '/',
+      b: '\b',
+      f: '\f',
+      n: '\n',
+      r: '\r',
+      t: '\t',
+    };
+    if (escape !== undefined && Object.hasOwn(simple, escape)) {
+      return simple[escape];
+    }
+    if (escape !== 'u') {
+      valueError('HQ_VALUE_INVALID_JSON');
+    }
+
+    const high = this.parseHexCodeUnit();
+    if (high >= 0xd800 && high <= 0xdbff) {
+      if (this.source.slice(this.index, this.index + 2) !== '\\u') {
+        valueError('HQ_VALUE_INVALID_UNICODE');
+      }
+      this.index += 2;
+      const low = this.parseHexCodeUnit();
+      if (low < 0xdc00 || low > 0xdfff) {
+        valueError('HQ_VALUE_INVALID_UNICODE');
+      }
+      return String.fromCharCode(high, low);
+    }
+    if (high >= 0xdc00 && high <= 0xdfff) {
+      valueError('HQ_VALUE_INVALID_UNICODE');
+    }
+    return String.fromCharCode(high);
+  }
+
+  private parseHexCodeUnit(): number {
+    const value = this.source.slice(this.index, this.index + 4);
+    if (!/^[0-9a-fA-F]{4}$/.test(value)) {
+      valueError('HQ_VALUE_INVALID_JSON');
+    }
+    this.index += 4;
+    return Number.parseInt(value, 16);
+  }
+
+  private parseNumber(): number {
+    const match = this.source.slice(this.index).match(
+      /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/,
+    );
+    if (!match) {
+      valueError('HQ_VALUE_INVALID_JSON');
+    }
+    const token = match[0];
+    this.index += token.length;
+    const value = Number(token);
+    if (!Number.isFinite(value)) {
+      valueError('HQ_VALUE_NON_FINITE_FLOAT');
+    }
+    if (Object.is(value, -0)) {
+      valueError('HQ_VALUE_NEGATIVE_ZERO');
+    }
+    return value;
+  }
+
+  private skipWhitespace(): void {
+    while (
+      this.source[this.index] === ' '
+      || this.source[this.index] === '\n'
+      || this.source[this.index] === '\r'
+      || this.source[this.index] === '\t'
+    ) {
+      this.index += 1;
+    }
+  }
+}
+
+export function parseDuplicateAwareJson(
+  input: string | Uint8Array,
+  limits: Readonly<CanonicalValueLimits>,
+): unknown {
+  let source: string;
+  let byteLength: number;
+
+  if (typeof input === 'string') {
+    source = input;
+    byteLength = new TextEncoder().encode(input).byteLength;
+  } else if (input instanceof Uint8Array) {
+    byteLength = input.byteLength;
+    try {
+      source = new TextDecoder('utf-8', { fatal: true }).decode(input);
+    } catch {
+      valueError('HQ_VALUE_INVALID_UNICODE');
+    }
+  } else {
+    valueError('HQ_VALUE_INVALID_JSON');
+  }
+
+  if (byteLength > limits.maxInputBytes) {
+    valueError('HQ_VALUE_TOO_LARGE');
+  }
+  if (source.charCodeAt(0) === 0xfeff) {
+    valueError('HQ_VALUE_INVALID_JSON');
+  }
+
+  return new DuplicateAwareJsonParser(source, limits).parse();
+}

--- a/packages/protocol/src/values/snapshot.ts
+++ b/packages/protocol/src/values/snapshot.ts
@@ -1,0 +1,155 @@
+import { valueError } from './errors.js';
+import type { CanonicalValueLimits } from './types.js';
+
+interface SnapshotState {
+  readonly limits: Readonly<CanonicalValueLimits>;
+  readonly active: WeakSet<object>;
+  nodes: number;
+}
+
+function incrementNodes(state: SnapshotState, path: string): void {
+  state.nodes += 1;
+  // Structural tag fields add overhead beyond logical value nodes. This guard
+  // prevents unbounded allocation before exact logical validation runs.
+  if (state.nodes > state.limits.maxNodes * 16) {
+    valueError('HQ_VALUE_TOO_MANY_NODES', path);
+  }
+}
+
+function snapshotArray(
+  input: readonly unknown[],
+  state: SnapshotState,
+  path: string,
+  syntaxDepth: number,
+): unknown[] {
+  const descriptors = Object.getOwnPropertyDescriptors(input) as unknown as Record<
+    PropertyKey,
+    PropertyDescriptor
+  >;
+  const ownKeys = Reflect.ownKeys(descriptors);
+  const lengthDescriptor = descriptors.length;
+
+  if (!lengthDescriptor || typeof lengthDescriptor.value !== 'number') {
+    valueError('HQ_VALUE_UNSAFE_OBJECT', path);
+  }
+
+  const length = lengthDescriptor.value;
+  if (!Number.isSafeInteger(length) || length < 0 || length > state.limits.maxNodes * 2) {
+    valueError('HQ_VALUE_TOO_MANY_NODES', path);
+  }
+
+  for (const key of ownKeys) {
+    if (key === 'length') continue;
+    if (typeof key !== 'string' || !/^(0|[1-9]\d*)$/.test(key)) {
+      valueError('HQ_VALUE_UNSAFE_OBJECT', path);
+    }
+  }
+
+  const result: unknown[] = [];
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = descriptors[String(index)];
+    if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) {
+      valueError('HQ_VALUE_INVALID_FORMAT', `${path}[${index}]`);
+    }
+    result.push(snapshotUnknown(
+      descriptor.value,
+      state,
+      `${path}[${index}]`,
+      syntaxDepth + 1,
+    ));
+  }
+
+  return result;
+}
+
+function snapshotObject(
+  input: object,
+  state: SnapshotState,
+  path: string,
+  syntaxDepth: number,
+): Record<string, unknown> {
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    valueError('HQ_VALUE_UNSAFE_OBJECT', path);
+  }
+
+  const descriptors = Object.getOwnPropertyDescriptors(input) as unknown as Record<
+    PropertyKey,
+    PropertyDescriptor
+  >;
+  const result: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
+
+  for (const key of Reflect.ownKeys(descriptors)) {
+    if (typeof key !== 'string') {
+      valueError('HQ_VALUE_UNSAFE_OBJECT', path);
+    }
+    const descriptor = descriptors[key];
+    if (!descriptor || !('value' in descriptor) || !descriptor.enumerable) {
+      valueError('HQ_VALUE_UNSAFE_OBJECT', `${path}.${key}`);
+    }
+    Object.defineProperty(result, key, {
+      value: snapshotUnknown(
+        descriptor.value,
+        state,
+        `${path}.${key}`,
+        syntaxDepth + 1,
+      ),
+      enumerable: true,
+      configurable: false,
+      writable: false,
+    });
+  }
+
+  return result;
+}
+
+function snapshotUnknown(
+  input: unknown,
+  state: SnapshotState,
+  path: string,
+  syntaxDepth: number,
+): unknown {
+  incrementNodes(state, path);
+
+  if (syntaxDepth > state.limits.maxDepth * 4 + 8) {
+    valueError('HQ_VALUE_TOO_DEEP', path);
+  }
+
+  if (
+    input === null
+    || typeof input === 'boolean'
+    || typeof input === 'string'
+    || typeof input === 'number'
+  ) {
+    return input;
+  }
+
+  if (typeof input !== 'object') {
+    valueError('HQ_VALUE_UNSAFE_OBJECT', path);
+  }
+
+  if (state.active.has(input)) {
+    valueError('HQ_VALUE_INVALID_FORMAT', path);
+  }
+  state.active.add(input);
+
+  try {
+    if (Array.isArray(input)) {
+      return snapshotArray(input, state, path, syntaxDepth);
+    }
+    return snapshotObject(input, state, path, syntaxDepth);
+  } finally {
+    state.active.delete(input);
+  }
+}
+
+export function snapshotPlainData(
+  input: unknown,
+  limits: Readonly<CanonicalValueLimits>,
+): unknown {
+  return snapshotUnknown(input, {
+    limits,
+    active: new WeakSet<object>(),
+    nodes: 0,
+  }, '$', 0);
+}

--- a/packages/protocol/src/values/types.ts
+++ b/packages/protocol/src/values/types.ts
@@ -11,6 +11,8 @@ export interface CanonicalValueLimits {
 export interface CanonicalValueOptions {
   /** Product policy may lower, but never raise, the version 1 limits. */
   readonly limits?: Partial<CanonicalValueLimits>;
+  /** Containing ClickHouse type when validation depends on schema context. */
+  readonly declaredClickHouseType?: string;
 }
 
 interface TagEnvelope<T> {

--- a/packages/protocol/src/values/types.ts
+++ b/packages/protocol/src/values/types.ts
@@ -1,0 +1,99 @@
+export interface CanonicalValueLimits {
+  readonly maxInputBytes: number;
+  readonly maxCanonicalBytes: number;
+  readonly maxDepth: number;
+  readonly maxNodes: number;
+  readonly maxCollectionItems: number;
+  readonly maxStringBytes: number;
+  readonly maxDecodedBytes: number;
+}
+
+export interface CanonicalValueOptions {
+  /** Product policy may lower, but never raise, the version 1 limits. */
+  readonly limits?: Partial<CanonicalValueLimits>;
+}
+
+interface TagEnvelope<T> {
+  readonly $hypequery: T;
+}
+
+interface VersionOneTag {
+  readonly type: string;
+  readonly version: 1;
+}
+
+export type IntegerTaggedValue = TagEnvelope<VersionOneTag & {
+  readonly type: 'integer';
+  readonly bits: 8 | 16 | 32 | 64 | 128 | 256;
+  readonly signed: boolean;
+  readonly value: string;
+}>;
+
+export type DecimalTaggedValue = TagEnvelope<VersionOneTag & {
+  readonly type: 'decimal';
+  readonly coefficient: string;
+  readonly precision: number;
+  readonly scale: number;
+}>;
+
+export type DateTaggedValue = TagEnvelope<VersionOneTag & {
+  readonly type: 'date';
+  readonly clickhouseType: 'Date' | 'Date32';
+  readonly value: string;
+}>;
+
+export type DatetimeTaggedValue = TagEnvelope<VersionOneTag & {
+  readonly type: 'datetime';
+  readonly clickhouseType: 'DateTime' | 'DateTime64';
+  readonly precision: number;
+  readonly timezone: string;
+  readonly value: string;
+}>;
+
+export type UuidTaggedValue = TagEnvelope<VersionOneTag & {
+  readonly type: 'uuid';
+  readonly value: string;
+}>;
+
+export type BytesTaggedValue = TagEnvelope<VersionOneTag & {
+  readonly type: 'bytes';
+  readonly encoding: 'base64url';
+  readonly value: string;
+}>;
+
+export type EnumTaggedValue = TagEnvelope<VersionOneTag & {
+  readonly type: 'enum';
+  readonly bits: 8 | 16;
+  readonly code: number;
+  readonly label: string;
+}>;
+
+export type ArrayTaggedValue = TagEnvelope<VersionOneTag & {
+  readonly type: 'array';
+  readonly values: readonly CanonicalValue[];
+}>;
+
+export type TupleTaggedValue = TagEnvelope<VersionOneTag & {
+  readonly type: 'tuple';
+  readonly values: readonly CanonicalValue[];
+}>;
+
+export type MapTaggedValue = TagEnvelope<VersionOneTag & {
+  readonly type: 'map';
+  readonly entries: readonly (readonly [CanonicalValue, CanonicalValue])[];
+}>;
+
+export type TaggedValue =
+  | IntegerTaggedValue
+  | DecimalTaggedValue
+  | DateTaggedValue
+  | DatetimeTaggedValue
+  | UuidTaggedValue
+  | BytesTaggedValue
+  | EnumTaggedValue
+  | ArrayTaggedValue
+  | TupleTaggedValue
+  | MapTaggedValue;
+
+/** Native numbers always carry floating-point semantics. Integers are tagged. */
+export type CanonicalValue = null | boolean | string | number | TaggedValue;

--- a/packages/protocol/src/values/validate.ts
+++ b/packages/protocol/src/values/validate.ts
@@ -63,7 +63,7 @@ function requireMetadataInteger(value: unknown, path: string): number {
 function validateUnicode(value: string, path: string, maxBytes: number): void {
   for (let index = 0; index < value.length; index += 1) {
     const code = value.charCodeAt(index);
-    if (code <= 0x1f || code === 0x7f) {
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) {
       valueError('HQ_VALUE_CONTROL_CHARACTER', path);
     }
     if (code >= 0xd800 && code <= 0xdbff) {
@@ -356,8 +356,38 @@ export function validateCanonicalValue(
   options: CanonicalValueOptions = {},
 ): CanonicalValue {
   const limits = resolveLimits(options);
-  const snapshot = snapshotPlainData(input, limits);
-  validateValue(snapshot, { limits, nodes: 0 }, '$', 0, options.declaredClickHouseType);
+  return validateCanonicalValueWithLimits(
+    input,
+    limits,
+    options.declaredClickHouseType,
+  );
+}
+
+function validateSnapshot(
+  snapshot: unknown,
+  limits: Readonly<CanonicalValueLimits>,
+  declaredClickHouseType?: string,
+): CanonicalValue {
+  validateValue(snapshot, { limits, nodes: 0 }, '$', 0, declaredClickHouseType);
   deepFreeze(snapshot);
   return snapshot as CanonicalValue;
+}
+
+/** Package-internal path for arbitrary input when limits are already resolved. */
+export function validateCanonicalValueWithLimits(
+  input: unknown,
+  limits: Readonly<CanonicalValueLimits>,
+  declaredClickHouseType?: string,
+): CanonicalValue {
+  const snapshot = snapshotPlainData(input, limits);
+  return validateSnapshot(snapshot, limits, declaredClickHouseType);
+}
+
+/** Package-internal path for trees created by the duplicate-aware parser. */
+export function validateParsedCanonicalValue(
+  parsed: unknown,
+  limits: Readonly<CanonicalValueLimits>,
+  declaredClickHouseType?: string,
+): CanonicalValue {
+  return validateSnapshot(parsed, limits, declaredClickHouseType);
 }

--- a/packages/protocol/src/values/validate.ts
+++ b/packages/protocol/src/values/validate.ts
@@ -88,7 +88,11 @@ function validateCanonicalIntegerString(value: string, path: string): bigint {
   return BigInt(value);
 }
 
-function validateIntegerTag(tag: JsonRecord, path: string): void {
+function validateIntegerTag(
+  tag: JsonRecord,
+  path: string,
+  declaredClickHouseType?: string,
+): void {
   assertExactFields(tag, ['bits', 'signed', 'type', 'value', 'version'], path);
   const bits = requireMetadataInteger(tag.bits, `${path}.bits`);
   if (!INTEGER_BITS.has(bits)) valueError('HQ_VALUE_OUT_OF_RANGE', `${path}.bits`);
@@ -102,6 +106,10 @@ function validateIntegerTag(tag: JsonRecord, path: string): void {
   const maximum = signed ? (1n << (width - 1n)) - 1n : (1n << width) - 1n;
   if (integer < minimum || integer > maximum) {
     valueError('HQ_VALUE_OUT_OF_RANGE', `${path}.value`);
+  }
+  const actualClickHouseType = `${signed ? '' : 'U'}Int${bits}`;
+  if (declaredClickHouseType && declaredClickHouseType !== actualClickHouseType) {
+    valueError('HQ_VALUE_TYPE_MISMATCH', path);
   }
 }
 
@@ -268,6 +276,7 @@ function validateValue(
   state: ValidationState,
   path: string,
   depth: number,
+  declaredClickHouseType?: string,
 ): void {
   incrementLogicalNode(state, path);
 
@@ -279,6 +288,9 @@ function validateValue(
   if (typeof value === 'number') {
     if (!Number.isFinite(value)) valueError('HQ_VALUE_NON_FINITE_FLOAT', path);
     if (Object.is(value, -0)) valueError('HQ_VALUE_NEGATIVE_ZERO', path);
+    if (/^(?:U?Int)(?:8|16|32|64|128|256)$/.test(declaredClickHouseType ?? '')) {
+      valueError('HQ_VALUE_INTEGER_TAG_REQUIRED', path);
+    }
     return;
   }
   if (Array.isArray(value)) valueError('HQ_VALUE_RAW_COMPOSITE', path);
@@ -292,7 +304,7 @@ function validateValue(
   if (version !== 1) valueError('HQ_VALUE_UNKNOWN_TAG_VERSION', `${tagPath}.version`);
 
   switch (type) {
-    case 'integer': validateIntegerTag(tag, tagPath); return;
+    case 'integer': validateIntegerTag(tag, tagPath, declaredClickHouseType); return;
     case 'decimal': validateDecimalTag(tag, tagPath); return;
     case 'date': validateDateTag(tag, tagPath); return;
     case 'datetime': validateDatetimeTag(tag, tagPath); return;
@@ -345,7 +357,7 @@ export function validateCanonicalValue(
 ): CanonicalValue {
   const limits = resolveLimits(options);
   const snapshot = snapshotPlainData(input, limits);
-  validateValue(snapshot, { limits, nodes: 0 }, '$', 0);
+  validateValue(snapshot, { limits, nodes: 0 }, '$', 0, options.declaredClickHouseType);
   deepFreeze(snapshot);
   return snapshot as CanonicalValue;
 }

--- a/packages/protocol/src/values/validate.ts
+++ b/packages/protocol/src/values/validate.ts
@@ -1,0 +1,351 @@
+import { valueError } from './errors.js';
+import { resolveLimits } from './limits.js';
+import { snapshotPlainData } from './snapshot.js';
+import type {
+  CanonicalValue,
+  CanonicalValueLimits,
+  CanonicalValueOptions,
+} from './types.js';
+
+type JsonRecord = Record<string, unknown>;
+
+interface ValidationState {
+  readonly limits: Readonly<CanonicalValueLimits>;
+  nodes: number;
+}
+
+const INTEGER_BITS = new Set([8, 16, 32, 64, 128, 256]);
+const BASE64URL_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+const textEncoder = new TextEncoder();
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, path: string): JsonRecord {
+  if (!isRecord(value)) valueError('HQ_VALUE_INVALID_FORMAT', path);
+  return value;
+}
+
+function assertExactFields(
+  value: JsonRecord,
+  fields: readonly string[],
+  path: string,
+): void {
+  const allowed = new Set(fields);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) valueError('HQ_VALUE_UNKNOWN_FIELD', `${path}.${key}`);
+  }
+  for (const field of fields) {
+    if (!Object.hasOwn(value, field)) {
+      valueError('HQ_VALUE_INVALID_FORMAT', `${path}.${field}`);
+    }
+  }
+}
+
+function requireString(value: unknown, path: string): string {
+  if (typeof value !== 'string') valueError('HQ_VALUE_INVALID_FORMAT', path);
+  return value;
+}
+
+function requireBoolean(value: unknown, path: string): boolean {
+  if (typeof value !== 'boolean') valueError('HQ_VALUE_INVALID_FORMAT', path);
+  return value;
+}
+
+function requireMetadataInteger(value: unknown, path: string): number {
+  if (!Number.isSafeInteger(value) || Object.is(value, -0)) {
+    valueError('HQ_VALUE_INVALID_FORMAT', path);
+  }
+  return value as number;
+}
+
+function validateUnicode(value: string, path: string, maxBytes: number): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) {
+      valueError('HQ_VALUE_CONTROL_CHARACTER', path);
+    }
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const low = value.charCodeAt(index + 1);
+      if (low < 0xdc00 || low > 0xdfff) {
+        valueError('HQ_VALUE_INVALID_UNICODE', path);
+      }
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      valueError('HQ_VALUE_INVALID_UNICODE', path);
+    }
+  }
+  if (textEncoder.encode(value).byteLength > maxBytes) {
+    valueError('HQ_VALUE_TOO_LARGE', path);
+  }
+}
+
+function validateCanonicalIntegerString(value: string, path: string): bigint {
+  if (!/^(?:0|-[1-9]\d*|[1-9]\d*)$/.test(value)) {
+    valueError('HQ_VALUE_INVALID_FORMAT', path);
+  }
+  return BigInt(value);
+}
+
+function validateIntegerTag(tag: JsonRecord, path: string): void {
+  assertExactFields(tag, ['bits', 'signed', 'type', 'value', 'version'], path);
+  const bits = requireMetadataInteger(tag.bits, `${path}.bits`);
+  if (!INTEGER_BITS.has(bits)) valueError('HQ_VALUE_OUT_OF_RANGE', `${path}.bits`);
+  const signed = requireBoolean(tag.signed, `${path}.signed`);
+  const integer = validateCanonicalIntegerString(
+    requireString(tag.value, `${path}.value`),
+    `${path}.value`,
+  );
+  const width = BigInt(bits);
+  const minimum = signed ? -(1n << (width - 1n)) : 0n;
+  const maximum = signed ? (1n << (width - 1n)) - 1n : (1n << width) - 1n;
+  if (integer < minimum || integer > maximum) {
+    valueError('HQ_VALUE_OUT_OF_RANGE', `${path}.value`);
+  }
+}
+
+function validateDecimalTag(tag: JsonRecord, path: string): void {
+  assertExactFields(tag, ['coefficient', 'precision', 'scale', 'type', 'version'], path);
+  const precision = requireMetadataInteger(tag.precision, `${path}.precision`);
+  const scale = requireMetadataInteger(tag.scale, `${path}.scale`);
+  if (precision < 1 || precision > 76 || scale < 0 || scale > precision) {
+    valueError('HQ_VALUE_OUT_OF_RANGE', path);
+  }
+  const coefficient = requireString(tag.coefficient, `${path}.coefficient`);
+  validateCanonicalIntegerString(coefficient, `${path}.coefficient`);
+  if (coefficient.replace('-', '').length > precision) {
+    valueError('HQ_VALUE_OUT_OF_RANGE', `${path}.coefficient`);
+  }
+}
+
+function parseDate(value: string, path: string): { year: number; month: number; day: number } {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) valueError('HQ_VALUE_INVALID_FORMAT', path);
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const days = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (month < 1 || month > 12 || day < 1 || day > days[month - 1]) {
+    valueError('HQ_VALUE_INVALID_FORMAT', path);
+  }
+  return { year, month, day };
+}
+
+function validateDateTag(tag: JsonRecord, path: string): void {
+  assertExactFields(tag, ['clickhouseType', 'type', 'value', 'version'], path);
+  const clickhouseType = requireString(tag.clickhouseType, `${path}.clickhouseType`);
+  if (clickhouseType !== 'Date' && clickhouseType !== 'Date32') {
+    valueError('HQ_VALUE_TYPE_MISMATCH', `${path}.clickhouseType`);
+  }
+  const value = requireString(tag.value, `${path}.value`);
+  parseDate(value, `${path}.value`);
+  const minimum = clickhouseType === 'Date' ? '1970-01-01' : '1900-01-01';
+  const maximum = clickhouseType === 'Date' ? '2149-06-06' : '2299-12-31';
+  if (value < minimum || value > maximum) {
+    valueError('HQ_VALUE_OUT_OF_RANGE', `${path}.value`);
+  }
+}
+
+function validateDatetimeTag(tag: JsonRecord, path: string): void {
+  assertExactFields(
+    tag,
+    ['clickhouseType', 'precision', 'timezone', 'type', 'value', 'version'],
+    path,
+  );
+  const clickhouseType = requireString(tag.clickhouseType, `${path}.clickhouseType`);
+  if (clickhouseType !== 'DateTime' && clickhouseType !== 'DateTime64') {
+    valueError('HQ_VALUE_TYPE_MISMATCH', `${path}.clickhouseType`);
+  }
+  const precision = requireMetadataInteger(tag.precision, `${path}.precision`);
+  if (
+    (clickhouseType === 'DateTime' && precision !== 0)
+    || (clickhouseType === 'DateTime64' && (precision < 0 || precision > 9))
+  ) {
+    valueError('HQ_VALUE_OUT_OF_RANGE', `${path}.precision`);
+  }
+  const timezone = requireString(tag.timezone, `${path}.timezone`);
+  validateUnicode(timezone, `${path}.timezone`, 64);
+  if (timezone !== 'UTC' && !/^[A-Za-z_]+(?:\/[A-Za-z0-9_+-]+)+$/.test(timezone)) {
+    valueError('HQ_VALUE_INVALID_FORMAT', `${path}.timezone`);
+  }
+
+  const value = requireString(tag.value, `${path}.value`);
+  const fraction = precision === 0 ? '' : `\\.(\\d{${precision}})`;
+  const match = value.match(new RegExp(
+    `^(\\d{4}-\\d{2}-\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})${fraction}Z$`,
+  ));
+  if (!match) valueError('HQ_VALUE_INVALID_FORMAT', `${path}.value`);
+  parseDate(match[1], `${path}.value`);
+  const hour = Number(match[2]);
+  const minute = Number(match[3]);
+  const second = Number(match[4]);
+  if (hour > 23 || minute > 59 || second > 59) {
+    valueError('HQ_VALUE_INVALID_FORMAT', `${path}.value`);
+  }
+
+  if (clickhouseType === 'DateTime') {
+    if (value < '1970-01-01T00:00:00Z' || value > '2106-02-07T06:28:15Z') {
+      valueError('HQ_VALUE_OUT_OF_RANGE', `${path}.value`);
+    }
+    return;
+  }
+
+  const minimum = `1900-01-01T00:00:00${precision === 0 ? '' : `.${'0'.repeat(precision)}`}Z`;
+  const maximum = precision === 9
+    ? '2262-04-11T23:47:16.854775807Z'
+    : `2299-12-31T23:59:59${precision === 0 ? '' : `.${'9'.repeat(precision)}`}Z`;
+  if (value < minimum || value > maximum) {
+    valueError('HQ_VALUE_OUT_OF_RANGE', `${path}.value`);
+  }
+}
+
+function validateUuidTag(tag: JsonRecord, path: string): void {
+  assertExactFields(tag, ['type', 'value', 'version'], path);
+  const value = requireString(tag.value, `${path}.value`);
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(value)) {
+    valueError('HQ_VALUE_INVALID_FORMAT', `${path}.value`);
+  }
+}
+
+function validateBytesTag(
+  tag: JsonRecord,
+  path: string,
+  limits: Readonly<CanonicalValueLimits>,
+): void {
+  assertExactFields(tag, ['encoding', 'type', 'value', 'version'], path);
+  if (tag.encoding !== 'base64url') {
+    valueError('HQ_VALUE_INVALID_FORMAT', `${path}.encoding`);
+  }
+  const value = requireString(tag.value, `${path}.value`);
+  if (!/^[A-Za-z0-9_-]*$/.test(value) || value.length % 4 === 1) {
+    valueError('HQ_VALUE_INVALID_FORMAT', `${path}.value`);
+  }
+  const remainder = value.length % 4;
+  if (remainder === 2 && (BASE64URL_ALPHABET.indexOf(value.at(-1) ?? '') & 0x0f) !== 0) {
+    valueError('HQ_VALUE_INVALID_FORMAT', `${path}.value`);
+  }
+  if (remainder === 3 && (BASE64URL_ALPHABET.indexOf(value.at(-1) ?? '') & 0x03) !== 0) {
+    valueError('HQ_VALUE_INVALID_FORMAT', `${path}.value`);
+  }
+  if (Math.floor(value.length * 6 / 8) > limits.maxDecodedBytes) {
+    valueError('HQ_VALUE_TOO_LARGE', `${path}.value`);
+  }
+}
+
+function validateEnumTag(
+  tag: JsonRecord,
+  path: string,
+  limits: Readonly<CanonicalValueLimits>,
+): void {
+  assertExactFields(tag, ['bits', 'code', 'label', 'type', 'version'], path);
+  const bits = requireMetadataInteger(tag.bits, `${path}.bits`);
+  if (bits !== 8 && bits !== 16) valueError('HQ_VALUE_OUT_OF_RANGE', `${path}.bits`);
+  const code = requireMetadataInteger(tag.code, `${path}.code`);
+  const minimum = -(2 ** (bits - 1));
+  const maximum = 2 ** (bits - 1) - 1;
+  if (code < minimum || code > maximum) valueError('HQ_VALUE_OUT_OF_RANGE', `${path}.code`);
+  const label = requireString(tag.label, `${path}.label`);
+  validateUnicode(label, `${path}.label`, limits.maxStringBytes);
+}
+
+function incrementLogicalNode(state: ValidationState, path: string): void {
+  state.nodes += 1;
+  if (state.nodes > state.limits.maxNodes) {
+    valueError('HQ_VALUE_TOO_MANY_NODES', path);
+  }
+}
+
+function validateCompositeDepth(depth: number, state: ValidationState, path: string): number {
+  const next = depth + 1;
+  if (next > state.limits.maxDepth) valueError('HQ_VALUE_TOO_DEEP', path);
+  return next;
+}
+
+function validateValue(
+  value: unknown,
+  state: ValidationState,
+  path: string,
+  depth: number,
+): void {
+  incrementLogicalNode(state, path);
+
+  if (value === null || typeof value === 'boolean') return;
+  if (typeof value === 'string') {
+    validateUnicode(value, path, state.limits.maxStringBytes);
+    return;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) valueError('HQ_VALUE_NON_FINITE_FLOAT', path);
+    if (Object.is(value, -0)) valueError('HQ_VALUE_NEGATIVE_ZERO', path);
+    return;
+  }
+  if (Array.isArray(value)) valueError('HQ_VALUE_RAW_COMPOSITE', path);
+
+  const envelope = requireRecord(value, path);
+  assertExactFields(envelope, ['$hypequery'], path);
+  const tagPath = `${path}.$hypequery`;
+  const tag = requireRecord(envelope.$hypequery, tagPath);
+  const type = requireString(tag.type, `${tagPath}.type`);
+  const version = requireMetadataInteger(tag.version, `${tagPath}.version`);
+  if (version !== 1) valueError('HQ_VALUE_UNKNOWN_TAG_VERSION', `${tagPath}.version`);
+
+  switch (type) {
+    case 'integer': validateIntegerTag(tag, tagPath); return;
+    case 'decimal': validateDecimalTag(tag, tagPath); return;
+    case 'date': validateDateTag(tag, tagPath); return;
+    case 'datetime': validateDatetimeTag(tag, tagPath); return;
+    case 'uuid': validateUuidTag(tag, tagPath); return;
+    case 'bytes': validateBytesTag(tag, tagPath, state.limits); return;
+    case 'enum': validateEnumTag(tag, tagPath, state.limits); return;
+    case 'array':
+    case 'tuple': {
+      assertExactFields(tag, ['type', 'values', 'version'], tagPath);
+      if (!Array.isArray(tag.values)) valueError('HQ_VALUE_INVALID_FORMAT', `${tagPath}.values`);
+      if (tag.values.length > state.limits.maxCollectionItems) {
+        valueError('HQ_VALUE_TOO_MANY_ITEMS', `${tagPath}.values`);
+      }
+      const nextDepth = validateCompositeDepth(depth, state, path);
+      tag.values.forEach((item, index) => {
+        validateValue(item, state, `${tagPath}.values[${index}]`, nextDepth);
+      });
+      return;
+    }
+    case 'map': {
+      assertExactFields(tag, ['entries', 'type', 'version'], tagPath);
+      if (!Array.isArray(tag.entries)) valueError('HQ_VALUE_INVALID_FORMAT', `${tagPath}.entries`);
+      if (tag.entries.length > state.limits.maxCollectionItems) {
+        valueError('HQ_VALUE_TOO_MANY_ITEMS', `${tagPath}.entries`);
+      }
+      const nextDepth = validateCompositeDepth(depth, state, path);
+      tag.entries.forEach((entry, index) => {
+        const entryPath = `${tagPath}.entries[${index}]`;
+        if (!Array.isArray(entry) || entry.length !== 2) {
+          valueError('HQ_VALUE_INVALID_FORMAT', entryPath);
+        }
+        validateValue(entry[0], state, `${entryPath}[0]`, nextDepth);
+        validateValue(entry[1], state, `${entryPath}[1]`, nextDepth);
+      });
+      return;
+    }
+    default: valueError('HQ_VALUE_UNKNOWN_TAG', `${tagPath}.type`);
+  }
+}
+
+function deepFreeze(value: unknown): void {
+  if (typeof value !== 'object' || value === null || Object.isFrozen(value)) return;
+  for (const child of Object.values(value)) deepFreeze(child);
+  Object.freeze(value);
+}
+
+export function validateCanonicalValue(
+  input: unknown,
+  options: CanonicalValueOptions = {},
+): CanonicalValue {
+  const limits = resolveLimits(options);
+  const snapshot = snapshotPlainData(input, limits);
+  validateValue(snapshot, { limits, nodes: 0 }, '$', 0);
+  deepFreeze(snapshot);
+  return snapshot as CanonicalValue;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,10 @@ importers:
         version: 3.2.6(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/protocol:
+    dependencies:
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
     devDependencies:
       typescript:
         specifier: ^5.7.3

--- a/specs/security-protocol/fixtures/tagged-values-v1/rejections.json
+++ b/specs/security-protocol/fixtures/tagged-values-v1/rejections.json
@@ -30,6 +30,12 @@
     "error": "HQ_VALUE_CONTROL_CHARACTER"
   },
   {
+    "id": "control-character-c1-next-line",
+    "phase": "model",
+    "sourceUtf8": "\"\\u0085\"",
+    "error": "HQ_VALUE_CONTROL_CHARACTER"
+  },
+  {
     "id": "negative-zero",
     "phase": "model",
     "sourceUtf8": "-0",

--- a/specs/security-protocol/rfc/0001-tagged-clickhouse-value-model.md
+++ b/specs/security-protocol/rfc/0001-tagged-clickhouse-value-model.md
@@ -78,8 +78,9 @@ The following values use native JSON representations:
 
 Strings MUST contain valid Unicode scalar values, MUST be preserved without
 Unicode normalization, and MUST NOT contain C0 control characters U+0000
-through U+001F or U+007F. Quotes, backslashes, comment-looking text, and other
-ordinary Unicode remain data.
+through U+001F, DEL U+007F, or C1 control characters U+0080 through U+009F.
+Quotes, backslashes, comment-looking text, and other ordinary Unicode remain
+data.
 
 Native JSON numbers are floating-point values. NaN, positive or negative
 Infinity, and lexical negative zero are forbidden. An integer-valued JSON token

--- a/specs/security-protocol/rfc/0001-tagged-clickhouse-value-model.md
+++ b/specs/security-protocol/rfc/0001-tagged-clickhouse-value-model.md
@@ -381,6 +381,7 @@ Version 1 conformance fixtures use these minimum codes:
 - `HQ_VALUE_TOO_MANY_NODES`
 - `HQ_VALUE_TOO_MANY_ITEMS`
 - `HQ_VALUE_TOO_LARGE`
+- `HQ_VALUE_UNSAFE_OBJECT`
 
 Products may attach safe source locations and expected types, but these codes
 and their meaning are part of the frozen value contract.


### PR DESCRIPTION
## Summary

- implement the TypeScript reference validator and codec for the proposed version 1 tagged ClickHouse value model
- add duplicate-aware JSON decoding, RFC 8785 canonical encoding, fixed protocol limits, stable errors, and raw SHA-256 conformance hashes
- expose the reviewed value API from `@hypequery/protocol` and document its pre-stable status
- add adversarial and fixture-backed tests covering canonical bytes, hashes, duplicate keys, invalid Unicode, unsafe objects, limits, and deep freezing

## Why

This is roadmap task R1A-03. Cloud bundles need one deterministic, language-neutral representation of typed ClickHouse values before bundle identities, signatures, or cross-runtime compatibility can be built safely.

This PR is stacked on #277, which introduces the language-neutral RFC and conformance fixtures. It should be reviewed and merged after that prerequisite.

## Impact

This adds a proposed API to the new public `@hypequery/protocol` package and carries a minor changeset. It does not change query execution or existing behavior in ClickHouse, datasets, Serve, React, MCP, Studio, or self-hosted deployments. The raw fixture hash helper is explicitly not a deployment identity or shared cache key.

## Validation

- `pnpm install --frozen-lockfile --offline`
- `pnpm turbo run build --filter='@hypequery/*'`
- `pnpm lint`
- `pnpm types`
- `pnpm test`
- focused protocol suite: 90 tests passing