### PR TITLE
fix changesets ignore validation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,5 +13,5 @@
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   },
-  "ignore": ["auth-playground", "next-dashboard", "next-starter", "node-embedded", "vite-starter"]
+  "ignore": []
 }


### PR DESCRIPTION
## Summary

- clear stale Changesets `ignore` entries for deleted example packages
- restore canary snapshot and release-version config validation

## Root cause

The example packages were deleted and `examples/*` was removed from `pnpm-workspace.yaml`, but their package names remained in `.changeset/config.json`. Changesets rejects ignored packages that no longer resolve to a workspace package, causing both release jobs to fail.

## Validation

- `pnpm exec changeset status`
- `pnpm changeset version --snapshot canary` in an isolated worktree using the workflow's canary changeset
- `pnpm release:version` in an isolated worktree
- `git diff --check`