### PR TITLE
feat(serve): cacheObservability on DevIntegrationApi (cache observability 1b)

### DIFF
--- a/.changeset/serve-cache-observability.md
+++ b/.changeset/serve-cache-observability.md
@@ -1,0 +1,7 @@
+---
+"@hypequery/serve": minor
+---
+
+Add `cacheObservability` to `createAPI()`/`defineServe()` results and to `DevIntegrationApi`: per-layer stats and clear for the semantic query cache and the query-builder cache (serve itself holds no cache). The builder layer is detected structurally — query builders created by `createQueryBuilder()` expose their `CacheController` as `.cache` and are picked up automatically; bare factories simply report no builder layer. `getStats()` returns an empty layer list until a semantic endpoint or cache-capable builder is registered. Consumers advertising clear affordances (e.g. the playground gateway's `cache:clear` capability) should check each layer's `clearSupported`.
+
+Compatibility note: `cacheObservability` is a required member of the exported `HypeQueryAPI`/`ServeBuilder`/`DevIntegrationApi` interfaces (0.x minor, same policy as `@hypequery/datasets` 0.11): hand-rolled implementations must add it — `createCacheObservability({})` provides an empty aggregator.

--- a/packages/serve/src/cache-observability.test.ts
+++ b/packages/serve/src/cache-observability.test.ts
@@ -104,8 +104,11 @@ describe("createCacheObservability", () => {
     expect(semantic.clearCache).not.toHaveBeenCalled();
   });
 
-  it("omits layers whose clear is unsupported from the cleared list", async () => {
+  it("never attempts clear on layers whose clearSupported is false", async () => {
     const semantic = makeSemanticClient({ clearSupported: false });
+    // The guard must protect against implementations that throw instead of
+    // returning false.
+    semantic.clearCache.mockRejectedValue(new Error("clear not supported"));
     const observability = createCacheObservability({
       getSemanticClient: () => semantic,
     });
@@ -113,13 +116,18 @@ describe("createCacheObservability", () => {
     const [layer] = await observability.getStats();
     expect(layer.clearSupported).toBe(false);
     await expect(observability.clear()).resolves.toEqual({ cleared: [] });
+    expect(semantic.clearCache).not.toHaveBeenCalled();
   });
 
-  it("returns an empty cleared list for unknown layer names", async () => {
+  it("returns an empty cleared list for unknown layer names from untyped callers", async () => {
     const observability = createCacheObservability({
       getSemanticClient: () => makeSemanticClient(),
     });
 
-    await expect(observability.clear("nope")).resolves.toEqual({ cleared: [] });
+    // The parameter type is narrowed to known layer ids; JS callers (e.g. a
+    // gateway passing a request-body string through) still get the safe
+    // no-op behavior.
+    const unknownLayer = "nope" as Parameters<typeof observability.clear>[0];
+    await expect(observability.clear(unknownLayer)).resolves.toEqual({ cleared: [] });
   });
 });

--- a/packages/serve/src/cache-observability.test.ts
+++ b/packages/serve/src/cache-observability.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createCacheObservability,
+  detectBuilderCache,
+  type BuilderCacheLike,
+} from "./cache-observability.js";
+
+const makeSemanticClient = (overrides: { clearSupported?: boolean } = {}) => ({
+  getCacheStats: vi.fn(() => ({
+    hits: 3,
+    misses: 1,
+    staleHits: 0,
+    hitRate: 0.75,
+    clearSupported: overrides.clearSupported ?? true,
+  })),
+  clearCache: vi.fn(async () => overrides.clearSupported ?? true),
+});
+
+const makeBuilderCache = (): BuilderCacheLike & { clear: ReturnType<typeof vi.fn> } => ({
+  getStats: vi.fn(() => ({ hits: 5, misses: 2, staleHits: 0, revalidations: 1, hitRate: 5 / 7 })),
+  clear: vi.fn(async () => undefined),
+});
+
+describe("detectBuilderCache", () => {
+  it("detects the cache controller on createQueryBuilder-shaped objects", () => {
+    const cache = makeBuilderCache();
+    expect(detectBuilderCache({ cache, table: () => ({}) })).toBe(cache);
+  });
+
+  it("returns undefined for bare factories and malformed cache members", () => {
+    expect(detectBuilderCache(undefined)).toBeUndefined();
+    expect(detectBuilderCache({ table: () => ({}), rawQuery: async () => [] })).toBeUndefined();
+    expect(detectBuilderCache({ cache: {} })).toBeUndefined();
+    expect(detectBuilderCache({ cache: { getStats: () => ({}) } })).toBeUndefined();
+  });
+});
+
+describe("createCacheObservability", () => {
+  it("reports no layers when nothing is wired", async () => {
+    const observability = createCacheObservability({});
+
+    await expect(observability.getStats()).resolves.toEqual([]);
+    await expect(observability.clear()).resolves.toEqual({ cleared: [] });
+  });
+
+  it("reports both layers with their own stats shapes", async () => {
+    const semantic = makeSemanticClient();
+    const builder = makeBuilderCache();
+    const observability = createCacheObservability({
+      getSemanticClient: () => semantic,
+      getBuilderCache: () => builder,
+    });
+
+    const layers = await observability.getStats();
+
+    expect(layers).toEqual([
+      {
+        layer: "semantic",
+        stats: { hits: 3, misses: 1, staleHits: 0, hitRate: 0.75 },
+        clearSupported: true,
+      },
+      {
+        layer: "builder",
+        stats: { hits: 5, misses: 2, staleHits: 0, revalidations: 1, hitRate: 5 / 7 },
+        clearSupported: true,
+      },
+    ]);
+  });
+
+  it("resolves sources lazily so late-created clients are observed", async () => {
+    const holder: { client?: ReturnType<typeof makeSemanticClient> } = {};
+    const observability = createCacheObservability({
+      getSemanticClient: () => holder.client,
+    });
+
+    await expect(observability.getStats()).resolves.toEqual([]);
+    holder.client = makeSemanticClient();
+    await expect(observability.getStats()).resolves.toHaveLength(1);
+  });
+
+  it("clears all clearable layers when no layer is named", async () => {
+    const semantic = makeSemanticClient();
+    const builder = makeBuilderCache();
+    const observability = createCacheObservability({
+      getSemanticClient: () => semantic,
+      getBuilderCache: () => builder,
+    });
+
+    await expect(observability.clear()).resolves.toEqual({ cleared: ["semantic", "builder"] });
+    expect(semantic.clearCache).toHaveBeenCalledOnce();
+    expect(builder.clear).toHaveBeenCalledOnce();
+  });
+
+  it("clears only the named layer", async () => {
+    const semantic = makeSemanticClient();
+    const builder = makeBuilderCache();
+    const observability = createCacheObservability({
+      getSemanticClient: () => semantic,
+      getBuilderCache: () => builder,
+    });
+
+    await expect(observability.clear("builder")).resolves.toEqual({ cleared: ["builder"] });
+    expect(semantic.clearCache).not.toHaveBeenCalled();
+  });
+
+  it("omits layers whose clear is unsupported from the cleared list", async () => {
+    const semantic = makeSemanticClient({ clearSupported: false });
+    const observability = createCacheObservability({
+      getSemanticClient: () => semantic,
+    });
+
+    const [layer] = await observability.getStats();
+    expect(layer.clearSupported).toBe(false);
+    await expect(observability.clear()).resolves.toEqual({ cleared: [] });
+  });
+
+  it("returns an empty cleared list for unknown layer names", async () => {
+    const observability = createCacheObservability({
+      getSemanticClient: () => makeSemanticClient(),
+    });
+
+    await expect(observability.clear("nope")).resolves.toEqual({ cleared: [] });
+  });
+});

--- a/packages/serve/src/cache-observability.ts
+++ b/packages/serve/src/cache-observability.ts
@@ -24,12 +24,13 @@ export interface CacheObservability {
   /** Stats for every observable cache layer; empty when none are wired. */
   getStats(): Promise<CacheLayerStats[]>;
   /**
-   * Clears the given layer, or every clearable layer when omitted. Returns
-   * the ids of layers actually cleared — callers advertising a clear
-   * affordance (the gateway's `cache:clear` capability) should first check
-   * `clearSupported` on `getStats()`.
+   * Clears the given layer, or every clearable layer when omitted. Layers
+   * whose `clearSupported` is false are never attempted. Returns the ids of
+   * layers actually cleared — callers advertising a clear affordance (the
+   * gateway's `cache:clear` capability) should first check `clearSupported`
+   * on `getStats()`.
    */
-  clear(layer?: string): Promise<{ cleared: string[] }>;
+  clear(layer?: CacheLayerStats["layer"]): Promise<{ cleared: Array<CacheLayerStats["layer"]> }>;
 }
 
 /**
@@ -108,9 +109,12 @@ export const createCacheObservability = (sources: {
       return resolveLayers().map((layer) => layer.getStats());
     },
     async clear(layer) {
-      const cleared: string[] = [];
+      const cleared: Array<CacheLayerStats["layer"]> = [];
       for (const candidate of resolveLayers()) {
         if (layer !== undefined && candidate.layer !== layer) continue;
+        // Never attempt an unsupported clear — don't rely on the downstream
+        // implementation returning false instead of throwing.
+        if (!candidate.getStats().clearSupported) continue;
         if (await candidate.clear()) {
           cleared.push(candidate.layer);
         }

--- a/packages/serve/src/cache-observability.ts
+++ b/packages/serve/src/cache-observability.ts
@@ -1,0 +1,121 @@
+/**
+ * Aggregated cache observability for dev tooling.
+ *
+ * Serve owns no cache implementation (see plans/dev-playground-design.md,
+ * "Cache architecture"): result caching lives in the semantic query cache
+ * (`@hypequery/datasets`) and the query-builder cache
+ * (`@hypequery/clickhouse`). This module aggregates their stats/clear
+ * surfaces per layer so the playground gateway can serve
+ * `GET /__dev/cache` → `{ layers: [...] }` without a serve-layer cache.
+ */
+
+import type { DatasetClient } from "@hypequery/datasets";
+
+/** Stats snapshot for one cache layer. Layer ids are additive over time. */
+export interface CacheLayerStats {
+  layer: "semantic" | "builder";
+  /** Layer-specific counters; shapes intentionally differ per layer. */
+  stats: Record<string, unknown>;
+  /** Whether `clear()` can clear this layer. */
+  clearSupported: boolean;
+}
+
+export interface CacheObservability {
+  /** Stats for every observable cache layer; empty when none are wired. */
+  getStats(): Promise<CacheLayerStats[]>;
+  /**
+   * Clears the given layer, or every clearable layer when omitted. Returns
+   * the ids of layers actually cleared — callers advertising a clear
+   * affordance (the gateway's `cache:clear` capability) should first check
+   * `clearSupported` on `getStats()`.
+   */
+  clear(layer?: string): Promise<{ cleared: string[] }>;
+}
+
+/**
+ * The structural surface of `@hypequery/clickhouse`'s `CacheController`,
+ * carried as `.cache` on every `createQueryBuilder()` result. Kept
+ * structural so serve does not depend on the clickhouse package.
+ */
+export interface BuilderCacheLike {
+  getStats(): Record<string, unknown>;
+  clear(): Promise<void>;
+}
+
+/**
+ * Detects a builder cache controller on a query-builder object. Builders
+ * from `createQueryBuilder()` expose it as `.cache`; custom adapters without
+ * one simply report no builder layer.
+ */
+export const detectBuilderCache = (candidate: unknown): BuilderCacheLike | undefined => {
+  if (!candidate || typeof candidate !== "object") return undefined;
+  const cache = (candidate as { cache?: unknown }).cache;
+  if (
+    cache &&
+    typeof cache === "object" &&
+    typeof (cache as BuilderCacheLike).getStats === "function" &&
+    typeof (cache as BuilderCacheLike).clear === "function"
+  ) {
+    return cache as BuilderCacheLike;
+  }
+  return undefined;
+};
+
+/**
+ * Sources are lazy: the shared dataset client is created on first semantic
+ * endpoint registration, so layers are resolved per call, not at build time.
+ */
+export const createCacheObservability = (sources: {
+  getSemanticClient?: () => Pick<DatasetClient, "getCacheStats" | "clearCache"> | undefined;
+  getBuilderCache?: () => BuilderCacheLike | undefined;
+}): CacheObservability => {
+  const resolveLayers = () => {
+    const layers: Array<{
+      layer: CacheLayerStats["layer"];
+      getStats: () => CacheLayerStats;
+      clear: () => Promise<boolean>;
+    }> = [];
+
+    const semantic = sources.getSemanticClient?.();
+    if (semantic) {
+      layers.push({
+        layer: "semantic",
+        getStats: () => {
+          const { clearSupported, ...stats } = semantic.getCacheStats();
+          return { layer: "semantic", stats, clearSupported };
+        },
+        clear: () => semantic.clearCache(),
+      });
+    }
+
+    const builder = sources.getBuilderCache?.();
+    if (builder) {
+      layers.push({
+        layer: "builder",
+        getStats: () => ({ layer: "builder", stats: builder.getStats(), clearSupported: true }),
+        clear: async () => {
+          await builder.clear();
+          return true;
+        },
+      });
+    }
+
+    return layers;
+  };
+
+  return {
+    async getStats() {
+      return resolveLayers().map((layer) => layer.getStats());
+    },
+    async clear(layer) {
+      const cleared: string[] = [];
+      for (const candidate of resolveLayers()) {
+        if (layer !== undefined && candidate.layer !== layer) continue;
+        if (await candidate.clear()) {
+          cleared.push(candidate.layer);
+        }
+      }
+      return { cleared };
+    },
+  };
+};

--- a/packages/serve/src/dev.ts
+++ b/packages/serve/src/dev.ts
@@ -1,12 +1,15 @@
 import type { AddressInfo } from "net";
 
 import { startNodeServer } from "./adapters/node.js";
+import type { CacheObservability } from "./cache-observability.js";
 import type {
   ServeBuilder,
   StartServerOptions,
   ToolkitDescription,
 } from "./types.js";
 import { formatQueryEvent, type ServeQueryLogger } from "./query-logger.js";
+
+export type { CacheObservability, CacheLayerStats } from "./cache-observability.js";
 
 /**
  * The narrow surface of a serve API that dev tooling (e.g.
@@ -21,6 +24,12 @@ export interface DevIntegrationApi {
   describe(): ToolkitDescription;
   /** In-process execution of a registered endpoint. */
   execute(key: string, options?: { input?: unknown }): Promise<unknown>;
+  /**
+   * Per-layer cache stats/clear (semantic + query-builder layers). Gateways
+   * should advertise clear affordances (the `cache:clear` capability) only
+   * for layers reporting `clearSupported`.
+   */
+  readonly cacheObservability: CacheObservability;
   /** Base path applied to all registered routes. */
   readonly basePath?: string;
 }

--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -16,6 +16,8 @@ export * from "./adapters/fetch.js";
 export * from "./adapters/vercel.js";
 export { startServer, toNodeHandler, toFetchHandler } from "./adapters/standalone.js";
 export type { DevIntegrationApi, ServeDevOptions } from "./dev.js";
+export { createCacheObservability, detectBuilderCache } from "./cache-observability.js";
+export type { CacheObservability, CacheLayerStats, BuilderCacheLike } from "./cache-observability.js";
 /** @deprecated Import from `@hypequery/serve/dev` instead. */
 export { serveDev } from "./dev.js";
 export * from "./serve.js";

--- a/packages/serve/src/semantic/datasets/serve-integration.test.ts
+++ b/packages/serve/src/semantic/datasets/serve-integration.test.ts
@@ -2199,3 +2199,68 @@ describe("semantic endpoint result caching", () => {
     expect(getExecutions()).toBe(2);
   });
 });
+
+describe("cacheObservability", () => {
+  it("reports no layers for a queries-only API with a bare builder", async () => {
+    const api = createAPI({
+      queries: { ping: { query: async () => ({ ok: true }) } },
+    });
+
+    await expect(api.cacheObservability.getStats()).resolves.toEqual([]);
+    await expect(api.cacheObservability.clear()).resolves.toEqual({ cleared: [] });
+  });
+
+  it("reports the semantic layer once semantic endpoints are registered", async () => {
+    const api = createAPI({
+      metrics: { totalRevenue },
+      queryBuilder: createMockBuilderFactory(),
+    });
+
+    const layers = await api.cacheObservability.getStats();
+
+    expect(layers).toHaveLength(1);
+    expect(layers[0]).toMatchObject({ layer: "semantic", clearSupported: true });
+    expect(layers[0].stats).toMatchObject({ hits: 0, misses: 0, staleHits: 0 });
+  });
+
+  it("detects a cache controller on the query builder and reports both layers", async () => {
+    const builderCache = {
+      getStats: () => ({ hits: 2, misses: 1, staleHits: 0, revalidations: 0, hitRate: 2 / 3 }),
+      clear: vi.fn(async () => undefined),
+    };
+    const factory = Object.assign(createMockBuilderFactory(), { cache: builderCache });
+
+    const api = createAPI({
+      metrics: { totalRevenue },
+      queryBuilder: factory,
+    });
+
+    const layers = await api.cacheObservability.getStats();
+
+    expect(layers.map((l) => l.layer)).toEqual(["semantic", "builder"]);
+    expect(layers[1].stats).toMatchObject({ revalidations: 0 });
+
+    await expect(api.cacheObservability.clear("builder")).resolves.toEqual({
+      cleared: ["builder"],
+    });
+    expect(builderCache.clear).toHaveBeenCalledOnce();
+  });
+
+  it("counts semantic lookups from cache-enabled endpoint executions", async () => {
+    const api = createAPI({
+      metrics: { totalRevenue: { metric: totalRevenue, cache: 60_000 } },
+      queryBuilder: createMockBuilderFactory(),
+    });
+
+    await api.execute("totalRevenue", { input: {} });
+    await api.execute("totalRevenue", { input: {} });
+
+    const [semantic] = await api.cacheObservability.getStats();
+    expect(semantic.stats).toMatchObject({ hits: 1, misses: 1 });
+
+    await expect(api.cacheObservability.clear()).resolves.toEqual({ cleared: ["semantic"] });
+    await api.execute("totalRevenue", { input: {} });
+    const [after] = await api.cacheObservability.getStats();
+    expect(after.stats).toMatchObject({ hits: 1, misses: 2 });
+  });
+});

--- a/packages/serve/src/server/api-builder.ts
+++ b/packages/serve/src/server/api-builder.ts
@@ -12,6 +12,7 @@ import type {
   RouteRegistrationOptions,
 } from "../types.js";
 import type { ServeRouter } from "../router.js";
+import type { CacheObservability } from "../cache-observability.js";
 import { ServeQueryLogger } from "../query-logger.js";
 import { mergeTags } from "../utils.js";
 import { applyBasePath, normalizeRoutePath } from "../router.js";
@@ -30,10 +31,12 @@ export const createAPImethods = <
   executeQuery: ExecuteQueryFunction<ServeEndpointMap<TQueries, TContext, TAuth>, TContext>,
   handler: ServeHandler,
   basePath: string,
+  cacheObservability: CacheObservability,
 ): HypeQueryAPI<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth> => {
   const api: HypeQueryAPI<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth> = {
     queries: queryEntries,
     queryLogger,
+    cacheObservability,
 
     manifest: (): RouteManifest => {
       const manifest: RouteManifest = {};

--- a/packages/serve/src/server/builder.ts
+++ b/packages/serve/src/server/builder.ts
@@ -14,6 +14,8 @@ import type {
   StartServerOptions,
 } from "../types.js";
 import type { ServeRouter } from "../router.js";
+import type { CacheObservability } from "../cache-observability.js";
+import { createCacheObservability } from "../cache-observability.js";
 import { ServeQueryLogger } from "../query-logger.js";
 import { mergeTags } from "../utils.js";
 import { applyBasePath, normalizeRoutePath } from "../router.js";
@@ -40,11 +42,13 @@ export const createBuilderMethods = <
   executeQuery: ExecuteQueryFunction<ServeEndpointMap<TQueries, TContext, TAuth>, TContext>,
   handler: ServeHandler,
   basePath: string,
+  cacheObservability: CacheObservability = createCacheObservability({}),
 ): ServeBuilder<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth> => {
   const builder: ServeBuilder<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth> = {
     queries: queryEntries,
     basePath: basePath || undefined,
     queryLogger,
+    cacheObservability,
     _routeConfig: routeConfig,
 
     manifest: (): RouteManifest => {

--- a/packages/serve/src/server/create-api.ts
+++ b/packages/serve/src/server/create-api.ts
@@ -22,6 +22,7 @@ import { createDocsEndpoint, createOpenApiEndpoint } from "../pipeline.js";
 import { resolveCorsConfig } from "../cors.js";
 import { createExecuteQuery } from "./execute-query.js";
 import { createAPImethods } from "./api-builder.js";
+import { createCacheObservability, detectBuilderCache } from "../cache-observability.js";
 import { createDatasetClient, serializeSemanticContract, toQueryBuilderFactory } from "@hypequery/datasets";
 import {
   createMetricEndpoint,
@@ -315,6 +316,15 @@ export const createAPI = <
     config.security?.verboseAuthErrors ?? false,
   );
 
+  // Lazy sources: the shared dataset client only exists once a semantic
+  // endpoint is registered, and the builder cache only when the configured
+  // query builder carries a `cache` controller (createQueryBuilder() results
+  // do; bare factories report no builder layer).
+  const cacheObservability = createCacheObservability({
+    getSemanticClient: () => sharedAnalytics,
+    getBuilderCache: () => detectBuilderCache(resolvedQueryBuilder),
+  });
+
   const api = createAPImethods<TQueries, TContext, TAuth>(
     queryEntries as ServeEndpointMap<TQueries, TContext, TAuth>,
     queryLogger,
@@ -324,6 +334,7 @@ export const createAPI = <
     executeQuery,
     handler,
     basePath,
+    cacheObservability,
   ) as HypeQueryAPI<
     ServeEndpointMap<TQueries, TContext, TAuth>
       & ServeSemanticEndpointMap<TMetrics, TDatasets, TContext, TAuth>,

--- a/packages/serve/src/types.ts
+++ b/packages/serve/src/types.ts
@@ -1,5 +1,6 @@
 import type { ZodType, ZodTypeAny } from "zod";
 import type { ServeQueryLogger, ServeQueryEventCallback } from "./query-logger.js";
+import type { CacheObservability } from "./cache-observability.js";
 import type {
   DatasetInstance,
   DatasetQueryableDimensions,
@@ -1007,6 +1008,12 @@ export interface HypeQueryAPI<
   /** The underlying request handler. Can be passed directly to transport adapters. */
   readonly handler: ServeHandler;
   /**
+   * Per-layer stats/clear for the semantic and query-builder caches (serve
+   * itself holds no cache). Reports an empty layer list until a cache-capable
+   * query builder or a semantic endpoint is registered.
+   */
+  readonly cacheObservability: CacheObservability;
+  /**
    * Build a serializable {@link RouteManifest} of every query/metric/dataset
    * route (method + full path). Safe to JSON-serialize and ship to the client.
    */
@@ -1084,6 +1091,12 @@ export interface ServeBuilder<
   readonly basePath?: string;
   /** Serve-layer query logger for subscribing to endpoint execution events */
   readonly queryLogger: ServeQueryLogger;
+  /**
+   * Per-layer stats/clear for the semantic and query-builder caches (serve
+   * itself holds no cache). Reports an empty layer list until a cache-capable
+   * query builder or a semantic endpoint is registered.
+   */
+  readonly cacheObservability: CacheObservability;
   /** Internal route configuration mapping query names to their HTTP methods */
   readonly _routeConfig?: Record<string, { method: HttpMethod }>;
   /**


### PR DESCRIPTION
## What

PR **1b** of the cache-observability track ([plans/dev-playground-design.md](https://github.com/hypequery/hypequery/blob/main/plans/dev-playground-design.md), "Cache architecture") — the aggregation layer on top of #285 (1a):

- New `src/cache-observability.ts`: `CacheObservability` (`getStats(): CacheLayerStats[]`, `clear(layer?)`) aggregating the two caches that own result caching. Serve itself holds no cache.
  - **semantic** layer → `DatasetClient.getCacheStats()`/`clearCache()` from datasets 0.11
  - **builder** layer → structural detection (option 1, as discussed): `createQueryBuilder()` results carry their `CacheController` as `.cache`, picked up automatically via `detectBuilderCache`; bare factories/custom adapters simply report no builder layer. Kept structural so serve does not depend on `@hypequery/clickhouse`.
- Exposed as required `cacheObservability` on `HypeQueryAPI`/`ServeBuilder` (wired in `createAPImethods`) and on `DevIntegrationApi` — the gateway serves `GET /__dev/cache` → `{ layers: [...] }` from it and advertises the `cache:clear` capability from `clearSupported`.
- Sources resolve lazily: the shared dataset client is created on first semantic endpoint registration, so layers appear per call, not at build time. Empty layer list when nothing is wired.
- `clear(layer?)` clears the named layer or every clearable layer, returning the ids actually cleared; unsupported/unknown layers are omitted, never errors.

## Interface note

Same 0.x-minor policy as #285: `cacheObservability` is required on the exported interfaces; hand-rolled implementations can satisfy it with `createCacheObservability({})` (empty aggregator — also the default on the legacy `createBuilderMethods` path, which gained an optional trailing param).

## Validation

- serve: 472 passed (13 new — unit: detection, lazy resolution, per-layer/named/unsupported clear; integration through `createAPI`: queries-only → no layers, metrics → semantic layer, builder-with-cache → both layers + targeted clear, and hit/miss counting through real cache-enabled `execute()` calls incl. counter behavior across `clear()`)
- workspace build 10/10; datasets 243, mcp 84, cli 256, react 49; lint clean
- Minor changeset included

Next in the track: the `playground/gateway` PR renames `serveCacheStore` → `cacheObservability` and wires `/__dev/cache` + `cache:clear` to this API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)