### PR TITLE
feat(datasets): semantic cache stats and clear (cache observability 1a)

### DIFF
--- a/.changeset/semantic-cache-stats.md
+++ b/.changeset/semantic-cache-stats.md
@@ -3,3 +3,5 @@
 ---
 
 Add cache observability to the semantic query cache: `SemanticQueryCache.getStats()` (hit/miss/stale counters, hit rate, clear support) and `clear()`, exposed on `DatasetClient` as `getCacheStats()` and `clearCache()`. Counters are per client instance; bypassed calls are not counted.
+
+Compatibility note: `getCacheStats()` and `clearCache()` are **required** members of the exported `DatasetClient` interface. Clients created by `createDatasetClient` gain them automatically, but hand-rolled implementations or test doubles that `implements DatasetClient` must add both members (delegating to a `SemanticQueryCache`, or returning empty stats and `false`) to compile after upgrading. This ships as a minor deliberately: the package is 0.x, where interface-breaking additions land in the minor slot, and the members are not optional so consumers never have to guard against `undefined`.

--- a/.changeset/semantic-cache-stats.md
+++ b/.changeset/semantic-cache-stats.md
@@ -1,0 +1,5 @@
+---
+"@hypequery/datasets": minor
+---
+
+Add cache observability to the semantic query cache: `SemanticQueryCache.getStats()` (hit/miss/stale counters, hit rate, clear support) and `clear()`, exposed on `DatasetClient` as `getCacheStats()` and `clearCache()`. Counters are per client instance; bypassed calls are not counted.

--- a/packages/datasets/src/cache/dataset-client-cache.test.ts
+++ b/packages/datasets/src/cache/dataset-client-cache.test.ts
@@ -308,3 +308,34 @@ describe('query signatures', () => {
     expect(unscoped('tenant_a')).toBe(unscoped('tenant_b'));
   });
 });
+
+describe('DatasetClient cache observability', () => {
+  it('exposes lookup stats and clear through the client', async () => {
+    const { factory } = createCountingFactory();
+    const client = createDatasetClient({ queryBuilder: factory, cache: { ttlMs: 60_000 } });
+
+    await client.execute(Orders, { measures: ['revenue'] }); // miss
+    await client.execute(Orders, { measures: ['revenue'] }); // hit
+
+    expect(client.getCacheStats()).toMatchObject({
+      hits: 1,
+      misses: 1,
+      staleHits: 0,
+      clearSupported: true,
+    });
+
+    await expect(client.clearCache()).resolves.toBe(true);
+    await client.execute(Orders, { measures: ['revenue'] }); // miss after clear
+    expect(client.getCacheStats().misses).toBe(2);
+  });
+
+  it('does not count uncached executions', async () => {
+    const { factory } = createCountingFactory();
+    const client = createDatasetClient({ queryBuilder: factory });
+
+    await client.execute(Orders, { measures: ['revenue'] });
+
+    const stats = client.getCacheStats();
+    expect(stats.hits + stats.misses + stats.staleHits).toBe(0);
+  });
+});

--- a/packages/datasets/src/cache/semantic-query-cache.test.ts
+++ b/packages/datasets/src/cache/semantic-query-cache.test.ts
@@ -362,3 +362,117 @@ describe('SemanticQueryCache.through', () => {
     expect(hit.data).toEqual([{ v: 'original' }]);
   });
 });
+
+describe('SemanticQueryCache stats and clear', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts empty with hitRate 0', () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    expect(cache.getStats()).toEqual({
+      hits: 0,
+      misses: 0,
+      staleHits: 0,
+      hitRate: 0,
+      clearSupported: true,
+    });
+  });
+
+  it('counts misses, fresh hits, and stale hits', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000, staleWhileRevalidateMs: 1000 });
+    const run = makeRunner();
+
+    await cache.through('k', run); // miss
+    await cache.through('k', run); // fresh hit
+    vi.advanceTimersByTime(1500); // past TTL, inside SWR window
+    await cache.through('k', run); // stale hit
+    await vi.runAllTimersAsync(); // let the background refresh settle
+
+    const stats = cache.getStats();
+    expect(stats.misses).toBe(1);
+    expect(stats.hits).toBe(1);
+    expect(stats.staleHits).toBe(1);
+    expect(stats.hitRate).toBeCloseTo(2 / 3);
+  });
+
+  it('counts each concurrent deduplicated caller', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    const run = makeRunner();
+
+    await Promise.all([cache.through('k', run), cache.through('k', run)]);
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(cache.getStats().misses).toBe(2);
+  });
+
+  it('counts refresh-mode calls as misses', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    const run = makeRunner();
+
+    await cache.through('k', run);
+    await cache.through('k', run, { mode: 'refresh' });
+
+    expect(cache.getStats().misses).toBe(2);
+  });
+
+  it('does not count bypassed or uncached calls', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    const uncached = new SemanticQueryCache();
+    const run = makeRunner();
+
+    await cache.through('k', run, { mode: 'bypass' });
+    await cache.through('k', run, false);
+    await uncached.through('k', run);
+
+    expect(cache.getStats().misses).toBe(0);
+    expect(uncached.getStats().misses).toBe(0);
+  });
+
+  it('does not count errored executions', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    const run = vi.fn(async (): Promise<TestResult> => {
+      throw new Error('boom');
+    });
+
+    await expect(cache.through('k', run)).rejects.toThrow('boom');
+
+    const stats = cache.getStats();
+    expect(stats.hits + stats.misses + stats.staleHits).toBe(0);
+  });
+
+  it('clear() empties the store but keeps lookup counters', async () => {
+    const cache = new SemanticQueryCache({ ttlMs: 1000 });
+    const run = makeRunner();
+
+    await cache.through('k', run); // miss
+    await cache.through('k', run); // hit
+    await expect(cache.clear()).resolves.toBe(true);
+    await cache.through('k', run); // miss again after clear
+
+    const stats = cache.getStats();
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(stats).toMatchObject({ hits: 1, misses: 2, staleHits: 0 });
+  });
+
+  it('clear() returns false when the store cannot clear', async () => {
+    const entries = new Map<string, SemanticCacheEntry>();
+    const store: SemanticCacheStore = {
+      get: (key) => entries.get(key),
+      set: (key, entry) => void entries.set(key, entry),
+      delete: (key) => void entries.delete(key),
+    };
+    const cache = new SemanticQueryCache({ ttlMs: 1000, store });
+    const run = makeRunner();
+
+    await cache.through('k', run);
+    await expect(cache.clear()).resolves.toBe(false);
+
+    expect(cache.getStats().clearSupported).toBe(false);
+    expect(entries.size).toBe(1);
+  });
+});

--- a/packages/datasets/src/cache/semantic-query-cache.ts
+++ b/packages/datasets/src/cache/semantic-query-cache.ts
@@ -87,6 +87,29 @@ export interface SemanticCacheMetaInfo {
   stale?: boolean;
 }
 
+/**
+ * Aggregate lookup counters, snapshot via `SemanticQueryCache.getStats()`.
+ *
+ * Counters are per cache instance and in-process: with a shared store (e.g.
+ * Redis) each process reports its own lookups, not cluster-wide totals. Every
+ * caller counts once — concurrent callers deduplicated onto one execution
+ * each record their own outcome. Bypassed calls (no TTL, `cache: false`,
+ * `mode: 'bypass'`, unscoped builder overrides) never reach the cache and are
+ * not counted.
+ */
+export interface SemanticCacheStats {
+  /** Fresh hits (within TTL). */
+  hits: number;
+  /** Lookups that executed the query (includes `mode: 'refresh'` calls). */
+  misses: number;
+  /** Hits served from the stale-while-revalidate window. */
+  staleHits: number;
+  /** (hits + staleHits) / total lookups; 0 when no lookups yet. */
+  hitRate: number;
+  /** Whether `clear()` can clear entries (the store implements `clear`). */
+  clearSupported: boolean;
+}
+
 const DEFAULT_MAX_ENTRIES = 500;
 
 export function createMemoryCacheStore(
@@ -161,6 +184,9 @@ export class SemanticQueryCache {
   private readonly pending = new Map<string, Promise<LookupOutcome>>();
   private readonly refreshing = new Set<string>();
   private warnedRefreshWithoutTtl = false;
+  private hits = 0;
+  private misses = 0;
+  private staleHits = 0;
 
   constructor(options: SemanticCacheOptions = {}) {
     this.defaults = options;
@@ -216,6 +242,7 @@ export class SemanticQueryCache {
       // an in-flight miss, just execute and repopulate the entry.
       const value = await execute();
       await this.writeEntry(key, value);
+      this.record({ hit: false });
       return annotate(value as T, { hit: false });
     }
 
@@ -225,6 +252,7 @@ export class SemanticQueryCache {
       // callers never share a result object. The outcome (hit, staleness) was
       // resolved with the initiating caller's TTL configuration.
       const shared = await inFlight;
+      this.record(shared.info);
       return annotate(cloneValue(shared.value) as T, shared.info);
     }
 
@@ -260,6 +288,7 @@ export class SemanticQueryCache {
     this.pending.set(key, promise);
     try {
       const outcome = await promise;
+      this.record(outcome.info);
       // Hits alias the stored entry and must be cloned; a freshly executed
       // result is owned by this caller.
       const value = outcome.info.hit ? cloneValue(outcome.value) : outcome.value;
@@ -267,6 +296,42 @@ export class SemanticQueryCache {
     } finally {
       this.pending.delete(key);
     }
+  }
+
+  private record(info: SemanticCacheMetaInfo): void {
+    if (info.stale) {
+      this.staleHits += 1;
+    } else if (info.hit) {
+      this.hits += 1;
+    } else {
+      this.misses += 1;
+    }
+  }
+
+  /** Snapshot of this instance's lookup counters (see `SemanticCacheStats`). */
+  getStats(): SemanticCacheStats {
+    const total = this.hits + this.misses + this.staleHits;
+    return {
+      hits: this.hits,
+      misses: this.misses,
+      staleHits: this.staleHits,
+      hitRate: total > 0 ? (this.hits + this.staleHits) / total : 0,
+      clearSupported: typeof this.store.clear === 'function',
+    };
+  }
+
+  /**
+   * Clears all entries. Returns false without touching anything when the
+   * store does not implement `clear` (see `SemanticCacheStats.clearSupported`
+   * — callers advertising a clear affordance should check it first). Lookup
+   * counters are not reset: they count lookups, not entries.
+   */
+  async clear(): Promise<boolean> {
+    if (typeof this.store.clear !== 'function') {
+      return false;
+    }
+    await this.store.clear();
+    return true;
   }
 
   /** Best-effort write: a failing store degrades to "no caching", never a failed call. */

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -72,6 +72,7 @@ import { applyPagination, overfetchLimit } from './utils/pagination.js';
 import {
   SemanticQueryCache,
   type SemanticCacheOptions,
+  type SemanticCacheStats,
 } from './cache/semantic-query-cache.js';
 import {
   buildDatasetQuerySignature,
@@ -328,6 +329,13 @@ export interface DatasetClient {
     query?: SemanticQuery<TTarget>,
     context?: ExecutionContext,
   ): ValidationResult;
+  /** Lookup counters for this client's semantic result cache. */
+  getCacheStats(): SemanticCacheStats;
+  /**
+   * Clears the semantic result cache. Returns false when the configured store
+   * does not support clearing (see `SemanticCacheStats.clearSupported`).
+   */
+  clearCache(): Promise<boolean>;
 }
 
 export class MetricQueryEngine {
@@ -647,6 +655,14 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
     this.queryCache = new SemanticQueryCache(options.cache);
     this.cacheEnabledByDefault = (options.cache?.ttlMs ?? 0) > 0;
     this.defaultCacheScope = options.cache?.scope;
+  }
+
+  getCacheStats(): SemanticCacheStats {
+    return this.queryCache.getStats();
+  }
+
+  clearCache(): Promise<boolean> {
+    return this.queryCache.clear();
   }
 
   /**

--- a/packages/datasets/src/index.ts
+++ b/packages/datasets/src/index.ts
@@ -92,6 +92,7 @@ export type {
   SemanticCacheMetaInfo,
   SemanticCacheOptions,
   SemanticCacheRuntime,
+  SemanticCacheStats,
   SemanticCacheStore,
 } from './cache/semantic-query-cache.js';
 export {


### PR DESCRIPTION
## What

Adds observability to the semantic query result cache (#253):

- `SemanticQueryCache.getStats()` → `{ hits, misses, staleHits, hitRate, clearSupported }`
- `SemanticQueryCache.clear()` → clears entries via the store's `clear()`; returns `false` untouched when the configured store doesn't implement it
- Exposed on `DatasetClient` as `getCacheStats()` / `clearCache()` so consumers (the serve dev integration) never need the cache class itself
- `SemanticCacheStats` exported from the package root

Counting semantics (documented on the type): counters are per client instance and in-process (with a shared Redis store each process reports its own lookups); every deduplicated concurrent caller records its own outcome; `refresh` calls count as misses; bypassed (`cache: false`, `mode: 'bypass'`, no TTL, unscoped builder override) and errored executions are not counted; `clear()` never resets counters — they count lookups, not entries.

## Why

PR **1a** of the cache-observability track in [plans/dev-playground-design.md](https://github.com/hypequery/hypequery/blob/main/plans/dev-playground-design.md) ("Cache architecture", decided 2026-07-14): the playground gateway reports per-layer cache stats instead of a serve-layer response cache. `clearSupported` is what the gateway checks before advertising the `cache:clear` sub-capability. Next: PR 1b adds `cacheObservability` to serve's `DevIntegrationApi` aggregating this layer with the query-builder cache's `CacheController`.

## Validation

- datasets: 243 tests passed (10 new: stats counting incl. dedup/refresh/bypass/error paths, clear semantics, client passthrough)
- dependents rebuilt and green: serve 456, mcp-server 49, react passing; workspace lint clean
- Minor changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)