### PR TITLE
Define portable protocol identifiers

### DIFF
--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -17,9 +17,10 @@ The normative source is
 
 The package contains deterministic, framework-independent implementations of
 accepted protocol rules. The current implementation provides strict tagged
-value validation, RFC 8785 canonical encoding, duplicate-aware decoding, and a
-raw SHA-256 conformance digest. Identifiers, portable AST structures, artifact
-envelopes, and compatibility checks will follow in separate changes.
+value validation, RFC 8785 canonical encoding, duplicate-aware decoding, a raw
+SHA-256 conformance digest, and draft portable logical identifiers. Portable
+AST structures, artifact envelopes, and compatibility checks will follow in
+separate changes.
 
 It will not connect to ClickHouse, execute queries, load project source, access
 credentials or the environment, perform network or filesystem I/O, implement
@@ -46,6 +47,10 @@ The proposed tagged-value surface exports:
 
 The raw conformance digest is not a deployment identity or shared cache key.
 Those domains require separate, versioned, domain-separated contracts.
+
+The proposed identifier surface exports strict parse, guard, split, and join
+helpers for simple and dot-qualified logical identifiers. Identifiers are
+ASCII, case-sensitive, preserved exactly, and are not SQL identifiers.
 
 ## Runtime compatibility
 

--- a/packages/protocol/src/identifiers/identifiers.test.ts
+++ b/packages/protocol/src/identifiers/identifiers.test.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  ProtocolIdentifierError,
+  isProtocolIdentifier,
+  isProtocolQualifiedIdentifier,
+  joinProtocolQualifiedIdentifier,
+  parseProtocolIdentifier,
+  parseProtocolQualifiedIdentifier,
+  splitProtocolQualifiedIdentifier,
+} from './index.js';
+
+type Mode = 'simple' | 'qualified';
+
+interface SuccessFixture {
+  id: string;
+  mode: Mode;
+  value: string;
+  segments: string[];
+}
+
+interface RejectionFixture {
+  id: string;
+  mode: Mode;
+  value?: unknown;
+  generator?: {
+    type: 'repeat-string' | 'qualified-segments';
+    value?: string;
+    segment?: string;
+    count: number;
+  };
+  error: string;
+}
+
+const FAILURE_CODES = [
+  'HQ_IDENTIFIER_TYPE',
+  'HQ_IDENTIFIER_EMPTY',
+  'HQ_IDENTIFIER_TOO_LONG',
+  'HQ_IDENTIFIER_INVALID_FORMAT',
+  'HQ_IDENTIFIER_RESERVED',
+  'HQ_IDENTIFIER_TOO_MANY_SEGMENTS',
+] as const;
+
+function readFixture<T>(name: string): T {
+  const path = fileURLToPath(new URL(
+    `../../../../specs/security-protocol/fixtures/identifiers-v1/${name}`,
+    import.meta.url,
+  ));
+  return JSON.parse(readFileSync(path, 'utf8')) as T;
+}
+
+function materialize(fixture: RejectionFixture): unknown {
+  if (!fixture.generator) return fixture.value;
+  if (fixture.generator.type === 'repeat-string') {
+    return (fixture.generator.value ?? '').repeat(fixture.generator.count);
+  }
+  return Array.from(
+    { length: fixture.generator.count },
+    () => fixture.generator?.segment ?? '',
+  ).join('.');
+}
+
+describe('portable protocol identifiers', () => {
+  const success = readFixture<SuccessFixture[]>('success.json');
+  const rejections = readFixture<RejectionFixture[]>('rejections.json');
+
+  it('has unique fixture IDs and covers every stable failure code', () => {
+    const ids = [...success, ...rejections].map((fixture) => fixture.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect([...new Set(rejections.map((fixture) => fixture.error))].sort())
+      .toEqual([...FAILURE_CODES].sort());
+  });
+
+  it.each(success)('$id preserves its exact spelling', (fixture) => {
+    if (fixture.mode === 'simple') {
+      expect(parseProtocolIdentifier(fixture.value)).toBe(fixture.value);
+      expect(fixture.segments).toEqual([fixture.value]);
+      return;
+    }
+    const parsed = parseProtocolQualifiedIdentifier(fixture.value);
+    expect(parsed).toBe(fixture.value);
+    expect(splitProtocolQualifiedIdentifier(parsed)).toEqual(fixture.segments);
+    expect(joinProtocolQualifiedIdentifier(fixture.segments)).toBe(fixture.value);
+  });
+
+  it.each(rejections)('rejects $id with its stable code', (fixture) => {
+    const action = fixture.mode === 'simple'
+      ? () => parseProtocolIdentifier(materialize(fixture))
+      : () => parseProtocolQualifiedIdentifier(materialize(fixture));
+    expect(action).toThrow(ProtocolIdentifierError);
+    try {
+      action();
+    } catch (error) {
+      expect((error as ProtocolIdentifierError).code).toBe(fixture.error);
+      expect((error as Error).message).toBe(fixture.error);
+    }
+  });
+
+  it('provides non-throwing guards', () => {
+    expect(isProtocolIdentifier('RevenueByDay')).toBe(true);
+    expect(isProtocolIdentifier('orders.customer')).toBe(false);
+    expect(isProtocolQualifiedIdentifier('orders.customer')).toBe(true);
+    expect(isProtocolQualifiedIdentifier('orders..customer')).toBe(false);
+  });
+
+  it('enforces exact segment, qualified-byte, and segment-count boundaries', () => {
+    const maxSegment = 'a'.repeat(128);
+    const qualifiedAt511Bytes = Array.from({ length: 4 }, () => 'a'.repeat(127)).join('.');
+    const qualifiedAt515Bytes = Array.from({ length: 4 }, () => maxSegment).join('.');
+    const eightSegments = Array.from({ length: 8 }, () => 'a').join('.');
+
+    expect(parseProtocolIdentifier(maxSegment)).toBe(maxSegment);
+    expect(parseProtocolQualifiedIdentifier(qualifiedAt511Bytes)).toBe(qualifiedAt511Bytes);
+    expect(parseProtocolQualifiedIdentifier(eightSegments)).toBe(eightSegments);
+
+    for (const value of ['a'.repeat(129), qualifiedAt515Bytes]) {
+      try {
+        parseProtocolQualifiedIdentifier(value);
+        throw new Error('Expected identifier validation to fail');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ProtocolIdentifierError);
+        expect((error as ProtocolIdentifierError).code).toBe('HQ_IDENTIFIER_TOO_LONG');
+      }
+    }
+  });
+});

--- a/packages/protocol/src/identifiers/identifiers.test.ts
+++ b/packages/protocol/src/identifiers/identifiers.test.ts
@@ -24,12 +24,9 @@ interface RejectionFixture {
   id: string;
   mode: Mode;
   value?: unknown;
-  generator?: {
-    type: 'repeat-string' | 'qualified-segments';
-    value?: string;
-    segment?: string;
-    count: number;
-  };
+  generator?:
+    | { type: 'repeat-string'; value: string; count: number }
+    | { type: 'qualified-segments'; segment: string; count: number };
   error: string;
 }
 
@@ -52,13 +49,34 @@ function readFixture<T>(name: string): T {
 
 function materialize(fixture: RejectionFixture): unknown {
   if (!fixture.generator) return fixture.value;
-  if (fixture.generator.type === 'repeat-string') {
-    return (fixture.generator.value ?? '').repeat(fixture.generator.count);
+  const generator = fixture.generator;
+  if (!Number.isSafeInteger(generator.count) || generator.count < 0) {
+    throw new Error(`Malformed fixture "${fixture.id}": generator.count`);
+  }
+  if (generator.type === 'repeat-string') {
+    if (typeof generator.value !== 'string') {
+      throw new Error(`Malformed fixture "${fixture.id}": generator.value`);
+    }
+    return generator.value.repeat(generator.count);
+  }
+  if (typeof generator.segment !== 'string') {
+    throw new Error(`Malformed fixture "${fixture.id}": generator.segment`);
   }
   return Array.from(
-    { length: fixture.generator.count },
-    () => fixture.generator?.segment ?? '',
+    { length: generator.count },
+    () => generator.segment,
   ).join('.');
+}
+
+function expectIdentifierError(action: () => unknown, code: string): void {
+  try {
+    action();
+    throw new Error('Expected identifier validation to fail');
+  } catch (error) {
+    expect(error).toBeInstanceOf(ProtocolIdentifierError);
+    expect((error as ProtocolIdentifierError).code).toBe(code);
+    expect((error as Error).message).toBe(code);
+  }
 }
 
 describe('portable protocol identifiers', () => {
@@ -88,13 +106,7 @@ describe('portable protocol identifiers', () => {
     const action = fixture.mode === 'simple'
       ? () => parseProtocolIdentifier(materialize(fixture))
       : () => parseProtocolQualifiedIdentifier(materialize(fixture));
-    expect(action).toThrow(ProtocolIdentifierError);
-    try {
-      action();
-    } catch (error) {
-      expect((error as ProtocolIdentifierError).code).toBe(fixture.error);
-      expect((error as Error).message).toBe(fixture.error);
-    }
+    expectIdentifierError(action, fixture.error);
   });
 
   it('provides non-throwing guards', () => {
@@ -114,14 +126,13 @@ describe('portable protocol identifiers', () => {
     expect(parseProtocolQualifiedIdentifier(qualifiedAt511Bytes)).toBe(qualifiedAt511Bytes);
     expect(parseProtocolQualifiedIdentifier(eightSegments)).toBe(eightSegments);
 
-    for (const value of ['a'.repeat(129), qualifiedAt515Bytes]) {
-      try {
-        parseProtocolQualifiedIdentifier(value);
-        throw new Error('Expected identifier validation to fail');
-      } catch (error) {
-        expect(error).toBeInstanceOf(ProtocolIdentifierError);
-        expect((error as ProtocolIdentifierError).code).toBe('HQ_IDENTIFIER_TOO_LONG');
-      }
-    }
+    expectIdentifierError(
+      () => parseProtocolIdentifier('a'.repeat(129)),
+      'HQ_IDENTIFIER_TOO_LONG',
+    );
+    expectIdentifierError(
+      () => parseProtocolQualifiedIdentifier(qualifiedAt515Bytes),
+      'HQ_IDENTIFIER_TOO_LONG',
+    );
   });
 });

--- a/packages/protocol/src/identifiers/identifiers.ts
+++ b/packages/protocol/src/identifiers/identifiers.ts
@@ -76,7 +76,10 @@ export function joinProtocolQualifiedIdentifier(
   const value = segments
     .map((segment) => parseSegment(segment, 'HQ_IDENTIFIER_INVALID_FORMAT'))
     .join('.');
-  return parseProtocolQualifiedIdentifier(value);
+  if (value.length > PROTOCOL_IDENTIFIER_LIMITS.maxQualifiedBytes) {
+    identifierError('HQ_IDENTIFIER_TOO_LONG');
+  }
+  return value as ProtocolQualifiedIdentifier;
 }
 
 export function isProtocolIdentifier(input: unknown): input is ProtocolIdentifier {

--- a/packages/protocol/src/identifiers/identifiers.ts
+++ b/packages/protocol/src/identifiers/identifiers.ts
@@ -1,0 +1,100 @@
+import {
+  PROTOCOL_IDENTIFIER_LIMITS,
+  type ProtocolIdentifier,
+  type ProtocolIdentifierErrorCode,
+  type ProtocolQualifiedIdentifier,
+} from './types.js';
+
+const IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const RESERVED_PREFIX = '__hypequery';
+const textEncoder = new TextEncoder();
+
+export class ProtocolIdentifierError extends TypeError {
+  readonly code: ProtocolIdentifierErrorCode;
+
+  constructor(code: ProtocolIdentifierErrorCode) {
+    super(code);
+    this.name = 'ProtocolIdentifierError';
+    this.code = code;
+  }
+}
+
+function identifierError(code: ProtocolIdentifierErrorCode): never {
+  throw new ProtocolIdentifierError(code);
+}
+
+function parseSegment(input: unknown, emptyCode: ProtocolIdentifierErrorCode): ProtocolIdentifier {
+  if (typeof input !== 'string') identifierError('HQ_IDENTIFIER_TYPE');
+  if (input.length === 0) identifierError(emptyCode);
+  if (textEncoder.encode(input).byteLength > PROTOCOL_IDENTIFIER_LIMITS.maxSegmentBytes) {
+    identifierError('HQ_IDENTIFIER_TOO_LONG');
+  }
+  if (!IDENTIFIER_PATTERN.test(input)) identifierError('HQ_IDENTIFIER_INVALID_FORMAT');
+  if (input.toLowerCase().startsWith(RESERVED_PREFIX)) {
+    identifierError('HQ_IDENTIFIER_RESERVED');
+  }
+  return input as ProtocolIdentifier;
+}
+
+/** Parses one portable, case-sensitive logical identifier segment. */
+export function parseProtocolIdentifier(input: unknown): ProtocolIdentifier {
+  return parseSegment(input, 'HQ_IDENTIFIER_EMPTY');
+}
+
+/** Parses a dot-qualified portable identifier without normalizing it. */
+export function parseProtocolQualifiedIdentifier(
+  input: unknown,
+): ProtocolQualifiedIdentifier {
+  if (typeof input !== 'string') identifierError('HQ_IDENTIFIER_TYPE');
+  if (input.length === 0) identifierError('HQ_IDENTIFIER_EMPTY');
+  if (textEncoder.encode(input).byteLength > PROTOCOL_IDENTIFIER_LIMITS.maxQualifiedBytes) {
+    identifierError('HQ_IDENTIFIER_TOO_LONG');
+  }
+  const segments = input.split('.');
+  if (segments.length > PROTOCOL_IDENTIFIER_LIMITS.maxSegments) {
+    identifierError('HQ_IDENTIFIER_TOO_MANY_SEGMENTS');
+  }
+  for (const segment of segments) {
+    parseSegment(segment, 'HQ_IDENTIFIER_INVALID_FORMAT');
+  }
+  return input as ProtocolQualifiedIdentifier;
+}
+
+export function splitProtocolQualifiedIdentifier(
+  input: ProtocolQualifiedIdentifier,
+): readonly ProtocolIdentifier[] {
+  return Object.freeze(input.split('.') as ProtocolIdentifier[]);
+}
+
+export function joinProtocolQualifiedIdentifier(
+  segments: readonly unknown[],
+): ProtocolQualifiedIdentifier {
+  if (segments.length === 0) identifierError('HQ_IDENTIFIER_EMPTY');
+  if (segments.length > PROTOCOL_IDENTIFIER_LIMITS.maxSegments) {
+    identifierError('HQ_IDENTIFIER_TOO_MANY_SEGMENTS');
+  }
+  const value = segments
+    .map((segment) => parseSegment(segment, 'HQ_IDENTIFIER_INVALID_FORMAT'))
+    .join('.');
+  return parseProtocolQualifiedIdentifier(value);
+}
+
+export function isProtocolIdentifier(input: unknown): input is ProtocolIdentifier {
+  try {
+    parseProtocolIdentifier(input);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isProtocolQualifiedIdentifier(
+  input: unknown,
+): input is ProtocolQualifiedIdentifier {
+  try {
+    parseProtocolQualifiedIdentifier(input);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/protocol/src/identifiers/index.ts
+++ b/packages/protocol/src/identifiers/index.ts
@@ -1,0 +1,15 @@
+export {
+  ProtocolIdentifierError,
+  isProtocolIdentifier,
+  isProtocolQualifiedIdentifier,
+  joinProtocolQualifiedIdentifier,
+  parseProtocolIdentifier,
+  parseProtocolQualifiedIdentifier,
+  splitProtocolQualifiedIdentifier,
+} from './identifiers.js';
+export { PROTOCOL_IDENTIFIER_LIMITS } from './types.js';
+export type {
+  ProtocolIdentifier,
+  ProtocolIdentifierErrorCode,
+  ProtocolQualifiedIdentifier,
+} from './types.js';

--- a/packages/protocol/src/identifiers/types.ts
+++ b/packages/protocol/src/identifiers/types.ts
@@ -1,0 +1,24 @@
+export const PROTOCOL_IDENTIFIER_LIMITS = Object.freeze({
+  maxSegmentBytes: 128,
+  maxQualifiedBytes: 512,
+  maxSegments: 8,
+} as const);
+
+declare const protocolIdentifierBrand: unique symbol;
+declare const protocolQualifiedIdentifierBrand: unique symbol;
+
+export type ProtocolIdentifier = string & {
+  readonly [protocolIdentifierBrand]: true;
+};
+
+export type ProtocolQualifiedIdentifier = string & {
+  readonly [protocolQualifiedIdentifierBrand]: true;
+};
+
+export type ProtocolIdentifierErrorCode =
+  | 'HQ_IDENTIFIER_TYPE'
+  | 'HQ_IDENTIFIER_EMPTY'
+  | 'HQ_IDENTIFIER_TOO_LONG'
+  | 'HQ_IDENTIFIER_INVALID_FORMAT'
+  | 'HQ_IDENTIFIER_RESERVED'
+  | 'HQ_IDENTIFIER_TOO_MANY_SEGMENTS';

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -1,15 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import * as protocol from './index.js';
 
-describe('@hypequery/protocol scaffold', () => {
-  it('exports only the reviewed canonical value surface', () => {
+describe('@hypequery/protocol public surface', () => {
+  it('exports only the reviewed value and identifier surfaces', () => {
     expect(Object.keys(protocol).sort()).toEqual([
       'DEFAULT_CANONICAL_VALUE_LIMITS',
+      'PROTOCOL_IDENTIFIER_LIMITS',
+      'ProtocolIdentifierError',
       'ProtocolValueError',
       'decodeCanonicalValue',
       'encodeCanonicalValue',
       'encodeCanonicalValueToString',
       'hashCanonicalValue',
+      'isProtocolIdentifier',
+      'isProtocolQualifiedIdentifier',
+      'joinProtocolQualifiedIdentifier',
+      'parseProtocolIdentifier',
+      'parseProtocolQualifiedIdentifier',
+      'splitProtocolQualifiedIdentifier',
       'validateCanonicalValue',
     ]);
   });

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -25,3 +25,20 @@ export type {
   TupleTaggedValue,
   UuidTaggedValue,
 } from './values/index.js';
+
+export {
+  PROTOCOL_IDENTIFIER_LIMITS,
+  ProtocolIdentifierError,
+  isProtocolIdentifier,
+  isProtocolQualifiedIdentifier,
+  joinProtocolQualifiedIdentifier,
+  parseProtocolIdentifier,
+  parseProtocolQualifiedIdentifier,
+  splitProtocolQualifiedIdentifier,
+} from './identifiers/index.js';
+
+export type {
+  ProtocolIdentifier,
+  ProtocolIdentifierErrorCode,
+  ProtocolQualifiedIdentifier,
+} from './identifiers/index.js';

--- a/specs/security-protocol/README.md
+++ b/specs/security-protocol/README.md
@@ -11,10 +11,10 @@ continues to execute project source within its existing trust model.
 
 ## Status
 
-The protocol is under active design and has no stable wire version yet. The
-initial `@hypequery/protocol` package is deliberately an empty public scaffold.
-Normative schemas and runtime exports are added only by reviewed follow-up
-decisions with conformance fixtures.
+The protocol is under active design and has no stable wire version yet.
+`@hypequery/protocol` contains draft reference implementations only where a
+reviewed proposal has matching language-neutral fixtures. Draft exports do not
+establish a stable artifact version.
 
 Do not treat a draft document or the npm package version as an executable
 artifact version.
@@ -40,8 +40,9 @@ a bug. Implementations must not silently establish competing protocol rules.
   validation failures.
 - `rfc/`: proposals that are not normative until accepted.
 
-The tagged-value proposal and its draft fixtures now live in `rfc/` and
-`fixtures/`. Empty directories are introduced only with their first artifact.
+Tagged-value and portable-identifier proposals and their draft fixtures live in
+`rfc/` and `fixtures/`. Empty directories are introduced only with their first
+artifact.
 
 ## Boundaries
 

--- a/specs/security-protocol/fixtures/identifiers-v1/README.md
+++ b/specs/security-protocol/fixtures/identifiers-v1/README.md
@@ -1,0 +1,15 @@
+# Portable identifier version 1 fixtures
+
+These draft language-neutral fixtures accompany RFC 0002.
+
+Success entries contain an `id`, a `mode` (`simple` or `qualified`), the exact
+`value`, and the expected `segments`. Rejection entries contain exactly one of
+`value` or `generator` and the required stable `error` code.
+
+Generators expand as follows:
+
+- `repeat-string`: concatenates `count` copies of `value`;
+- `qualified-segments`: joins `count` copies of `segment` with `.`.
+
+Fixture consumers must preserve accepted strings exactly. They must not trim,
+case-fold, normalize, or reinterpret qualified identifiers as SQL names.

--- a/specs/security-protocol/fixtures/identifiers-v1/rejections.json
+++ b/specs/security-protocol/fixtures/identifiers-v1/rejections.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "non-string",
+    "mode": "simple",
+    "value": 42,
+    "error": "HQ_IDENTIFIER_TYPE"
+  },
+  {
+    "id": "empty",
+    "mode": "simple",
+    "value": "",
+    "error": "HQ_IDENTIFIER_EMPTY"
+  },
+  {
+    "id": "segment-bytes-129",
+    "mode": "simple",
+    "generator": {
+      "type": "repeat-string",
+      "value": "a",
+      "count": 129
+    },
+    "error": "HQ_IDENTIFIER_TOO_LONG"
+  },
+  {
+    "id": "leading-digit",
+    "mode": "simple",
+    "value": "1orders",
+    "error": "HQ_IDENTIFIER_INVALID_FORMAT"
+  },
+  {
+    "id": "unicode-letter",
+    "mode": "simple",
+    "value": "café",
+    "error": "HQ_IDENTIFIER_INVALID_FORMAT"
+  },
+  {
+    "id": "reserved-protocol-prefix",
+    "mode": "simple",
+    "value": "__HypequeryInternal",
+    "error": "HQ_IDENTIFIER_RESERVED"
+  },
+  {
+    "id": "qualified-empty-segment",
+    "mode": "qualified",
+    "value": "orders..country",
+    "error": "HQ_IDENTIFIER_INVALID_FORMAT"
+  },
+  {
+    "id": "qualified-segments-9",
+    "mode": "qualified",
+    "generator": {
+      "type": "qualified-segments",
+      "segment": "a",
+      "count": 9
+    },
+    "error": "HQ_IDENTIFIER_TOO_MANY_SEGMENTS"
+  }
+]

--- a/specs/security-protocol/fixtures/identifiers-v1/success.json
+++ b/specs/security-protocol/fixtures/identifiers-v1/success.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "simple-lowercase",
+    "mode": "simple",
+    "value": "orders",
+    "segments": ["orders"]
+  },
+  {
+    "id": "simple-leading-underscore",
+    "mode": "simple",
+    "value": "_tenant_id",
+    "segments": ["_tenant_id"]
+  },
+  {
+    "id": "simple-case-preserved",
+    "mode": "simple",
+    "value": "RevenueByDay",
+    "segments": ["RevenueByDay"]
+  },
+  {
+    "id": "qualified-relationship-field",
+    "mode": "qualified",
+    "value": "orders.customer.country",
+    "segments": ["orders", "customer", "country"]
+  }
+]

--- a/specs/security-protocol/rfc/0002-portable-identifiers.md
+++ b/specs/security-protocol/rfc/0002-portable-identifiers.md
@@ -1,0 +1,90 @@
+# RFC 0002: Portable logical identifiers
+
+- Status: Proposed
+- Version: identifier extension 1
+
+## Summary
+
+Portable Hypequery artifacts need stable names for projects, datasets, queries,
+metrics, dimensions, measures, filters, parameters, and relationships. These
+names must have the same interpretation in TypeScript, Python, Studio, Serve,
+and Cloud and must not depend on SQL dialect quoting or Unicode normalization.
+
+This RFC defines one simple identifier grammar and a qualified form composed of
+identifier segments separated by `.`.
+
+## Simple identifiers
+
+A version 1 identifier MUST:
+
+- be a JSON string;
+- contain between 1 and 128 UTF-8 bytes;
+- match `^[A-Za-z_][A-Za-z0-9_]*$`;
+- be compared byte-for-byte and case-sensitively;
+- not begin with `__hypequery`, using an ASCII case-insensitive comparison.
+
+Implementations MUST preserve the original spelling. They MUST NOT trim,
+case-fold, percent-decode, or apply Unicode normalization. Version 1 is ASCII
+only, so visually equivalent Unicode spellings are rejected rather than
+normalized.
+
+The `__hypequery` prefix is reserved for protocol-defined names. A future core
+version may define such names; applications cannot claim them in version 1.
+
+## Qualified identifiers
+
+A qualified identifier is between 1 and 8 simple identifier segments joined by
+one literal `.` byte. Its complete UTF-8 representation MUST NOT exceed 512
+bytes. Empty segments, leading or trailing dots, repeated dots, and alternate
+separator encodings are invalid.
+
+Examples:
+
+```text
+orders
+orders.customer
+orders.customer.country
+```
+
+Qualification expresses logical containment or traversal only. It is not a SQL
+identifier, table path, filename, URL, or package export. Product adapters own
+translation into those domains.
+
+## Limits
+
+| Limit | Maximum |
+| --- | ---: |
+| UTF-8 bytes in one segment | 128 |
+| Segments in one qualified identifier | 8 |
+| UTF-8 bytes in one qualified identifier | 512 |
+
+Products may impose lower limits but cannot reinterpret accepted version 1
+identifiers.
+
+## Stable failure codes
+
+- `HQ_IDENTIFIER_TYPE`
+- `HQ_IDENTIFIER_EMPTY`
+- `HQ_IDENTIFIER_TOO_LONG`
+- `HQ_IDENTIFIER_INVALID_FORMAT`
+- `HQ_IDENTIFIER_RESERVED`
+- `HQ_IDENTIFIER_TOO_MANY_SEGMENTS`
+
+Errors and diagnostics MUST NOT include the rejected identifier unless the
+calling product explicitly chooses a safe redacted presentation.
+
+## Security considerations
+
+- ASCII-only names avoid confusable and normalization disagreements at the
+  portable artifact boundary.
+- The reserved namespace prevents user data from impersonating future protocol
+  fields.
+- Parsers validate limits before allocating derived structures.
+- SQL quoting and filesystem sanitization remain mandatory in their respective
+  adapters; passing this grammar does not make a name safe for another domain.
+
+## Compatibility
+
+Changing the grammar, comparison rules, reserved namespace, or limits requires
+a new identifier extension or core protocol version. Package SemVer does not
+select this version.


### PR DESCRIPTION
## What changed

- add RFC 0002 defining portable logical identifiers and dot-qualified references
- add language-neutral success and rejection fixtures with stable failure codes
- add strict TypeScript parse, guard, split, and join helpers to `@hypequery/protocol`
- enforce ASCII, case-sensitive spelling, byte and segment limits, and the reserved `__hypequery` namespace
- update the public export allowlist and protocol documentation

## Why

Portable query ASTs and deployment artifacts need one language-neutral identifier format before their schemas can be frozen. This keeps TypeScript, Python, Studio, Serve, and Cloud aligned without treating logical names as SQL identifiers.

## Impact

The package gains a draft identifier API and conformance fixtures. It does not add SQL quoting, deployment bundles, runtime behavior, or product integration. No changeset is included because the protocol is still under active pre-release design.

## Validation

- `pnpm --filter @hypequery/protocol types`
- `pnpm --filter @hypequery/protocol test` — 121 tests passed
- `pnpm --filter @hypequery/protocol lint`
- `git diff --check origin/main...HEAD`