### PR TITLE
Define portable query schemas

### DIFF
--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -20,7 +20,8 @@ accepted protocol rules. The current implementation provides strict tagged
 value validation, RFC 8785 canonical encoding, duplicate-aware decoding, a raw
 SHA-256 conformance digest, draft portable logical identifiers, and a proposed
 closed dataset expression/query AST. Artifact envelopes and compatibility
-checks will follow in separate changes.
+checks will follow in separate changes. A closed portable query-schema tree
+provides the next layer for named-query input and output contracts.
 
 It will not connect to ClickHouse, execute queries, load project source, access
 credentials or the environment, perform network or filesystem I/O, implement
@@ -57,6 +58,11 @@ for derived formulas, comparisons, filtered aggregations, all current dataset
 aggregations, and dataset/metric query envelopes. It intentionally excludes raw
 SQL and tenant identity; consumers validate names and policy against a dataset
 contract before execution.
+
+The proposed schema surface exports strict types and validation for portable
+query input/output schemas. It covers the current declarative Serve/Zod schema
+features without depending on Zod or embedding executable transforms and
+refinements.
 
 ## Runtime compatibility
 

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -6,9 +6,11 @@ describe('@hypequery/protocol public surface', () => {
     expect(Object.keys(protocol).sort()).toEqual([
       'DEFAULT_CANONICAL_VALUE_LIMITS',
       'DEFAULT_PROTOCOL_EXPRESSION_LIMITS',
+      'DEFAULT_PROTOCOL_SCHEMA_LIMITS',
       'PROTOCOL_IDENTIFIER_LIMITS',
       'ProtocolExpressionError',
       'ProtocolIdentifierError',
+      'ProtocolSchemaError',
       'ProtocolValueError',
       'decodeCanonicalValue',
       'encodeCanonicalValue',
@@ -22,6 +24,7 @@ describe('@hypequery/protocol public surface', () => {
       'splitProtocolQualifiedIdentifier',
       'validateCanonicalValue',
       'validateProtocolExpression',
+      'validateProtocolSchema',
       'validateProtocolSemanticQuery',
     ]);
   });

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -44,6 +44,19 @@ export {
   validateProtocolSemanticQuery,
 } from './expressions/index.js';
 
+export {
+  DEFAULT_PROTOCOL_SCHEMA_LIMITS,
+  ProtocolSchemaError,
+  validateProtocolSchema,
+} from './schemas/index.js';
+
+export type {
+  ProtocolSchema,
+  ProtocolSchemaErrorCode,
+  ProtocolSchemaLimits,
+  ProtocolSchemaOptions,
+} from './schemas/index.js';
+
 export type {
   ProtocolAggregation,
   ProtocolBinaryOperator,

--- a/packages/protocol/src/schemas/errors.ts
+++ b/packages/protocol/src/schemas/errors.ts
@@ -1,0 +1,17 @@
+import type { ProtocolSchemaErrorCode } from './types.js';
+
+export class ProtocolSchemaError extends TypeError {
+  readonly code: ProtocolSchemaErrorCode;
+  readonly path: string;
+
+  constructor(code: ProtocolSchemaErrorCode, path = '$') {
+    super(`${code} at ${path}`);
+    this.name = 'ProtocolSchemaError';
+    this.code = code;
+    this.path = path;
+  }
+}
+
+export function schemaError(code: ProtocolSchemaErrorCode, path = '$'): never {
+  throw new ProtocolSchemaError(code, path);
+}

--- a/packages/protocol/src/schemas/index.ts
+++ b/packages/protocol/src/schemas/index.ts
@@ -1,0 +1,9 @@
+export { ProtocolSchemaError } from './errors.js';
+export { DEFAULT_PROTOCOL_SCHEMA_LIMITS } from './limits.js';
+export { validateProtocolSchema } from './validate.js';
+export type {
+  ProtocolSchema,
+  ProtocolSchemaErrorCode,
+  ProtocolSchemaLimits,
+  ProtocolSchemaOptions,
+} from './types.js';

--- a/packages/protocol/src/schemas/limits.ts
+++ b/packages/protocol/src/schemas/limits.ts
@@ -1,0 +1,23 @@
+import type { ProtocolSchemaLimits, ProtocolSchemaOptions } from './types.js';
+
+export const DEFAULT_PROTOCOL_SCHEMA_LIMITS: Readonly<ProtocolSchemaLimits> = Object.freeze({
+  maxDepth: 16,
+  maxNodes: 1_000,
+  maxCollectionItems: 100,
+  maxDescriptionBytes: 4_096,
+});
+
+export function resolveSchemaLimits(
+  options: ProtocolSchemaOptions = {},
+): Readonly<ProtocolSchemaLimits> {
+  const limits = { ...DEFAULT_PROTOCOL_SCHEMA_LIMITS };
+  for (const key of Object.keys(options.limits ?? {}) as (keyof ProtocolSchemaLimits)[]) {
+    const value = options.limits?.[key];
+    if (!Number.isSafeInteger(value) || (value as number) < 1
+      || (value as number) > DEFAULT_PROTOCOL_SCHEMA_LIMITS[key]) {
+      throw new RangeError(`${key} must be a positive integer no greater than the protocol v1 maximum`);
+    }
+    limits[key] = value as number;
+  }
+  return Object.freeze(limits);
+}

--- a/packages/protocol/src/schemas/schemas.test.ts
+++ b/packages/protocol/src/schemas/schemas.test.ts
@@ -1,0 +1,160 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { ProtocolSchemaError, validateProtocolSchema } from './index.js';
+
+interface SuccessFixture { id: string; value: unknown }
+interface RejectionFixture {
+  id: string;
+  value?: unknown;
+  generator?:
+    | { type: 'nested-array'; depth: number }
+    | { type: 'union-tree' }
+    | { type: 'enum-values'; count: number }
+    | { type: 'description'; bytes: number }
+    | { type: 'unsafe-accessor' };
+  error: string;
+}
+
+const FAILURE_CODES = [
+  'HQ_SCHEMA_TYPE', 'HQ_SCHEMA_UNKNOWN_FIELD', 'HQ_SCHEMA_UNKNOWN_KIND',
+  'HQ_SCHEMA_INVALID_IDENTIFIER', 'HQ_SCHEMA_INVALID_VALUE',
+  'HQ_SCHEMA_INVALID_CONSTRAINT', 'HQ_SCHEMA_INVALID_REQUIRED',
+  'HQ_SCHEMA_DUPLICATE_VALUE', 'HQ_SCHEMA_TOO_DEEP',
+  'HQ_SCHEMA_TOO_MANY_NODES', 'HQ_SCHEMA_TOO_MANY_ITEMS',
+  'HQ_SCHEMA_TOO_LARGE', 'HQ_SCHEMA_UNSAFE_OBJECT',
+] as const;
+
+function readFixture<T>(name: string): T {
+  const path = fileURLToPath(new URL(
+    `../../../../specs/security-protocol/fixtures/query-schemas-v1/${name}`,
+    import.meta.url,
+  ));
+  return JSON.parse(readFileSync(path, 'utf8')) as T;
+}
+
+function materialize(fixture: RejectionFixture): unknown {
+  if (!fixture.generator) return fixture.value;
+  const generator = fixture.generator;
+  switch (generator.type) {
+    case 'nested-array': {
+      let value: unknown = { kind: 'any' };
+      for (let index = 0; index < generator.depth; index += 1) {
+        value = { kind: 'array', items: value };
+      }
+      return value;
+    }
+    case 'union-tree': {
+      const groups = Array.from({ length: 10 }, () => ({
+        kind: 'union',
+        variants: Array.from({ length: 100 }, () => ({ kind: 'any' })),
+      }));
+      return { kind: 'union', variants: groups };
+    }
+    case 'enum-values':
+      return { kind: 'enum', values: Array.from({ length: generator.count }, (_, index) => `v${index}`) };
+    case 'description':
+      return { kind: 'string', description: 'a'.repeat(generator.bytes) };
+    case 'unsafe-accessor': {
+      const value = {} as { kind?: string };
+      Object.defineProperty(value, 'kind', { enumerable: true, get: () => 'string' });
+      return value;
+    }
+  }
+}
+
+function expectSchemaError(action: () => unknown, code: string): void {
+  try {
+    action();
+    throw new Error('Expected schema validation to fail');
+  } catch (error) {
+    expect(error).toBeInstanceOf(ProtocolSchemaError);
+    expect((error as ProtocolSchemaError).code).toBe(code);
+  }
+}
+
+describe('portable query schemas', () => {
+  const success = readFixture<SuccessFixture[]>('success.json');
+  const rejections = readFixture<RejectionFixture[]>('rejections.json');
+
+  it('has unique fixture IDs and covers every stable failure code', () => {
+    const fixtures = [...success, ...rejections];
+    expect(new Set(fixtures.map(fixture => fixture.id)).size).toBe(fixtures.length);
+    expect([...new Set(rejections.map(fixture => fixture.error))].sort())
+      .toEqual([...FAILURE_CODES].sort());
+  });
+
+  it.each(success)('accepts $id', ({ value }) => {
+    expect(validateProtocolSchema(value)).toEqual(value);
+  });
+
+  it.each(rejections)('rejects $id with its stable code', fixture => {
+    expectSchemaError(() => validateProtocolSchema(materialize(fixture)), fixture.error);
+  });
+
+  it('covers every portable schema kind and object unknown-property policy', () => {
+    const values = success.map(fixture => fixture.value as { kind: string; unknownProperties?: string });
+    expect([...new Set(values.map(value => value.kind))].sort()).toEqual([
+      'any', 'array', 'boolean', 'enum', 'integer', 'literal', 'null', 'number',
+      'object', 'record', 'string', 'union', 'void',
+    ]);
+    expect(values
+      .map(value => value.unknownProperties)
+      .filter((value): value is string => value !== undefined)
+      .sort()).toEqual(['preserve', 'reject', 'strip']);
+  });
+
+  it('rejects conflicting, fractional integer, and negative collection bounds', () => {
+    for (const value of [
+      { kind: 'number', minimum: 0.5, exclusiveMinimum: 1.5 },
+      { kind: 'integer', minimum: 0.5 },
+      { kind: 'string', minLength: -1 },
+      { kind: 'array', items: { kind: 'any' }, maxItems: -1 },
+    ]) {
+      expectSchemaError(() => validateProtocolSchema(value), 'HQ_SCHEMA_INVALID_CONSTRAINT');
+    }
+  });
+
+  it('requires defaults to satisfy the complete schema', () => {
+    for (const value of [
+      { kind: 'integer', minimum: 1, default: 0 },
+      { kind: 'string', minLength: 2, default: 'a' },
+      { kind: 'literal', value: true, default: false },
+      { kind: 'enum', values: ['one', 'two'], default: 'three' },
+      {
+        kind: 'array',
+        items: { kind: 'string' },
+        default: { $hypequery: { type: 'array', version: 1, values: [1.5] } },
+      },
+    ]) {
+      expectSchemaError(() => validateProtocolSchema(value), 'HQ_SCHEMA_INVALID_VALUE');
+    }
+  });
+
+  it('returns detached, deeply immutable snapshots', () => {
+    const input = {
+      kind: 'object',
+      properties: { name: { kind: 'string' } },
+      required: ['name'],
+      unknownProperties: 'reject',
+    };
+    const schema = validateProtocolSchema(input);
+    input.properties.name.kind = 'number';
+    expect(schema).toMatchObject({ properties: { name: { kind: 'string' } } });
+    expect(Object.isFrozen(schema)).toBe(true);
+    expect(Object.isFrozen((schema as { properties: object }).properties)).toBe(true);
+    expect(Object.isFrozen((schema as { required: object }).required)).toBe(true);
+  });
+
+  it('permits lower product limits but rejects raised limits', () => {
+    expectSchemaError(
+      () => validateProtocolSchema(
+        { kind: 'object', properties: { one: { kind: 'any' }, two: { kind: 'any' } }, required: [], unknownProperties: 'reject' },
+        { limits: { maxCollectionItems: 1 } },
+      ),
+      'HQ_SCHEMA_TOO_MANY_ITEMS',
+    );
+    expect(() => validateProtocolSchema({ kind: 'any' }, { limits: { maxNodes: 1_001 } }))
+      .toThrow(RangeError);
+  });
+});

--- a/packages/protocol/src/schemas/types.ts
+++ b/packages/protocol/src/schemas/types.ts
@@ -1,0 +1,79 @@
+import type { ProtocolIdentifier } from '../identifiers/index.js';
+import type { CanonicalValue } from '../values/index.js';
+
+interface ProtocolSchemaAnnotations {
+  readonly description?: string;
+  readonly default?: CanonicalValue;
+}
+
+export type ProtocolSchema =
+  | (ProtocolSchemaAnnotations & { readonly kind: 'any' })
+  | { readonly kind: 'void'; readonly description?: string }
+  | (ProtocolSchemaAnnotations & { readonly kind: 'null' })
+  | (ProtocolSchemaAnnotations & { readonly kind: 'boolean' })
+  | (ProtocolSchemaAnnotations & {
+      readonly kind: 'string';
+      readonly minLength?: number;
+      readonly maxLength?: number;
+    })
+  | (ProtocolSchemaAnnotations & {
+      readonly kind: 'number' | 'integer';
+      readonly minimum?: number;
+      readonly exclusiveMinimum?: number;
+      readonly maximum?: number;
+      readonly exclusiveMaximum?: number;
+    })
+  | (ProtocolSchemaAnnotations & {
+      readonly kind: 'literal';
+      readonly value: CanonicalValue;
+    })
+  | (ProtocolSchemaAnnotations & {
+      readonly kind: 'enum';
+      readonly values: readonly CanonicalValue[];
+    })
+  | (ProtocolSchemaAnnotations & {
+      readonly kind: 'array';
+      readonly items: ProtocolSchema;
+      readonly minItems?: number;
+      readonly maxItems?: number;
+    })
+  | (ProtocolSchemaAnnotations & {
+      readonly kind: 'object';
+      readonly properties: Readonly<Record<ProtocolIdentifier, ProtocolSchema>>;
+      readonly required: readonly ProtocolIdentifier[];
+      readonly unknownProperties: 'reject' | 'strip' | 'preserve';
+    })
+  | (ProtocolSchemaAnnotations & {
+      readonly kind: 'record';
+      readonly values: ProtocolSchema;
+    })
+  | (ProtocolSchemaAnnotations & {
+      readonly kind: 'union';
+      readonly variants: readonly ProtocolSchema[];
+    });
+
+export interface ProtocolSchemaLimits {
+  readonly maxDepth: number;
+  readonly maxNodes: number;
+  readonly maxCollectionItems: number;
+  readonly maxDescriptionBytes: number;
+}
+
+export interface ProtocolSchemaOptions {
+  readonly limits?: Partial<ProtocolSchemaLimits>;
+}
+
+export type ProtocolSchemaErrorCode =
+  | 'HQ_SCHEMA_TYPE'
+  | 'HQ_SCHEMA_UNKNOWN_FIELD'
+  | 'HQ_SCHEMA_UNKNOWN_KIND'
+  | 'HQ_SCHEMA_INVALID_IDENTIFIER'
+  | 'HQ_SCHEMA_INVALID_VALUE'
+  | 'HQ_SCHEMA_INVALID_CONSTRAINT'
+  | 'HQ_SCHEMA_INVALID_REQUIRED'
+  | 'HQ_SCHEMA_DUPLICATE_VALUE'
+  | 'HQ_SCHEMA_TOO_DEEP'
+  | 'HQ_SCHEMA_TOO_MANY_NODES'
+  | 'HQ_SCHEMA_TOO_MANY_ITEMS'
+  | 'HQ_SCHEMA_TOO_LARGE'
+  | 'HQ_SCHEMA_UNSAFE_OBJECT';

--- a/packages/protocol/src/schemas/validate.ts
+++ b/packages/protocol/src/schemas/validate.ts
@@ -1,0 +1,433 @@
+import { ProtocolIdentifierError, parseProtocolIdentifier } from '../identifiers/index.js';
+import {
+  ProtocolValueError,
+  encodeCanonicalValueToString,
+  type CanonicalValue,
+  validateCanonicalValue,
+} from '../values/index.js';
+import { schemaError } from './errors.js';
+import { resolveSchemaLimits } from './limits.js';
+import type {
+  ProtocolSchema,
+  ProtocolSchemaLimits,
+  ProtocolSchemaOptions,
+} from './types.js';
+
+type DataRecord = Record<string, unknown>;
+
+interface State {
+  readonly limits: Readonly<ProtocolSchemaLimits>;
+  readonly active: WeakSet<object>;
+  nodes: number;
+}
+
+const textEncoder = new TextEncoder();
+const ANNOTATIONS = ['description', 'default'] as const;
+
+function requireRecord(input: unknown, path: string): DataRecord {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    schemaError('HQ_SCHEMA_TYPE', path);
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) schemaError('HQ_SCHEMA_UNSAFE_OBJECT', path);
+  if (Object.getOwnPropertySymbols(input).length > 0) schemaError('HQ_SCHEMA_UNSAFE_OBJECT', path);
+  for (const descriptor of Object.values(Object.getOwnPropertyDescriptors(input))) {
+    if (!descriptor.enumerable || !('value' in descriptor)) schemaError('HQ_SCHEMA_UNSAFE_OBJECT', path);
+  }
+  return input as DataRecord;
+}
+
+function requireArray(input: unknown, path: string, state: State): readonly unknown[] {
+  if (!Array.isArray(input)) schemaError('HQ_SCHEMA_TYPE', path);
+  if (Object.getPrototypeOf(input) !== Array.prototype || Object.getOwnPropertySymbols(input).length > 0) {
+    schemaError('HQ_SCHEMA_UNSAFE_OBJECT', path);
+  }
+  if (input.length > state.limits.maxCollectionItems) schemaError('HQ_SCHEMA_TOO_MANY_ITEMS', path);
+  const descriptors = Object.getOwnPropertyDescriptors(input);
+  for (let index = 0; index < input.length; index += 1) {
+    const descriptor = descriptors[String(index)];
+    if (!descriptor || !descriptor.enumerable || !('value' in descriptor)) {
+      schemaError('HQ_SCHEMA_UNSAFE_OBJECT', `${path}[${index}]`);
+    }
+  }
+  if (Object.keys(input).length !== input.length) schemaError('HQ_SCHEMA_UNSAFE_OBJECT', path);
+  return input;
+}
+
+function exactFields(
+  value: DataRecord,
+  required: readonly string[],
+  optional: readonly string[],
+  path: string,
+): void {
+  const allowed = new Set([...required, ...optional]);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) schemaError('HQ_SCHEMA_UNKNOWN_FIELD', `${path}.${key}`);
+  }
+  for (const key of required) {
+    if (!Object.hasOwn(value, key)) schemaError('HQ_SCHEMA_TYPE', `${path}.${key}`);
+  }
+}
+
+function enter(value: object, depth: number, state: State, path: string): void {
+  if (depth > state.limits.maxDepth) schemaError('HQ_SCHEMA_TOO_DEEP', path);
+  state.nodes += 1;
+  if (state.nodes > state.limits.maxNodes) schemaError('HQ_SCHEMA_TOO_MANY_NODES', path);
+  if (state.active.has(value)) schemaError('HQ_SCHEMA_UNSAFE_OBJECT', path);
+  state.active.add(value);
+}
+
+function freezeRecord(entries: Record<string, unknown>): DataRecord {
+  return Object.freeze(Object.assign(Object.create(null), entries)) as DataRecord;
+}
+
+function validateAnnotations(
+  value: DataRecord,
+  result: Record<string, unknown>,
+  state: State,
+  path: string,
+  allowDefault = true,
+): void {
+  if (value.description !== undefined) {
+    if (typeof value.description !== 'string') schemaError('HQ_SCHEMA_TYPE', `${path}.description`);
+    canonicalValue(value.description, `${path}.description`);
+    if (value.description.length > state.limits.maxDescriptionBytes) {
+      schemaError('HQ_SCHEMA_TOO_LARGE', `${path}.description`);
+    }
+    if (textEncoder.encode(value.description).byteLength > state.limits.maxDescriptionBytes) {
+      schemaError('HQ_SCHEMA_TOO_LARGE', `${path}.description`);
+    }
+    result.description = value.description;
+  }
+  if (value.default !== undefined) {
+    if (!allowDefault) schemaError('HQ_SCHEMA_INVALID_VALUE', `${path}.default`);
+    try {
+      result.default = validateCanonicalValue(value.default);
+    } catch (error) {
+      if (error instanceof ProtocolValueError) schemaError('HQ_SCHEMA_INVALID_VALUE', `${path}.default`);
+      throw error;
+    }
+  }
+}
+
+function nonNegativeInteger(value: unknown, path: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', path);
+  }
+  return value as number;
+}
+
+function finiteNumber(value: unknown, path: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || Object.is(value, -0)) {
+    schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', path);
+  }
+  return value;
+}
+
+function copyRange(
+  value: DataRecord,
+  result: Record<string, unknown>,
+  minimumKey: string,
+  maximumKey: string,
+  path: string,
+  integer: boolean,
+): void {
+  if (value[minimumKey] !== undefined) {
+    const number = finiteNumber(value[minimumKey], `${path}.${minimumKey}`);
+    if (integer && !Number.isSafeInteger(number)) schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', `${path}.${minimumKey}`);
+    result[minimumKey] = number;
+  }
+  if (value[maximumKey] !== undefined) {
+    const number = finiteNumber(value[maximumKey], `${path}.${maximumKey}`);
+    if (integer && !Number.isSafeInteger(number)) schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', `${path}.${maximumKey}`);
+    result[maximumKey] = number;
+  }
+}
+
+function copyNonNegativeRange(
+  value: DataRecord,
+  result: Record<string, unknown>,
+  minimumKey: string,
+  maximumKey: string,
+  path: string,
+): void {
+  if (value[minimumKey] !== undefined) {
+    result[minimumKey] = nonNegativeInteger(value[minimumKey], `${path}.${minimumKey}`);
+  }
+  if (value[maximumKey] !== undefined) {
+    result[maximumKey] = nonNegativeInteger(value[maximumKey], `${path}.${maximumKey}`);
+  }
+}
+
+function assertOrderedBounds(result: Record<string, unknown>, path: string): void {
+  const lower = result.exclusiveMinimum ?? result.minimum;
+  const upper = result.exclusiveMaximum ?? result.maximum;
+  const emptyAtEqual = lower === upper
+    && (result.exclusiveMinimum !== undefined || result.exclusiveMaximum !== undefined);
+  if (lower !== undefined && upper !== undefined
+    && ((lower as number) > (upper as number) || emptyAtEqual)) {
+    schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', path);
+  }
+  if (result.minimum !== undefined && result.exclusiveMinimum !== undefined) {
+    schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', path);
+  }
+  if (result.maximum !== undefined && result.exclusiveMaximum !== undefined) {
+    schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', path);
+  }
+}
+
+function validateSchema(input: unknown, path: string, depth: number, state: State): ProtocolSchema {
+  const value = requireRecord(input, path);
+  enter(value, depth, state, path);
+  try {
+    if (typeof value.kind !== 'string') schemaError('HQ_SCHEMA_TYPE', `${path}.kind`);
+    const kind = value.kind;
+    const result: Record<string, unknown> = { kind };
+    switch (kind) {
+      case 'any':
+      case 'null':
+      case 'boolean':
+        exactFields(value, ['kind'], ANNOTATIONS, path);
+        validateAnnotations(value, result, state, path);
+        break;
+      case 'void':
+        exactFields(value, ['kind'], ['description'], path);
+        validateAnnotations(value, result, state, path, false);
+        break;
+      case 'string': {
+        exactFields(value, ['kind'], [...ANNOTATIONS, 'minLength', 'maxLength'], path);
+        validateAnnotations(value, result, state, path);
+        copyNonNegativeRange(value, result, 'minLength', 'maxLength', path);
+        if (result.minLength !== undefined && result.maxLength !== undefined
+          && (result.minLength as number) > (result.maxLength as number)) {
+          schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', path);
+        }
+        break;
+      }
+      case 'number':
+      case 'integer':
+        exactFields(value, ['kind'], [
+          ...ANNOTATIONS, 'minimum', 'exclusiveMinimum', 'maximum', 'exclusiveMaximum',
+        ], path);
+        validateAnnotations(value, result, state, path);
+        copyRange(value, result, 'minimum', 'maximum', path, kind === 'integer');
+        copyRange(value, result, 'exclusiveMinimum', 'exclusiveMaximum', path, kind === 'integer');
+        assertOrderedBounds(result, path);
+        break;
+      case 'literal':
+        exactFields(value, ['kind', 'value'], ANNOTATIONS, path);
+        validateAnnotations(value, result, state, path);
+        result.value = canonicalValue(value.value, `${path}.value`);
+        break;
+      case 'enum':
+        exactFields(value, ['kind', 'values'], ANNOTATIONS, path);
+        validateAnnotations(value, result, state, path);
+        result.values = validateEnum(value.values, `${path}.values`, state);
+        break;
+      case 'array': {
+        exactFields(value, ['kind', 'items'], [...ANNOTATIONS, 'minItems', 'maxItems'], path);
+        validateAnnotations(value, result, state, path);
+        result.items = validateSchema(value.items, `${path}.items`, depth + 1, state);
+        copyNonNegativeRange(value, result, 'minItems', 'maxItems', path);
+        if (result.minItems !== undefined && result.maxItems !== undefined
+          && (result.minItems as number) > (result.maxItems as number)) {
+          schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', path);
+        }
+        break;
+      }
+      case 'object':
+        validateObject(value, result, path, depth, state);
+        break;
+      case 'record':
+        exactFields(value, ['kind', 'values'], ANNOTATIONS, path);
+        validateAnnotations(value, result, state, path);
+        result.values = validateSchema(value.values, `${path}.values`, depth + 1, state);
+        break;
+      case 'union': {
+        exactFields(value, ['kind', 'variants'], ANNOTATIONS, path);
+        validateAnnotations(value, result, state, path);
+        const variants = requireArray(value.variants, `${path}.variants`, state);
+        if (variants.length < 2) schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', `${path}.variants`);
+        result.variants = Object.freeze(variants.map((variant, index) =>
+          validateSchema(variant, `${path}.variants[${index}]`, depth + 1, state)));
+        break;
+      }
+      default:
+        schemaError('HQ_SCHEMA_UNKNOWN_KIND', `${path}.kind`);
+    }
+    validateDefault(result, path);
+    return freezeRecord(result) as unknown as ProtocolSchema;
+  } finally {
+    state.active.delete(value);
+  }
+}
+
+function canonicalValue(input: unknown, path: string) {
+  try {
+    return validateCanonicalValue(input);
+  } catch (error) {
+    if (error instanceof ProtocolValueError) schemaError('HQ_SCHEMA_INVALID_VALUE', path);
+    throw error;
+  }
+}
+
+function validateEnum(input: unknown, path: string, state: State): readonly unknown[] {
+  const values = requireArray(input, path, state);
+  if (values.length === 0) schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', path);
+  const validated = values.map((value, index) => canonicalValue(value, `${path}[${index}]`));
+  const encoded = validated.map(value => encodeCanonicalValueToString(value));
+  if (new Set(encoded).size !== encoded.length) schemaError('HQ_SCHEMA_DUPLICATE_VALUE', path);
+  return Object.freeze(validated);
+}
+
+function validateObject(
+  value: DataRecord,
+  result: Record<string, unknown>,
+  path: string,
+  depth: number,
+  state: State,
+): void {
+  exactFields(value, ['kind', 'properties', 'required', 'unknownProperties'], ANNOTATIONS, path);
+  validateAnnotations(value, result, state, path);
+  const properties = requireRecord(value.properties, `${path}.properties`);
+  if (state.active.has(properties)) schemaError('HQ_SCHEMA_UNSAFE_OBJECT', `${path}.properties`);
+  state.active.add(properties);
+  const propertyEntries = Object.entries(properties);
+  if (propertyEntries.length > state.limits.maxCollectionItems) {
+    schemaError('HQ_SCHEMA_TOO_MANY_ITEMS', `${path}.properties`);
+  }
+  const snapshot: Record<string, unknown> = Object.create(null);
+  try {
+    for (const [name, schema] of propertyEntries) {
+      try {
+        parseProtocolIdentifier(name);
+      } catch (error) {
+        if (error instanceof ProtocolIdentifierError) schemaError('HQ_SCHEMA_INVALID_IDENTIFIER', `${path}.properties`);
+        throw error;
+      }
+      snapshot[name] = validateSchema(schema, `${path}.properties.${name}`, depth + 1, state);
+    }
+  } finally {
+    state.active.delete(properties);
+  }
+  result.properties = Object.freeze(snapshot);
+  const required = requireArray(value.required, `${path}.required`, state);
+  const requiredNames = required.map((name, index) => {
+    if (typeof name !== 'string' || !Object.hasOwn(snapshot, name)) {
+      schemaError('HQ_SCHEMA_INVALID_REQUIRED', `${path}.required[${index}]`);
+    }
+    return name;
+  });
+  if (new Set(requiredNames).size !== requiredNames.length) {
+    schemaError('HQ_SCHEMA_INVALID_REQUIRED', `${path}.required`);
+  }
+  result.required = Object.freeze(requiredNames);
+  if (value.unknownProperties !== 'reject' && value.unknownProperties !== 'strip'
+    && value.unknownProperties !== 'preserve') {
+    schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', `${path}.unknownProperties`);
+  }
+  result.unknownProperties = value.unknownProperties;
+}
+
+function validateDefault(schema: Record<string, unknown>, path: string): void {
+  if (schema.default === undefined) return;
+  if (!matchesSchema(schema as unknown as ProtocolSchema, schema.default as CanonicalValue)) {
+    schemaError('HQ_SCHEMA_INVALID_VALUE', `${path}.default`);
+  }
+}
+
+function matchesSchema(schema: ProtocolSchema, value: CanonicalValue): boolean {
+  switch (schema.kind) {
+    case 'any':
+      return true;
+    case 'void':
+      return false;
+    case 'null':
+      return value === null;
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'string': {
+      if (typeof value !== 'string') return false;
+      const length = [...value].length;
+      return (schema.minLength === undefined || length >= schema.minLength)
+        && (schema.maxLength === undefined || length <= schema.maxLength);
+    }
+    case 'number':
+    case 'integer':
+      return matchesNumber(schema, value);
+    case 'literal':
+      return encodeCanonicalValueToString(value) === encodeCanonicalValueToString(schema.value);
+    case 'enum': {
+      const encoded = encodeCanonicalValueToString(value);
+      return schema.values.some(item => encodeCanonicalValueToString(item) === encoded);
+    }
+    case 'array': {
+      const values = taggedValues(value, 'array');
+      return values !== undefined
+        && (schema.minItems === undefined || values.length >= schema.minItems)
+        && (schema.maxItems === undefined || values.length <= schema.maxItems)
+        && values.every(item => matchesSchema(schema.items, item));
+    }
+    case 'object': {
+      const entries = taggedEntries(value);
+      if (!entries) return false;
+      const found = new Set<string>();
+      for (const [key, item] of entries) {
+        if (typeof key !== 'string') return false;
+        const property = schema.properties[key as keyof typeof schema.properties];
+        if (property) {
+          if (!matchesSchema(property, item)) return false;
+          found.add(key);
+        } else if (schema.unknownProperties === 'reject') {
+          return false;
+        }
+      }
+      return schema.required.every(name => found.has(name));
+    }
+    case 'record': {
+      const entries = taggedEntries(value);
+      return entries !== undefined
+        && entries.every(([key, item]) => typeof key === 'string' && matchesSchema(schema.values, item));
+    }
+    case 'union':
+      return schema.variants.some(variant => matchesSchema(variant, value));
+  }
+}
+
+function matchesNumber(
+  schema: Extract<ProtocolSchema, { kind: 'number' | 'integer' }>,
+  value: CanonicalValue,
+): boolean {
+  if (typeof value !== 'number' || (schema.kind === 'integer' && !Number.isSafeInteger(value))) {
+    return false;
+  }
+  return (schema.minimum === undefined || value >= schema.minimum)
+    && (schema.exclusiveMinimum === undefined || value > schema.exclusiveMinimum)
+    && (schema.maximum === undefined || value <= schema.maximum)
+    && (schema.exclusiveMaximum === undefined || value < schema.exclusiveMaximum);
+}
+
+function taggedValues(value: CanonicalValue, type: 'array'): readonly CanonicalValue[] | undefined {
+  if (typeof value !== 'object' || value === null || !('$hypequery' in value)) return undefined;
+  const tag = value.$hypequery;
+  return tag.type === type ? tag.values : undefined;
+}
+
+function taggedEntries(
+  value: CanonicalValue,
+): readonly (readonly [CanonicalValue, CanonicalValue])[] | undefined {
+  if (typeof value !== 'object' || value === null || !('$hypequery' in value)) return undefined;
+  const tag = value.$hypequery;
+  return tag.type === 'map' ? tag.entries : undefined;
+}
+
+export function validateProtocolSchema(
+  input: unknown,
+  options: ProtocolSchemaOptions = {},
+): ProtocolSchema {
+  return validateSchema(input, '$', 1, {
+    limits: resolveSchemaLimits(options),
+    active: new WeakSet(),
+    nodes: 0,
+  });
+}

--- a/packages/protocol/src/schemas/validate.ts
+++ b/packages/protocol/src/schemas/validate.ts
@@ -90,14 +90,15 @@ function validateAnnotations(
 ): void {
   if (value.description !== undefined) {
     if (typeof value.description !== 'string') schemaError('HQ_SCHEMA_TYPE', `${path}.description`);
-    canonicalValue(value.description, `${path}.description`);
+    const description = canonicalValue(value.description, `${path}.description`);
+    // UTF-16 code units are a conservative allocation-free lower bound on UTF-8 bytes.
     if (value.description.length > state.limits.maxDescriptionBytes) {
       schemaError('HQ_SCHEMA_TOO_LARGE', `${path}.description`);
     }
     if (textEncoder.encode(value.description).byteLength > state.limits.maxDescriptionBytes) {
       schemaError('HQ_SCHEMA_TOO_LARGE', `${path}.description`);
     }
-    result.description = value.description;
+    result.description = description;
   }
   if (value.default !== undefined) {
     if (!allowDefault) schemaError('HQ_SCHEMA_INVALID_VALUE', `${path}.default`);
@@ -160,18 +161,18 @@ function copyNonNegativeRange(
 }
 
 function assertOrderedBounds(result: Record<string, unknown>, path: string): void {
+  if (result.minimum !== undefined && result.exclusiveMinimum !== undefined) {
+    schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', path);
+  }
+  if (result.maximum !== undefined && result.exclusiveMaximum !== undefined) {
+    schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', path);
+  }
   const lower = result.exclusiveMinimum ?? result.minimum;
   const upper = result.exclusiveMaximum ?? result.maximum;
   const emptyAtEqual = lower === upper
     && (result.exclusiveMinimum !== undefined || result.exclusiveMaximum !== undefined);
   if (lower !== undefined && upper !== undefined
     && ((lower as number) > (upper as number) || emptyAtEqual)) {
-    schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', path);
-  }
-  if (result.minimum !== undefined && result.exclusiveMinimum !== undefined) {
-    schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', path);
-  }
-  if (result.maximum !== undefined && result.exclusiveMaximum !== undefined) {
     schemaError('HQ_SCHEMA_INVALID_CONSTRAINT', path);
   }
 }

--- a/specs/security-protocol/fixtures/query-schemas-v1/README.md
+++ b/specs/security-protocol/fixtures/query-schemas-v1/README.md
@@ -1,0 +1,6 @@
+# Portable query schema fixtures, version 1
+
+These fixtures accompany RFC 0004. Success fixtures cover every schema kind
+and every currently portable Serve/Zod feature. Rejection fixtures cover every
+stable failure code; generators describe oversized or unsafe inputs that
+cannot be represented directly in JSON.

--- a/specs/security-protocol/fixtures/query-schemas-v1/rejections.json
+++ b/specs/security-protocol/fixtures/query-schemas-v1/rejections.json
@@ -1,0 +1,15 @@
+[
+  { "id": "not-object", "value": null, "error": "HQ_SCHEMA_TYPE" },
+  { "id": "unknown-field", "value": { "kind": "string", "format": "uuid" }, "error": "HQ_SCHEMA_UNKNOWN_FIELD" },
+  { "id": "unknown-kind", "value": { "kind": "function" }, "error": "HQ_SCHEMA_UNKNOWN_KIND" },
+  { "id": "invalid-property-identifier", "value": { "kind": "object", "properties": { "bad-name": { "kind": "string" } }, "required": [], "unknownProperties": "reject" }, "error": "HQ_SCHEMA_INVALID_IDENTIFIER" },
+  { "id": "invalid-raw-default", "value": { "kind": "object", "properties": {}, "required": [], "unknownProperties": "strip", "default": {} }, "error": "HQ_SCHEMA_INVALID_VALUE" },
+  { "id": "reversed-bounds", "value": { "kind": "integer", "minimum": 10, "maximum": 1 }, "error": "HQ_SCHEMA_INVALID_CONSTRAINT" },
+  { "id": "required-name-not-declared", "value": { "kind": "object", "properties": {}, "required": ["missing"], "unknownProperties": "reject" }, "error": "HQ_SCHEMA_INVALID_REQUIRED" },
+  { "id": "duplicate-enum", "value": { "kind": "enum", "values": ["same", "same"] }, "error": "HQ_SCHEMA_DUPLICATE_VALUE" },
+  { "id": "too-deep", "generator": { "type": "nested-array", "depth": 17 }, "error": "HQ_SCHEMA_TOO_DEEP" },
+  { "id": "too-many-nodes", "generator": { "type": "union-tree" }, "error": "HQ_SCHEMA_TOO_MANY_NODES" },
+  { "id": "too-many-items", "generator": { "type": "enum-values", "count": 101 }, "error": "HQ_SCHEMA_TOO_MANY_ITEMS" },
+  { "id": "description-too-large", "generator": { "type": "description", "bytes": 4097 }, "error": "HQ_SCHEMA_TOO_LARGE" },
+  { "id": "unsafe-accessor", "generator": { "type": "unsafe-accessor" }, "error": "HQ_SCHEMA_UNSAFE_OBJECT" }
+]

--- a/specs/security-protocol/fixtures/query-schemas-v1/success.json
+++ b/specs/security-protocol/fixtures/query-schemas-v1/success.json
@@ -1,0 +1,17 @@
+[
+  { "id": "any", "value": { "kind": "any", "description": "Any protocol value" } },
+  { "id": "void", "value": { "kind": "void" } },
+  { "id": "null", "value": { "kind": "null", "default": null } },
+  { "id": "boolean", "value": { "kind": "boolean", "default": true } },
+  { "id": "string-bounds", "value": { "kind": "string", "minLength": 1, "maxLength": 128, "default": "all" } },
+  { "id": "number-bounds", "value": { "kind": "number", "exclusiveMinimum": 0.0, "maximum": 100.5, "default": 10.5 } },
+  { "id": "integer-bounds", "value": { "kind": "integer", "minimum": 1, "maximum": 100, "default": 10 } },
+  { "id": "literal", "value": { "kind": "literal", "value": true } },
+  { "id": "enum", "value": { "kind": "enum", "values": ["hit", "miss", "stale-hit", "bypass"], "default": "miss" } },
+  { "id": "array-bounds", "value": { "kind": "array", "items": { "kind": "string" }, "minItems": 1, "maxItems": 10 } },
+  { "id": "object-strip-optional-default", "value": { "kind": "object", "properties": { "limit": { "kind": "integer", "minimum": 1, "maximum": 100, "default": 10 }, "dictionary": { "kind": "string" } }, "required": [], "unknownProperties": "strip", "default": { "$hypequery": { "type": "map", "version": 1, "entries": [] } } } },
+  { "id": "object-reject-required", "value": { "kind": "object", "properties": { "start": { "kind": "string" }, "end": { "kind": "string" } }, "required": ["start", "end"], "unknownProperties": "reject" } },
+  { "id": "object-preserve", "value": { "kind": "object", "properties": {}, "required": [], "unknownProperties": "preserve" } },
+  { "id": "record", "value": { "kind": "record", "values": { "kind": "any" } } },
+  { "id": "union-nullable", "value": { "kind": "union", "variants": [{ "kind": "string" }, { "kind": "number" }, { "kind": "null" }] } }
+]

--- a/specs/security-protocol/rfc/0004-portable-query-schemas.md
+++ b/specs/security-protocol/rfc/0004-portable-query-schemas.md
@@ -1,0 +1,139 @@
+# RFC 0004: Portable query schemas
+
+- Status: Proposed
+- Version: schema extension 1
+
+## Summary
+
+Named queries need language-neutral input and output contracts. Zod, Pydantic,
+TypeScript types, and generated OpenAPI documents are authoring or presentation
+formats; none is the shared protocol authority.
+
+This RFC defines a closed, JSON-Schema-derived schema tree. Producers lower
+source-language schemas into this tree during a trusted build. Serve, Cloud,
+Studio, generated clients, and agent tools can then inspect the same contract
+without loading project source.
+
+## Schema nodes
+
+Every node contains a closed `kind` discriminator. Unknown kinds and fields are
+rejected. All nodes except `void` may have a canonical `default`; every node
+may have a bounded `description`.
+
+- `any`: any JSON/protocol value.
+- `void`: no value or request body. This is distinct from `null`.
+- `null`, `boolean`, and `string`.
+- `number`: a finite JSON number.
+- `integer`: a safe JSON integer. This API-schema meaning is separate from the
+  width-aware ClickHouse integer tag used for result values.
+- `literal`: one exact canonical value.
+- `enum`: a non-empty list of distinct canonical values.
+- `array`: one `items` schema and optional inclusive item-count bounds.
+- `object`: named properties, an explicit required-property list, and an
+  `unknownProperties` policy of `reject`, `strip`, or `preserve`.
+- `record`: arbitrary string keys whose values share one schema.
+- `union`: at least two variant schemas.
+
+String length bounds count Unicode code points. Numeric minimum and maximum
+bounds are inclusive; exclusive bounds use separate fields. Inclusive and
+exclusive bounds for the same side cannot both appear. Array and string bounds
+are non-negative safe integers. Integer bounds must themselves be safe
+integers.
+
+Object property names are portable simple identifiers. Required names must
+refer to declared properties and cannot repeat. Optionality is represented by
+omission from `required`, not by an `optional` wrapper node. Nullability is a
+union containing `null`.
+
+## Authoring-language lowering
+
+The current Serve schema surface lowers as follows:
+
+| Serve/Zod feature | Portable representation |
+| --- | --- |
+| `void`, `any`, `unknown` | `void` or `any` |
+| String, number, integer, boolean | Corresponding scalar node |
+| `min`, `max`, positive, non-negative | Numeric or collection bounds |
+| Literal and enum | `literal` and `enum` |
+| Array | `array` |
+| Object shape | `object.properties` and `required` |
+| Optional property | Omitted from `required` |
+| Default | Canonical `default` plus input optionality |
+| Strict/default/passthrough object | `reject`, `strip`, or `preserve` |
+| Record | `record` |
+| Union and nullable | `union` |
+| Schema description | `description` |
+
+Arbitrary refinements, preprocessors, transformations, custom validators,
+effects, and source-language coercions are executable code and cannot be
+serialized. A producer MAY lower one only when it can prove an exact mapping to
+the closed vocabulary. Otherwise bundle creation MUST fail with an actionable
+diagnostic or require an explicit portable wire schema. It MUST NOT silently
+drop the behavior, execute the callback in Cloud, or infer semantics from the
+callback's source text.
+
+In particular, an output transformation describes both accepted resolver
+values and emitted wire values. The portable query contract describes the wire
+value. If a producer cannot derive that wire schema exactly, the author must
+provide it explicitly.
+
+## Compatibility
+
+Schemas describe sets of accepted wire values. For an existing named query:
+
+- an input change is caller-compatible when every value accepted by the old
+  input schema is accepted by the new input schema (`old input ⊆ new input`);
+- an output change is caller-compatible when every value permitted by the new
+  output schema was permitted by the old output schema
+  (`new output ⊆ old output`).
+
+Metadata-only description changes do not affect value compatibility. Defaults
+are execution behavior and are compatibility-significant even when the set of
+accepted explicit values is unchanged. Unknown-property policy is also
+significant because `strip` and `preserve` deliver different values to a query
+resolver.
+
+A later compatibility-checking extension may automate these rules. Consumers
+MUST NOT substitute ordinary JSON Schema compatibility heuristics where this
+RFC gives different meaning.
+
+## Limits
+
+| Limit | Maximum |
+| --- | ---: |
+| Schema depth | 16 |
+| Schema nodes per validation operation | 1,000 |
+| Items in one schema collection | 100 |
+| UTF-8 bytes in one description | 4,096 |
+
+Products may impose lower limits but cannot raise these limits while claiming
+schema extension 1 conformance. Recursive schemas and references are not part
+of version 1.
+
+## Stable failure codes
+
+- `HQ_SCHEMA_TYPE`
+- `HQ_SCHEMA_UNKNOWN_FIELD`
+- `HQ_SCHEMA_UNKNOWN_KIND`
+- `HQ_SCHEMA_INVALID_IDENTIFIER`
+- `HQ_SCHEMA_INVALID_VALUE`
+- `HQ_SCHEMA_INVALID_CONSTRAINT`
+- `HQ_SCHEMA_INVALID_REQUIRED`
+- `HQ_SCHEMA_DUPLICATE_VALUE`
+- `HQ_SCHEMA_TOO_DEEP`
+- `HQ_SCHEMA_TOO_MANY_NODES`
+- `HQ_SCHEMA_TOO_MANY_ITEMS`
+- `HQ_SCHEMA_TOO_LARGE`
+- `HQ_SCHEMA_UNSAFE_OBJECT`
+
+## Security
+
+Validation returns a detached, deeply immutable snapshot. Objects with custom
+prototypes, accessors, symbols, hidden properties, cycles, sparse arrays, or
+extra array properties are rejected. Defaults and enum/literal values use the
+canonical value protocol and inherit its limits and failure rules.
+
+Schemas contain no validators, callbacks, source code, regular expressions,
+credentials, runtime references, or database details. Regular expressions and
+format names are intentionally absent in version 1 because their validation
+semantics vary across languages and libraries.


### PR DESCRIPTION
## Summary

- define a closed, language-neutral schema tree for named-query inputs and outputs
- cover every declarative schema feature currently used by Serve queries: void/any, scalars and bounds, literals/enums, arrays, objects, optional fields, defaults, strict/strip/preserve objects, records, unions, and nullability
- define directional compatibility rules for query inputs and outputs
- reject source-language transforms, refinements, callbacks, regexes, and other behavior that cannot be lowered exactly
- add bounded, immutable TypeScript validation plus language-neutral success/rejection fixtures

Defaults are canonical protocol values and are checked against the complete schema. This gives the next named-query-contract PR a Zod-independent input/output vocabulary.

## Stack

- targets `codex/protocol-expression-ast`
- depends on #286

## Validation

- `pnpm --filter @hypequery/protocol test` (215 tests)
- `pnpm --filter @hypequery/protocol types`
- `pnpm --filter @hypequery/protocol lint`
- `pnpm --filter @hypequery/protocol build`

No changeset: the protocol remains pre-release.