### PR TITLE
Define portable query implementations

### DIFF
--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -55,14 +55,20 @@ ASCII, case-sensitive, preserved exactly, and are not SQL identifiers.
 
 The proposed expression surface exports strict validators and immutable types
 for derived formulas, comparisons, filtered aggregations, all current dataset
-aggregations, and dataset/metric query envelopes. It intentionally excludes raw
-SQL and tenant identity; consumers validate names and policy against a dataset
-contract before execution.
+aggregations, and dataset/metric query envelopes. It intentionally excludes
+caller-supplied SQL and tenant identity; consumers validate names and policy
+against a dataset contract before execution.
 
 The proposed schema surface exports strict types and validation for portable
 query input/output schemas. It covers the current declarative Serve/Zod schema
 features without depending on Zod or embedding executable transforms and
 refinements.
+
+The proposed query-implementation surface keeps trusted implementation details
+separate from public query intent. It covers Dataset SQL expressions, fixed
+semantic plans, compiled read-only ClickHouse statements with bound input or
+tenant parameters, and hashed Node/Python runtime references for Serve handlers
+that cannot be lowered portably. Validation does not execute or authorize SQL.
 
 ## Runtime compatibility
 

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -6,10 +6,12 @@ describe('@hypequery/protocol public surface', () => {
     expect(Object.keys(protocol).sort()).toEqual([
       'DEFAULT_CANONICAL_VALUE_LIMITS',
       'DEFAULT_PROTOCOL_EXPRESSION_LIMITS',
+      'DEFAULT_PROTOCOL_QUERY_IMPLEMENTATION_LIMITS',
       'DEFAULT_PROTOCOL_SCHEMA_LIMITS',
       'PROTOCOL_IDENTIFIER_LIMITS',
       'ProtocolExpressionError',
       'ProtocolIdentifierError',
+      'ProtocolQueryImplementationError',
       'ProtocolSchemaError',
       'ProtocolValueError',
       'decodeCanonicalValue',
@@ -24,8 +26,10 @@ describe('@hypequery/protocol public surface', () => {
       'splitProtocolQualifiedIdentifier',
       'validateCanonicalValue',
       'validateProtocolExpression',
+      'validateProtocolQueryImplementation',
       'validateProtocolSchema',
       'validateProtocolSemanticQuery',
+      'validateProtocolSqlExpression',
     ]);
   });
 });

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -78,3 +78,22 @@ export type {
   ProtocolIdentifierErrorCode,
   ProtocolQualifiedIdentifier,
 } from './identifiers/index.js';
+
+export {
+  DEFAULT_PROTOCOL_QUERY_IMPLEMENTATION_LIMITS,
+  ProtocolQueryImplementationError,
+  validateProtocolQueryImplementation,
+  validateProtocolSqlExpression,
+} from './query-implementations/index.js';
+
+export type {
+  ProtocolQueryImplementation,
+  ProtocolQueryImplementationErrorCode,
+  ProtocolQueryImplementationLimits,
+  ProtocolQueryImplementationOptions,
+  ProtocolSqlDialect,
+  ProtocolSqlExpression,
+  ProtocolSqlParameter,
+  ProtocolSqlParameterSource,
+  ProtocolSqlTenantPolicy,
+} from './query-implementations/index.js';

--- a/packages/protocol/src/query-implementations/errors.ts
+++ b/packages/protocol/src/query-implementations/errors.ts
@@ -1,0 +1,20 @@
+import type { ProtocolQueryImplementationErrorCode } from './types.js';
+
+export class ProtocolQueryImplementationError extends TypeError {
+  readonly code: ProtocolQueryImplementationErrorCode;
+  readonly path: string;
+
+  constructor(code: ProtocolQueryImplementationErrorCode, path = '$') {
+    super(`${code} at ${path}`);
+    this.name = 'ProtocolQueryImplementationError';
+    this.code = code;
+    this.path = path;
+  }
+}
+
+export function queryImplementationError(
+  code: ProtocolQueryImplementationErrorCode,
+  path = '$',
+): never {
+  throw new ProtocolQueryImplementationError(code, path);
+}

--- a/packages/protocol/src/query-implementations/index.ts
+++ b/packages/protocol/src/query-implementations/index.ts
@@ -1,0 +1,17 @@
+export { ProtocolQueryImplementationError } from './errors.js';
+export { DEFAULT_PROTOCOL_QUERY_IMPLEMENTATION_LIMITS } from './limits.js';
+export {
+  validateProtocolQueryImplementation,
+  validateProtocolSqlExpression,
+} from './validate.js';
+export type {
+  ProtocolQueryImplementation,
+  ProtocolQueryImplementationErrorCode,
+  ProtocolQueryImplementationLimits,
+  ProtocolQueryImplementationOptions,
+  ProtocolSqlDialect,
+  ProtocolSqlExpression,
+  ProtocolSqlParameter,
+  ProtocolSqlParameterSource,
+  ProtocolSqlTenantPolicy,
+} from './types.js';

--- a/packages/protocol/src/query-implementations/limits.ts
+++ b/packages/protocol/src/query-implementations/limits.ts
@@ -1,0 +1,29 @@
+import type {
+  ProtocolQueryImplementationLimits,
+  ProtocolQueryImplementationOptions,
+} from './types.js';
+
+export const DEFAULT_PROTOCOL_QUERY_IMPLEMENTATION_LIMITS: Readonly<ProtocolQueryImplementationLimits> = Object.freeze({
+  maxStatementBytes: 1_048_576,
+  maxExpressionBytes: 65_536,
+  maxTypeBytes: 256,
+  maxSourceBytes: 1_024,
+  maxCollectionItems: 100,
+});
+
+export function resolveQueryImplementationLimits(
+  options: ProtocolQueryImplementationOptions,
+): Readonly<ProtocolQueryImplementationLimits> {
+  const configured = options.limits ?? {};
+  const result = { ...DEFAULT_PROTOCOL_QUERY_IMPLEMENTATION_LIMITS };
+  for (const key of Object.keys(result) as (keyof ProtocolQueryImplementationLimits)[]) {
+    const value = configured[key];
+    if (value === undefined) continue;
+    if (!Number.isSafeInteger(value) || value < 1
+      || value > DEFAULT_PROTOCOL_QUERY_IMPLEMENTATION_LIMITS[key]) {
+      throw new RangeError(`Invalid query implementation limit: ${key}`);
+    }
+    result[key] = value;
+  }
+  return Object.freeze(result);
+}

--- a/packages/protocol/src/query-implementations/query-implementations.test.ts
+++ b/packages/protocol/src/query-implementations/query-implementations.test.ts
@@ -1,0 +1,187 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  ProtocolQueryImplementationError,
+  validateProtocolQueryImplementation,
+  validateProtocolSqlExpression,
+} from './index.js';
+
+type Surface = 'query-implementation' | 'sql-expression';
+interface SuccessFixture { id: string; surface: Surface; value: unknown }
+interface RejectionFixture {
+  id: string;
+  surface: Surface;
+  value?: unknown;
+  generator?:
+    | { type: 'parameters'; count: number }
+    | { type: 'sql-expression'; bytes: number }
+    | { type: 'unsafe-accessor' };
+  error: string;
+}
+
+const FAILURE_CODES = [
+  'HQ_QUERY_IMPLEMENTATION_TYPE',
+  'HQ_QUERY_IMPLEMENTATION_UNKNOWN_FIELD',
+  'HQ_QUERY_IMPLEMENTATION_UNKNOWN_KIND',
+  'HQ_QUERY_IMPLEMENTATION_INVALID_IDENTIFIER',
+  'HQ_QUERY_IMPLEMENTATION_INVALID_VALUE',
+  'HQ_QUERY_IMPLEMENTATION_INVALID_REFERENCE',
+  'HQ_QUERY_IMPLEMENTATION_TOO_MANY_ITEMS',
+  'HQ_QUERY_IMPLEMENTATION_TOO_LARGE',
+  'HQ_QUERY_IMPLEMENTATION_UNSAFE_OBJECT',
+] as const;
+
+function readFixture<T>(name: string): T {
+  const path = fileURLToPath(new URL(
+    `../../../../specs/security-protocol/fixtures/query-implementations-v1/${name}`,
+    import.meta.url,
+  ));
+  return JSON.parse(readFileSync(path, 'utf8')) as T;
+}
+
+function compiledSql(parameters: unknown[]) {
+  return {
+    kind: 'compiled-sql',
+    dialect: 'clickhouse',
+    operation: 'select',
+    statement: 'SELECT 1',
+    parameters,
+    readSources: [],
+    tenant: { kind: 'not-required' },
+  };
+}
+
+function materialize(fixture: RejectionFixture): unknown {
+  if (!fixture.generator) return fixture.value;
+  switch (fixture.generator.type) {
+    case 'parameters':
+      return compiledSql(Array.from({ length: fixture.generator.count }, (_, index) => ({
+        name: `param${index}`,
+        source: { kind: 'input', path: `param${index}` },
+        clickHouseType: 'String',
+      })));
+    case 'sql-expression':
+      return {
+        kind: 'sql-expression',
+        dialect: 'clickhouse',
+        sql: 'a'.repeat(fixture.generator.bytes),
+        output: { kind: 'string' },
+        dependencies: [],
+      };
+    case 'unsafe-accessor': {
+      const value = {} as { kind?: string };
+      Object.defineProperty(value, 'kind', { enumerable: true, get: () => 'semantic-plan' });
+      return value;
+    }
+  }
+}
+
+function validate(surface: Surface, value: unknown): unknown {
+  return surface === 'sql-expression'
+    ? validateProtocolSqlExpression(value)
+    : validateProtocolQueryImplementation(value);
+}
+
+function expectImplementationError(action: () => unknown, code: string): void {
+  try {
+    action();
+    throw new Error('Expected query implementation validation to fail');
+  } catch (error) {
+    expect(error).toBeInstanceOf(ProtocolQueryImplementationError);
+    expect((error as ProtocolQueryImplementationError).code).toBe(code);
+  }
+}
+
+describe('portable query implementations', () => {
+  const success = readFixture<SuccessFixture[]>('success.json');
+  const rejections = readFixture<RejectionFixture[]>('rejections.json');
+
+  it('has unique fixture IDs and covers every stable failure code', () => {
+    const fixtures = [...success, ...rejections];
+    expect(new Set(fixtures.map(fixture => fixture.id)).size).toBe(fixtures.length);
+    expect([...new Set(rejections.map(fixture => fixture.error))].sort())
+      .toEqual([...FAILURE_CODES].sort());
+  });
+
+  it.each(success)('accepts $id', fixture => {
+    expect(validate(fixture.surface, fixture.value)).toEqual(fixture.value);
+  });
+
+  it.each(rejections)('rejects $id with its stable code', fixture => {
+    expectImplementationError(
+      () => validate(fixture.surface, materialize(fixture)),
+      fixture.error,
+    );
+  });
+
+  it('covers every implementation kind and both runtime kinds', () => {
+    const implementations = success
+      .filter(fixture => fixture.surface === 'query-implementation')
+      .map(fixture => fixture.value as { kind: string; runtime?: string });
+    expect([...new Set(implementations.map(value => value.kind))].sort())
+      .toEqual(['compiled-sql', 'runtime-reference', 'semantic-plan']);
+    expect(implementations.flatMap(value => value.runtime ? [value.runtime] : []).sort())
+      .toEqual(['node', 'python']);
+  });
+
+  it('returns detached, deeply immutable snapshots', () => {
+    const input = compiledSql([{
+      name: 'from',
+      source: { kind: 'input', path: 'range.from' },
+      clickHouseType: 'Date',
+    }]);
+    const result = validateProtocolQueryImplementation(input);
+    (input.parameters[0] as { clickHouseType: string }).clickHouseType = 'String';
+    expect(result).toMatchObject({ parameters: [{ clickHouseType: 'Date' }] });
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen((result as { parameters: object }).parameters)).toBe(true);
+  });
+
+  it('requires tenant parameters and policy to agree exactly', () => {
+    const tenantParameter = {
+      name: 'tenantId', source: { kind: 'tenant' }, clickHouseType: 'UUID',
+    };
+    expectImplementationError(
+      () => validateProtocolQueryImplementation(compiledSql([tenantParameter])),
+      'HQ_QUERY_IMPLEMENTATION_INVALID_REFERENCE',
+    );
+    expectImplementationError(
+      () => validateProtocolQueryImplementation({
+        ...compiledSql([tenantParameter, {
+          name: 'otherTenant', source: { kind: 'tenant' }, clickHouseType: 'UUID',
+        }]),
+        tenant: { kind: 'required', parameter: 'tenantId' },
+      }),
+      'HQ_QUERY_IMPLEMENTATION_INVALID_REFERENCE',
+    );
+  });
+
+  it('allows multiline SQL but rejects controls in SQL and physical metadata', () => {
+    expect(() => validateProtocolQueryImplementation({
+      ...compiledSql([]), statement: 'SELECT\n  1',
+    })).not.toThrow();
+    for (const value of [
+      { ...compiledSql([]), statement: 'SELECT\u00001' },
+      { ...compiledSql([]), readSources: ['trips\narchive'] },
+      compiledSql([{
+        name: 'value', source: { kind: 'input', path: 'value' }, clickHouseType: 'String\u0085',
+      }]),
+    ]) {
+      expectImplementationError(
+        () => validateProtocolQueryImplementation(value),
+        'HQ_QUERY_IMPLEMENTATION_INVALID_VALUE',
+      );
+    }
+  });
+
+  it('permits lower product limits but rejects raised limits', () => {
+    expectImplementationError(
+      () => validateProtocolQueryImplementation(compiledSql([]), { limits: { maxStatementBytes: 4 } }),
+      'HQ_QUERY_IMPLEMENTATION_TOO_LARGE',
+    );
+    expect(() => validateProtocolQueryImplementation(compiledSql([]), {
+      limits: { maxStatementBytes: 1_048_577 },
+    })).toThrow(RangeError);
+  });
+});

--- a/packages/protocol/src/query-implementations/types.ts
+++ b/packages/protocol/src/query-implementations/types.ts
@@ -1,0 +1,71 @@
+import type { ProtocolSemanticQuery } from '../expressions/index.js';
+import type { ProtocolIdentifier, ProtocolQualifiedIdentifier } from '../identifiers/index.js';
+import type { ProtocolSchema } from '../schemas/index.js';
+
+export type ProtocolSqlDialect = 'clickhouse';
+
+export interface ProtocolSqlExpression {
+  readonly kind: 'sql-expression';
+  readonly dialect: ProtocolSqlDialect;
+  readonly sql: string;
+  readonly output: ProtocolSchema;
+  readonly dependencies: readonly ProtocolQualifiedIdentifier[];
+}
+
+export type ProtocolSqlParameterSource =
+  | { readonly kind: 'input'; readonly path: ProtocolQualifiedIdentifier }
+  | { readonly kind: 'tenant' };
+
+export interface ProtocolSqlParameter {
+  readonly name: ProtocolIdentifier;
+  readonly source: ProtocolSqlParameterSource;
+  readonly clickHouseType: string;
+}
+
+export type ProtocolSqlTenantPolicy =
+  | { readonly kind: 'required'; readonly parameter: ProtocolIdentifier }
+  | { readonly kind: 'not-required' };
+
+export type ProtocolQueryImplementation =
+  | {
+      readonly kind: 'semantic-plan';
+      readonly query: ProtocolSemanticQuery;
+    }
+  | {
+      readonly kind: 'compiled-sql';
+      readonly dialect: ProtocolSqlDialect;
+      readonly operation: 'select';
+      readonly statement: string;
+      readonly parameters: readonly ProtocolSqlParameter[];
+      readonly readSources: readonly string[];
+      readonly tenant: ProtocolSqlTenantPolicy;
+    }
+  | {
+      readonly kind: 'runtime-reference';
+      readonly runtime: 'node' | 'python';
+      readonly artifactSha256: string;
+      readonly entrypoint: ProtocolQualifiedIdentifier;
+    };
+
+export interface ProtocolQueryImplementationLimits {
+  readonly maxStatementBytes: number;
+  readonly maxExpressionBytes: number;
+  readonly maxTypeBytes: number;
+  readonly maxSourceBytes: number;
+  readonly maxCollectionItems: number;
+}
+
+export interface ProtocolQueryImplementationOptions {
+  readonly limits?: Partial<ProtocolQueryImplementationLimits>;
+}
+
+export type ProtocolQueryImplementationErrorCode =
+  | 'HQ_QUERY_IMPLEMENTATION_TYPE'
+  | 'HQ_QUERY_IMPLEMENTATION_UNKNOWN_FIELD'
+  | 'HQ_QUERY_IMPLEMENTATION_UNKNOWN_KIND'
+  | 'HQ_QUERY_IMPLEMENTATION_INVALID_IDENTIFIER'
+  | 'HQ_QUERY_IMPLEMENTATION_INVALID_VALUE'
+  | 'HQ_QUERY_IMPLEMENTATION_INVALID_REFERENCE'
+  | 'HQ_QUERY_IMPLEMENTATION_TOO_MANY_ITEMS'
+  | 'HQ_QUERY_IMPLEMENTATION_TOO_LARGE'
+  | 'HQ_QUERY_IMPLEMENTATION_UNSAFE_OBJECT';

--- a/packages/protocol/src/query-implementations/validate.ts
+++ b/packages/protocol/src/query-implementations/validate.ts
@@ -1,0 +1,290 @@
+import { ProtocolExpressionError, validateProtocolSemanticQuery } from '../expressions/index.js';
+import {
+  ProtocolIdentifierError,
+  parseProtocolIdentifier,
+  parseProtocolQualifiedIdentifier,
+} from '../identifiers/index.js';
+import { ProtocolSchemaError, validateProtocolSchema } from '../schemas/index.js';
+import { queryImplementationError } from './errors.js';
+import { resolveQueryImplementationLimits } from './limits.js';
+import type {
+  ProtocolQueryImplementation,
+  ProtocolQueryImplementationLimits,
+  ProtocolQueryImplementationOptions,
+  ProtocolSqlExpression,
+  ProtocolSqlParameter,
+  ProtocolSqlParameterSource,
+  ProtocolSqlTenantPolicy,
+} from './types.js';
+
+type DataRecord = Record<string, unknown>;
+const textEncoder = new TextEncoder();
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+
+function requireRecord(input: unknown, path: string): DataRecord {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    queryImplementationError('HQ_QUERY_IMPLEMENTATION_TYPE', path);
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    queryImplementationError('HQ_QUERY_IMPLEMENTATION_UNSAFE_OBJECT', path);
+  }
+  if (Object.getOwnPropertySymbols(input).length > 0) {
+    queryImplementationError('HQ_QUERY_IMPLEMENTATION_UNSAFE_OBJECT', path);
+  }
+  for (const descriptor of Object.values(Object.getOwnPropertyDescriptors(input))) {
+    if (!descriptor.enumerable || !('value' in descriptor)) {
+      queryImplementationError('HQ_QUERY_IMPLEMENTATION_UNSAFE_OBJECT', path);
+    }
+  }
+  return input as DataRecord;
+}
+
+function requireArray(input: unknown, path: string, maxItems: number): readonly unknown[] {
+  if (!Array.isArray(input)) queryImplementationError('HQ_QUERY_IMPLEMENTATION_TYPE', path);
+  if (Object.getPrototypeOf(input) !== Array.prototype || Object.getOwnPropertySymbols(input).length > 0) {
+    queryImplementationError('HQ_QUERY_IMPLEMENTATION_UNSAFE_OBJECT', path);
+  }
+  if (input.length > maxItems) queryImplementationError('HQ_QUERY_IMPLEMENTATION_TOO_MANY_ITEMS', path);
+  const descriptors = Object.getOwnPropertyDescriptors(input);
+  for (let index = 0; index < input.length; index += 1) {
+    const descriptor = descriptors[String(index)];
+    if (!descriptor || !descriptor.enumerable || !('value' in descriptor)) {
+      queryImplementationError('HQ_QUERY_IMPLEMENTATION_UNSAFE_OBJECT', `${path}[${index}]`);
+    }
+  }
+  if (Object.keys(input).length !== input.length) {
+    queryImplementationError('HQ_QUERY_IMPLEMENTATION_UNSAFE_OBJECT', path);
+  }
+  return input;
+}
+
+function exactFields(
+  value: DataRecord,
+  required: readonly string[],
+  optional: readonly string[],
+  path: string,
+): void {
+  const allowed = new Set([...required, ...optional]);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) queryImplementationError('HQ_QUERY_IMPLEMENTATION_UNKNOWN_FIELD', `${path}.${key}`);
+  }
+  for (const key of required) {
+    if (!Object.hasOwn(value, key)) queryImplementationError('HQ_QUERY_IMPLEMENTATION_TYPE', `${path}.${key}`);
+  }
+}
+
+function freezeRecord(entries: Record<string, unknown>): DataRecord {
+  return Object.freeze(Object.assign(Object.create(null), entries)) as DataRecord;
+}
+
+function identifier(value: unknown, path: string, qualified = false): string {
+  try {
+    return qualified ? parseProtocolQualifiedIdentifier(value) : parseProtocolIdentifier(value);
+  } catch (error) {
+    if (error instanceof ProtocolIdentifierError) {
+      queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_IDENTIFIER', path);
+    }
+    throw error;
+  }
+}
+
+function boundedText(
+  value: unknown,
+  path: string,
+  maxBytes: number,
+  allowSqlWhitespace = false,
+): string {
+  if (typeof value !== 'string') queryImplementationError('HQ_QUERY_IMPLEMENTATION_TYPE', path);
+  if (value.trim().length === 0) queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_VALUE', path);
+  for (const character of value) {
+    const code = character.codePointAt(0)!;
+    if ((code <= 0x1f && !(allowSqlWhitespace && (code === 0x09 || code === 0x0a || code === 0x0d)))
+      || code === 0x7f || (code >= 0x80 && code <= 0x9f)) {
+      queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_VALUE', path);
+    }
+  }
+  if (value.length > maxBytes || textEncoder.encode(value).byteLength > maxBytes) {
+    queryImplementationError('HQ_QUERY_IMPLEMENTATION_TOO_LARGE', path);
+  }
+  return value;
+}
+
+function dialect(value: unknown, path: string): 'clickhouse' {
+  if (value !== 'clickhouse') queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_VALUE', path);
+  return value;
+}
+
+function validateParameterSource(input: unknown, path: string): ProtocolSqlParameterSource {
+  const value = requireRecord(input, path);
+  if (value.kind === 'input') {
+    exactFields(value, ['kind', 'path'], [], path);
+    return freezeRecord({
+      kind: 'input', path: identifier(value.path, `${path}.path`, true),
+    }) as unknown as ProtocolSqlParameterSource;
+  }
+  if (value.kind === 'tenant') {
+    exactFields(value, ['kind'], [], path);
+    return freezeRecord({ kind: 'tenant' }) as unknown as ProtocolSqlParameterSource;
+  }
+  if (typeof value.kind !== 'string') queryImplementationError('HQ_QUERY_IMPLEMENTATION_TYPE', `${path}.kind`);
+  queryImplementationError('HQ_QUERY_IMPLEMENTATION_UNKNOWN_KIND', `${path}.kind`);
+}
+
+function validateParameters(
+  input: unknown,
+  path: string,
+  limits: Readonly<ProtocolQueryImplementationLimits>,
+): readonly ProtocolSqlParameter[] {
+  const values = requireArray(input, path, limits.maxCollectionItems);
+  const names = new Set<string>();
+  const result = values.map((inputValue, index) => {
+    const itemPath = `${path}[${index}]`;
+    const value = requireRecord(inputValue, itemPath);
+    exactFields(value, ['name', 'source', 'clickHouseType'], [], itemPath);
+    const name = identifier(value.name, `${itemPath}.name`);
+    if (names.has(name)) queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_REFERENCE', `${itemPath}.name`);
+    names.add(name);
+    return freezeRecord({
+      name,
+      source: validateParameterSource(value.source, `${itemPath}.source`),
+      clickHouseType: boundedText(value.clickHouseType, `${itemPath}.clickHouseType`, limits.maxTypeBytes),
+    }) as unknown as ProtocolSqlParameter;
+  });
+  return Object.freeze(result);
+}
+
+function validateTenant(
+  input: unknown,
+  path: string,
+  parameters: readonly ProtocolSqlParameter[],
+): ProtocolSqlTenantPolicy {
+  const value = requireRecord(input, path);
+  if (value.kind === 'not-required') {
+    exactFields(value, ['kind'], [], path);
+    if (parameters.some(parameter => parameter.source.kind === 'tenant')) {
+      queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_REFERENCE', path);
+    }
+    return freezeRecord({ kind: 'not-required' }) as unknown as ProtocolSqlTenantPolicy;
+  }
+  if (value.kind === 'required') {
+    exactFields(value, ['kind', 'parameter'], [], path);
+    const parameter = identifier(value.parameter, `${path}.parameter`);
+    if (!parameters.some(candidate => candidate.name === parameter && candidate.source.kind === 'tenant')) {
+      queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_REFERENCE', `${path}.parameter`);
+    }
+    if (parameters.filter(candidate => candidate.source.kind === 'tenant').length !== 1) {
+      queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_REFERENCE', path);
+    }
+    return freezeRecord({ kind: 'required', parameter }) as unknown as ProtocolSqlTenantPolicy;
+  }
+  if (typeof value.kind !== 'string') queryImplementationError('HQ_QUERY_IMPLEMENTATION_TYPE', `${path}.kind`);
+  queryImplementationError('HQ_QUERY_IMPLEMENTATION_UNKNOWN_KIND', `${path}.kind`);
+}
+
+function validateReadSources(
+  input: unknown,
+  path: string,
+  limits: Readonly<ProtocolQueryImplementationLimits>,
+): readonly string[] {
+  const values = requireArray(input, path, limits.maxCollectionItems);
+  const result = values.map((value, index) =>
+    boundedText(value, `${path}[${index}]`, limits.maxSourceBytes));
+  if (new Set(result).size !== result.length) {
+    queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_VALUE', path);
+  }
+  return Object.freeze(result);
+}
+
+export function validateProtocolSqlExpression(
+  input: unknown,
+  options: ProtocolQueryImplementationOptions = {},
+): ProtocolSqlExpression {
+  const limits = resolveQueryImplementationLimits(options);
+  const value = requireRecord(input, '$');
+  exactFields(value, ['kind', 'dialect', 'sql', 'output', 'dependencies'], [], '$');
+  if (value.kind !== 'sql-expression') {
+    if (typeof value.kind !== 'string') queryImplementationError('HQ_QUERY_IMPLEMENTATION_TYPE', '$.kind');
+    queryImplementationError('HQ_QUERY_IMPLEMENTATION_UNKNOWN_KIND', '$.kind');
+  }
+  const dependencies = requireArray(value.dependencies, '$.dependencies', limits.maxCollectionItems)
+    .map((dependency, index) => identifier(dependency, `$.dependencies[${index}]`, true));
+  if (new Set(dependencies).size !== dependencies.length) {
+    queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_VALUE', '$.dependencies');
+  }
+  let output;
+  try {
+    output = validateProtocolSchema(value.output);
+  } catch (error) {
+    if (error instanceof ProtocolSchemaError) {
+      queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_VALUE', '$.output');
+    }
+    throw error;
+  }
+  return freezeRecord({
+    kind: 'sql-expression',
+    dialect: dialect(value.dialect, '$.dialect'),
+    sql: boundedText(value.sql, '$.sql', limits.maxExpressionBytes, true),
+    output,
+    dependencies: Object.freeze(dependencies),
+  }) as unknown as ProtocolSqlExpression;
+}
+
+export function validateProtocolQueryImplementation(
+  input: unknown,
+  options: ProtocolQueryImplementationOptions = {},
+): ProtocolQueryImplementation {
+  const limits = resolveQueryImplementationLimits(options);
+  const value = requireRecord(input, '$');
+  if (typeof value.kind !== 'string') queryImplementationError('HQ_QUERY_IMPLEMENTATION_TYPE', '$.kind');
+  switch (value.kind) {
+    case 'semantic-plan': {
+      exactFields(value, ['kind', 'query'], [], '$');
+      try {
+        return freezeRecord({
+          kind: 'semantic-plan', query: validateProtocolSemanticQuery(value.query),
+        }) as unknown as ProtocolQueryImplementation;
+      } catch (error) {
+        if (error instanceof ProtocolExpressionError) {
+          queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_VALUE', '$.query');
+        }
+        throw error;
+      }
+    }
+    case 'compiled-sql': {
+      exactFields(value, [
+        'kind', 'dialect', 'operation', 'statement', 'parameters', 'readSources', 'tenant',
+      ], [], '$');
+      if (value.operation !== 'select') {
+        queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_VALUE', '$.operation');
+      }
+      const parameters = validateParameters(value.parameters, '$.parameters', limits);
+      return freezeRecord({
+        kind: 'compiled-sql',
+        dialect: dialect(value.dialect, '$.dialect'),
+        operation: 'select',
+        statement: boundedText(value.statement, '$.statement', limits.maxStatementBytes, true),
+        parameters,
+        readSources: validateReadSources(value.readSources, '$.readSources', limits),
+        tenant: validateTenant(value.tenant, '$.tenant', parameters),
+      }) as unknown as ProtocolQueryImplementation;
+    }
+    case 'runtime-reference': {
+      exactFields(value, ['kind', 'runtime', 'artifactSha256', 'entrypoint'], [], '$');
+      if (value.runtime !== 'node' && value.runtime !== 'python') {
+        queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_VALUE', '$.runtime');
+      }
+      if (typeof value.artifactSha256 !== 'string' || !SHA256_PATTERN.test(value.artifactSha256)) {
+        queryImplementationError('HQ_QUERY_IMPLEMENTATION_INVALID_VALUE', '$.artifactSha256');
+      }
+      return freezeRecord({
+        kind: 'runtime-reference',
+        runtime: value.runtime,
+        artifactSha256: value.artifactSha256,
+        entrypoint: identifier(value.entrypoint, '$.entrypoint', true),
+      }) as unknown as ProtocolQueryImplementation;
+    }
+    default:
+      queryImplementationError('HQ_QUERY_IMPLEMENTATION_UNKNOWN_KIND', '$.kind');
+  }
+}

--- a/packages/protocol/src/schemas/limits.ts
+++ b/packages/protocol/src/schemas/limits.ts
@@ -13,11 +13,12 @@ export function resolveSchemaLimits(
   const limits = { ...DEFAULT_PROTOCOL_SCHEMA_LIMITS };
   for (const key of Object.keys(options.limits ?? {}) as (keyof ProtocolSchemaLimits)[]) {
     const value = options.limits?.[key];
-    if (!Number.isSafeInteger(value) || (value as number) < 1
-      || (value as number) > DEFAULT_PROTOCOL_SCHEMA_LIMITS[key]) {
+    if (value === undefined) continue;
+    if (!Number.isSafeInteger(value) || value < 1
+      || value > DEFAULT_PROTOCOL_SCHEMA_LIMITS[key]) {
       throw new RangeError(`${key} must be a positive integer no greater than the protocol v1 maximum`);
     }
-    limits[key] = value as number;
+    limits[key] = value;
   }
   return Object.freeze(limits);
 }

--- a/packages/protocol/src/schemas/schemas.test.ts
+++ b/packages/protocol/src/schemas/schemas.test.ts
@@ -119,6 +119,7 @@ describe('portable query schemas', () => {
     for (const value of [
       { kind: 'integer', minimum: 1, default: 0 },
       { kind: 'string', minLength: 2, default: 'a' },
+      { kind: 'string', description: 'a'.repeat(65_537) },
       { kind: 'literal', value: true, default: false },
       { kind: 'enum', values: ['one', 'two'], default: 'three' },
       {
@@ -127,8 +128,25 @@ describe('portable query schemas', () => {
         default: { $hypequery: { type: 'array', version: 1, values: [1.5] } },
       },
     ]) {
-      expectSchemaError(() => validateProtocolSchema(value), 'HQ_SCHEMA_INVALID_VALUE');
+      const expectedCode = 'description' in value ? 'HQ_SCHEMA_TOO_LARGE' : 'HQ_SCHEMA_INVALID_VALUE';
+      expectSchemaError(() => validateProtocolSchema(value), expectedCode);
     }
+  });
+
+  it('rejects strip-policy defaults containing unknown properties', () => {
+    expectSchemaError(() => validateProtocolSchema({
+      kind: 'object',
+      properties: { known: { kind: 'string' } },
+      required: [],
+      unknownProperties: 'strip',
+      default: {
+        $hypequery: {
+          type: 'map',
+          version: 1,
+          entries: [['unknown', 'value']],
+        },
+      },
+    }), 'HQ_SCHEMA_INVALID_VALUE');
   });
 
   it('returns detached, deeply immutable snapshots', () => {
@@ -156,5 +174,12 @@ describe('portable query schemas', () => {
     );
     expect(() => validateProtocolSchema({ kind: 'any' }, { limits: { maxNodes: 1_001 } }))
       .toThrow(RangeError);
+  });
+
+  it('ignores explicitly undefined schema limits', () => {
+    expect(validateProtocolSchema(
+      { kind: 'any' },
+      { limits: { maxDepth: undefined, maxNodes: undefined } },
+    )).toEqual({ kind: 'any' });
   });
 });

--- a/packages/protocol/src/schemas/validate.ts
+++ b/packages/protocol/src/schemas/validate.ts
@@ -90,7 +90,6 @@ function validateAnnotations(
 ): void {
   if (value.description !== undefined) {
     if (typeof value.description !== 'string') schemaError('HQ_SCHEMA_TYPE', `${path}.description`);
-    const description = canonicalValue(value.description, `${path}.description`);
     // UTF-16 code units are a conservative allocation-free lower bound on UTF-8 bytes.
     if (value.description.length > state.limits.maxDescriptionBytes) {
       schemaError('HQ_SCHEMA_TOO_LARGE', `${path}.description`);
@@ -98,6 +97,7 @@ function validateAnnotations(
     if (textEncoder.encode(value.description).byteLength > state.limits.maxDescriptionBytes) {
       schemaError('HQ_SCHEMA_TOO_LARGE', `${path}.description`);
     }
+    const description = canonicalValue(value.description, `${path}.description`);
     result.description = description;
   }
   if (value.default !== undefined) {

--- a/packages/protocol/src/schemas/validate.ts
+++ b/packages/protocol/src/schemas/validate.ts
@@ -379,7 +379,7 @@ function matchesSchema(schema: ProtocolSchema, value: CanonicalValue): boolean {
         if (property) {
           if (!matchesSchema(property, item)) return false;
           found.add(key);
-        } else if (schema.unknownProperties === 'reject') {
+        } else if (schema.unknownProperties === 'reject' || schema.unknownProperties === 'strip') {
           return false;
         }
       }

--- a/specs/security-protocol/fixtures/query-implementations-v1/README.md
+++ b/specs/security-protocol/fixtures/query-implementations-v1/README.md
@@ -1,0 +1,10 @@
+# Query implementation extension 1 fixtures
+
+`success.json` contains trusted SQL expressions and all three closed named-query
+implementation kinds. `rejections.json` maps invalid artifacts to stable RFC
+0005 failure codes. Generator entries create values that JSON cannot represent
+concisely or safely.
+
+These fixtures validate artifact structure only. They do not assert that SQL is
+valid ClickHouse SQL or authorize it for execution; the trusted ClickHouse
+adapter performs those checks.

--- a/specs/security-protocol/fixtures/query-implementations-v1/rejections.json
+++ b/specs/security-protocol/fixtures/query-implementations-v1/rejections.json
@@ -1,0 +1,80 @@
+[
+  {
+    "id": "implementation-not-object",
+    "surface": "query-implementation",
+    "value": null,
+    "error": "HQ_QUERY_IMPLEMENTATION_TYPE"
+  },
+  {
+    "id": "implementation-extra-field",
+    "surface": "query-implementation",
+    "value": {
+      "kind": "runtime-reference",
+      "runtime": "node",
+      "artifactSha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "entrypoint": "queries.run",
+      "path": "./queries.js"
+    },
+    "error": "HQ_QUERY_IMPLEMENTATION_UNKNOWN_FIELD"
+  },
+  {
+    "id": "implementation-unknown-kind",
+    "surface": "query-implementation",
+    "value": { "kind": "raw-sql" },
+    "error": "HQ_QUERY_IMPLEMENTATION_UNKNOWN_KIND"
+  },
+  {
+    "id": "runtime-invalid-entrypoint",
+    "surface": "query-implementation",
+    "value": {
+      "kind": "runtime-reference",
+      "runtime": "node",
+      "artifactSha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "entrypoint": "queries/customerRevenue"
+    },
+    "error": "HQ_QUERY_IMPLEMENTATION_INVALID_IDENTIFIER"
+  },
+  {
+    "id": "runtime-uppercase-digest",
+    "surface": "query-implementation",
+    "value": {
+      "kind": "runtime-reference",
+      "runtime": "node",
+      "artifactSha256": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+      "entrypoint": "queries.run"
+    },
+    "error": "HQ_QUERY_IMPLEMENTATION_INVALID_VALUE"
+  },
+  {
+    "id": "compiled-sql-missing-tenant-parameter",
+    "surface": "query-implementation",
+    "value": {
+      "kind": "compiled-sql",
+      "dialect": "clickhouse",
+      "operation": "select",
+      "statement": "SELECT * FROM trips WHERE tenant_id = {tenantId:UUID}",
+      "parameters": [],
+      "readSources": ["trips"],
+      "tenant": { "kind": "required", "parameter": "tenantId" }
+    },
+    "error": "HQ_QUERY_IMPLEMENTATION_INVALID_REFERENCE"
+  },
+  {
+    "id": "compiled-sql-too-many-parameters",
+    "surface": "query-implementation",
+    "generator": { "type": "parameters", "count": 101 },
+    "error": "HQ_QUERY_IMPLEMENTATION_TOO_MANY_ITEMS"
+  },
+  {
+    "id": "sql-expression-too-large",
+    "surface": "sql-expression",
+    "generator": { "type": "sql-expression", "bytes": 65537 },
+    "error": "HQ_QUERY_IMPLEMENTATION_TOO_LARGE"
+  },
+  {
+    "id": "implementation-accessor",
+    "surface": "query-implementation",
+    "generator": { "type": "unsafe-accessor" },
+    "error": "HQ_QUERY_IMPLEMENTATION_UNSAFE_OBJECT"
+  }
+]

--- a/specs/security-protocol/fixtures/query-implementations-v1/success.json
+++ b/specs/security-protocol/fixtures/query-implementations-v1/success.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "sql-dimension-expression",
+    "surface": "sql-expression",
+    "value": {
+      "kind": "sql-expression",
+      "dialect": "clickhouse",
+      "sql": "toDate(pickup_datetime)",
+      "output": { "kind": "string" },
+      "dependencies": ["pickup_datetime"]
+    }
+  },
+  {
+    "id": "sql-measure-expression",
+    "surface": "sql-expression",
+    "value": {
+      "kind": "sql-expression",
+      "dialect": "clickhouse",
+      "sql": "quantileExact(0.95)(trip_distance)",
+      "output": { "kind": "number" },
+      "dependencies": ["trip_distance"]
+    }
+  },
+  {
+    "id": "fixed-semantic-plan",
+    "surface": "query-implementation",
+    "value": {
+      "kind": "semantic-plan",
+      "query": {
+        "kind": "dataset",
+        "dataset": "trips",
+        "dimensions": ["pickup_date"],
+        "measures": ["count", "total_revenue"],
+        "limit": 100
+      }
+    }
+  },
+  {
+    "id": "compiled-sql-input-parameters",
+    "surface": "query-implementation",
+    "value": {
+      "kind": "compiled-sql",
+      "dialect": "clickhouse",
+      "operation": "select",
+      "statement": "SELECT pickup_date, count() AS count FROM trips WHERE pickup_date >= {from:Date} GROUP BY pickup_date",
+      "parameters": [
+        {
+          "name": "from",
+          "source": { "kind": "input", "path": "range.from" },
+          "clickHouseType": "Date"
+        }
+      ],
+      "readSources": ["analytics.trips"],
+      "tenant": { "kind": "not-required" }
+    }
+  },
+  {
+    "id": "compiled-sql-required-tenant",
+    "surface": "query-implementation",
+    "value": {
+      "kind": "compiled-sql",
+      "dialect": "clickhouse",
+      "operation": "select",
+      "statement": "SELECT sum(total_amount) AS revenue FROM trips WHERE tenant_id = {tenantId:UUID}",
+      "parameters": [
+        {
+          "name": "tenantId",
+          "source": { "kind": "tenant" },
+          "clickHouseType": "UUID"
+        }
+      ],
+      "readSources": ["trips"],
+      "tenant": { "kind": "required", "parameter": "tenantId" }
+    }
+  },
+  {
+    "id": "node-runtime-reference",
+    "surface": "query-implementation",
+    "value": {
+      "kind": "runtime-reference",
+      "runtime": "node",
+      "artifactSha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "entrypoint": "queries.customerRevenue"
+    }
+  },
+  {
+    "id": "python-runtime-reference",
+    "surface": "query-implementation",
+    "value": {
+      "kind": "runtime-reference",
+      "runtime": "python",
+      "artifactSha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+      "entrypoint": "queries.customer_revenue"
+    }
+  }
+]

--- a/specs/security-protocol/rfc/0003-portable-dataset-expressions.md
+++ b/specs/security-protocol/rfc/0003-portable-dataset-expressions.md
@@ -131,7 +131,10 @@ Objects with accessors, symbols, non-enumerable properties, custom prototypes,
 or cycles MUST be rejected. Successful validation returns an immutable plain
 data snapshot and never retains caller-owned containers.
 
-Raw SQL, arbitrary function names, source-language callbacks, tenant identity,
-credentials, and database connection details are outside this AST. Unknown
-fields and operators fail closed. Changing node meaning, arity, limits, or the
-closed registries requires a new expression extension or core protocol version.
+Caller-supplied SQL, arbitrary function names, source-language callbacks,
+tenant identity, credentials, and database connection details are outside this
+AST. Trusted SQL produced during a build is specified separately by the query
+implementation extension; it never becomes an untrusted expression node.
+Unknown fields and operators fail closed. Changing node meaning, arity, limits,
+or the closed registries requires a new expression extension or core protocol
+version.

--- a/specs/security-protocol/rfc/0005-portable-query-implementations.md
+++ b/specs/security-protocol/rfc/0005-portable-query-implementations.md
@@ -1,0 +1,142 @@
+# RFC 0005: Portable query implementations
+
+- Status: Proposed
+- Version: query implementation extension 1
+
+## Summary
+
+The expression protocol describes untrusted query intent. It deliberately does
+not describe every trusted implementation that can produce a query result.
+Datasets currently permit developer-authored SQL dimensions and measures, and
+Serve named queries may execute a semantic query, compiled SQL, or arbitrary
+Node/Python code.
+
+This RFC defines the trusted boundary between those implementation choices and
+the public request protocol. Caller-provided SQL remains prohibited. SQL in
+this extension is trusted build output carried in a deployment bundle and is
+never accepted from a dataset query, dashboard, agent tool, or public query
+request.
+
+## Closed implementation union
+
+A named query has portable input and output schemas defined by RFC 0004 and
+exactly one implementation:
+
+- `semantic-plan`: a validated RFC 0003 dataset or metric query. Version 1 is a
+  concrete plan; parameterized semantic templates may be added by a later
+  extension.
+- `compiled-sql`: one read-only ClickHouse statement with typed, bound
+  parameters and declared read sources.
+- `runtime-reference`: an entrypoint in a separately hashed Node or Python
+  artifact. This is the fallback for callbacks and source-language behavior
+  that cannot be lowered without changing semantics.
+
+The implementation union does not contain credentials, connection details,
+tenant values, source code, environment variables, or interpolated parameter
+values.
+
+## Trusted SQL expressions
+
+Dataset dimensions and measures may carry a `sql-expression` artifact. It has
+an explicit `clickhouse` dialect, bounded SQL text, a portable output schema,
+and the logical field dependencies used by tooling and compatibility checks.
+Callers select the containing dimension or measure by identifier; they cannot
+submit or alter the SQL text.
+
+An SQL expression is a fragment, not a complete statement. A backend adapter
+MUST parse or safely compose it in the syntactic position declared by the
+dataset contract. The protocol validator does not claim to be a ClickHouse SQL
+parser.
+
+## Compiled SQL
+
+`compiled-sql` contains:
+
+- `dialect: "clickhouse"`;
+- `operation: "select"`;
+- the statement text;
+- distinct named parameters, each bound from query input or trusted tenant
+  context and carrying an explicit ClickHouse type;
+- the physical sources the statement may read; and
+- an explicit tenant policy.
+
+Input parameters identify a path in the named query input object. Tenant
+parameters obtain their value only from trusted execution context. A required
+tenant policy names exactly one declared tenant parameter. A `not-required`
+policy is an explicit security assertion and is not inferred from the absence
+of a tenant parameter.
+
+SQL text and physical source names are trusted, dialect-specific strings rather
+than portable logical identifiers. SQL text permits tabs and line endings;
+other controls are rejected. Physical sources and ClickHouse types reject all
+controls. Every string is bounded, but full SQL and ClickHouse type grammar
+validation belongs to the ClickHouse build/runtime adapter. A conforming
+runtime MUST parse the statement, confirm that it is one read-only query of the
+declared operation, bind values without string interpolation, enforce its
+source allow-list, and apply its own lower resource limits before execution.
+
+## Runtime references
+
+A runtime reference contains a runtime (`node` or `python`), the lowercase
+SHA-256 digest of an artifact present in the containing deployment bundle, and
+a portable entrypoint name. The bundle envelope owns artifact location,
+signature, runtime version, permissions, and isolation policy. Resolving a
+digest from an ambient registry or filesystem path is not permitted by this
+extension.
+
+## Existing API coverage
+
+| Existing feature | Portable treatment |
+| --- | --- |
+| Dynamic dataset/metric requests | RFC 0003 public semantic query |
+| Plain dimensions, measures, formulas and filters | Dataset contract plus RFC 0003 |
+| SQL-backed dimensions and measures | Trusted `sql-expression` |
+| Fixed semantic named query | `semantic-plan` |
+| Query builder lowered during build | `compiled-sql` |
+| `rawQuery` lowered during build | `compiled-sql` when safely parameterized and read-only |
+| Serve resolver callback | `runtime-reference` unless exactly lowerable |
+| Zod/Pydantic input and output | RFC 0004 portable schemas |
+| Authentication, roles, cache and HTTP metadata | Named-query/deployment contract extensions |
+| Credentials, tenant value and connection | Trusted runtime context; never this artifact |
+
+This extension therefore does not promise that arbitrary application code is
+language-neutral. It makes the choice between a portable plan, portable
+compiled SQL, and a language runtime explicit and inspectable.
+
+## Limits
+
+| Limit | Maximum |
+| --- | ---: |
+| SQL statement UTF-8 bytes | 1,048,576 |
+| SQL expression UTF-8 bytes | 65,536 |
+| ClickHouse type UTF-8 bytes | 256 |
+| Physical source UTF-8 bytes | 1,024 |
+| Parameters, sources, or dependencies in one object | 100 |
+
+Products may impose lower limits. They cannot raise these limits while
+claiming query implementation extension 1 conformance.
+
+## Stable failure codes
+
+- `HQ_QUERY_IMPLEMENTATION_TYPE`
+- `HQ_QUERY_IMPLEMENTATION_UNKNOWN_FIELD`
+- `HQ_QUERY_IMPLEMENTATION_UNKNOWN_KIND`
+- `HQ_QUERY_IMPLEMENTATION_INVALID_IDENTIFIER`
+- `HQ_QUERY_IMPLEMENTATION_INVALID_VALUE`
+- `HQ_QUERY_IMPLEMENTATION_INVALID_REFERENCE`
+- `HQ_QUERY_IMPLEMENTATION_TOO_MANY_ITEMS`
+- `HQ_QUERY_IMPLEMENTATION_TOO_LARGE`
+- `HQ_QUERY_IMPLEMENTATION_UNSAFE_OBJECT`
+
+## Security and compatibility
+
+Unknown kinds and fields fail closed. Objects with custom prototypes,
+accessors, symbols, hidden properties, cycles, sparse arrays, or extra array
+properties are rejected. Validation returns a detached, deeply immutable
+snapshot.
+
+Changing SQL text, parameter source/type, read sources, tenant policy, runtime,
+artifact digest, entrypoint, semantic plan, or expression dependencies changes
+implementation identity and requires deployment review. SQL text is never
+returned by public discovery by default. Tooling may expose it only on an
+authenticated trusted diagnostics surface.


### PR DESCRIPTION
## Summary

- Define the portable query implementation protocol artifacts for Dataset and Serve integrations.
- Add trusted dataset SQL-expression artifacts, fixed semantic query plans, compiled ClickHouse SQL with typed input and tenant bindings, and runtime references for non-portable Serve handlers.
- Add strict validators, immutable snapshots, RFC documentation, and v1 conformance fixtures.

## Validation

- Types, lint, build, and all 238 tests pass.

## Follow-up

The next step is to define the complete Dataset deployment contract and build the adapter that converts existing Dataset/Serve definitions into these protocol artifacts.
