### PR TITLE
fix(protocol): validate grained metric invariants

### DIFF
--- a/.changeset/fix-grained-metric-validation.md
+++ b/.changeset/fix-grained-metric-validation.md
@@ -1,0 +1,5 @@
+---
+'@hypequery/protocol': patch
+---
+
+Reject grained deployment metrics whose fixed grain is not included in their supported grains, and require a dataset time field for every grained metric.

--- a/packages/protocol/src/deployments/deployments.test.ts
+++ b/packages/protocol/src/deployments/deployments.test.ts
@@ -56,6 +56,23 @@ function baseDeployment() {
   };
 }
 
+function minimalMetric(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'revenue',
+    kind: 'grained-metric',
+    expression: { kind: 'literal', value: 1 },
+    dimensions: [],
+    filters: [],
+    grains: ['day'],
+    grain: 'day',
+    endpoint: {
+      access: { kind: 'public' },
+      tenant: { kind: 'not-required' },
+    },
+    ...overrides,
+  };
+}
+
 function materialize(type: string): unknown {
   const value = baseDeployment();
   switch (type) {
@@ -116,13 +133,14 @@ function materialize(type: string): unknown {
   }
 }
 
-function expectDeploymentError(action: () => unknown, code: string): void {
+function expectDeploymentError(action: () => unknown, code: string, path?: string): void {
   try {
     action();
     throw new Error('Expected deployment validation to fail');
   } catch (error) {
     expect(error).toBeInstanceOf(ProtocolDeploymentError);
     expect((error as ProtocolDeploymentError).code).toBe(code);
+    if (path !== undefined) expect((error as ProtocolDeploymentError).path).toBe(path);
   }
 }
 
@@ -164,6 +182,68 @@ describe('deployment contract v1', () => {
     expect(() => validateProtocolDeploymentContract(baseDeployment(), { limits: { maxDatasets: 101 } }))
       .toThrow('maxDatasets must be a positive safe integer no greater than 100 '
         + '(the deployment contract v1 maximum)');
+  });
+
+  it('requires a grained metric fixed grain to be supported by the metric', () => {
+    const deployment = {
+      ...baseDeployment(),
+      datasets: [{
+        ...minimalDataset(),
+        timeField: 'created_at',
+        metrics: [minimalMetric({ grain: 'month', grains: ['day'] })],
+      }],
+    };
+
+    expectDeploymentError(
+      () => validateProtocolDeploymentContract(deployment),
+      'HQ_DEPLOYMENT_INVALID_VALUE',
+      '$.datasets[0].metrics[0].grain',
+    );
+  });
+
+  it('rejects grained metrics with no supported grains', () => {
+    const deployment = {
+      ...baseDeployment(),
+      datasets: [{
+        ...minimalDataset(),
+        metrics: [minimalMetric({ grains: [] })],
+      }],
+    };
+
+    expectDeploymentError(
+      () => validateProtocolDeploymentContract(deployment),
+      'HQ_DEPLOYMENT_INVALID_VALUE',
+      '$.datasets[0].metrics[0].grain',
+    );
+  });
+
+  it('requires a dataset time field for a valid grained metric', () => {
+    const deployment = {
+      ...baseDeployment(),
+      datasets: [{
+        ...minimalDataset(),
+        metrics: [minimalMetric()],
+      }],
+    };
+
+    expectDeploymentError(
+      () => validateProtocolDeploymentContract(deployment),
+      'HQ_DEPLOYMENT_INVALID_REFERENCE',
+      '$.datasets[0].metrics[0].grains',
+    );
+  });
+
+  it('accepts a grained metric with a supported grain and dataset time field', () => {
+    const deployment = {
+      ...baseDeployment(),
+      datasets: [{
+        ...minimalDataset(),
+        timeField: 'created_at',
+        metrics: [minimalMetric()],
+      }],
+    };
+
+    expect(() => validateProtocolDeploymentContract(deployment)).not.toThrow();
   });
 
   it('validates compiled input bindings against the named-query input schema', () => {

--- a/packages/protocol/src/deployments/deployments.test.ts
+++ b/packages/protocol/src/deployments/deployments.test.ts
@@ -213,7 +213,7 @@ describe('deployment contract v1', () => {
     expectDeploymentError(
       () => validateProtocolDeploymentContract(deployment),
       'HQ_DEPLOYMENT_INVALID_VALUE',
-      '$.datasets[0].metrics[0].grain',
+      '$.datasets[0].metrics[0].grains',
     );
   });
 

--- a/packages/protocol/src/deployments/validate.ts
+++ b/packages/protocol/src/deployments/validate.ts
@@ -439,6 +439,9 @@ function validateMetric(
   const grain = value.grain === undefined
     ? undefined
     : parseGrain(value.grain, `${path}.grain`);
+  if (grain !== undefined && grains.length === 0) {
+    deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.grains`);
+  }
   if (grain !== undefined && !grains.includes(grain)) {
     deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.grain`);
   }

--- a/packages/protocol/src/deployments/validate.ts
+++ b/packages/protocol/src/deployments/validate.ts
@@ -436,6 +436,12 @@ function validateMetric(
   if ((value.kind === 'grained-metric') !== (value.grain !== undefined)) {
     deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.grain`);
   }
+  const grain = value.grain === undefined
+    ? undefined
+    : parseGrain(value.grain, `${path}.grain`);
+  if (grain !== undefined && !grains.includes(grain)) {
+    deploymentError('HQ_DEPLOYMENT_INVALID_VALUE', `${path}.grain`);
+  }
   const result: Record<string, unknown> = {
     name: identifier(value.name, `${path}.name`),
     kind: value.kind,
@@ -455,7 +461,7 @@ function validateMetric(
     grains,
     endpoint: validateEndpoint(value.endpoint, `${path}.endpoint`, limits),
   };
-  if (value.grain !== undefined) result.grain = parseGrain(value.grain, `${path}.grain`);
+  if (grain !== undefined) result.grain = grain;
   optionalText(value.label, 'label', result, path, limits);
   optionalText(value.description, 'description', result, path, limits);
   return freezeRecord(result) as unknown as ProtocolDatasetMetric;
@@ -609,7 +615,8 @@ function validateReferences(contract: ProtocolDeploymentContract): void {
           `$.datasets[${datasetIndex}].metrics[${metricIndex}]`,
         );
       }
-      if (metric.grains.length > 0 && dataset.timeField === undefined) {
+      if ((metric.kind === 'grained-metric' || metric.grains.length > 0)
+        && dataset.timeField === undefined) {
         deploymentError(
           'HQ_DEPLOYMENT_INVALID_REFERENCE',
           `$.datasets[${datasetIndex}].metrics[${metricIndex}].grains`,


### PR DESCRIPTION
## Summary

Closes two deployment-contract validation gaps for grained Dataset metrics:

- requires a grained metric's fixed `grain` to appear in its supported `grains` list
- requires a dataset `timeField` whenever a metric is grained or advertises supported grains
- parses the fixed grain once and reuses the validated value
- adds rejection coverage for mismatched and empty grain sets, plus missing-time-field and valid cases

## Why

The v1 validator previously accepted internally inconsistent artifacts such as `grain: "month"` with `grains: ["day"]`, and accepted `kind: "grained-metric"` with `grains: []` and no dataset time field. Build and runtime consumers are allowed to trust validated contracts, so these invariants must be enforced at the protocol boundary.

## Validation

- `@hypequery/protocol`: 257 tests passed
- protocol lint passed
- protocol type checks passed
- protocol build passed
