### PR TITLE
feat(studio): compact toolbar with icon buttons; fix table column alignment

### DIFF
--- a/packages/studio/src/components/Logo.tsx
+++ b/packages/studio/src/components/Logo.tsx
@@ -14,7 +14,7 @@ export function Logo({ collapsed, className }: LogoProps) {
     return (
       <span
         className={cn(
-          'font-mono text-[19px] font-bold tracking-[-0.02em] text-foreground',
+          'font-mono tracking-[-0.02em] text-foreground',
           className
         )}
         title="hypequery"
@@ -27,7 +27,7 @@ export function Logo({ collapsed, className }: LogoProps) {
   return (
     <span
       className={cn(
-        'font-mono text-[18px] font-bold tracking-[-0.02em] text-foreground sm:text-[19px]',
+        'font-mono text-[14px] font-bold tracking-[-0.02em] text-foreground',
         className
       )}
     >

--- a/packages/studio/src/components/QueryHistory.tsx
+++ b/packages/studio/src/components/QueryHistory.tsx
@@ -10,6 +10,7 @@ import { QueryListSkeleton } from './Skeleton';
 import type { QueryFilters } from '@/lib/types';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
+import { Tooltip } from './ui/tooltip';
 
 interface QueryHistoryProps {
   className?: string;
@@ -60,21 +61,9 @@ export function QueryHistory({ className }: QueryHistoryProps) {
 
   return (
     <div className={cn('flex h-full flex-col min-w-0', className)}>
-      {/* Toolbar */}
-      <div className="flex-shrink-0 border-b border-border bg-card/45 px-4 py-5 md:px-6">
-        <div className="mb-4 flex items-end justify-between gap-4">
-          <div>
-            <p className="mb-1 font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-primary">
-              Execution history
-            </p>
-            <h1 className="text-lg font-semibold tracking-[-0.02em]">Query runs</h1>
-          </div>
-          <span className="hidden text-right text-xs text-muted-foreground sm:block">
-            Live updates from your API
-          </span>
-        </div>
-        {/* Search */}
-        <div className="relative mb-3">
+      {/* Toolbar: search + actions on one row */}
+      <div className="flex flex-shrink-0 items-center gap-2 border-b border-border bg-card/45 px-4 py-3 md:px-6">
+        <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
             type="text"
@@ -84,20 +73,22 @@ export function QueryHistory({ className }: QueryHistoryProps) {
             className="pl-9"
           />
         </div>
-
-        <div className="flex items-center justify-end gap-2">
+        <Tooltip content="Refresh">
           <Button
             variant="outline"
             size="sm"
+            aria-label="Refresh"
             onClick={() => refetch()}
             disabled={loading}
           >
             <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} />
-            Refresh
           </Button>
+        </Tooltip>
+        <Tooltip content="Clear history">
           <Button
             variant="outline"
             size="sm"
+            aria-label="Clear history"
             onClick={() => {
               if (confirm('Clear all query history?')) {
                 clearHistory();
@@ -105,9 +96,8 @@ export function QueryHistory({ className }: QueryHistoryProps) {
             }}
           >
             <Trash2 className="h-4 w-4" />
-            Clear
           </Button>
-        </div>
+        </Tooltip>
       </div>
 
       {/* Query count */}
@@ -115,24 +105,27 @@ export function QueryHistory({ className }: QueryHistoryProps) {
         {loading ? 'Loading...' : `${total} ${total === 1 ? 'query' : 'queries'}`}
       </div>
 
-      {table.getHeaderGroups().map((headerGroup) => (
-        <div
-          key={headerGroup.id}
-          className={cn(
-            'grid gap-3 border-b border-border bg-muted/45 px-4 py-2 font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground md:px-6',
-            QUERY_GRID_COLS
-          )}
-        >
-          {headerGroup.headers.map((header) => (
-            <div key={header.id}>
-              {flexRender(header.column.columnDef.header, header.getContext())}
-            </div>
-          ))}
-        </div>
-      ))}
-
-      {/* Query list */}
+      {/* Header lives inside the scroll container so it shares the rows'
+          scrollbar gutter — outside it, header and cells disagree by the
+          scrollbar width. Sticky keeps it visible; the solid background
+          layer stops rows showing through as they scroll under. */}
       <div className="flex-1 overflow-auto">
+        {table.getHeaderGroups().map((headerGroup) => (
+          <div key={headerGroup.id} className="sticky top-0 z-10 bg-background">
+            <div
+              className={cn(
+                'grid gap-3 border-b border-border bg-muted/45 px-4 py-2 font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground md:px-6',
+                QUERY_GRID_COLS
+              )}
+            >
+              {headerGroup.headers.map((header) => (
+                <div key={header.id}>
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
         {loading && queries.length === 0 ? (
           <QueryListSkeleton count={8} />
         ) : queries.length === 0 ? (

--- a/packages/studio/src/components/query-columns.tsx
+++ b/packages/studio/src/components/query-columns.tsx
@@ -7,9 +7,14 @@ import { StatusBadge } from './StatusBadge';
 import { TenantBadge } from './TenantBadge';
 import type { QueryHistoryEntry } from '@/lib/types';
 
-/** Shared grid template so the header and rows always align. */
+/**
+ * Shared grid template so the header and rows always align. Every track must
+ * be fixed or fractional — never `auto`/content-sized: each row is its own
+ * grid container, so a content-sized track would resolve to a different width
+ * per row and the columns would visibly wander between rows.
+ */
 export const QUERY_GRID_COLS =
-  'grid-cols-[140px_minmax(0,1.25fr)_minmax(0,0.95fr)_120px_110px_110px_auto]';
+  'grid-cols-[110px_minmax(0,1.25fr)_minmax(0,0.95fr)_110px_90px_90px_72px]';
 
 function formatInputPreview(input: unknown): string {
   if (input == null) return '-';
@@ -94,9 +99,9 @@ export const queryColumns = [
   }),
   columnHelper.display({
     id: 'meta',
-    header: () => <div className="text-right">Meta</div>,
+    header: 'Meta',
     cell: ({ row }) => (
-      <div className="flex justify-end gap-2">
+      <div className="flex justify-start gap-2">
         {row.original.tenantId && <TenantBadge tenantId={row.original.tenantId} />}
         {row.original.error && (
           <AlertCircle className={cn(ICON_SIZES.md, 'text-destructive')} />


### PR DESCRIPTION
## What

Follow-up to #291 — the working-tree changes that were iterated live against the demo gateway but missed the merge:

- **One-row toolbar**: search takes the flexible width; Refresh and Clear are icon-only buttons with tooltips (`Tooltip` from the UI kit) and matching `aria-label`s. The page-heading block is removed.
- **Structural column-alignment fix**: the grid template's last track was `auto` — and since each row is its own grid container, rows containing an error icon resolved *different* column widths than rows without, so columns visibly wandered row-to-row. Every track is now fixed or fractional, with a comment in `query-columns.tsx` banning content-sized tracks in this template.
- **Header inside the scroll container** as a sticky row, so it shares the rows' scrollbar gutter (it previously disagreed with the cells by the scrollbar width); Meta is left-aligned like the other columns.
- Track widths rebalanced so the Query column isn't starved/truncated at narrow viewports; small logo sizing tweak.

## Validation

Verified in the live HMR preview against the demo gateway: across 10 rows × 7 columns, every cell's left edge measures exactly 0px from its header; sticky header holds position under scroll; no truncation at an 800px viewport. Typecheck and `vite build` clean (main chunk 91KB gz).

🤖 Generated with [Claude Code](https://claude.com/claude-code)