### PR TITLE
Add portable Dataset deployment contracts and adapters

### DIFF
--- a/.changeset/portable-deployment-contract.md
+++ b/.changeset/portable-deployment-contract.md
@@ -1,0 +1,9 @@
+---
+'@hypequery/protocol': minor
+'@hypequery/datasets': minor
+'@hypequery/serve': minor
+---
+
+Add the portable Dataset deployment contract, strict protocol validation, and
+Dataset/Serve adapters for producing deployment artifacts from existing
+definitions.

--- a/packages/datasets/package.json
+++ b/packages/datasets/package.json
@@ -40,6 +40,7 @@
     "dist"
   ],
   "dependencies": {
+    "@hypequery/protocol": "^0.1.0",
     "@noble/hashes": "^1.8.0",
     "zod": "^3.22.4"
   },

--- a/packages/datasets/src/field.ts
+++ b/packages/datasets/src/field.ts
@@ -28,6 +28,7 @@ function createFieldHelper<T extends FieldType>(fieldType: T) {
     description: opts?.description,
     column: opts?.column,
     sql: opts?.sql,
+    dependencies: opts?.dependencies,
     filterable: opts?.filterable,
     groupable: opts?.groupable,
   }) as DimensionDefinition<T> & (TOptions extends DimensionOptions ? TOptions : object);

--- a/packages/datasets/src/index.ts
+++ b/packages/datasets/src/index.ts
@@ -52,6 +52,10 @@ export {
   hashContract,
   SEMANTIC_CONTRACT_VERSION,
 } from './contract.js';
+
+// Portable deployment contract adapter
+export { buildProtocolDatasetContract } from './protocol-adapter.js';
+export type { BuildProtocolDatasetContractOptions } from './protocol-adapter.js';
 export type {
   SemanticContract,
   SerializeSemanticContractOptions,

--- a/packages/datasets/src/measure.ts
+++ b/packages/datasets/src/measure.ts
@@ -6,6 +6,7 @@ function createMeasureHelper(aggregation: MeasureAggregation) {
     aggregation,
     field,
     sql: opts?.sql,
+    dependencies: opts?.dependencies,
     label: opts?.label,
     description: opts?.description,
     filters: opts?.filters,
@@ -29,6 +30,7 @@ function createArgMeasureHelper(aggregation: 'argMax' | 'argMin') {
       field,
       argField: by,
       sql: opts?.sql,
+      dependencies: opts?.dependencies,
       label: opts?.label,
       description: opts?.description,
     };
@@ -43,6 +45,7 @@ function createPercentileMeasure(field: string, level: number, opts?: MeasureOpt
     field,
     level,
     sql: opts?.sql,
+    dependencies: opts?.dependencies,
     label: opts?.label,
     description: opts?.description,
     filters: opts?.filters,

--- a/packages/datasets/src/protocol-adapter.test.ts
+++ b/packages/datasets/src/protocol-adapter.test.ts
@@ -23,12 +23,18 @@ describe('Dataset protocol adapter', () => {
       dimensions: {
         id: dimension.string(),
         amount: dimension.number(),
-        netAmount: dimension.number({ sql: 'amount - discount' }),
+        netAmount: dimension.number({
+          sql: 'amount - discount',
+          dependencies: ['amount', 'discount'],
+        }),
       },
       measures: {
         revenue: measure.sum('amount', { filters: [eq('amount', 10)] }),
         orderCount: measure.count('id'),
-        netRevenue: measure.sum('amount', { sql: 'amount - discount' }),
+        netRevenue: measure.sum('amount', {
+          sql: 'amount - discount',
+          dependencies: ['amount', 'discount'],
+        }),
       },
       relationships: {
         customer: belongsTo(() => Customers, { from: 'customer_id', to: 'id' }),
@@ -73,7 +79,7 @@ describe('Dataset protocol adapter', () => {
         kind: 'sql-expression',
         dialect: 'clickhouse',
         sql: 'amount - discount',
-        dependencies: ['amount', 'id'],
+        dependencies: ['amount', 'discount'],
       });
     expect(contract.measures.find(item => item.name === 'revenue')?.filters)
       .toHaveLength(1);
@@ -100,5 +106,17 @@ describe('Dataset protocol adapter', () => {
     });
     expect(Object.isFrozen(contract)).toBe(true);
     expect(Object.isFrozen(contract.dimensions)).toBe(true);
+  });
+
+  it('requires exact dependencies for every SQL-backed field', () => {
+    const Dataset = dataset('orders', {
+      source: 'orders',
+      dimensions: {
+        computed: dimension.number({ sql: 'amount - discount' }),
+      },
+    });
+
+    expect(() => buildProtocolDatasetContract(Dataset))
+      .toThrow('SQL-backed dimension "computed" must declare dependencies');
   });
 });

--- a/packages/datasets/src/protocol-adapter.test.ts
+++ b/packages/datasets/src/protocol-adapter.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { belongsTo } from './relationships.js';
+import { dataset } from './dataset.js';
+import { dimension } from './field.js';
+import { measure } from './measure.js';
+import { eq } from './query-helpers.js';
+import { divide, nullIfZero } from './formulas.js';
+import { buildProtocolDatasetContract } from './protocol-adapter.js';
+
+describe('Dataset protocol adapter', () => {
+  it('lowers Dataset fields, trusted SQL, relationships, filters, and metrics', () => {
+    const Customers = dataset('customers', {
+      source: 'customers',
+      dimensions: {
+        id: dimension.string(),
+        region: dimension.string(),
+      },
+    });
+    const Orders = dataset('orders', {
+      source: 'analytics.orders',
+      tenantKey: 'tenant_id',
+      timeKey: 'created_at',
+      dimensions: {
+        id: dimension.string(),
+        amount: dimension.number(),
+        netAmount: dimension.number({ sql: 'amount - discount' }),
+      },
+      measures: {
+        revenue: measure.sum('amount', { filters: [eq('amount', 10)] }),
+        orderCount: measure.count('id'),
+        netRevenue: measure.sum('amount', { sql: 'amount - discount' }),
+      },
+      relationships: {
+        customer: belongsTo(() => Customers, { from: 'customer_id', to: 'id' }),
+      },
+      limits: { maxResultSize: 250 },
+    });
+    const totalRevenue = Orders.metric('totalRevenue', { measure: 'revenue' });
+    const orderCount = Orders.metric('orderCount', { measure: 'orderCount' });
+    const averageOrderValue = Orders.metric('averageOrderValue', {
+      uses: { totalRevenue, orderCount },
+      formula: ({ totalRevenue: revenue, orderCount: count }) =>
+        divide(revenue, nullIfZero(count)),
+    });
+
+    const contract = buildProtocolDatasetContract(Orders, {
+      endpoint: {
+        access: { kind: 'authenticated', roles: [], scopes: ['read:orders'] },
+        tenant: { kind: 'required', mode: 'auto-inject', column: 'tenant_id' },
+        maxLimit: 250,
+        path: '/api/analytics/datasets/orders/query',
+      },
+      metrics: { averageOrderValue, totalRevenue },
+      metricEndpoints: {
+        averageOrderValue: {
+          access: { kind: 'public' },
+          tenant: { kind: 'required', mode: 'auto-inject', column: 'tenant_id' },
+          maxLimit: 250,
+          path: '/api/analytics/metrics/averageOrderValue',
+        },
+        totalRevenue: {
+          access: { kind: 'public' },
+          tenant: { kind: 'required', mode: 'auto-inject', column: 'tenant_id' },
+          maxLimit: 250,
+          path: '/api/analytics/metrics/totalRevenue',
+        },
+      },
+    });
+
+    expect(contract.tenant).toEqual({ kind: 'required', field: 'tenant_id' });
+    expect(contract.dimensions.find(item => item.name === 'netAmount')?.source)
+      .toMatchObject({
+        kind: 'sql-expression',
+        dialect: 'clickhouse',
+        sql: 'amount - discount',
+        dependencies: ['amount', 'id'],
+      });
+    expect(contract.measures.find(item => item.name === 'revenue')?.filters)
+      .toHaveLength(1);
+    expect(contract.metrics.find(item => item.name === 'totalRevenue')).toMatchObject({
+      name: 'totalRevenue',
+      kind: 'metric',
+      expression: { kind: 'aggregate', aggregation: 'sum', field: 'amount' },
+    });
+    expect(contract.metrics.find(item => item.name === 'averageOrderValue')).toMatchObject({
+      kind: 'derived-metric',
+      expression: {
+        kind: 'binary',
+        operator: 'divide',
+        left: { kind: 'aggregate', aggregation: 'sum', field: 'amount' },
+        right: {
+          kind: 'call',
+          function: 'nullIfZero',
+          args: [{ kind: 'aggregate', aggregation: 'count', field: 'id' }],
+        },
+      },
+    });
+    expect(contract.relationships[0]).toMatchObject({
+      name: 'customer', target: 'customers', queryable: true,
+    });
+    expect(Object.isFrozen(contract)).toBe(true);
+    expect(Object.isFrozen(contract.dimensions)).toBe(true);
+  });
+});

--- a/packages/datasets/src/protocol-adapter.ts
+++ b/packages/datasets/src/protocol-adapter.ts
@@ -1,4 +1,6 @@
 import {
+  parseProtocolIdentifier,
+  parseProtocolQualifiedIdentifier,
   validateCanonicalValue,
   validateProtocolDatasetContract,
   type CanonicalValue,
@@ -20,6 +22,13 @@ import type {
   MetricHandle,
   MetricRef,
 } from './types.js';
+
+type ProtocolReferenceExpression = Extract<ProtocolExpression, { readonly kind: 'reference' }>;
+type ProtocolLiteralExpression = Extract<ProtocolExpression, { readonly kind: 'literal' }>;
+type ProtocolBinaryExpression = Extract<ProtocolExpression, { readonly kind: 'binary' }>;
+type ProtocolCallExpression = Extract<ProtocolExpression, { readonly kind: 'call' }>;
+type ProtocolComparisonExpression = Extract<ProtocolExpression, { readonly kind: 'comparison' }>;
+type ProtocolAggregateExpression = Extract<ProtocolExpression, { readonly kind: 'aggregate' }>;
 
 export interface BuildProtocolDatasetContractOptions {
   readonly metrics?: Readonly<Record<string, MetricHandle>>;
@@ -75,25 +84,37 @@ function canonicalValue(input: unknown): CanonicalValue {
 }
 
 function filterExpression(filter: MetricFilter): ProtocolExpression {
-  return {
+  const left: ProtocolReferenceExpression = {
+    kind: 'reference',
+    name: parseProtocolQualifiedIdentifier(filter.field),
+  };
+  const right: ProtocolLiteralExpression = {
+    kind: 'literal',
+    value: canonicalValue(filter.value),
+  };
+  const result: ProtocolComparisonExpression = {
     kind: 'comparison',
     operator: filter.operator,
-    left: { kind: 'reference', name: filter.field },
-    right: { kind: 'literal', value: canonicalValue(filter.value) },
-  } as unknown as ProtocolExpression;
+    left,
+    right,
+  };
+  return result;
 }
 
 function aggregationExpression(spec: AggregationSpec): ProtocolExpression {
-  return {
+  const result: ProtocolAggregateExpression = {
     kind: 'aggregate',
     aggregation: spec.aggregation,
-    field: spec.field,
-    ...(spec.argField !== undefined ? { argField: spec.argField } : {}),
+    field: parseProtocolQualifiedIdentifier(spec.field),
+    ...(spec.argField !== undefined
+      ? { argField: parseProtocolQualifiedIdentifier(spec.argField) }
+      : {}),
     ...(spec.level !== undefined ? { level: spec.level } : {}),
     ...(spec.filters?.length
       ? { filters: spec.filters.map(filterExpression) }
       : {}),
-  } as unknown as ProtocolExpression;
+  };
+  return result;
 }
 
 function semanticExpression(
@@ -103,7 +124,10 @@ function semanticExpression(
   switch (expression.kind) {
     case 'ref':
       return references[expression.name]
-        ?? ({ kind: 'reference', name: expression.name } as unknown as ProtocolExpression);
+        ?? {
+          kind: 'reference',
+          name: parseProtocolQualifiedIdentifier(expression.name),
+        } satisfies ProtocolReferenceExpression;
     case 'literal':
       return { kind: 'literal', value: canonicalValue(expression.value) };
     case 'binary':
@@ -112,13 +136,13 @@ function semanticExpression(
         operator: expression.operator,
         left: semanticExpression(expression.left, references),
         right: semanticExpression(expression.right, references),
-      } as unknown as ProtocolExpression;
+      } satisfies ProtocolBinaryExpression;
     case 'function':
       return {
         kind: 'call',
         function: expression.name,
         args: expression.args.map(argument => semanticExpression(argument, references)),
-      } as unknown as ProtocolExpression;
+      } satisfies ProtocolCallExpression;
   }
 }
 
@@ -148,22 +172,23 @@ function metricContract(
 ): ProtocolDatasetMetric {
   const { ref, grain } = unwrapMetric(metric);
   const contract = metric.contract();
-  return {
-    name: exposedName,
+  const result: ProtocolDatasetMetric = {
+    name: parseProtocolIdentifier(exposedName),
     kind: grain
       ? 'grained-metric'
       : ref.spec.__type === 'derived_metric_spec'
         ? 'derived-metric'
         : 'metric',
     expression: metricExpression(ref.spec),
-    dimensions: [...contract.dimensions].sort(),
-    filters: [...contract.filters].sort(),
+    dimensions: [...contract.dimensions].sort().map(parseProtocolQualifiedIdentifier),
+    filters: [...contract.filters].sort().map(parseProtocolIdentifier),
     grains: [...contract.grains].sort(),
     ...(grain !== undefined ? { grain } : {}),
     ...(ref.label !== undefined ? { label: ref.label } : {}),
     ...(ref.description !== undefined ? { description: ref.description } : {}),
     endpoint,
-  } as unknown as ProtocolDatasetMetric;
+  };
+  return result;
 }
 
 function sqlExpression(
@@ -176,8 +201,21 @@ function sqlExpression(
     dialect: 'clickhouse',
     sql,
     output,
-    dependencies,
-  } as unknown as ProtocolSqlExpression;
+    dependencies: [...dependencies].sort().map(parseProtocolQualifiedIdentifier),
+  };
+}
+
+function requiredSqlDependencies(
+  kind: 'dimension' | 'measure',
+  name: string,
+  dependencies: readonly string[] | undefined,
+): readonly string[] {
+  if (dependencies === undefined) {
+    throw new Error(
+      `SQL-backed ${kind} "${name}" must declare dependencies for the protocol artifact.`,
+    );
+  }
+  return dependencies;
 }
 
 /**
@@ -188,10 +226,6 @@ export function buildProtocolDatasetContract(
   dataset: AnyDatasetInstance,
   options: BuildProtocolDatasetContractOptions = {},
 ): ProtocolDatasetContract {
-  const dependencies = Object.entries(dataset.dimensions)
-    .filter(([, dimension]) => dimension.sql === undefined)
-    .map(([name]) => name)
-    .sort();
   const metrics = Object.entries(options.metrics ?? {})
     .filter(([, metric]) => unwrapMetric(metric).ref.datasetName === dataset.name)
     .map(([name, metric]) => {
@@ -214,7 +248,11 @@ export function buildProtocolDatasetContract(
       name,
       type: dimension.fieldType,
       source: dimension.sql !== undefined
-        ? sqlExpression(dimension.sql, fieldSchema(dimension.fieldType), dependencies)
+        ? sqlExpression(
+            dimension.sql,
+            fieldSchema(dimension.fieldType),
+            requiredSqlDependencies('dimension', name, dimension.dependencies),
+          )
         : { kind: 'column' as const, column: dimension.column ?? name },
       filterable: dimension.filterable !== false,
       groupable: dimension.groupable !== false,
@@ -232,7 +270,7 @@ export function buildProtocolDatasetContract(
             sql: sqlExpression(
               measure.sql,
               fieldSchema(dataset.dimensions[measure.field]?.fieldType),
-              dependencies,
+              requiredSqlDependencies('measure', name, measure.dependencies),
             ),
           }
         : {}),

--- a/packages/datasets/src/protocol-adapter.ts
+++ b/packages/datasets/src/protocol-adapter.ts
@@ -1,0 +1,284 @@
+import {
+  validateCanonicalValue,
+  validateProtocolDatasetContract,
+  type CanonicalValue,
+  type ProtocolDatasetContract,
+  type ProtocolDatasetMetric,
+  type ProtocolEndpointPolicy,
+  type ProtocolExpression,
+  type ProtocolSchema,
+  type ProtocolSqlExpression,
+} from '@hypequery/protocol';
+import { SEMANTIC_FILTER_OPERATORS } from './constants.js';
+import type { SemanticExpression } from './semantic-plan.js';
+import type {
+  AggregationSpec,
+  AnyDatasetInstance,
+  DerivedMetricSpec,
+  FieldType,
+  MetricFilter,
+  MetricHandle,
+  MetricRef,
+} from './types.js';
+
+export interface BuildProtocolDatasetContractOptions {
+  readonly metrics?: Readonly<Record<string, MetricHandle>>;
+  readonly endpoint?: ProtocolEndpointPolicy;
+  readonly metricEndpoints?: Readonly<Record<string, ProtocolEndpointPolicy>>;
+}
+
+function byName<T extends { readonly name: string }>(left: T, right: T): number {
+  return left.name.localeCompare(right.name);
+}
+
+function fieldSchema(type: FieldType | undefined): ProtocolSchema {
+  switch (type) {
+    case 'string':
+    case 'timestamp':
+      return { kind: 'string' };
+    case 'number':
+      return { kind: 'number' };
+    case 'boolean':
+      return { kind: 'boolean' };
+    default:
+      return { kind: 'any' };
+  }
+}
+
+function canonicalValue(input: unknown): CanonicalValue {
+  if (Array.isArray(input)) {
+    return validateCanonicalValue({
+      $hypequery: {
+        type: 'array',
+        version: 1,
+        values: input.map(canonicalValue),
+      },
+    });
+  }
+  if (typeof input === 'object' && input !== null) {
+    if ('$hypequery' in input) return validateCanonicalValue(input);
+    const prototype = Object.getPrototypeOf(input);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError('Dataset protocol adapter only accepts plain filter values.');
+    }
+    return validateCanonicalValue({
+      $hypequery: {
+        type: 'map',
+        version: 1,
+        entries: Object.entries(input as Record<string, unknown>)
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([key, value]) => [key, canonicalValue(value)]),
+      },
+    });
+  }
+  return validateCanonicalValue(input);
+}
+
+function filterExpression(filter: MetricFilter): ProtocolExpression {
+  return {
+    kind: 'comparison',
+    operator: filter.operator,
+    left: { kind: 'reference', name: filter.field },
+    right: { kind: 'literal', value: canonicalValue(filter.value) },
+  } as unknown as ProtocolExpression;
+}
+
+function aggregationExpression(spec: AggregationSpec): ProtocolExpression {
+  return {
+    kind: 'aggregate',
+    aggregation: spec.aggregation,
+    field: spec.field,
+    ...(spec.argField !== undefined ? { argField: spec.argField } : {}),
+    ...(spec.level !== undefined ? { level: spec.level } : {}),
+    ...(spec.filters?.length
+      ? { filters: spec.filters.map(filterExpression) }
+      : {}),
+  } as unknown as ProtocolExpression;
+}
+
+function semanticExpression(
+  expression: SemanticExpression,
+  references: Readonly<Record<string, ProtocolExpression>> = {},
+): ProtocolExpression {
+  switch (expression.kind) {
+    case 'ref':
+      return references[expression.name]
+        ?? ({ kind: 'reference', name: expression.name } as unknown as ProtocolExpression);
+    case 'literal':
+      return { kind: 'literal', value: canonicalValue(expression.value) };
+    case 'binary':
+      return {
+        kind: 'binary',
+        operator: expression.operator,
+        left: semanticExpression(expression.left, references),
+        right: semanticExpression(expression.right, references),
+      } as unknown as ProtocolExpression;
+    case 'function':
+      return {
+        kind: 'call',
+        function: expression.name,
+        args: expression.args.map(argument => semanticExpression(argument, references)),
+      } as unknown as ProtocolExpression;
+  }
+}
+
+function unwrapMetric(metric: MetricHandle): {
+  readonly ref: MetricRef;
+  readonly grain?: 'day' | 'week' | 'month' | 'quarter' | 'year';
+} {
+  return metric.__type === 'grained_metric_ref'
+    ? { ref: metric.metric, grain: metric.grain }
+    : { ref: metric };
+}
+
+function metricExpression(spec: AggregationSpec | DerivedMetricSpec): ProtocolExpression {
+  if (spec.__type === 'aggregation_spec') return aggregationExpression(spec);
+  const aliases = Object.fromEntries(Object.keys(spec.uses).map(alias => [alias, alias]));
+  const references = Object.fromEntries(Object.entries(spec.uses).map(([alias, metric]) => [
+    alias,
+    aggregationExpression(metric.spec),
+  ]));
+  return semanticExpression(spec.formula(aliases).expression, references);
+}
+
+function metricContract(
+  exposedName: string,
+  metric: MetricHandle,
+  endpoint: ProtocolEndpointPolicy,
+): ProtocolDatasetMetric {
+  const { ref, grain } = unwrapMetric(metric);
+  const contract = metric.contract();
+  return {
+    name: exposedName,
+    kind: grain
+      ? 'grained-metric'
+      : ref.spec.__type === 'derived_metric_spec'
+        ? 'derived-metric'
+        : 'metric',
+    expression: metricExpression(ref.spec),
+    dimensions: [...contract.dimensions].sort(),
+    filters: [...contract.filters].sort(),
+    grains: [...contract.grains].sort(),
+    ...(grain !== undefined ? { grain } : {}),
+    ...(ref.label !== undefined ? { label: ref.label } : {}),
+    ...(ref.description !== undefined ? { description: ref.description } : {}),
+    endpoint,
+  } as unknown as ProtocolDatasetMetric;
+}
+
+function sqlExpression(
+  sql: string,
+  output: ProtocolSchema,
+  dependencies: readonly string[],
+): ProtocolSqlExpression {
+  return {
+    kind: 'sql-expression',
+    dialect: 'clickhouse',
+    sql,
+    output,
+    dependencies,
+  } as unknown as ProtocolSqlExpression;
+}
+
+/**
+ * Converts one existing Dataset instance into the versioned deployment
+ * contract consumed by protocol-aware build and runtime tooling.
+ */
+export function buildProtocolDatasetContract(
+  dataset: AnyDatasetInstance,
+  options: BuildProtocolDatasetContractOptions = {},
+): ProtocolDatasetContract {
+  const dependencies = Object.entries(dataset.dimensions)
+    .filter(([, dimension]) => dimension.sql === undefined)
+    .map(([name]) => name)
+    .sort();
+  const metrics = Object.entries(options.metrics ?? {})
+    .filter(([, metric]) => unwrapMetric(metric).ref.datasetName === dataset.name)
+    .map(([name, metric]) => {
+      const endpoint = options.metricEndpoints?.[name];
+      if (!endpoint) {
+        throw new Error(`Missing protocol endpoint policy for metric "${name}".`);
+      }
+      return metricContract(name, metric, endpoint);
+    })
+    .sort(byName);
+
+  const contract = {
+    name: dataset.name,
+    source: dataset.source,
+    tenant: dataset.tenantKey
+      ? { kind: 'required', field: dataset.tenantKey }
+      : { kind: 'not-required' },
+    ...(dataset.timeKey !== undefined ? { timeField: dataset.timeKey } : {}),
+    dimensions: Object.entries(dataset.dimensions).map(([name, dimension]) => ({
+      name,
+      type: dimension.fieldType,
+      source: dimension.sql !== undefined
+        ? sqlExpression(dimension.sql, fieldSchema(dimension.fieldType), dependencies)
+        : { kind: 'column' as const, column: dimension.column ?? name },
+      filterable: dimension.filterable !== false,
+      groupable: dimension.groupable !== false,
+      ...(dimension.label !== undefined ? { label: dimension.label } : {}),
+      ...(dimension.description !== undefined ? { description: dimension.description } : {}),
+    })).sort(byName),
+    measures: Object.entries(dataset.measures).map(([name, measure]) => ({
+      name,
+      aggregation: measure.aggregation,
+      field: measure.field,
+      ...(measure.argField !== undefined ? { argField: measure.argField } : {}),
+      ...(measure.level !== undefined ? { level: measure.level } : {}),
+      ...(measure.sql !== undefined
+        ? {
+            sql: sqlExpression(
+              measure.sql,
+              fieldSchema(dataset.dimensions[measure.field]?.fieldType),
+              dependencies,
+            ),
+          }
+        : {}),
+      filters: (measure.filters ?? []).map(filterExpression),
+      ...(measure.label !== undefined ? { label: measure.label } : {}),
+      ...(measure.description !== undefined ? { description: measure.description } : {}),
+    })).sort(byName),
+    filters: Object.entries(dataset.filters).map(([name, filter]) => ({
+      name,
+      field: filter.field,
+      operators: [...(filter.operators ?? SEMANTIC_FILTER_OPERATORS)],
+      ...(filter.label !== undefined ? { label: filter.label } : {}),
+      ...(filter.description !== undefined ? { description: filter.description } : {}),
+    })).sort(byName),
+    metrics,
+    relationships: Object.entries(dataset.relationships).map(([name, relationship]) => ({
+      name,
+      kind: relationship.kind,
+      target: relationship.target().name,
+      from: relationship.from,
+      to: relationship.to,
+      queryable: relationship.kind !== 'hasMany',
+    })).sort(byName),
+    ...(dataset.limits !== undefined
+      ? {
+          limits: {
+            ...(dataset.limits.maxDimensions !== undefined
+              ? { maxDimensions: dataset.limits.maxDimensions }
+              : {}),
+            ...(dataset.limits.maxMeasures !== undefined
+              ? { maxMeasures: dataset.limits.maxMeasures }
+              : {}),
+            ...(dataset.limits.maxFilters !== undefined
+              ? { maxFilters: dataset.limits.maxFilters }
+              : {}),
+            ...(dataset.limits.maxResultSize !== undefined
+              ? { maxResultSize: dataset.limits.maxResultSize }
+              : {}),
+          },
+        }
+      : {}),
+    ...(options.endpoint !== undefined ? { endpoint: options.endpoint } : {}),
+  };
+
+  // Reuse the protocol validator for strict identifiers, expression limits,
+  // and a deeply immutable return value. Cross-dataset references are checked
+  // by the containing deployment validator.
+  return validateProtocolDatasetContract(contract);
+}

--- a/packages/datasets/src/types.ts
+++ b/packages/datasets/src/types.ts
@@ -10,6 +10,8 @@ export interface DimensionOptions {
   description?: string;
   column?: string;
   sql?: string;
+  /** Identifiers referenced by `sql`; required when producing a protocol artifact. */
+  dependencies?: readonly string[];
   filterable?: boolean;
   groupable?: boolean;
 }
@@ -21,6 +23,8 @@ export interface DimensionDefinition<TType extends DimensionType = DimensionType
   description?: string;
   column?: string;
   sql?: string;
+  /** Identifiers referenced by `sql`; required when producing a protocol artifact. */
+  dependencies?: readonly string[];
   filterable?: boolean;
   groupable?: boolean;
 }
@@ -73,6 +77,8 @@ export interface AggregationSpec {
 
 export interface MeasureOptions {
   sql?: string;
+  /** Identifiers referenced by `sql`; required when producing a protocol artifact. */
+  dependencies?: readonly string[];
   label?: string;
   description?: string;
   filters?: MetricFilter[];
@@ -87,6 +93,8 @@ export interface MeasureDefinition {
   /** Percentile level in [0, 1]. Required when aggregation is 'percentile'. */
   level?: number;
   sql?: string;
+  /** Identifiers referenced by `sql`; required when producing a protocol artifact. */
+  dependencies?: readonly string[];
   label?: string;
   description?: string;
   filters?: MetricFilter[];

--- a/packages/datasets/tsconfig.json
+++ b/packages/datasets/tsconfig.json
@@ -24,5 +24,8 @@
     "node_modules",
     "dist",
     "**/*.test.ts"
+  ],
+  "references": [
+    { "path": "../protocol" }
   ]
 }

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -70,6 +70,11 @@ semantic plans, compiled read-only ClickHouse statements with bound input or
 tenant parameters, and hashed Node/Python runtime references for Serve handlers
 that cannot be lowered portably. Validation does not execute or authorize SQL.
 
+The proposed deployment surface combines complete Dataset definitions, named
+Serve queries, endpoint policy, and runtime artifact identities into one strict
+versioned envelope. Dataset and Serve adapters live in their owning packages;
+the protocol package remains deterministic and framework-independent.
+
 ## Runtime compatibility
 
 This package is ESM-only. Consumers must load it with `import`; CommonJS

--- a/packages/protocol/src/deployments/deployments.test.ts
+++ b/packages/protocol/src/deployments/deployments.test.ts
@@ -1,0 +1,207 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  ProtocolDeploymentError,
+  validateProtocolDeploymentContract,
+} from './index.js';
+
+interface SuccessFixture { id: string; value: unknown }
+interface RejectionFixture {
+  id: string;
+  generator: { type: string };
+  error: string;
+}
+
+const FAILURE_CODES = [
+  'HQ_DEPLOYMENT_TYPE',
+  'HQ_DEPLOYMENT_UNKNOWN_FIELD',
+  'HQ_DEPLOYMENT_INVALID_VERSION',
+  'HQ_DEPLOYMENT_INVALID_IDENTIFIER',
+  'HQ_DEPLOYMENT_INVALID_VALUE',
+  'HQ_DEPLOYMENT_INVALID_REFERENCE',
+  'HQ_DEPLOYMENT_TOO_MANY_ITEMS',
+  'HQ_DEPLOYMENT_TOO_LARGE',
+  'HQ_DEPLOYMENT_UNSAFE_OBJECT',
+] as const;
+
+function readFixture<T>(name: string): T {
+  const path = fileURLToPath(new URL(
+    `../../../../specs/security-protocol/fixtures/deployments-v1/${name}`,
+    import.meta.url,
+  ));
+  return JSON.parse(readFileSync(path, 'utf8')) as T;
+}
+
+function minimalDataset(name = 'orders') {
+  return {
+    name,
+    source: 'orders',
+    tenant: { kind: 'not-required' },
+    dimensions: [],
+    measures: [],
+    filters: [],
+    metrics: [],
+    relationships: [],
+  };
+}
+
+function baseDeployment() {
+  return {
+    kind: 'hypequery-deployment',
+    version: 1,
+    datasets: [minimalDataset()],
+    queries: [],
+    artifacts: [],
+  };
+}
+
+function materialize(type: string): unknown {
+  const value = baseDeployment();
+  switch (type) {
+    case 'wrong-root-type':
+      return [];
+    case 'unknown-root-field':
+      return { ...value, extra: true };
+    case 'unsupported-version':
+      return { ...value, version: 2 };
+    case 'invalid-dataset-identifier':
+      return { ...value, datasets: [minimalDataset('bad-name')] };
+    case 'invalid-relationship-queryability':
+      return {
+        ...value,
+        datasets: [{
+          ...minimalDataset(),
+          relationships: [{
+            name: 'items', kind: 'hasMany', target: 'orders', from: 'id', to: 'order_id', queryable: true,
+          }],
+        }],
+      };
+    case 'missing-runtime-artifact':
+      return {
+        ...value,
+        queries: [{
+          name: 'health',
+          input: { kind: 'any' },
+          output: { kind: 'any' },
+          implementation: {
+            kind: 'runtime-reference',
+            runtime: 'node',
+            artifactSha256: '0'.repeat(64),
+            entrypoint: 'queries.health',
+          },
+          endpoint: {
+            access: { kind: 'public' },
+            tenant: { kind: 'not-required' },
+            method: 'GET',
+            path: '/health',
+          },
+          tags: [],
+        }],
+      };
+    case 'too-many-datasets':
+      return {
+        ...value,
+        datasets: Array.from({ length: 101 }, (_, index) => minimalDataset(`dataset_${index}`)),
+      };
+    case 'source-too-large':
+      return { ...value, datasets: [{ ...minimalDataset(), source: 'a'.repeat(1_025) }] };
+    case 'unsafe-accessor': {
+      const unsafe = baseDeployment() as Record<string, unknown>;
+      Object.defineProperty(unsafe, 'kind', { enumerable: true, get: () => 'hypequery-deployment' });
+      return unsafe;
+    }
+    default:
+      throw new Error(`Unknown fixture generator: ${type}`);
+  }
+}
+
+function expectDeploymentError(action: () => unknown, code: string): void {
+  try {
+    action();
+    throw new Error('Expected deployment validation to fail');
+  } catch (error) {
+    expect(error).toBeInstanceOf(ProtocolDeploymentError);
+    expect((error as ProtocolDeploymentError).code).toBe(code);
+  }
+}
+
+describe('deployment contract v1', () => {
+  const success = readFixture<SuccessFixture[]>('success.json');
+  const rejections = readFixture<RejectionFixture[]>('rejections.json');
+
+  it('has unique fixtures and covers every stable error code', () => {
+    const fixtures = [...success, ...rejections];
+    expect(new Set(fixtures.map(fixture => fixture.id)).size).toBe(fixtures.length);
+    expect([...new Set(rejections.map(fixture => fixture.error))].sort())
+      .toEqual([...FAILURE_CODES].sort());
+  });
+
+  it.each(success)('accepts $id as an immutable snapshot', ({ value }) => {
+    const contract = validateProtocolDeploymentContract(value);
+    expect(contract).toEqual(value);
+    expect(Object.isFrozen(contract)).toBe(true);
+    expect(Object.isFrozen(contract.datasets)).toBe(true);
+    expect(Object.isFrozen(contract.queries[0]?.implementation)).toBe(true);
+  });
+
+  it.each(rejections)('rejects $id with its stable code', fixture => {
+    expectDeploymentError(
+      () => validateProtocolDeploymentContract(materialize(fixture.generator.type)),
+      fixture.error,
+    );
+  });
+
+  it('permits lower product limits but rejects raised limits', () => {
+    const twoDatasets = {
+      ...baseDeployment(),
+      datasets: [minimalDataset('orders'), minimalDataset('customers')],
+    };
+    expectDeploymentError(
+      () => validateProtocolDeploymentContract(twoDatasets, { limits: { maxDatasets: 1 } }),
+      'HQ_DEPLOYMENT_TOO_MANY_ITEMS',
+    );
+    expect(() => validateProtocolDeploymentContract(baseDeployment(), { limits: { maxDatasets: 101 } }))
+      .toThrow(RangeError);
+  });
+
+  it('validates compiled input bindings against the named-query input schema', () => {
+    const deployment = {
+      ...baseDeployment(),
+      queries: [{
+        name: 'lookup',
+        input: {
+          kind: 'object',
+          properties: { id: { kind: 'string' } },
+          required: ['id'],
+          unknownProperties: 'reject',
+        },
+        output: { kind: 'any' },
+        implementation: {
+          kind: 'compiled-sql',
+          dialect: 'clickhouse',
+          operation: 'select',
+          statement: 'SELECT * FROM orders WHERE id = {id:String}',
+          parameters: [{
+            name: 'id',
+            source: { kind: 'input', path: 'missing' },
+            clickHouseType: 'String',
+          }],
+          readSources: ['orders'],
+          tenant: { kind: 'not-required' },
+        },
+        endpoint: {
+          access: { kind: 'public' },
+          tenant: { kind: 'not-required' },
+          method: 'GET',
+          path: '/lookup',
+        },
+        tags: [],
+      }],
+    };
+    expectDeploymentError(
+      () => validateProtocolDeploymentContract(deployment),
+      'HQ_DEPLOYMENT_INVALID_REFERENCE',
+    );
+  });
+});

--- a/packages/protocol/src/deployments/deployments.test.ts
+++ b/packages/protocol/src/deployments/deployments.test.ts
@@ -162,7 +162,8 @@ describe('deployment contract v1', () => {
       'HQ_DEPLOYMENT_TOO_MANY_ITEMS',
     );
     expect(() => validateProtocolDeploymentContract(baseDeployment(), { limits: { maxDatasets: 101 } }))
-      .toThrow(RangeError);
+      .toThrow('maxDatasets must be a positive safe integer no greater than 100 '
+        + '(the deployment contract v1 maximum)');
   });
 
   it('validates compiled input bindings against the named-query input schema', () => {

--- a/packages/protocol/src/deployments/errors.ts
+++ b/packages/protocol/src/deployments/errors.ts
@@ -1,0 +1,20 @@
+import type { ProtocolDeploymentErrorCode } from './types.js';
+
+export class ProtocolDeploymentError extends TypeError {
+  readonly code: ProtocolDeploymentErrorCode;
+  readonly path: string;
+
+  constructor(code: ProtocolDeploymentErrorCode, path = '$') {
+    super(`${code} at ${path}`);
+    this.name = 'ProtocolDeploymentError';
+    this.code = code;
+    this.path = path;
+  }
+}
+
+export function deploymentError(
+  code: ProtocolDeploymentErrorCode,
+  path = '$',
+): never {
+  throw new ProtocolDeploymentError(code, path);
+}

--- a/packages/protocol/src/deployments/index.ts
+++ b/packages/protocol/src/deployments/index.ts
@@ -1,0 +1,28 @@
+export { ProtocolDeploymentError } from './errors.js';
+export { DEFAULT_PROTOCOL_DEPLOYMENT_LIMITS } from './limits.js';
+export {
+  validateProtocolDatasetContract,
+  validateProtocolDeploymentContract,
+} from './validate.js';
+
+export type {
+  ProtocolAccessPolicy,
+  ProtocolDatasetContract,
+  ProtocolDatasetDimension,
+  ProtocolDatasetFieldSource,
+  ProtocolDatasetFieldType,
+  ProtocolDatasetFilter,
+  ProtocolDatasetLimits,
+  ProtocolDatasetMeasure,
+  ProtocolDatasetMetric,
+  ProtocolDatasetRelationship,
+  ProtocolDatasetTenantPolicy,
+  ProtocolDeploymentContract,
+  ProtocolDeploymentErrorCode,
+  ProtocolDeploymentLimits,
+  ProtocolDeploymentOptions,
+  ProtocolEndpointPolicy,
+  ProtocolEndpointTenantPolicy,
+  ProtocolNamedQueryContract,
+  ProtocolRuntimeArtifact,
+} from './types.js';

--- a/packages/protocol/src/deployments/limits.ts
+++ b/packages/protocol/src/deployments/limits.ts
@@ -1,0 +1,26 @@
+import type { ProtocolDeploymentLimits, ProtocolDeploymentOptions } from './types.js';
+
+export const DEFAULT_PROTOCOL_DEPLOYMENT_LIMITS: Readonly<ProtocolDeploymentLimits> = Object.freeze({
+  maxDatasets: 100,
+  maxQueries: 1_000,
+  maxArtifacts: 100,
+  maxDatasetItems: 1_000,
+  maxTextBytes: 4_096,
+  maxSourceBytes: 1_024,
+  maxPathBytes: 2_048,
+});
+
+export function resolveDeploymentLimits(
+  options: ProtocolDeploymentOptions = {},
+): Readonly<ProtocolDeploymentLimits> {
+  const result = { ...DEFAULT_PROTOCOL_DEPLOYMENT_LIMITS };
+  for (const key of Object.keys(result) as (keyof ProtocolDeploymentLimits)[]) {
+    const value = options.limits?.[key];
+    if (value === undefined) continue;
+    if (!Number.isSafeInteger(value) || value < 1 || value > DEFAULT_PROTOCOL_DEPLOYMENT_LIMITS[key]) {
+      throw new RangeError(`Invalid deployment limit: ${key}`);
+    }
+    result[key] = value;
+  }
+  return Object.freeze(result);
+}

--- a/packages/protocol/src/deployments/limits.ts
+++ b/packages/protocol/src/deployments/limits.ts
@@ -17,8 +17,11 @@ export function resolveDeploymentLimits(
   for (const key of Object.keys(result) as (keyof ProtocolDeploymentLimits)[]) {
     const value = options.limits?.[key];
     if (value === undefined) continue;
-    if (!Number.isSafeInteger(value) || value < 1 || value > DEFAULT_PROTOCOL_DEPLOYMENT_LIMITS[key]) {
-      throw new RangeError(`Invalid deployment limit: ${key}`);
+    const maximum = DEFAULT_PROTOCOL_DEPLOYMENT_LIMITS[key];
+    if (!Number.isSafeInteger(value) || value < 1 || value > maximum) {
+      throw new RangeError(
+        `${key} must be a positive safe integer no greater than ${maximum} (the deployment contract v1 maximum)`,
+      );
     }
     result[key] = value;
   }

--- a/packages/protocol/src/deployments/types.ts
+++ b/packages/protocol/src/deployments/types.ts
@@ -155,6 +155,14 @@ export interface ProtocolDeploymentLimits {
   readonly maxPathBytes: number;
 }
 
+/**
+ * Validation budgets for a deployment contract.
+ *
+ * Each configured value must be a positive safe integer no greater than the
+ * corresponding value in `DEFAULT_PROTOCOL_DEPLOYMENT_LIMITS`. These options
+ * may tighten the deployment-contract v1 conformance limits, but cannot raise
+ * them; they are not deployment capacity settings.
+ */
 export interface ProtocolDeploymentOptions {
   readonly limits?: Partial<ProtocolDeploymentLimits>;
 }

--- a/packages/protocol/src/deployments/types.ts
+++ b/packages/protocol/src/deployments/types.ts
@@ -1,0 +1,171 @@
+import type { ProtocolExpression, ProtocolTimeGrain } from '../expressions/index.js';
+import type { ProtocolIdentifier, ProtocolQualifiedIdentifier } from '../identifiers/index.js';
+import type {
+  ProtocolQueryImplementation,
+  ProtocolSqlExpression,
+} from '../query-implementations/index.js';
+import type { ProtocolSchema } from '../schemas/index.js';
+
+export type ProtocolDatasetFieldType = 'string' | 'number' | 'boolean' | 'timestamp';
+
+export type ProtocolAccessPolicy =
+  | { readonly kind: 'public' }
+  | {
+      readonly kind: 'authenticated';
+      readonly roles: readonly string[];
+      readonly scopes: readonly string[];
+    };
+
+export type ProtocolEndpointTenantPolicy =
+  | { readonly kind: 'not-required' }
+  | {
+      readonly kind: 'required' | 'optional';
+      readonly mode: 'auto-inject' | 'manual';
+      readonly column?: string;
+    };
+
+export interface ProtocolEndpointPolicy {
+  readonly access: ProtocolAccessPolicy;
+  readonly tenant: ProtocolEndpointTenantPolicy;
+  readonly cacheTtlMs?: number;
+  readonly maxLimit?: number;
+  readonly path?: string;
+}
+
+export type ProtocolDatasetTenantPolicy =
+  | { readonly kind: 'required'; readonly field: string }
+  | { readonly kind: 'not-required' };
+
+export type ProtocolDatasetFieldSource =
+  | { readonly kind: 'column'; readonly column: string }
+  | ProtocolSqlExpression;
+
+export interface ProtocolDatasetDimension {
+  readonly name: ProtocolIdentifier;
+  readonly type: ProtocolDatasetFieldType;
+  readonly source: ProtocolDatasetFieldSource;
+  readonly filterable: boolean;
+  readonly groupable: boolean;
+  readonly label?: string;
+  readonly description?: string;
+}
+
+export interface ProtocolDatasetMeasure {
+  readonly name: ProtocolIdentifier;
+  readonly aggregation:
+    | 'sum' | 'count' | 'countDistinct' | 'avg' | 'min' | 'max'
+    | 'argMax' | 'argMin' | 'percentile' | 'stddev' | 'variance';
+  readonly field: ProtocolQualifiedIdentifier;
+  readonly argField?: ProtocolQualifiedIdentifier;
+  readonly level?: number;
+  readonly sql?: ProtocolSqlExpression;
+  readonly filters: readonly ProtocolExpression[];
+  readonly label?: string;
+  readonly description?: string;
+}
+
+export interface ProtocolDatasetFilter {
+  readonly name: ProtocolIdentifier;
+  readonly field: ProtocolQualifiedIdentifier;
+  readonly operators: readonly (
+    | 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte'
+    | 'in' | 'notIn' | 'between' | 'like'
+  )[];
+  readonly label?: string;
+  readonly description?: string;
+}
+
+export interface ProtocolDatasetRelationship {
+  readonly name: ProtocolIdentifier;
+  readonly kind: 'belongsTo' | 'hasMany' | 'hasOne';
+  readonly target: ProtocolIdentifier;
+  readonly from: ProtocolQualifiedIdentifier;
+  readonly to: ProtocolQualifiedIdentifier;
+  readonly queryable: boolean;
+}
+
+export interface ProtocolDatasetMetric {
+  readonly name: ProtocolIdentifier;
+  readonly kind: 'metric' | 'derived-metric' | 'grained-metric';
+  readonly expression: ProtocolExpression;
+  readonly dimensions: readonly ProtocolQualifiedIdentifier[];
+  readonly filters: readonly ProtocolIdentifier[];
+  readonly grains: readonly ProtocolTimeGrain[];
+  readonly grain?: ProtocolTimeGrain;
+  readonly label?: string;
+  readonly description?: string;
+  readonly endpoint: ProtocolEndpointPolicy;
+}
+
+export interface ProtocolDatasetLimits {
+  readonly maxDimensions?: number;
+  readonly maxMeasures?: number;
+  readonly maxFilters?: number;
+  readonly maxResultSize?: number;
+}
+
+export interface ProtocolDatasetContract {
+  readonly name: ProtocolIdentifier;
+  readonly source: string;
+  readonly tenant: ProtocolDatasetTenantPolicy;
+  readonly timeField?: ProtocolQualifiedIdentifier;
+  readonly dimensions: readonly ProtocolDatasetDimension[];
+  readonly measures: readonly ProtocolDatasetMeasure[];
+  readonly filters: readonly ProtocolDatasetFilter[];
+  readonly metrics: readonly ProtocolDatasetMetric[];
+  readonly relationships: readonly ProtocolDatasetRelationship[];
+  readonly limits?: ProtocolDatasetLimits;
+  readonly endpoint?: ProtocolEndpointPolicy;
+}
+
+export interface ProtocolNamedQueryContract {
+  readonly name: ProtocolIdentifier;
+  readonly input: ProtocolSchema;
+  readonly output: ProtocolSchema;
+  readonly implementation: ProtocolQueryImplementation;
+  readonly endpoint: ProtocolEndpointPolicy & {
+    readonly method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
+    readonly path: string;
+  };
+  readonly summary?: string;
+  readonly description?: string;
+  readonly tags: readonly string[];
+}
+
+export interface ProtocolRuntimeArtifact {
+  readonly runtime: 'node' | 'python';
+  readonly artifactSha256: string;
+}
+
+export interface ProtocolDeploymentContract {
+  readonly kind: 'hypequery-deployment';
+  readonly version: 1;
+  readonly datasets: readonly ProtocolDatasetContract[];
+  readonly queries: readonly ProtocolNamedQueryContract[];
+  readonly artifacts: readonly ProtocolRuntimeArtifact[];
+}
+
+export interface ProtocolDeploymentLimits {
+  readonly maxDatasets: number;
+  readonly maxQueries: number;
+  readonly maxArtifacts: number;
+  readonly maxDatasetItems: number;
+  readonly maxTextBytes: number;
+  readonly maxSourceBytes: number;
+  readonly maxPathBytes: number;
+}
+
+export interface ProtocolDeploymentOptions {
+  readonly limits?: Partial<ProtocolDeploymentLimits>;
+}
+
+export type ProtocolDeploymentErrorCode =
+  | 'HQ_DEPLOYMENT_TYPE'
+  | 'HQ_DEPLOYMENT_UNKNOWN_FIELD'
+  | 'HQ_DEPLOYMENT_INVALID_VERSION'
+  | 'HQ_DEPLOYMENT_INVALID_IDENTIFIER'
+  | 'HQ_DEPLOYMENT_INVALID_VALUE'
+  | 'HQ_DEPLOYMENT_INVALID_REFERENCE'
+  | 'HQ_DEPLOYMENT_TOO_MANY_ITEMS'
+  | 'HQ_DEPLOYMENT_TOO_LARGE'
+  | 'HQ_DEPLOYMENT_UNSAFE_OBJECT';

--- a/packages/protocol/src/deployments/validate.ts
+++ b/packages/protocol/src/deployments/validate.ts
@@ -1,0 +1,733 @@
+import { ProtocolExpressionError, validateProtocolExpression } from '../expressions/index.js';
+import {
+  ProtocolIdentifierError,
+  parseProtocolIdentifier,
+  parseProtocolQualifiedIdentifier,
+} from '../identifiers/index.js';
+import {
+  ProtocolQueryImplementationError,
+  validateProtocolQueryImplementation,
+  validateProtocolSqlExpression,
+} from '../query-implementations/index.js';
+import {
+  ProtocolSchemaError,
+  validateProtocolSchema,
+  type ProtocolSchema,
+} from '../schemas/index.js';
+import { deploymentError } from './errors.js';
+import { resolveDeploymentLimits } from './limits.js';
+import type {
+  ProtocolAccessPolicy,
+  ProtocolDatasetContract,
+  ProtocolDatasetDimension,
+  ProtocolDatasetFieldSource,
+  ProtocolDatasetFilter,
+  ProtocolDatasetLimits,
+  ProtocolDatasetMeasure,
+  ProtocolDatasetMetric,
+  ProtocolDatasetRelationship,
+  ProtocolDatasetTenantPolicy,
+  ProtocolDeploymentContract,
+  ProtocolDeploymentLimits,
+  ProtocolDeploymentOptions,
+  ProtocolEndpointPolicy,
+  ProtocolEndpointTenantPolicy,
+  ProtocolNamedQueryContract,
+  ProtocolRuntimeArtifact,
+} from './types.js';
+
+type DataRecord = Record<string, unknown>;
+const textEncoder = new TextEncoder();
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const AGGREGATIONS = new Set([
+  'sum', 'count', 'countDistinct', 'avg', 'min', 'max',
+  'argMax', 'argMin', 'percentile', 'stddev', 'variance',
+]);
+const OPERATORS = new Set([
+  'eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'in', 'notIn', 'between', 'like',
+]);
+const GRAINS = new Set(['day', 'week', 'month', 'quarter', 'year']);
+
+function requireRecord(input: unknown, path: string): DataRecord {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    deploymentError('HQ_DEPLOYMENT_TYPE', path);
+  }
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    deploymentError('HQ_DEPLOYMENT_UNSAFE_OBJECT', path);
+  }
+  if (Object.getOwnPropertySymbols(input).length > 0) {
+    deploymentError('HQ_DEPLOYMENT_UNSAFE_OBJECT', path);
+  }
+  for (const descriptor of Object.values(Object.getOwnPropertyDescriptors(input))) {
+    if (!descriptor.enumerable || !('value' in descriptor)) {
+      deploymentError('HQ_DEPLOYMENT_UNSAFE_OBJECT', path);
+    }
+  }
+  return input as DataRecord;
+}
+
+function requireArray(input: unknown, path: string, maxItems: number): readonly unknown[] {
+  if (!Array.isArray(input)) deploymentError('HQ_DEPLOYMENT_TYPE', path);
+  if (Object.getPrototypeOf(input) !== Array.prototype || Object.getOwnPropertySymbols(input).length > 0) {
+    deploymentError('HQ_DEPLOYMENT_UNSAFE_OBJECT', path);
+  }
+  if (input.length > maxItems) deploymentError('HQ_DEPLOYMENT_TOO_MANY_ITEMS', path);
+  const descriptors = Object.getOwnPropertyDescriptors(input);
+  for (let index = 0; index < input.length; index += 1) {
+    const descriptor = descriptors[String(index)];
+    if (!descriptor || !descriptor.enumerable || !('value' in descriptor)) {
+      deploymentError('HQ_DEPLOYMENT_UNSAFE_OBJECT', `${path}[${index}]`);
+    }
+  }
+  if (Object.keys(input).length !== input.length) deploymentError('HQ_DEPLOYMENT_UNSAFE_OBJECT', path);
+  return input;
+}
+
+function exactFields(
+  value: DataRecord,
+  required: readonly string[],
+  optional: readonly string[],
+  path: string,
+): void {
+  const allowed = new Set([...required, ...optional]);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) deploymentError('HQ_DEPLOYMENT_UNKNOWN_FIELD', `${path}.${key}`);
+  }
+  for (const key of required) {
+    if (!Object.hasOwn(value, key)) deploymentError('HQ_DEPLOYMENT_TYPE', `${path}.${key}`);
+  }
+}
+
+function freezeRecord(entries: Record<string, unknown>): DataRecord {
+  return Object.freeze(Object.assign(Object.create(null), entries)) as DataRecord;
+}
+
+function identifier(value: unknown, path: string, qualified = false): string {
+  try {
+    return qualified ? parseProtocolQualifiedIdentifier(value) : parseProtocolIdentifier(value);
+  } catch (error) {
+    if (error instanceof ProtocolIdentifierError) {
+      deploymentError('HQ_DEPLOYMENT_INVALID_IDENTIFIER', path);
+    }
+    throw error;
+  }
+}
+
+function boundedText(value: unknown, path: string, maxBytes: number): string {
+  if (typeof value !== 'string') deploymentError('HQ_DEPLOYMENT_TYPE', path);
+  if (value.trim().length === 0) deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', path);
+  for (const character of value) {
+    const code = character.codePointAt(0)!;
+    if (code <= 0x1f || code === 0x7f || (code >= 0x80 && code <= 0x9f)) {
+      deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', path);
+    }
+  }
+  if (value.length > maxBytes || textEncoder.encode(value).byteLength > maxBytes) {
+    deploymentError('HQ_DEPLOYMENT_TOO_LARGE', path);
+  }
+  return value;
+}
+
+function optionalText(
+  value: unknown,
+  key: string,
+  result: Record<string, unknown>,
+  path: string,
+  limits: Readonly<ProtocolDeploymentLimits>,
+): void {
+  if (value !== undefined) result[key] = boundedText(value, `${path}.${key}`, limits.maxTextBytes);
+}
+
+function positiveInteger(value: unknown, path: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 1) {
+    deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', path);
+  }
+  return value as number;
+}
+
+function uniqueStrings(
+  input: unknown,
+  path: string,
+  maxItems: number,
+  parse: (value: unknown, path: string) => string,
+): readonly string[] {
+  const result = requireArray(input, path, maxItems).map((value, index) => parse(value, `${path}[${index}]`));
+  if (new Set(result).size !== result.length) deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', path);
+  return Object.freeze(result);
+}
+
+function validateAccess(
+  input: unknown,
+  path: string,
+  limits: Readonly<ProtocolDeploymentLimits>,
+): ProtocolAccessPolicy {
+  const value = requireRecord(input, path);
+  if (value.kind === 'public') {
+    exactFields(value, ['kind'], [], path);
+    return freezeRecord({ kind: 'public' }) as unknown as ProtocolAccessPolicy;
+  }
+  if (value.kind === 'authenticated') {
+    exactFields(value, ['kind', 'roles', 'scopes'], [], path);
+    const parseClaim = (claim: unknown, claimPath: string) =>
+      boundedText(claim, claimPath, limits.maxTextBytes);
+    return freezeRecord({
+      kind: 'authenticated',
+      roles: uniqueStrings(value.roles, `${path}.roles`, limits.maxDatasetItems, parseClaim),
+      scopes: uniqueStrings(value.scopes, `${path}.scopes`, limits.maxDatasetItems, parseClaim),
+    }) as unknown as ProtocolAccessPolicy;
+  }
+  if (typeof value.kind !== 'string') deploymentError('HQ_DEPLOYMENT_TYPE', `${path}.kind`);
+  deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.kind`);
+}
+
+function validateEndpointTenant(
+  input: unknown,
+  path: string,
+  limits: Readonly<ProtocolDeploymentLimits>,
+): ProtocolEndpointTenantPolicy {
+  const value = requireRecord(input, path);
+  if (value.kind === 'not-required') {
+    exactFields(value, ['kind'], [], path);
+    return freezeRecord({ kind: 'not-required' }) as unknown as ProtocolEndpointTenantPolicy;
+  }
+  if (value.kind === 'required' || value.kind === 'optional') {
+    exactFields(value, ['kind', 'mode'], ['column'], path);
+    if (value.mode !== 'auto-inject' && value.mode !== 'manual') {
+      deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.mode`);
+    }
+    const result: Record<string, unknown> = { kind: value.kind, mode: value.mode };
+    if (value.column !== undefined) {
+      result.column = boundedText(value.column, `${path}.column`, limits.maxSourceBytes);
+    }
+    if (value.mode === 'auto-inject' && value.column === undefined) {
+      deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.column`);
+    }
+    return freezeRecord(result) as unknown as ProtocolEndpointTenantPolicy;
+  }
+  if (typeof value.kind !== 'string') deploymentError('HQ_DEPLOYMENT_TYPE', `${path}.kind`);
+  deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.kind`);
+}
+
+function validateEndpoint(
+  input: unknown,
+  path: string,
+  limits: Readonly<ProtocolDeploymentLimits>,
+  transport = false,
+): ProtocolEndpointPolicy & { method?: string; path?: string } {
+  const value = requireRecord(input, path);
+  exactFields(
+    value,
+    transport ? ['access', 'tenant', 'method', 'path'] : ['access', 'tenant'],
+    transport ? ['cacheTtlMs', 'maxLimit'] : ['cacheTtlMs', 'maxLimit', 'path'],
+    path,
+  );
+  const result: Record<string, unknown> = {
+    access: validateAccess(value.access, `${path}.access`, limits),
+    tenant: validateEndpointTenant(value.tenant, `${path}.tenant`, limits),
+  };
+  if (value.cacheTtlMs !== undefined) result.cacheTtlMs = positiveInteger(value.cacheTtlMs, `${path}.cacheTtlMs`);
+  if (value.maxLimit !== undefined) result.maxLimit = positiveInteger(value.maxLimit, `${path}.maxLimit`);
+  if (!transport && value.path !== undefined) {
+    const endpointPath = boundedText(value.path, `${path}.path`, limits.maxPathBytes);
+    if (!endpointPath.startsWith('/')) deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.path`);
+    result.path = endpointPath;
+  }
+  if (transport) {
+    if (!['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'].includes(value.method as string)) {
+      deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.method`);
+    }
+    const endpointPath = boundedText(value.path, `${path}.path`, limits.maxPathBytes);
+    if (!endpointPath.startsWith('/')) deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.path`);
+    result.method = value.method;
+    result.path = endpointPath;
+  }
+  return freezeRecord(result) as unknown as ProtocolEndpointPolicy & { method?: string; path?: string };
+}
+
+function validateTenant(input: unknown, path: string, limits: Readonly<ProtocolDeploymentLimits>): ProtocolDatasetTenantPolicy {
+  const value = requireRecord(input, path);
+  if (value.kind === 'not-required') {
+    exactFields(value, ['kind'], [], path);
+    return freezeRecord({ kind: 'not-required' }) as unknown as ProtocolDatasetTenantPolicy;
+  }
+  if (value.kind === 'required') {
+    exactFields(value, ['kind', 'field'], [], path);
+    return freezeRecord({
+      kind: 'required',
+      field: boundedText(value.field, `${path}.field`, limits.maxSourceBytes),
+    }) as unknown as ProtocolDatasetTenantPolicy;
+  }
+  if (typeof value.kind !== 'string') deploymentError('HQ_DEPLOYMENT_TYPE', `${path}.kind`);
+  deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.kind`);
+}
+
+function nested<T>(action: () => T, path: string): T {
+  try {
+    return action();
+  } catch (error) {
+    if (error instanceof ProtocolExpressionError
+      || error instanceof ProtocolQueryImplementationError
+      || error instanceof ProtocolSchemaError) {
+      deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', path);
+    }
+    throw error;
+  }
+}
+
+function validateFieldSource(
+  input: unknown,
+  path: string,
+  limits: Readonly<ProtocolDeploymentLimits>,
+): ProtocolDatasetFieldSource {
+  const value = requireRecord(input, path);
+  if (value.kind === 'column') {
+    exactFields(value, ['kind', 'column'], [], path);
+    return freezeRecord({
+      kind: 'column',
+      column: boundedText(value.column, `${path}.column`, limits.maxSourceBytes),
+    }) as unknown as ProtocolDatasetFieldSource;
+  }
+  return nested(() => validateProtocolSqlExpression(value), path);
+}
+
+function validateDimension(
+  input: unknown,
+  path: string,
+  limits: Readonly<ProtocolDeploymentLimits>,
+): ProtocolDatasetDimension {
+  const value = requireRecord(input, path);
+  exactFields(value, ['name', 'type', 'source', 'filterable', 'groupable'], ['label', 'description'], path);
+  if (!['string', 'number', 'boolean', 'timestamp'].includes(value.type as string)) {
+    deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.type`);
+  }
+  if (typeof value.filterable !== 'boolean') deploymentError('HQ_DEPLOYMENT_TYPE', `${path}.filterable`);
+  if (typeof value.groupable !== 'boolean') deploymentError('HQ_DEPLOYMENT_TYPE', `${path}.groupable`);
+  const result: Record<string, unknown> = {
+    name: identifier(value.name, `${path}.name`),
+    type: value.type,
+    source: validateFieldSource(value.source, `${path}.source`, limits),
+    filterable: value.filterable,
+    groupable: value.groupable,
+  };
+  optionalText(value.label, 'label', result, path, limits);
+  optionalText(value.description, 'description', result, path, limits);
+  return freezeRecord(result) as unknown as ProtocolDatasetDimension;
+}
+
+function validateMeasure(
+  input: unknown,
+  path: string,
+  limits: Readonly<ProtocolDeploymentLimits>,
+): ProtocolDatasetMeasure {
+  const value = requireRecord(input, path);
+  exactFields(
+    value,
+    ['name', 'aggregation', 'field', 'filters'],
+    ['argField', 'level', 'sql', 'label', 'description'],
+    path,
+  );
+  if (typeof value.aggregation !== 'string' || !AGGREGATIONS.has(value.aggregation)) {
+    deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.aggregation`);
+  }
+  const needsArg = value.aggregation === 'argMax' || value.aggregation === 'argMin';
+  if (needsArg !== (value.argField !== undefined)) {
+    deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.argField`);
+  }
+  if (value.aggregation === 'percentile') {
+    if (typeof value.level !== 'number' || !Number.isFinite(value.level) || value.level < 0 || value.level > 1) {
+      deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.level`);
+    }
+  } else if (value.level !== undefined) {
+    deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.level`);
+  }
+  const result: Record<string, unknown> = {
+    name: identifier(value.name, `${path}.name`),
+    aggregation: value.aggregation,
+    field: identifier(value.field, `${path}.field`, true),
+    filters: Object.freeze(requireArray(value.filters, `${path}.filters`, limits.maxDatasetItems)
+      .map((filter, index) => nested(
+        () => validateProtocolExpression(filter),
+        `${path}.filters[${index}]`,
+      ))),
+  };
+  if (value.argField !== undefined) result.argField = identifier(value.argField, `${path}.argField`, true);
+  if (value.level !== undefined) result.level = value.level;
+  if (value.sql !== undefined) result.sql = nested(() => validateProtocolSqlExpression(value.sql), `${path}.sql`);
+  optionalText(value.label, 'label', result, path, limits);
+  optionalText(value.description, 'description', result, path, limits);
+  return freezeRecord(result) as unknown as ProtocolDatasetMeasure;
+}
+
+function validateFilter(
+  input: unknown,
+  path: string,
+  limits: Readonly<ProtocolDeploymentLimits>,
+): ProtocolDatasetFilter {
+  const value = requireRecord(input, path);
+  exactFields(value, ['name', 'field', 'operators'], ['label', 'description'], path);
+  const operators = uniqueStrings(
+    value.operators,
+    `${path}.operators`,
+    limits.maxDatasetItems,
+    (operator, operatorPath) => {
+      if (typeof operator !== 'string' || !OPERATORS.has(operator)) {
+        deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', operatorPath);
+      }
+      return operator;
+    },
+  );
+  if (operators.length === 0) deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.operators`);
+  const result: Record<string, unknown> = {
+    name: identifier(value.name, `${path}.name`),
+    field: identifier(value.field, `${path}.field`, true),
+    operators,
+  };
+  optionalText(value.label, 'label', result, path, limits);
+  optionalText(value.description, 'description', result, path, limits);
+  return freezeRecord(result) as unknown as ProtocolDatasetFilter;
+}
+
+function validateRelationship(
+  input: unknown,
+  path: string,
+): ProtocolDatasetRelationship {
+  const value = requireRecord(input, path);
+  exactFields(value, ['name', 'kind', 'target', 'from', 'to', 'queryable'], [], path);
+  if (!['belongsTo', 'hasMany', 'hasOne'].includes(value.kind as string)) {
+    deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.kind`);
+  }
+  if (typeof value.queryable !== 'boolean') deploymentError('HQ_DEPLOYMENT_TYPE', `${path}.queryable`);
+  if ((value.kind === 'hasMany') === value.queryable) {
+    deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.queryable`);
+  }
+  return freezeRecord({
+    name: identifier(value.name, `${path}.name`),
+    kind: value.kind,
+    target: identifier(value.target, `${path}.target`),
+    from: identifier(value.from, `${path}.from`, true),
+    to: identifier(value.to, `${path}.to`, true),
+    queryable: value.queryable,
+  }) as unknown as ProtocolDatasetRelationship;
+}
+
+function validateMetric(
+  input: unknown,
+  path: string,
+  limits: Readonly<ProtocolDeploymentLimits>,
+): ProtocolDatasetMetric {
+  const value = requireRecord(input, path);
+  exactFields(
+    value,
+    ['name', 'kind', 'expression', 'dimensions', 'filters', 'grains', 'endpoint'],
+    ['grain', 'label', 'description'],
+    path,
+  );
+  if (!['metric', 'derived-metric', 'grained-metric'].includes(value.kind as string)) {
+    deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.kind`);
+  }
+  const parseGrain = (grain: unknown, grainPath: string) => {
+    if (typeof grain !== 'string' || !GRAINS.has(grain)) {
+      deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', grainPath);
+    }
+    return grain;
+  };
+  const grains = uniqueStrings(value.grains, `${path}.grains`, limits.maxDatasetItems, parseGrain);
+  if ((value.kind === 'grained-metric') !== (value.grain !== undefined)) {
+    deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.grain`);
+  }
+  const result: Record<string, unknown> = {
+    name: identifier(value.name, `${path}.name`),
+    kind: value.kind,
+    expression: nested(() => validateProtocolExpression(value.expression), `${path}.expression`),
+    dimensions: uniqueStrings(
+      value.dimensions,
+      `${path}.dimensions`,
+      limits.maxDatasetItems,
+      (item, itemPath) => identifier(item, itemPath, true),
+    ),
+    filters: uniqueStrings(
+      value.filters,
+      `${path}.filters`,
+      limits.maxDatasetItems,
+      (item, itemPath) => identifier(item, itemPath),
+    ),
+    grains,
+    endpoint: validateEndpoint(value.endpoint, `${path}.endpoint`, limits),
+  };
+  if (value.grain !== undefined) result.grain = parseGrain(value.grain, `${path}.grain`);
+  optionalText(value.label, 'label', result, path, limits);
+  optionalText(value.description, 'description', result, path, limits);
+  return freezeRecord(result) as unknown as ProtocolDatasetMetric;
+}
+
+function validateLimits(input: unknown, path: string): ProtocolDatasetLimits {
+  const value = requireRecord(input, path);
+  exactFields(value, [], ['maxDimensions', 'maxMeasures', 'maxFilters', 'maxResultSize'], path);
+  const result: Record<string, unknown> = {};
+  for (const key of ['maxDimensions', 'maxMeasures', 'maxFilters', 'maxResultSize'] as const) {
+    if (value[key] !== undefined) result[key] = positiveInteger(value[key], `${path}.${key}`);
+  }
+  return freezeRecord(result) as unknown as ProtocolDatasetLimits;
+}
+
+function namedItems<T extends { readonly name: string }>(
+  input: unknown,
+  path: string,
+  maxItems: number,
+  validate: (value: unknown, path: string) => T,
+): readonly T[] {
+  const items = requireArray(input, path, maxItems).map((value, index) => validate(value, `${path}[${index}]`));
+  if (new Set(items.map(item => item.name)).size !== items.length) {
+    deploymentError('HQ_DEPLOYMENT_INVALID_REFERENCE', path);
+  }
+  return Object.freeze(items);
+}
+
+function validateDataset(
+  input: unknown,
+  path: string,
+  limits: Readonly<ProtocolDeploymentLimits>,
+): ProtocolDatasetContract {
+  const value = requireRecord(input, path);
+  exactFields(
+    value,
+    ['name', 'source', 'tenant', 'dimensions', 'measures', 'filters', 'metrics', 'relationships'],
+    ['timeField', 'limits', 'endpoint'],
+    path,
+  );
+  const result: Record<string, unknown> = {
+    name: identifier(value.name, `${path}.name`),
+    source: boundedText(value.source, `${path}.source`, limits.maxSourceBytes),
+    tenant: validateTenant(value.tenant, `${path}.tenant`, limits),
+    dimensions: namedItems(
+      value.dimensions, `${path}.dimensions`, limits.maxDatasetItems,
+      (item, itemPath) => validateDimension(item, itemPath, limits),
+    ),
+    measures: namedItems(
+      value.measures, `${path}.measures`, limits.maxDatasetItems,
+      (item, itemPath) => validateMeasure(item, itemPath, limits),
+    ),
+    filters: namedItems(
+      value.filters, `${path}.filters`, limits.maxDatasetItems,
+      (item, itemPath) => validateFilter(item, itemPath, limits),
+    ),
+    metrics: namedItems(
+      value.metrics, `${path}.metrics`, limits.maxDatasetItems,
+      (item, itemPath) => validateMetric(item, itemPath, limits),
+    ),
+    relationships: namedItems(
+      value.relationships, `${path}.relationships`, limits.maxDatasetItems,
+      (item, itemPath) => validateRelationship(item, itemPath),
+    ),
+  };
+  if (value.timeField !== undefined) result.timeField = identifier(value.timeField, `${path}.timeField`, true);
+  if (value.limits !== undefined) result.limits = validateLimits(value.limits, `${path}.limits`);
+  if (value.endpoint !== undefined) result.endpoint = validateEndpoint(value.endpoint, `${path}.endpoint`, limits);
+  return freezeRecord(result) as unknown as ProtocolDatasetContract;
+}
+
+export function validateProtocolDatasetContract(
+  input: unknown,
+  options: ProtocolDeploymentOptions = {},
+): ProtocolDatasetContract {
+  return validateDataset(input, '$', resolveDeploymentLimits(options));
+}
+
+function validateQuery(
+  input: unknown,
+  path: string,
+  limits: Readonly<ProtocolDeploymentLimits>,
+): ProtocolNamedQueryContract {
+  const value = requireRecord(input, path);
+  exactFields(
+    value,
+    ['name', 'input', 'output', 'implementation', 'endpoint', 'tags'],
+    ['summary', 'description'],
+    path,
+  );
+  const result: Record<string, unknown> = {
+    name: identifier(value.name, `${path}.name`),
+    input: nested(() => validateProtocolSchema(value.input), `${path}.input`),
+    output: nested(() => validateProtocolSchema(value.output), `${path}.output`),
+    implementation: nested(
+      () => validateProtocolQueryImplementation(value.implementation),
+      `${path}.implementation`,
+    ),
+    endpoint: validateEndpoint(value.endpoint, `${path}.endpoint`, limits, true),
+    tags: uniqueStrings(
+      value.tags,
+      `${path}.tags`,
+      limits.maxDatasetItems,
+      (tag, tagPath) => boundedText(tag, tagPath, limits.maxTextBytes),
+    ),
+  };
+  optionalText(value.summary, 'summary', result, path, limits);
+  optionalText(value.description, 'description', result, path, limits);
+  return freezeRecord(result) as unknown as ProtocolNamedQueryContract;
+}
+
+function validateArtifact(input: unknown, path: string): ProtocolRuntimeArtifact {
+  const value = requireRecord(input, path);
+  exactFields(value, ['runtime', 'artifactSha256'], [], path);
+  if (value.runtime !== 'node' && value.runtime !== 'python') {
+    deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.runtime`);
+  }
+  if (typeof value.artifactSha256 !== 'string' || !SHA256_PATTERN.test(value.artifactSha256)) {
+    deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.artifactSha256`);
+  }
+  return freezeRecord({
+    runtime: value.runtime,
+    artifactSha256: value.artifactSha256,
+  }) as unknown as ProtocolRuntimeArtifact;
+}
+
+function validateReferences(contract: ProtocolDeploymentContract): void {
+  const datasets = new Map(contract.datasets.map(dataset => [dataset.name, dataset]));
+  for (const [datasetIndex, dataset] of contract.datasets.entries()) {
+    for (const [relationshipIndex, relationship] of dataset.relationships.entries()) {
+      if (!datasets.has(relationship.target)) {
+        deploymentError(
+          'HQ_DEPLOYMENT_INVALID_REFERENCE',
+          `$.datasets[${datasetIndex}].relationships[${relationshipIndex}].target`,
+        );
+      }
+    }
+    const filters = new Set(dataset.filters.map(filter => filter.name));
+    const hasDimension = (name: string): boolean => {
+      const [head, ...tail] = name.split('.');
+      if (tail.length === 0) return dataset.dimensions.some(dimension => dimension.name === head);
+      const relationship = dataset.relationships.find(candidate => candidate.name === head && candidate.queryable);
+      const target = relationship ? datasets.get(relationship.target) : undefined;
+      return target?.dimensions.some(dimension => dimension.name === tail.join('.')) ?? false;
+    };
+    for (const [metricIndex, metric] of dataset.metrics.entries()) {
+      if (metric.dimensions.some(dimension => !hasDimension(dimension))
+        || metric.filters.some(filter => !filters.has(filter))) {
+        deploymentError(
+          'HQ_DEPLOYMENT_INVALID_REFERENCE',
+          `$.datasets[${datasetIndex}].metrics[${metricIndex}]`,
+        );
+      }
+      if (metric.grains.length > 0 && dataset.timeField === undefined) {
+        deploymentError(
+          'HQ_DEPLOYMENT_INVALID_REFERENCE',
+          `$.datasets[${datasetIndex}].metrics[${metricIndex}].grains`,
+        );
+      }
+      if (dataset.tenant.kind === 'required' && metric.endpoint.tenant.kind !== 'required') {
+        deploymentError(
+          'HQ_DEPLOYMENT_INVALID_REFERENCE',
+          `$.datasets[${datasetIndex}].metrics[${metricIndex}].endpoint.tenant`,
+        );
+      }
+    }
+    if (dataset.tenant.kind === 'required'
+      && dataset.endpoint !== undefined
+      && dataset.endpoint.tenant.kind !== 'required') {
+      deploymentError(
+        'HQ_DEPLOYMENT_INVALID_REFERENCE',
+        `$.datasets[${datasetIndex}].endpoint.tenant`,
+      );
+    }
+  }
+  const artifacts = new Map(contract.artifacts.map(artifact => [artifact.artifactSha256, artifact.runtime]));
+  for (const [queryIndex, query] of contract.queries.entries()) {
+    if (query.implementation.kind === 'runtime-reference'
+      && artifacts.get(query.implementation.artifactSha256) !== query.implementation.runtime) {
+      deploymentError(
+        'HQ_DEPLOYMENT_INVALID_REFERENCE',
+        `$.queries[${queryIndex}].implementation.artifactSha256`,
+      );
+    }
+    if (query.implementation.kind === 'compiled-sql') {
+      const implementationRequiresTenant = query.implementation.tenant.kind === 'required';
+      const endpointRequiresTenant = query.endpoint.tenant.kind === 'required';
+      if (implementationRequiresTenant !== endpointRequiresTenant) {
+        deploymentError(
+          'HQ_DEPLOYMENT_INVALID_REFERENCE',
+          `$.queries[${queryIndex}].endpoint.tenant`,
+        );
+      }
+      for (const [parameterIndex, parameter] of query.implementation.parameters.entries()) {
+        if (parameter.source.kind === 'input'
+          && !schemaContainsPath(query.input, parameter.source.path.split('.'))) {
+          deploymentError(
+            'HQ_DEPLOYMENT_INVALID_REFERENCE',
+            `$.queries[${queryIndex}].implementation.parameters[${parameterIndex}].source.path`,
+          );
+        }
+      }
+    }
+    if (query.implementation.kind === 'semantic-plan') {
+      const dataset = datasets.get(query.implementation.query.dataset);
+      if (!dataset) {
+        deploymentError(
+          'HQ_DEPLOYMENT_INVALID_REFERENCE',
+          `$.queries[${queryIndex}].implementation.query.dataset`,
+        );
+      }
+      if (dataset.tenant.kind === 'required' && query.endpoint.tenant.kind !== 'required') {
+        deploymentError(
+          'HQ_DEPLOYMENT_INVALID_REFERENCE',
+          `$.queries[${queryIndex}].endpoint.tenant`,
+        );
+      }
+    }
+  }
+}
+
+function schemaContainsPath(
+  schema: ProtocolSchema,
+  segments: readonly string[],
+): boolean {
+  if (segments.length === 0) return true;
+  if (schema.kind === 'any') return true;
+  if (schema.kind === 'union') {
+    return schema.variants.every(variant => schemaContainsPath(variant, segments));
+  }
+  if (schema.kind === 'record') {
+    return schemaContainsPath(schema.values, segments.slice(1));
+  }
+  if (schema.kind !== 'object') return false;
+  const [head, ...tail] = segments;
+  const property = schema.properties[head as keyof typeof schema.properties];
+  return property !== undefined && schemaContainsPath(property, tail);
+}
+
+export function validateProtocolDeploymentContract(
+  input: unknown,
+  options: ProtocolDeploymentOptions = {},
+): ProtocolDeploymentContract {
+  const limits = resolveDeploymentLimits(options);
+  const value = requireRecord(input, '$');
+  exactFields(value, ['kind', 'version', 'datasets', 'queries', 'artifacts'], [], '$');
+  if (value.kind !== 'hypequery-deployment') deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', '$.kind');
+  if (value.version !== 1) deploymentError('HQ_DEPLOYMENT_INVALID_VERSION', '$.version');
+  const datasets = namedItems(
+    value.datasets,
+    '$.datasets',
+    limits.maxDatasets,
+    (dataset, path) => validateDataset(dataset, path, limits),
+  );
+  const queries = namedItems(
+    value.queries,
+    '$.queries',
+    limits.maxQueries,
+    (query, path) => validateQuery(query, path, limits),
+  );
+  const artifacts = Object.freeze(requireArray(value.artifacts, '$.artifacts', limits.maxArtifacts)
+    .map((artifact, index) => validateArtifact(artifact, `$.artifacts[${index}]`)));
+  if (new Set(artifacts.map(artifact => artifact.artifactSha256)).size !== artifacts.length) {
+    deploymentError('HQ_DEPLOYMENT_INVALID_REFERENCE', '$.artifacts');
+  }
+  const result = freezeRecord({
+    kind: 'hypequery-deployment',
+    version: 1,
+    datasets,
+    queries,
+    artifacts,
+  }) as unknown as ProtocolDeploymentContract;
+  validateReferences(result);
+  return result;
+}

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -5,10 +5,12 @@ describe('@hypequery/protocol public surface', () => {
   it('exports only the reviewed protocol surfaces', () => {
     expect(Object.keys(protocol).sort()).toEqual([
       'DEFAULT_CANONICAL_VALUE_LIMITS',
+      'DEFAULT_PROTOCOL_DEPLOYMENT_LIMITS',
       'DEFAULT_PROTOCOL_EXPRESSION_LIMITS',
       'DEFAULT_PROTOCOL_QUERY_IMPLEMENTATION_LIMITS',
       'DEFAULT_PROTOCOL_SCHEMA_LIMITS',
       'PROTOCOL_IDENTIFIER_LIMITS',
+      'ProtocolDeploymentError',
       'ProtocolExpressionError',
       'ProtocolIdentifierError',
       'ProtocolQueryImplementationError',
@@ -25,6 +27,8 @@ describe('@hypequery/protocol public surface', () => {
       'parseProtocolQualifiedIdentifier',
       'splitProtocolQualifiedIdentifier',
       'validateCanonicalValue',
+      'validateProtocolDatasetContract',
+      'validateProtocolDeploymentContract',
       'validateProtocolExpression',
       'validateProtocolQueryImplementation',
       'validateProtocolSchema',

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -86,6 +86,35 @@ export {
   validateProtocolSqlExpression,
 } from './query-implementations/index.js';
 
+export {
+  DEFAULT_PROTOCOL_DEPLOYMENT_LIMITS,
+  ProtocolDeploymentError,
+  validateProtocolDatasetContract,
+  validateProtocolDeploymentContract,
+} from './deployments/index.js';
+
+export type {
+  ProtocolAccessPolicy,
+  ProtocolDatasetContract,
+  ProtocolDatasetDimension,
+  ProtocolDatasetFieldSource,
+  ProtocolDatasetFieldType,
+  ProtocolDatasetFilter,
+  ProtocolDatasetLimits,
+  ProtocolDatasetMeasure,
+  ProtocolDatasetMetric,
+  ProtocolDatasetRelationship,
+  ProtocolDatasetTenantPolicy,
+  ProtocolDeploymentContract,
+  ProtocolDeploymentErrorCode,
+  ProtocolDeploymentLimits,
+  ProtocolDeploymentOptions,
+  ProtocolEndpointPolicy,
+  ProtocolEndpointTenantPolicy,
+  ProtocolNamedQueryContract,
+  ProtocolRuntimeArtifact,
+} from './deployments/index.js';
+
 export type {
   ProtocolQueryImplementation,
   ProtocolQueryImplementationErrorCode,

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -31,6 +31,7 @@
     "types": "tsc --project tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@hypequery/protocol": "^0.1.0",
     "jose": "^5.9.6",
     "openapi-typescript": "^7.13.0",
     "zod": "^3.23.8",

--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -18,6 +18,9 @@ export { startServer, toNodeHandler, toFetchHandler } from "./adapters/standalon
 export type { DevIntegrationApi, ServeDevOptions } from "./dev.js";
 export { createCacheObservability, detectBuilderCache } from "./cache-observability.js";
 export type { CacheObservability, CacheLayerStats, BuilderCacheLike } from "./cache-observability.js";
+export { buildProtocolDeploymentContract } from './protocol-adapter.js';
+export type { BuildProtocolDeploymentOptions } from './protocol-adapter.js';
+export { ProtocolSchemaAdapterError, zodToProtocolSchema } from './protocol-schema-adapter.js';
 /** @deprecated Import from `@hypequery/serve/dev` instead. */
 export { serveDev } from "./dev.js";
 export * from "./serve.js";

--- a/packages/serve/src/protocol-adapter.test.ts
+++ b/packages/serve/src/protocol-adapter.test.ts
@@ -167,6 +167,29 @@ describe('Serve protocol adapter', () => {
     });
   });
 
+  it('preserves discriminator properties when lowering discriminated unions', () => {
+    const schema = z.discriminatedUnion('type', [
+      z.object({ type: z.literal('created'), id: z.string() }),
+      z.object({ type: z.literal('deleted'), reason: z.string() }),
+    ]);
+
+    expect(zodToProtocolSchema(schema)).toMatchObject({
+      kind: 'union',
+      variants: [
+        {
+          kind: 'object',
+          properties: { type: { kind: 'literal', value: 'created' } },
+          required: ['type', 'id'],
+        },
+        {
+          kind: 'object',
+          properties: { type: { kind: 'literal', value: 'deleted' } },
+          required: ['type', 'reason'],
+        },
+      ],
+    });
+  });
+
   it('unwraps readonly Zod schemas', () => {
     expect(zodToProtocolSchema(z.string().readonly())).toEqual({ kind: 'string' });
   });

--- a/packages/serve/src/protocol-adapter.test.ts
+++ b/packages/serve/src/protocol-adapter.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { dataset, dimension } from '@hypequery/datasets';
+import {
+  buildProtocolDeploymentContract,
+  ProtocolSchemaAdapterError,
+  zodToProtocolSchema,
+} from './index.js';
+
+const ARTIFACT_SHA = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+describe('Serve protocol adapter', () => {
+  it('converts Serve queries and Dataset endpoints into one deployment contract', () => {
+    const Orders = dataset('orders', {
+      source: 'orders',
+      tenantKey: 'tenant_id',
+      dimensions: { id: dimension.string() },
+    });
+    const contract = buildProtocolDeploymentContract({
+      basePath: '/analytics',
+      tenant: {
+        extract: auth => auth.tenantId,
+        required: true,
+        mode: 'auto-inject',
+        column: 'tenant_id',
+      },
+      datasets: { orders: Orders },
+      queries: {
+        greeting: {
+          method: 'POST',
+          inputSchema: z.object({
+            name: z.string().min(1),
+            loud: z.boolean().optional(),
+          }).strict(),
+          outputSchema: z.object({ message: z.string() }),
+          query: async ({ input }) => ({ message: input.name }),
+          requiredScopes: ['read:greeting'],
+          tags: ['example'],
+        },
+      },
+    }, {
+      runtimeArtifact: {
+        runtime: 'node',
+        artifactSha256: ARTIFACT_SHA,
+      },
+    });
+
+    expect(contract.datasets[0]?.endpoint).toMatchObject({
+      access: { kind: 'public' },
+      tenant: { kind: 'required', mode: 'auto-inject', column: 'tenant_id' },
+      maxLimit: 1000,
+      path: '/analytics/datasets/orders/query',
+    });
+    expect(contract.queries[0]).toMatchObject({
+      name: 'greeting',
+      input: {
+        kind: 'object',
+        required: ['name'],
+        unknownProperties: 'reject',
+      },
+      implementation: {
+        kind: 'runtime-reference',
+        runtime: 'node',
+        artifactSha256: ARTIFACT_SHA,
+        entrypoint: 'queries.greeting',
+      },
+      endpoint: {
+        access: { kind: 'authenticated', roles: [], scopes: ['read:greeting'] },
+        tenant: { kind: 'required', mode: 'auto-inject', column: 'tenant_id' },
+        method: 'POST',
+        path: '/analytics/queries/greeting',
+      },
+    });
+    expect(contract.artifacts).toEqual([{ runtime: 'node', artifactSha256: ARTIFACT_SHA }]);
+    expect(Object.isFrozen(contract)).toBe(true);
+  });
+
+  it('fails closed for Zod behavior the portable schema cannot preserve', () => {
+    expect(() => zodToProtocolSchema(z.string().email()))
+      .toThrow(ProtocolSchemaAdapterError);
+  });
+
+  it('preserves role enforcement even when auth is explicitly null', () => {
+    const contract = buildProtocolDeploymentContract({
+      queries: {
+        guarded: {
+          inputSchema: z.void(),
+          outputSchema: z.string(),
+          query: async () => 'ok',
+          auth: null,
+          requiredRoles: ['admin'],
+        },
+      },
+    }, {
+      runtimeArtifact: {
+        runtime: 'node',
+        artifactSha256: ARTIFACT_SHA,
+      },
+    });
+
+    expect(contract.queries[0]?.endpoint.access).toEqual({
+      kind: 'authenticated',
+      roles: ['admin'],
+      scopes: [],
+    });
+  });
+
+  it('preserves global auth for named queries with no local strategy', () => {
+    const contract = buildProtocolDeploymentContract({
+      auth: async () => ({ userId: 'user_1' }),
+      queries: {
+        guarded: {
+          inputSchema: z.void(),
+          outputSchema: z.string(),
+          query: async () => 'ok',
+          auth: null,
+        },
+      },
+    }, {
+      runtimeArtifact: {
+        runtime: 'node',
+        artifactSha256: ARTIFACT_SHA,
+      },
+    });
+
+    expect(contract.queries[0]?.endpoint.access.kind).toBe('authenticated');
+  });
+
+  it('rejects typed object catchalls that the protocol cannot represent', () => {
+    expect(() => zodToProtocolSchema(z.object({ id: z.string() }).catchall(z.number())))
+      .toThrow(ProtocolSchemaAdapterError);
+  });
+
+  it('rejects constrained record keys that the protocol cannot represent', () => {
+    expect(() => zodToProtocolSchema(z.record(z.enum(['a', 'b']), z.string())))
+      .toThrow(ProtocolSchemaAdapterError);
+    expect(zodToProtocolSchema(z.record(z.string()))).toMatchObject({
+      kind: 'record',
+      values: { kind: 'string' },
+    });
+  });
+
+  it('excludes reverse mappings from numeric native enums', () => {
+    enum NumericEnum {
+      Alpha,
+      Beta,
+    }
+
+    expect(zodToProtocolSchema(z.nativeEnum(NumericEnum))).toEqual({
+      kind: 'enum',
+      values: [0, 1],
+    });
+  });
+
+  it('unwraps readonly Zod schemas', () => {
+    expect(zodToProtocolSchema(z.string().readonly())).toEqual({ kind: 'string' });
+  });
+});

--- a/packages/serve/src/protocol-adapter.test.ts
+++ b/packages/serve/src/protocol-adapter.test.ts
@@ -126,6 +126,21 @@ describe('Serve protocol adapter', () => {
     expect(contract.queries[0]?.endpoint.access.kind).toBe('authenticated');
   });
 
+  it('preserves the semantic endpoint public override for auth null', () => {
+    const Orders = dataset('orders', {
+      source: 'orders',
+      dimensions: { id: dimension.string() },
+    });
+    const contract = buildProtocolDeploymentContract({
+      auth: async () => ({ userId: 'user_1' }),
+      datasets: {
+        orders: { dataset: Orders, auth: null },
+      },
+    });
+
+    expect(contract.datasets[0]?.endpoint?.access).toEqual({ kind: 'public' });
+  });
+
   it('rejects typed object catchalls that the protocol cannot represent', () => {
     expect(() => zodToProtocolSchema(z.object({ id: z.string() }).catchall(z.number())))
       .toThrow(ProtocolSchemaAdapterError);

--- a/packages/serve/src/protocol-adapter.ts
+++ b/packages/serve/src/protocol-adapter.ts
@@ -71,14 +71,14 @@ function accessPolicy(
     readonly requiredScopes?: readonly string[];
   },
   globalAuth: AnyServeConfig['auth'],
-  authNullIsPublic: boolean,
+  nullAuthOverridesGlobal: boolean,
 ): ProtocolAccessPolicy {
   const roles = [...new Set(local.requiredRoles ?? [])].sort();
   const scopes = [...new Set(local.requiredScopes ?? [])].sort();
   if (roles.length > 0 || scopes.length > 0) {
     return { kind: 'authenticated', roles, scopes };
   }
-  if (local.requiresAuth === false || (authNullIsPublic && local.auth === null)) {
+  if (local.requiresAuth === false || (nullAuthOverridesGlobal && local.auth === null)) {
     return { kind: 'public' };
   }
   if (local.requiresAuth === true || local.auth != null || hasGlobalAuth(globalAuth)) {
@@ -102,11 +102,13 @@ function endpointPolicy(
   globalTenant: AnyServeConfig['tenant'],
   path: string,
   defaultMaxLimit?: number,
-  authNullIsPublic = false,
+  // Dataset/metric endpoints use `auth: null` as an explicit public override;
+  // named queries use it only to omit a local strategy and still inherit global auth.
+  nullAuthOverridesGlobal = false,
 ): ProtocolEndpointPolicy {
   const cacheTtlMs = local.cacheTtlMs ?? local.cache ?? undefined;
   return {
-    access: accessPolicy(local, globalAuth, authNullIsPublic),
+    access: accessPolicy(local, globalAuth, nullAuthOverridesGlobal),
     tenant: endpointTenantPolicy(local.tenant, globalTenant),
     ...(typeof cacheTtlMs === 'number' && cacheTtlMs > 0 ? { cacheTtlMs } : {}),
     ...((local.maxLimit ?? defaultMaxLimit) !== undefined

--- a/packages/serve/src/protocol-adapter.ts
+++ b/packages/serve/src/protocol-adapter.ts
@@ -1,0 +1,292 @@
+import {
+  validateProtocolDeploymentContract,
+  type ProtocolAccessPolicy,
+  type ProtocolDeploymentContract,
+  type ProtocolEndpointPolicy,
+  type ProtocolEndpointTenantPolicy,
+  type ProtocolQueryImplementation,
+  type ProtocolRuntimeArtifact,
+  type ProtocolSchema,
+} from '@hypequery/protocol';
+import {
+  buildProtocolDatasetContract,
+  type AnyDatasetInstance,
+  type MetricHandle,
+} from '@hypequery/datasets';
+import type {
+  AuthContext,
+  AuthStrategy,
+  DatasetEntry,
+  DatasetsConfig,
+  MetricEntry,
+  MetricsConfig,
+  ServeConfig,
+  ServeQueriesMap,
+  TenantConfigOverride,
+} from './types.js';
+import { resolveDatasetEntry } from './semantic/datasets/utils/dataset-entry.js';
+import { resolveMetricEntry } from './semantic/datasets/metric-endpoint.js';
+import { zodToProtocolSchema } from './protocol-schema-adapter.js';
+
+export interface BuildProtocolDeploymentOptions {
+  /** Runtime artifact used for Serve callbacks without an explicit implementation override. */
+  readonly runtimeArtifact?: ProtocolRuntimeArtifact & {
+    readonly entrypointPrefix?: string;
+  };
+  /** Per-query implementation overrides for fixed semantic plans or compiled SQL. */
+  readonly queryImplementations?: Readonly<Record<string, ProtocolQueryImplementation>>;
+  /** Schema overrides for Zod constructs outside the portable RFC 0004 subset. */
+  readonly querySchemas?: Readonly<Record<string, {
+    readonly input?: ProtocolSchema;
+    readonly output?: ProtocolSchema;
+  }>>;
+}
+
+type AnyServeConfig = ServeConfig<
+  Record<string, unknown>,
+  AuthContext,
+  ServeQueriesMap<Record<string, unknown>, AuthContext>,
+  MetricsConfig<AuthContext>,
+  DatasetsConfig<AuthContext>
+>;
+
+function normalizePath(...parts: string[]): string {
+  const joined = parts
+    .filter(Boolean)
+    .map((part, index) => index === 0 ? part.replace(/\/+$/g, '') : part.replace(/^\/+|\/+$/g, ''))
+    .filter(Boolean)
+    .join('/');
+  return `/${joined.replace(/^\/+/, '')}`.replace(/\/{2,}/g, '/');
+}
+
+function hasGlobalAuth(auth: AuthStrategy<AuthContext> | AuthStrategy<AuthContext>[] | undefined): boolean {
+  return Array.isArray(auth) ? auth.length > 0 : auth !== undefined;
+}
+
+function accessPolicy(
+  local: {
+    readonly auth?: AuthStrategy<AuthContext> | null;
+    readonly requiresAuth?: boolean;
+    readonly requiredRoles?: readonly string[];
+    readonly requiredScopes?: readonly string[];
+  },
+  globalAuth: AnyServeConfig['auth'],
+  authNullIsPublic: boolean,
+): ProtocolAccessPolicy {
+  const roles = [...new Set(local.requiredRoles ?? [])].sort();
+  const scopes = [...new Set(local.requiredScopes ?? [])].sort();
+  if (roles.length > 0 || scopes.length > 0) {
+    return { kind: 'authenticated', roles, scopes };
+  }
+  if (local.requiresAuth === false || (authNullIsPublic && local.auth === null)) {
+    return { kind: 'public' };
+  }
+  if (local.requiresAuth === true || local.auth != null || hasGlobalAuth(globalAuth)) {
+    return { kind: 'authenticated', roles, scopes };
+  }
+  return { kind: 'public' };
+}
+
+function endpointPolicy(
+  local: {
+    readonly auth?: AuthStrategy<AuthContext> | null;
+    readonly requiresAuth?: boolean;
+    readonly requiredRoles?: readonly string[];
+    readonly requiredScopes?: readonly string[];
+    readonly cache?: number | null;
+    readonly cacheTtlMs?: number | null;
+    readonly maxLimit?: number;
+    readonly tenant?: TenantConfigOverride<AuthContext>;
+  },
+  globalAuth: AnyServeConfig['auth'],
+  globalTenant: AnyServeConfig['tenant'],
+  path: string,
+  defaultMaxLimit?: number,
+  authNullIsPublic = false,
+): ProtocolEndpointPolicy {
+  const cacheTtlMs = local.cacheTtlMs ?? local.cache ?? undefined;
+  return {
+    access: accessPolicy(local, globalAuth, authNullIsPublic),
+    tenant: endpointTenantPolicy(local.tenant, globalTenant),
+    ...(typeof cacheTtlMs === 'number' && cacheTtlMs > 0 ? { cacheTtlMs } : {}),
+    ...((local.maxLimit ?? defaultMaxLimit) !== undefined
+      ? { maxLimit: local.maxLimit ?? defaultMaxLimit }
+      : {}),
+    path,
+  };
+}
+
+function endpointTenantPolicy(
+  local: TenantConfigOverride<AuthContext> | undefined,
+  global: AnyServeConfig['tenant'],
+): ProtocolEndpointTenantPolicy {
+  if (local === undefined && global === undefined) return { kind: 'not-required' };
+  const effective = { ...(global ?? {}), ...(local ?? {}) };
+  return {
+    kind: effective.required === false ? 'optional' : 'required',
+    mode: effective.mode ?? 'manual',
+    ...(effective.column !== undefined ? { column: effective.column } : {}),
+  };
+}
+
+function metricHandle(entry: MetricEntry<AuthContext>): MetricHandle {
+  return resolveMetricEntry(entry).metric;
+}
+
+function metricDataset(metric: MetricHandle): AnyDatasetInstance {
+  return metric.__type === 'grained_metric_ref' ? metric.metric.dataset : metric.dataset;
+}
+
+function collectDataset(
+  datasets: Map<string, AnyDatasetInstance>,
+  dataset: AnyDatasetInstance,
+): void {
+  const existing = datasets.get(dataset.name);
+  if (existing && existing !== dataset) {
+    throw new Error(`Multiple Dataset definitions use the protocol name "${dataset.name}".`);
+  }
+  if (existing) return;
+  datasets.set(dataset.name, dataset);
+  for (const relationship of Object.values(dataset.relationships)) {
+    collectDataset(datasets, relationship.target() as AnyDatasetInstance);
+  }
+}
+
+function queryImplementation(
+  name: string,
+  options: BuildProtocolDeploymentOptions,
+): ProtocolQueryImplementation {
+  const override = options.queryImplementations?.[name];
+  if (override) return override;
+  if (!options.runtimeArtifact) {
+    throw new Error(
+      `Serve query "${name}" needs runtimeArtifact or an explicit queryImplementations override.`,
+    );
+  }
+  const prefix = options.runtimeArtifact.entrypointPrefix ?? 'queries';
+  return {
+    kind: 'runtime-reference',
+    runtime: options.runtimeArtifact.runtime,
+    artifactSha256: options.runtimeArtifact.artifactSha256,
+    entrypoint: `${prefix}.${name}`,
+  } as unknown as ProtocolQueryImplementation;
+}
+
+function runtimeArtifacts(
+  implementations: readonly ProtocolQueryImplementation[],
+  configured?: ProtocolRuntimeArtifact,
+): readonly ProtocolRuntimeArtifact[] {
+  const artifacts = new Map<string, ProtocolRuntimeArtifact>();
+  if (configured) {
+    artifacts.set(configured.artifactSha256, {
+      runtime: configured.runtime,
+      artifactSha256: configured.artifactSha256,
+    });
+  }
+  for (const implementation of implementations) {
+    if (implementation.kind !== 'runtime-reference') continue;
+    const existing = artifacts.get(implementation.artifactSha256);
+    if (existing && existing.runtime !== implementation.runtime) {
+      throw new Error(`Runtime artifact ${implementation.artifactSha256} has conflicting runtimes.`);
+    }
+    artifacts.set(implementation.artifactSha256, {
+      runtime: implementation.runtime,
+      artifactSha256: implementation.artifactSha256,
+    });
+  }
+  return [...artifacts.values()].sort((left, right) =>
+    left.artifactSha256.localeCompare(right.artifactSha256));
+}
+
+/**
+ * Converts an existing Serve configuration and its Dataset/metric definitions
+ * into the strict, immutable protocol deployment contract.
+ */
+export function buildProtocolDeploymentContract(
+  config: ServeConfig<any, any, any, any, any>,
+  options: BuildProtocolDeploymentOptions = {},
+): ProtocolDeploymentContract {
+  const serveConfig = config as unknown as AnyServeConfig;
+  const basePath = serveConfig.basePath ?? '/api/analytics';
+  const datasetsPath = serveConfig.semanticPaths?.datasets ?? '/datasets';
+  const metricsPath = serveConfig.semanticPaths?.metrics ?? '/metrics';
+  const datasets = new Map<string, AnyDatasetInstance>();
+  const datasetEndpoints = new Map<string, ProtocolEndpointPolicy>();
+  const metricHandles: Record<string, MetricHandle> = {};
+  const metricEndpoints: Record<string, ProtocolEndpointPolicy> = {};
+
+  for (const [exposedName, entry] of Object.entries(serveConfig.datasets ?? {})) {
+    const resolved = resolveDatasetEntry(entry as DatasetEntry<AuthContext>);
+    collectDataset(datasets, resolved.dataset);
+    if (datasetEndpoints.has(resolved.dataset.name)) {
+      throw new Error(`Dataset "${resolved.dataset.name}" is exposed more than once.`);
+    }
+    datasetEndpoints.set(resolved.dataset.name, endpointPolicy(
+      resolved,
+      serveConfig.auth,
+      serveConfig.tenant,
+      normalizePath(basePath, datasetsPath, exposedName, 'query'),
+      resolved.dataset.limits?.maxResultSize ?? 1_000,
+      true,
+    ));
+  }
+
+  for (const [exposedName, entry] of Object.entries(serveConfig.metrics ?? {})) {
+    const resolved = resolveMetricEntry(entry as MetricEntry<AuthContext>);
+    const metric = metricHandle(entry as MetricEntry<AuthContext>);
+    const dataset = metricDataset(metric);
+    collectDataset(datasets, dataset);
+    metricHandles[exposedName] = metric;
+    metricEndpoints[exposedName] = endpointPolicy(
+      resolved,
+      serveConfig.auth,
+      serveConfig.tenant,
+      normalizePath(basePath, metricsPath, exposedName),
+      resolved.maxLimit ?? dataset.limits?.maxResultSize ?? 1_000,
+      true,
+    );
+  }
+
+  const datasetContracts = [...datasets.values()]
+    .map(dataset => buildProtocolDatasetContract(dataset, {
+      metrics: metricHandles,
+      metricEndpoints,
+      ...(datasetEndpoints.get(dataset.name) !== undefined
+        ? { endpoint: datasetEndpoints.get(dataset.name) }
+        : {}),
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  const implementations: ProtocolQueryImplementation[] = [];
+  const queries = Object.entries(serveConfig.queries ?? {}).map(([name, query]) => {
+    const implementation = queryImplementation(name, options);
+    implementations.push(implementation);
+    const schemaOverride = options.querySchemas?.[name];
+    return {
+      name,
+      input: schemaOverride?.input ?? zodToProtocolSchema(query.inputSchema, `queries.${name}.input`),
+      output: schemaOverride?.output ?? zodToProtocolSchema(query.outputSchema, `queries.${name}.output`),
+      implementation,
+      endpoint: {
+        ...endpointPolicy(
+          query,
+          serveConfig.auth,
+          serveConfig.tenant,
+          normalizePath(basePath, 'queries', name),
+        ),
+        method: query.method ?? 'GET',
+      },
+      ...(query.summary !== undefined ? { summary: query.summary } : {}),
+      ...(query.description !== undefined ? { description: query.description } : {}),
+      tags: [...new Set(query.tags ?? [])].sort(),
+    };
+  }).sort((left, right) => left.name.localeCompare(right.name));
+
+  return validateProtocolDeploymentContract({
+    kind: 'hypequery-deployment',
+    version: 1,
+    datasets: datasetContracts,
+    queries,
+    artifacts: runtimeArtifacts(implementations, options.runtimeArtifact),
+  });
+}

--- a/packages/serve/src/protocol-schema-adapter.ts
+++ b/packages/serve/src/protocol-schema-adapter.ts
@@ -1,0 +1,255 @@
+import type { ZodTypeAny } from 'zod';
+import {
+  validateCanonicalValue,
+  validateProtocolSchema,
+  type CanonicalValue,
+  type ProtocolSchema,
+} from '@hypequery/protocol';
+
+export class ProtocolSchemaAdapterError extends TypeError {
+  readonly path: string;
+
+  constructor(message: string, path = '$') {
+    super(`${message} at ${path}`);
+    this.name = 'ProtocolSchemaAdapterError';
+    this.path = path;
+  }
+}
+
+function canonicalValue(input: unknown, path: string): CanonicalValue {
+  try {
+    if (Array.isArray(input)) {
+      return validateCanonicalValue({
+        $hypequery: {
+          type: 'array',
+          version: 1,
+          values: input.map((item, index) => canonicalValue(item, `${path}[${index}]`)),
+        },
+      });
+    }
+    if (typeof input === 'object' && input !== null) {
+      if ('$hypequery' in input) return validateCanonicalValue(input);
+      const prototype = Object.getPrototypeOf(input);
+      if (prototype !== Object.prototype && prototype !== null) {
+        throw new ProtocolSchemaAdapterError('Default is not portable plain data', path);
+      }
+      return validateCanonicalValue({
+        $hypequery: {
+          type: 'map',
+          version: 1,
+          entries: Object.entries(input as Record<string, unknown>)
+            .sort(([left], [right]) => left.localeCompare(right))
+            .map(([key, value]) => [key, canonicalValue(value, `${path}.${key}`)]),
+        },
+      });
+    }
+    return validateCanonicalValue(input);
+  } catch (error) {
+    if (error instanceof ProtocolSchemaAdapterError) throw error;
+    throw new ProtocolSchemaAdapterError('Default is not a canonical protocol value', path);
+  }
+}
+
+function typeName(schema: ZodTypeAny): string {
+  return String((schema as any)?._def?.typeName ?? 'Unknown');
+}
+
+function description(schema: ZodTypeAny): string | undefined {
+  return typeof (schema as any).description === 'string'
+    ? (schema as any).description
+    : undefined;
+}
+
+function annotate(schema: ZodTypeAny, result: Record<string, unknown>): Record<string, unknown> {
+  const value = description(schema);
+  return value === undefined ? result : { ...result, description: value };
+}
+
+function convertString(schema: ZodTypeAny, path: string): Record<string, unknown> {
+  const result: Record<string, unknown> = { kind: 'string' };
+  for (const check of (schema as any)._def.checks as Array<Record<string, unknown>>) {
+    switch (check.kind) {
+      case 'min':
+        result.minLength = check.value;
+        break;
+      case 'max':
+        result.maxLength = check.value;
+        break;
+      case 'length':
+        result.minLength = check.value;
+        result.maxLength = check.value;
+        break;
+      default:
+        throw new ProtocolSchemaAdapterError(`Unsupported Zod string check "${String(check.kind)}"`, path);
+    }
+  }
+  return annotate(schema, result);
+}
+
+function convertNumber(schema: ZodTypeAny, path: string): Record<string, unknown> {
+  const result: Record<string, unknown> = { kind: 'number' };
+  for (const check of (schema as any)._def.checks as Array<Record<string, unknown>>) {
+    switch (check.kind) {
+      case 'int':
+        result.kind = 'integer';
+        break;
+      case 'min':
+        result[check.inclusive === false ? 'exclusiveMinimum' : 'minimum'] = check.value;
+        break;
+      case 'max':
+        result[check.inclusive === false ? 'exclusiveMaximum' : 'maximum'] = check.value;
+        break;
+      case 'finite':
+        break;
+      default:
+        throw new ProtocolSchemaAdapterError(`Unsupported Zod number check "${String(check.kind)}"`, path);
+    }
+  }
+  return annotate(schema, result);
+}
+
+function isOptionalProperty(schema: ZodTypeAny): boolean {
+  const name = typeName(schema);
+  return name === 'ZodOptional' || name === 'ZodDefault';
+}
+
+function nativeEnumValues(input: Record<string, string | number>): readonly (string | number)[] {
+  const values = Object.keys(input)
+    .filter(key => typeof input[String(input[key])] !== 'number')
+    .map(key => input[key]);
+  return [...new Set(values)];
+}
+
+function isUnconstrainedRecordKey(schema: ZodTypeAny | undefined): boolean {
+  if (schema === undefined || typeName(schema) !== 'ZodString') return false;
+  const definition = (schema as any)._def as Record<string, unknown>;
+  return Array.isArray(definition.checks)
+    && definition.checks.length === 0
+    && definition.coerce !== true;
+}
+
+function convert(schema: ZodTypeAny, path: string): Record<string, unknown> {
+  const definition = (schema as any)._def as Record<string, any>;
+  switch (typeName(schema)) {
+    case 'ZodAny':
+    case 'ZodUnknown':
+      return annotate(schema, { kind: 'any' });
+    case 'ZodNever':
+    case 'ZodVoid':
+    case 'ZodUndefined':
+      return annotate(schema, { kind: 'void' });
+    case 'ZodNull':
+      return annotate(schema, { kind: 'null' });
+    case 'ZodBoolean':
+      return annotate(schema, { kind: 'boolean' });
+    case 'ZodString':
+      return convertString(schema, path);
+    case 'ZodNumber':
+      return convertNumber(schema, path);
+    case 'ZodLiteral':
+      return annotate(schema, {
+        kind: 'literal',
+        value: canonicalValue(definition.value, `${path}.value`),
+      });
+    case 'ZodEnum':
+      return annotate(schema, {
+        kind: 'enum',
+        values: [...definition.values],
+      });
+    case 'ZodNativeEnum': {
+      const values = nativeEnumValues(definition.values);
+      return annotate(schema, { kind: 'enum', values });
+    }
+    case 'ZodArray': {
+      const result: Record<string, unknown> = {
+        kind: 'array',
+        items: convert(definition.type, `${path}.items`),
+      };
+      if (definition.minLength?.value !== undefined) result.minItems = definition.minLength.value;
+      if (definition.maxLength?.value !== undefined) result.maxItems = definition.maxLength.value;
+      if (definition.exactLength?.value !== undefined) {
+        result.minItems = definition.exactLength.value;
+        result.maxItems = definition.exactLength.value;
+      }
+      return annotate(schema, result);
+    }
+    case 'ZodObject': {
+      if (typeName(definition.catchall) !== 'ZodNever') {
+        throw new ProtocolSchemaAdapterError('Unsupported Zod object catchall', path);
+      }
+      const shape = definition.shape() as Record<string, ZodTypeAny>;
+      const properties = Object.fromEntries(
+        Object.entries(shape).map(([name, property]) => [
+          name,
+          convert(property, `${path}.properties.${name}`),
+        ]),
+      );
+      const required = Object.entries(shape)
+        .filter(([, property]) => !isOptionalProperty(property))
+        .map(([name]) => name);
+      const unknownProperties = definition.unknownKeys === 'passthrough'
+        ? 'preserve'
+        : definition.unknownKeys === 'strict'
+          ? 'reject'
+          : 'strip';
+      return annotate(schema, {
+        kind: 'object',
+        properties,
+        required,
+        unknownProperties,
+      });
+    }
+    case 'ZodRecord':
+      if (!isUnconstrainedRecordKey(definition.keyType)) {
+        throw new ProtocolSchemaAdapterError('Unsupported constrained Zod record key', path);
+      }
+      return annotate(schema, {
+        kind: 'record',
+        values: convert(definition.valueType, `${path}.values`),
+      });
+    case 'ZodUnion':
+      return annotate(schema, {
+        kind: 'union',
+        variants: definition.options.map((option: ZodTypeAny, index: number) =>
+          convert(option, `${path}.variants[${index}]`)),
+      });
+    case 'ZodDiscriminatedUnion':
+      return annotate(schema, {
+        kind: 'union',
+        variants: [...definition.options.values()].map((option: ZodTypeAny, index: number) =>
+          convert(option, `${path}.variants[${index}]`)),
+      });
+    case 'ZodNullable':
+      return annotate(schema, {
+        kind: 'union',
+        variants: [convert(definition.innerType, `${path}.variants[0]`), { kind: 'null' }],
+      });
+    case 'ZodOptional':
+      return annotate(schema, convert(definition.innerType, path));
+    case 'ZodDefault': {
+      const inner = convert(definition.innerType, path);
+      if (inner.kind === 'void') {
+        throw new ProtocolSchemaAdapterError('Void schemas cannot carry defaults', path);
+      }
+      return annotate(schema, {
+        ...inner,
+        default: canonicalValue(definition.defaultValue(), `${path}.default`),
+      });
+    }
+    case 'ZodBranded':
+      return annotate(schema, convert(definition.type, path));
+    case 'ZodReadonly':
+      return annotate(schema, convert(definition.innerType, path));
+    default:
+      throw new ProtocolSchemaAdapterError(`Unsupported Zod type "${typeName(schema)}"`, path);
+  }
+}
+
+/** Converts the portable subset of a Zod v3 schema into RFC 0004. */
+export function zodToProtocolSchema(
+  schema: ZodTypeAny | undefined,
+  path = '$',
+): ProtocolSchema {
+  if (schema === undefined) return validateProtocolSchema({ kind: 'any' });
+  return validateProtocolSchema(convert(schema, path));
+}

--- a/packages/serve/src/protocol-schema-adapter.ts
+++ b/packages/serve/src/protocol-schema-adapter.ts
@@ -214,6 +214,9 @@ function convert(schema: ZodTypeAny, path: string): Record<string, unknown> {
           convert(option, `${path}.variants[${index}]`)),
       });
     case 'ZodDiscriminatedUnion':
+      // RFC 0004 has no separate discriminator index. Converting every option
+      // drops only Zod's lookup metadata; each object's literal discriminator
+      // property remains part of its protocol variant.
       return annotate(schema, {
         kind: 'union',
         variants: [...definition.options.values()].map((option: ZodTypeAny, index: number) =>

--- a/packages/serve/src/semantic/datasets/utils/dataset-entry.ts
+++ b/packages/serve/src/semantic/datasets/utils/dataset-entry.ts
@@ -10,6 +10,7 @@ export type DatasetEntry<TAuth extends AuthContext = AuthContext> =
   | AnyDatasetInstance
   | {
       dataset: AnyDatasetInstance;
+      /** `null` makes this semantic endpoint public instead of inheriting global auth. */
       auth?: AuthStrategy<TAuth> | null;
       tenant?: TenantConfigOverride<TAuth>;
       cache?: number | null;

--- a/packages/serve/src/types.ts
+++ b/packages/serve/src/types.ts
@@ -587,6 +587,7 @@ export type MetricEntry<TAuth extends AuthContext = AuthContext> =
   | MetricHandle<any, any>
   | {
       metric: MetricHandle<any, any>;
+      /** `null` makes this semantic endpoint public instead of inheriting global auth. */
       auth?: AuthStrategy<TAuth> | null;
       tenant?: TenantConfigOverride<TAuth>;
       cache?: number | null;

--- a/packages/serve/tsconfig.json
+++ b/packages/serve/tsconfig.json
@@ -20,6 +20,7 @@
     "src/**/*.spec.ts"
   ],
   "references": [
+    { "path": "../protocol" },
     { "path": "../datasets" },
     { "path": "../clickhouse" }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
 
   packages/datasets:
     dependencies:
+      '@hypequery/protocol':
+        specifier: ^0.1.0
+        version: link:../protocol
       '@noble/hashes':
         specifier: ^1.8.0
         version: 1.8.0
@@ -267,6 +270,9 @@ importers:
       '@hypequery/datasets':
         specifier: ^0.11.0
         version: link:../datasets
+      '@hypequery/protocol':
+        specifier: ^0.1.0
+        version: link:../protocol
       jose:
         specifier: ^5.9.6
         version: 5.10.0

--- a/specs/security-protocol/fixtures/deployments-v1/README.md
+++ b/specs/security-protocol/fixtures/deployments-v1/README.md
@@ -1,0 +1,6 @@
+# Deployment contract v1 fixtures
+
+These fixtures exercise RFC 0006 deployment envelopes. `success.json`
+contains language-neutral accepted values. `rejections.json` identifies
+deterministic generated inputs and the stable error code every conforming
+implementation must return.

--- a/specs/security-protocol/fixtures/deployments-v1/rejections.json
+++ b/specs/security-protocol/fixtures/deployments-v1/rejections.json
@@ -1,0 +1,11 @@
+[
+  { "id": "wrong-root-type", "generator": { "type": "wrong-root-type" }, "error": "HQ_DEPLOYMENT_TYPE" },
+  { "id": "unknown-root-field", "generator": { "type": "unknown-root-field" }, "error": "HQ_DEPLOYMENT_UNKNOWN_FIELD" },
+  { "id": "unsupported-version", "generator": { "type": "unsupported-version" }, "error": "HQ_DEPLOYMENT_INVALID_VERSION" },
+  { "id": "invalid-dataset-identifier", "generator": { "type": "invalid-dataset-identifier" }, "error": "HQ_DEPLOYMENT_INVALID_IDENTIFIER" },
+  { "id": "invalid-relationship-queryability", "generator": { "type": "invalid-relationship-queryability" }, "error": "HQ_DEPLOYMENT_INVALID_VALUE" },
+  { "id": "missing-runtime-artifact", "generator": { "type": "missing-runtime-artifact" }, "error": "HQ_DEPLOYMENT_INVALID_REFERENCE" },
+  { "id": "too-many-datasets", "generator": { "type": "too-many-datasets" }, "error": "HQ_DEPLOYMENT_TOO_MANY_ITEMS" },
+  { "id": "source-too-large", "generator": { "type": "source-too-large" }, "error": "HQ_DEPLOYMENT_TOO_LARGE" },
+  { "id": "unsafe-accessor", "generator": { "type": "unsafe-accessor" }, "error": "HQ_DEPLOYMENT_UNSAFE_OBJECT" }
+]

--- a/specs/security-protocol/fixtures/deployments-v1/success.json
+++ b/specs/security-protocol/fixtures/deployments-v1/success.json
@@ -1,0 +1,81 @@
+[
+  {
+    "id": "dataset-and-runtime-query",
+    "value": {
+      "kind": "hypequery-deployment",
+      "version": 1,
+      "datasets": [
+        {
+          "name": "orders",
+          "source": "analytics.orders",
+          "tenant": { "kind": "required", "field": "tenant_id" },
+          "timeField": "created_at",
+          "dimensions": [
+            {
+              "name": "status",
+              "type": "string",
+              "source": { "kind": "column", "column": "status" },
+              "filterable": true,
+              "groupable": true
+            }
+          ],
+          "measures": [
+            {
+              "name": "revenue",
+              "aggregation": "sum",
+              "field": "amount",
+              "filters": []
+            }
+          ],
+          "filters": [
+            {
+              "name": "status",
+              "field": "status",
+              "operators": ["eq", "neq"]
+            }
+          ],
+          "metrics": [],
+          "relationships": [],
+          "limits": { "maxResultSize": 1000 },
+          "endpoint": {
+            "access": { "kind": "authenticated", "roles": [], "scopes": ["read:orders"] },
+            "tenant": { "kind": "required", "mode": "auto-inject", "column": "tenant_id" },
+            "maxLimit": 1000,
+            "path": "/api/analytics/datasets/orders/query"
+          }
+        }
+      ],
+      "queries": [
+        {
+          "name": "health",
+          "input": { "kind": "any" },
+          "output": {
+            "kind": "object",
+            "properties": { "ok": { "kind": "boolean" } },
+            "required": ["ok"],
+            "unknownProperties": "strip"
+          },
+          "implementation": {
+            "kind": "runtime-reference",
+            "runtime": "node",
+            "artifactSha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "entrypoint": "queries.health"
+          },
+          "endpoint": {
+            "access": { "kind": "public" },
+            "tenant": { "kind": "not-required" },
+            "method": "GET",
+            "path": "/api/analytics/queries/health"
+          },
+          "tags": ["system"]
+        }
+      ],
+      "artifacts": [
+        {
+          "runtime": "node",
+          "artifactSha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        }
+      ]
+    }
+  }
+]

--- a/specs/security-protocol/rfc/0006-dataset-deployment-contract.md
+++ b/specs/security-protocol/rfc/0006-dataset-deployment-contract.md
@@ -1,0 +1,133 @@
+# RFC 0006: Dataset deployment contract
+
+- Status: Proposed
+- Version: deployment contract 1
+
+## Summary
+
+This RFC defines the deterministic envelope produced when Hypequery Dataset,
+metric, and Serve definitions cross a deployment boundary. It binds the
+portable values, identifiers, expressions, schemas, and query implementations
+from RFCs 0001 through 0005 into one inspectable contract.
+
+The contract is trusted build output. It contains no credentials, connection
+configuration, tenant values, auth callbacks, middleware, source code, or
+runtime artifact bytes. Self-hosted Serve does not need to build this envelope.
+
+## Envelope
+
+A deployment has `kind: "hypequery-deployment"`, `version: 1`, and three
+closed collections:
+
+- `datasets`: executable semantic Dataset contracts;
+- `queries`: named Serve queries with portable schemas and one RFC 0005
+  implementation; and
+- `artifacts`: the runtime and SHA-256 identity of every runtime artifact
+  referenced by a named query.
+
+Names within each collection are unique. Runtime references MUST resolve to an
+artifact in the same envelope with the same runtime. Dataset relationships MUST
+resolve to another Dataset in the envelope. Compiled SQL input bindings MUST
+resolve against the named query input schema, and tenant requirements in an
+implementation MUST agree with endpoint policy. Unknown fields fail closed.
+
+## Dataset contract
+
+A Dataset declares its logical name, physical source, tenant policy, optional
+time field, dimensions, measures, filters, metrics, relationships, resource
+limits, and optional endpoint policy.
+
+Dimensions declare their logical type and one source:
+
+- `column` names a trusted physical column; or
+- `sql-expression` embeds the bounded RFC 0005 trusted expression artifact,
+  output schema, and compatibility dependencies.
+
+Measures declare their aggregation, input field, optional arg field or
+percentile level, optional trusted SQL input expression, and fixed filters as
+RFC 0003 expressions. `argMax` and `argMin` require exactly one arg field.
+`percentile` requires a finite level in `[0, 1]`. Other aggregations reject
+those fields.
+
+Filters declare the logical field and closed operator allow-list. Relationships
+declare target Dataset and join fields. `belongsTo` and `hasOne` are queryable;
+`hasMany` is metadata-only in version 1 to prevent aggregate fan-out.
+
+Metrics carry their fixed RFC 0003 expression, queryable dimensions and
+filters, supported grains, and endpoint policy. A grained metric declares its
+fixed grain. Derived metric formulas use the same expression AST and therefore
+do not carry source-language callbacks.
+
+## Endpoint policy
+
+Dataset, metric, and named-query endpoints declare whether access is public or
+authenticated. Authenticated policies carry exact role and scope requirements.
+Every endpoint separately declares tenant context as required, optional, or
+not required. Tenant-aware endpoints preserve `auto-inject` or `manual` mode
+and the auto-injected column, while tenant extraction remains runtime code.
+Endpoints may also declare a positive cache TTL, positive page-size cap, and
+route path. Named queries additionally declare their HTTP method.
+
+These fields describe enforcement requirements; authentication strategies,
+tenant extraction callbacks, middleware, and HTTP server behavior remain
+runtime concerns.
+
+## Serve query adapter
+
+An adapter may convert the portable subset of Zod or Pydantic into RFC 0004
+schemas. It MUST reject refinements, transformations, or schema features it
+cannot represent without semantic loss. A caller may provide an explicit
+portable schema override.
+
+Arbitrary Serve callbacks lower to `runtime-reference`. The build supplies the
+runtime artifact digest and stable entrypoint. Fixed semantic plans and safely
+compiled SQL may be supplied as explicit implementation overrides. Function
+source text, ambient paths, and inferred hashes are prohibited.
+
+## Determinism and compatibility
+
+Reference adapters sort unordered definitions by logical name and return
+detached, deeply immutable snapshots. Contract consumers MUST validate the
+entire envelope before accepting any contained Dataset or query.
+
+Changes to physical sources, tenant policy, SQL expressions, fields,
+aggregations, fixed filters, formulas, relationships, schemas, endpoint access,
+implementations, or artifact hashes are deployment-significant. Labels,
+descriptions, tags, cache TTLs, limits, and routes are also preserved so build
+diffs can distinguish execution changes from presentation and operations.
+
+## Limits
+
+| Limit | Maximum |
+| --- | ---: |
+| Datasets | 100 |
+| Named queries | 1,000 |
+| Runtime artifacts | 100 |
+| Fields, filters, metrics, relationships, claims, or tags per object | 1,000 |
+| Label, description, role, scope, or tag UTF-8 bytes | 4,096 |
+| Physical source or column UTF-8 bytes | 1,024 |
+| Endpoint path UTF-8 bytes | 2,048 |
+
+Products may lower but not raise these limits while claiming deployment
+contract version 1 conformance.
+
+## Stable failure codes
+
+- `HQ_DEPLOYMENT_TYPE`
+- `HQ_DEPLOYMENT_UNKNOWN_FIELD`
+- `HQ_DEPLOYMENT_INVALID_VERSION`
+- `HQ_DEPLOYMENT_INVALID_IDENTIFIER`
+- `HQ_DEPLOYMENT_INVALID_VALUE`
+- `HQ_DEPLOYMENT_INVALID_REFERENCE`
+- `HQ_DEPLOYMENT_TOO_MANY_ITEMS`
+- `HQ_DEPLOYMENT_TOO_LARGE`
+- `HQ_DEPLOYMENT_UNSAFE_OBJECT`
+
+## Security
+
+Objects with custom prototypes, accessors, symbols, hidden properties, cycles,
+sparse arrays, or extra array properties are rejected. SQL remains trusted
+build output and is never accepted from caller input. Runtime references can
+resolve only inside the containing deployment by digest. The validator returns
+a detached, deeply immutable snapshot and performs all cross-reference checks
+before the contract is executable.

--- a/specs/security-protocol/rfc/0006-dataset-deployment-contract.md
+++ b/specs/security-protocol/rfc/0006-dataset-deployment-contract.md
@@ -72,6 +72,13 @@ These fields describe enforcement requirements; authentication strategies,
 tenant extraction callbacks, middleware, and HTTP server behavior remain
 runtime concerns.
 
+The reference Serve adapter preserves the runtime distinction for explicit
+`auth: null`: Dataset and metric entries use it to opt out of a global auth
+strategy, while named queries use it only to omit a local strategy and continue
+to inherit global auth. Role or scope requirements still make either endpoint
+authenticated. Named queries use `requiresAuth: false` for an explicit public
+override.
+
 ## Serve query adapter
 
 An adapter may convert the portable subset of Zod or Pydantic into RFC 0004


### PR DESCRIPTION
## Summary

- define RFC 0006 and the versioned Dataset deployment contract
- add strict validators, immutable snapshots, limits, and conformance fixtures
- convert existing Dataset definitions, metrics, relationships, and trusted SQL expressions into protocol artifacts
- convert Serve queries and endpoint policies, with fail-closed Zod schema lowering and runtime artifact references
- preserve runtime auth enforcement and reject Zod constructs that cannot be represented without semantic loss

## Why

This provides the complete deployment envelope needed to turn existing Dataset and Serve definitions into deterministic, reviewable protocol artifacts for build and runtime tooling.

## Validation

- `pnpm types`
- `pnpm lint`
- `pnpm build`
- `pnpm test`