### PR TITLE
Normalize dataset and metric auth semantics

### DIFF
--- a/.changeset/quiet-datasets-auth.md
+++ b/.changeset/quiet-datasets-auth.md
@@ -1,0 +1,7 @@
+---
+'@hypequery/serve': minor
+---
+
+Normalize auth overrides across queries, datasets, and metrics. Semantic entries
+with `auth: null` now continue to inherit global auth; use
+`requiresAuth: false` to make a dataset or metric endpoint explicitly public.

--- a/.changeset/quiet-datasets-auth.md
+++ b/.changeset/quiet-datasets-auth.md
@@ -5,3 +5,8 @@
 Normalize auth overrides across queries, datasets, and metrics. Semantic entries
 with `auth: null` now continue to inherit global auth; use
 `requiresAuth: false` to make a dataset or metric endpoint explicitly public.
+
+Compatibility note: semantic endpoints that previously used `auth: null` as a
+public override must migrate to `requiresAuth: false`. This breaking behavior
+change ships as a minor deliberately because `@hypequery/serve` is 0.x, where
+breaking changes use the minor version slot.

--- a/packages/serve/README.md
+++ b/packages/serve/README.md
@@ -87,6 +87,25 @@ await api.execute('dataset:orders', {
 });
 ```
 
+### Semantic endpoint auth
+
+Dataset and metric entries follow the same auth rules as named queries. An
+entry with no local strategy, including `auth: null`, still inherits the global
+`auth` configuration. Use `requiresAuth: false` for an explicitly public
+endpoint; `requiredRoles` or `requiredScopes` always require authentication.
+
+```ts
+const api = serve({
+  auth: globalAuth,
+  metrics: {
+    revenue: { metric: revenue, auth: null }, // inherits globalAuth
+  },
+  datasets: {
+    publicOrders: { dataset: Orders, requiresAuth: false },
+  },
+});
+```
+
 ## Main Ideas
 
 ### `query({ ... })`

--- a/packages/serve/src/auth-requirement.ts
+++ b/packages/serve/src/auth-requirement.ts
@@ -1,0 +1,19 @@
+interface EndpointAuthRequirement {
+  readonly auth?: unknown | null;
+  readonly requiresAuth?: boolean;
+  readonly requiredRoles?: readonly string[];
+  readonly requiredScopes?: readonly string[];
+}
+
+/** Resolve an endpoint's local auth requirement before applying global auth. */
+export function resolveLocalAuthRequirement(
+  endpoint: EndpointAuthRequirement,
+): boolean | undefined {
+  if ((endpoint.requiredRoles?.length ?? 0) > 0
+    || (endpoint.requiredScopes?.length ?? 0) > 0) {
+    return true;
+  }
+  if (endpoint.requiresAuth !== undefined) return endpoint.requiresAuth;
+  if (endpoint.auth != null) return true;
+  return undefined;
+}

--- a/packages/serve/src/auth-requirement.ts
+++ b/packages/serve/src/auth-requirement.ts
@@ -1,5 +1,6 @@
 interface EndpointAuthRequirement {
   readonly auth?: unknown | null;
+  /** Explicit local requirement; roles or scopes take precedence over `false`. */
   readonly requiresAuth?: boolean;
   readonly requiredRoles?: readonly string[];
   readonly requiredScopes?: readonly string[];

--- a/packages/serve/src/endpoint.ts
+++ b/packages/serve/src/endpoint.ts
@@ -14,6 +14,7 @@ import type {
   ServeEndpoint,
   ServeQueryConfig,
 } from "./types.js";
+import { resolveLocalAuthRequirement } from "./auth-requirement.js";
 
 const fallbackSchema = z.any();
 
@@ -78,8 +79,6 @@ export const createEndpoint = <
     : SchemaOutput<OutputSchema>;
 
   const method = definition.method ?? "GET";
-  const hasRolesOrScopes = (definition.requiredRoles?.length ?? 0) > 0
-    || (definition.requiredScopes?.length ?? 0) > 0;
   const metadata: EndpointMetadata = {
     path: "",
     method: method as HttpMethod,
@@ -87,7 +86,7 @@ export const createEndpoint = <
     summary: definition.summary,
     description: definition.description,
     tags: definition.tags ?? [],
-    requiresAuth: definition.requiresAuth ?? (definition.auth ? true : hasRolesOrScopes ? true : undefined),
+    requiresAuth: resolveLocalAuthRequirement(definition),
     requiredRoles: definition.requiredRoles,
     requiredScopes: definition.requiredScopes,
     deprecated: undefined,

--- a/packages/serve/src/pipeline.ts
+++ b/packages/serve/src/pipeline.ts
@@ -33,6 +33,7 @@ import {
   AuthError,
 } from './auth.js';
 import { type ResolvedCorsConfig, handleCorsRequest } from './cors.js';
+import { resolveLocalAuthRequirement } from './auth-requirement.js';
 
 const safeInvokeHook = async <T>(
   name: string,
@@ -159,21 +160,12 @@ const computeRequiresAuth = <TAuth extends AuthContext>(
   globalStrategies: AuthStrategy<TAuth>[],
   endpoint: ServeEndpoint<any, any, any, TAuth>,
 ) => {
-  // Explicit .public() overrides everything
-  if (metadata.requiresAuth === false) {
-    return false;
-  }
-  // Explicit .requireAuth() or roles/scopes imply auth
-  if (metadata.requiresAuth === true) {
-    return true;
-  }
-  if ((endpoint.requiredRoles?.length ?? 0) > 0 || (endpoint.requiredScopes?.length ?? 0) > 0) {
-    return true;
-  }
-  if (endpointStrategy) {
-    return true;
-  }
-  return globalStrategies.length > 0;
+  return resolveLocalAuthRequirement({
+    auth: endpointStrategy,
+    requiresAuth: metadata.requiresAuth,
+    requiredRoles: endpoint.requiredRoles,
+    requiredScopes: endpoint.requiredScopes,
+  }) ?? globalStrategies.length > 0;
 };
 
 const checkAuthorization = <TAuth extends AuthContext>(

--- a/packages/serve/src/protocol-adapter.test.ts
+++ b/packages/serve/src/protocol-adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
-import { dataset, dimension } from '@hypequery/datasets';
+import { dataset, dimension, measure } from '@hypequery/datasets';
 import {
   buildProtocolDeploymentContract,
   ProtocolSchemaAdapterError,
@@ -126,7 +126,7 @@ describe('Serve protocol adapter', () => {
     expect(contract.queries[0]?.endpoint.access.kind).toBe('authenticated');
   });
 
-  it('preserves the semantic endpoint public override for auth null', () => {
+  it('preserves global auth for semantic endpoints with no local strategy', () => {
     const Orders = dataset('orders', {
       source: 'orders',
       dimensions: { id: dimension.string() },
@@ -138,7 +138,34 @@ describe('Serve protocol adapter', () => {
       },
     });
 
+    expect(contract.datasets[0]?.endpoint?.access).toEqual({
+      kind: 'authenticated',
+      roles: [],
+      scopes: [],
+    });
+  });
+
+  it('uses requiresAuth false for explicitly public semantic endpoints', () => {
+    const Orders = dataset('orders', {
+      source: 'orders',
+      dimensions: { id: dimension.string() },
+      measures: { count: measure.count('id') },
+    });
+    const revenue = Orders.metric('revenue', {
+      measure: 'count',
+    });
+    const contract = buildProtocolDeploymentContract({
+      auth: async () => ({ userId: 'user_1' }),
+      datasets: {
+        orders: { dataset: Orders, requiresAuth: false },
+      },
+      metrics: {
+        revenue: { metric: revenue, requiresAuth: false },
+      },
+    });
+
     expect(contract.datasets[0]?.endpoint?.access).toEqual({ kind: 'public' });
+    expect(contract.datasets[0]?.metrics[0]?.endpoint.access).toEqual({ kind: 'public' });
   });
 
   it('rejects typed object catchalls that the protocol cannot represent', () => {

--- a/packages/serve/src/protocol-adapter.ts
+++ b/packages/serve/src/protocol-adapter.ts
@@ -27,6 +27,7 @@ import type {
 import { resolveDatasetEntry } from './semantic/datasets/utils/dataset-entry.js';
 import { resolveMetricEntry } from './semantic/datasets/metric-endpoint.js';
 import { zodToProtocolSchema } from './protocol-schema-adapter.js';
+import { resolveLocalAuthRequirement } from './auth-requirement.js';
 
 export interface BuildProtocolDeploymentOptions {
   /** Runtime artifact used for Serve callbacks without an explicit implementation override. */
@@ -71,17 +72,15 @@ function accessPolicy(
     readonly requiredScopes?: readonly string[];
   },
   globalAuth: AnyServeConfig['auth'],
-  nullAuthOverridesGlobal: boolean,
 ): ProtocolAccessPolicy {
   const roles = [...new Set(local.requiredRoles ?? [])].sort();
   const scopes = [...new Set(local.requiredScopes ?? [])].sort();
-  if (roles.length > 0 || scopes.length > 0) {
-    return { kind: 'authenticated', roles, scopes };
-  }
-  if (local.requiresAuth === false || (nullAuthOverridesGlobal && local.auth === null)) {
-    return { kind: 'public' };
-  }
-  if (local.requiresAuth === true || local.auth != null || hasGlobalAuth(globalAuth)) {
+  const localRequirement = resolveLocalAuthRequirement({
+    ...local,
+    requiredRoles: roles,
+    requiredScopes: scopes,
+  });
+  if (localRequirement ?? hasGlobalAuth(globalAuth)) {
     return { kind: 'authenticated', roles, scopes };
   }
   return { kind: 'public' };
@@ -102,13 +101,10 @@ function endpointPolicy(
   globalTenant: AnyServeConfig['tenant'],
   path: string,
   defaultMaxLimit?: number,
-  // Dataset/metric endpoints use `auth: null` as an explicit public override;
-  // named queries use it only to omit a local strategy and still inherit global auth.
-  nullAuthOverridesGlobal = false,
 ): ProtocolEndpointPolicy {
   const cacheTtlMs = local.cacheTtlMs ?? local.cache ?? undefined;
   return {
-    access: accessPolicy(local, globalAuth, nullAuthOverridesGlobal),
+    access: accessPolicy(local, globalAuth),
     tenant: endpointTenantPolicy(local.tenant, globalTenant),
     ...(typeof cacheTtlMs === 'number' && cacheTtlMs > 0 ? { cacheTtlMs } : {}),
     ...((local.maxLimit ?? defaultMaxLimit) !== undefined
@@ -229,7 +225,6 @@ export function buildProtocolDeploymentContract(
       serveConfig.tenant,
       normalizePath(basePath, datasetsPath, exposedName, 'query'),
       resolved.dataset.limits?.maxResultSize ?? 1_000,
-      true,
     ));
   }
 
@@ -245,7 +240,6 @@ export function buildProtocolDeploymentContract(
       serveConfig.tenant,
       normalizePath(basePath, metricsPath, exposedName),
       resolved.maxLimit ?? dataset.limits?.maxResultSize ?? 1_000,
-      true,
     );
   }
 

--- a/packages/serve/src/semantic/datasets/dataset-endpoint.ts
+++ b/packages/serve/src/semantic/datasets/dataset-endpoint.ts
@@ -30,6 +30,7 @@ import {
 import { buildDatasetQueryDescription } from './utils/dataset-query-metadata.js';
 import { resolveDatasetEntry, type DatasetEntry } from './utils/dataset-entry.js';
 import { buildDatasetInputSchema } from './utils/semantic-input-schema.js';
+import { resolveLocalAuthRequirement } from '../../auth-requirement.js';
 
 export type { DatasetEntry } from './utils/dataset-entry.js';
 
@@ -83,7 +84,7 @@ export function createDatasetEndpoint<TAuth extends AuthContext>(
     summary: `Query the "${name}" semantic dataset`,
     description: buildDatasetQueryDescription(ds, effectiveMaxLimit),
     tags: ['datasets'],
-    requiresAuth: resolved.auth !== null ? undefined : false,
+    requiresAuth: resolveLocalAuthRequirement(resolved),
     requiredRoles: resolved.requiredRoles,
     requiredScopes: resolved.requiredScopes,
     cacheTtlMs: resolved.cache,

--- a/packages/serve/src/semantic/datasets/metric-endpoint.ts
+++ b/packages/serve/src/semantic/datasets/metric-endpoint.ts
@@ -25,6 +25,7 @@ import {
   resolveSemanticQueryBuilder,
 } from '../query-builder-context.js';
 import { buildMetricInputSchema } from './utils/semantic-input-schema.js';
+import { resolveLocalAuthRequirement } from '../../auth-requirement.js';
 
 // ---------------------------------------------------------------------------
 // Zod schemas for metric query input / output
@@ -80,6 +81,7 @@ export function resolveMetricEntry<TAuth extends AuthContext>(
 ): {
   metric: MetricHandle<any, any>;
   auth?: AuthStrategy<TAuth> | null;
+  requiresAuth?: boolean;
   tenant?: TenantConfigOverride<TAuth>;
   cache?: number | null;
   requiredRoles?: string[];
@@ -128,7 +130,7 @@ export function createMetricEndpoint<TAuth extends AuthContext>(
     summary: `Query the "${name}" metric`,
     description: buildDescription(contract, effectiveMaxLimit),
     tags: ['metrics'],
-    requiresAuth: resolved.auth !== null ? undefined : false,
+    requiresAuth: resolveLocalAuthRequirement(resolved),
     requiredRoles: resolved.requiredRoles,
     requiredScopes: resolved.requiredScopes,
     cacheTtlMs: resolved.cache,

--- a/packages/serve/src/semantic/datasets/serve-integration.test.ts
+++ b/packages/serve/src/semantic/datasets/serve-integration.test.ts
@@ -1154,6 +1154,90 @@ describe("Serve integration — metrics", () => {
     });
   });
 
+  describe("semantic auth overrides", () => {
+    it("inherits global auth when auth is null", async () => {
+      const api = createAPI({
+        auth: async ({ request }) => request.headers.authorization === "Bearer valid"
+          ? { userId: "user-123" }
+          : null,
+        metrics: {
+          totalRevenue: { metric: totalRevenue, auth: null },
+        },
+        datasets: {
+          orders: { dataset: Orders, auth: null },
+        },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      const metricRequest = (authorized: boolean) => api.handler(createRequest({
+        path: "/metrics/totalRevenue",
+        method: "POST",
+        body: {},
+        ...(authorized ? { headers: { authorization: "Bearer valid" } } : {}),
+      }));
+      const datasetRequest = (authorized: boolean) => api.handler(createRequest({
+        path: "/datasets/orders/query",
+        method: "POST",
+        body: { dimensions: ["country"], measures: ["revenue"] },
+        ...(authorized ? { headers: { authorization: "Bearer valid" } } : {}),
+      }));
+
+      expect((await metricRequest(false)).status).toBe(401);
+      expect((await datasetRequest(false)).status).toBe(401);
+      expect((await metricRequest(true)).status).toBe(200);
+      expect((await datasetRequest(true)).status).toBe(200);
+    });
+
+    it("uses requiresAuth false as the explicit public override", async () => {
+      const api = createAPI({
+        auth: async () => null,
+        metrics: {
+          totalRevenue: { metric: totalRevenue, requiresAuth: false },
+        },
+        datasets: {
+          orders: { dataset: Orders, requiresAuth: false },
+        },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      const metricResponse = await api.handler(createRequest({
+        path: "/metrics/totalRevenue",
+        method: "POST",
+        body: {},
+      }));
+      const datasetResponse = await api.handler(createRequest({
+        path: "/datasets/orders/query",
+        method: "POST",
+        body: { dimensions: ["country"], measures: ["revenue"] },
+      }));
+
+      expect(metricResponse.status).toBe(200);
+      expect(datasetResponse.status).toBe(200);
+    });
+
+    it("requires authentication when semantic entries declare roles", async () => {
+      const api = createAPI({
+        auth: async () => null,
+        datasets: {
+          orders: {
+            dataset: Orders,
+            requiresAuth: false,
+            requiredRoles: ["admin"],
+          },
+        },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      const response = await api.handler(createRequest({
+        path: "/datasets/orders/query",
+        method: "POST",
+        body: { dimensions: ["country"], measures: ["revenue"] },
+      }));
+
+      expect(response.status).toBe(401);
+    });
+  });
+
   describe("OpenAPI", () => {
     it("includes metric endpoints in OpenAPI spec", async () => {
       const api = createAPI({

--- a/packages/serve/src/semantic/datasets/utils/dataset-entry.ts
+++ b/packages/serve/src/semantic/datasets/utils/dataset-entry.ts
@@ -10,8 +10,10 @@ export type DatasetEntry<TAuth extends AuthContext = AuthContext> =
   | AnyDatasetInstance
   | {
       dataset: AnyDatasetInstance;
-      /** `null` makes this semantic endpoint public instead of inheriting global auth. */
+      /** Local auth strategy. `null` omits it while still inheriting global auth. */
       auth?: AuthStrategy<TAuth> | null;
+      /** Explicit auth requirement. Set to `false` to make this endpoint public. */
+      requiresAuth?: boolean;
       tenant?: TenantConfigOverride<TAuth>;
       cache?: number | null;
       requiredRoles?: string[];
@@ -40,6 +42,7 @@ export function resolveDatasetEntry<TAuth extends AuthContext>(
 ): {
   dataset: AnyDatasetInstance;
   auth?: AuthStrategy<TAuth> | null;
+  requiresAuth?: boolean;
   tenant?: TenantConfigOverride<TAuth>;
   cache?: number | null;
   requiredRoles?: string[];

--- a/packages/serve/src/semantic/datasets/utils/dataset-entry.ts
+++ b/packages/serve/src/semantic/datasets/utils/dataset-entry.ts
@@ -12,7 +12,7 @@ export type DatasetEntry<TAuth extends AuthContext = AuthContext> =
       dataset: AnyDatasetInstance;
       /** Local auth strategy. `null` omits it while still inheriting global auth. */
       auth?: AuthStrategy<TAuth> | null;
-      /** Explicit auth requirement. Set to `false` to make this endpoint public. */
+      /** Set to `false` for public access. Required roles or scopes take precedence. */
       requiresAuth?: boolean;
       tenant?: TenantConfigOverride<TAuth>;
       cache?: number | null;

--- a/packages/serve/src/types.ts
+++ b/packages/serve/src/types.ts
@@ -451,7 +451,7 @@ export interface ServeQueryConfig<
     TAuth
   >[];
   auth?: AuthStrategy<TAuth> | null;
-  /** Explicitly set whether authentication is required. Set by .requireAuth() or .public(). */
+  /** Explicit auth requirement. Required roles or scopes take precedence over `false`. */
   requiresAuth?: boolean;
   tenant?: TenantConfigOverride<TAuth>;
   cacheTtlMs?: number | null;
@@ -489,6 +489,7 @@ export interface QueryObjectConfig<
   summary?: string;
   tags?: string[];
   auth?: AuthStrategy<TAuth> | null;
+  /** Explicit auth requirement. Required roles or scopes take precedence over `false`. */
   requiresAuth?: boolean;
   tenant?: TenantConfigOverride<TAuth>;
   cacheTtlMs?: number | null;
@@ -589,7 +590,7 @@ export type MetricEntry<TAuth extends AuthContext = AuthContext> =
       metric: MetricHandle<any, any>;
       /** Local auth strategy. `null` omits it while still inheriting global auth. */
       auth?: AuthStrategy<TAuth> | null;
-      /** Explicit auth requirement. Set to `false` to make this endpoint public. */
+      /** Set to `false` for public access. Required roles or scopes take precedence. */
       requiresAuth?: boolean;
       tenant?: TenantConfigOverride<TAuth>;
       cache?: number | null;

--- a/packages/serve/src/types.ts
+++ b/packages/serve/src/types.ts
@@ -587,8 +587,10 @@ export type MetricEntry<TAuth extends AuthContext = AuthContext> =
   | MetricHandle<any, any>
   | {
       metric: MetricHandle<any, any>;
-      /** `null` makes this semantic endpoint public instead of inheriting global auth. */
+      /** Local auth strategy. `null` omits it while still inheriting global auth. */
       auth?: AuthStrategy<TAuth> | null;
+      /** Explicit auth requirement. Set to `false` to make this endpoint public. */
+      requiresAuth?: boolean;
       tenant?: TenantConfigOverride<TAuth>;
       cache?: number | null;
       requiredRoles?: string[];

--- a/website-next/docs/authentication.mdx
+++ b/website-next/docs/authentication.mdx
@@ -330,7 +330,7 @@ Use object-style auth fields by default on `query({ ... })`. Use the chainable g
 
 ## Auth on semantic endpoints
 
-Auto-generated `metrics` and `datasets` endpoints are protected the same way as queries, but you declare the requirements on the per-entry config object instead of inside a `query({ ... })` definition. Each entry accepts `auth`, `requiredRoles`, and `requiredScopes`.
+Auto-generated `metrics` and `datasets` endpoints are protected the same way as queries, but you declare the requirements on the per-entry config object instead of inside a `query({ ... })` definition. Each entry accepts `auth`, `requiresAuth`, `requiredRoles`, and `requiredScopes`.
 
 <CodeBlock>
 ```typescript
@@ -365,9 +365,14 @@ The semantics match `query({ ... })`:
 - `requiredRoles` uses OR semantics (any listed role grants access)
 - `requiredScopes` uses AND semantics (all listed scopes required)
 - declaring either one implies authentication
-- `auth` on an entry overrides the global strategy for that endpoint; `auth: null` makes it public
+- `auth` on an entry adds a local strategy; omitting it or setting `auth: null` still inherits global auth
+- `requiresAuth: false` makes an entry public unless it declares required roles or scopes
+- `requiresAuth: true` requires authentication even when no local or global strategy is configured
 
-Metrics use the same shape via `{ metric, requiredRoles, requiredScopes, auth }`. See [Serve integration](/docs/datasets/serve-integration) for the full set of per-entry options.
+If you previously used `auth: null` as a public override on a dataset or metric,
+replace it with `requiresAuth: false` when upgrading.
+
+Metrics use the same shape via `{ metric, auth, requiresAuth, requiredRoles, requiredScopes }`. See [Serve integration](/docs/datasets/serve-integration) for the full set of per-entry options.
 
 ## See Also
 


### PR DESCRIPTION
## Summary

- make `auth: null` consistently mean “no local strategy” while continuing to inherit global auth for named queries, datasets, and metrics
- add `requiresAuth?: boolean` to dataset and metric entries, with `requiresAuth: false` as the explicit public override
- ensure required roles or scopes always imply authentication
- use one local auth-requirement resolver in runtime endpoint construction, request handling, and protocol deployment artifacts
- document the behavior and add a `@hypequery/serve` minor changeset

## Why

Dataset and metric endpoints previously interpreted `auth: null` as public, while named queries interpreted it as omitting only the local strategy and still inherited global auth. That asymmetry could unintentionally expose semantic endpoints and made runtime behavior disagree with the mental model used elsewhere in Serve.

## Migration

Dataset or metric entries that intentionally used `auth: null` to bypass global auth must change to:

```ts
{ dataset: Orders, requiresAuth: false }
{ metric: revenue, requiresAuth: false }
```

Entries using `auth: null` only to omit a local strategy need no change; they now inherit global auth consistently.

## Validation

- `pnpm --filter @hypequery/serve... build`
- `pnpm --filter @hypequery/serve types`
- `pnpm --filter @hypequery/serve lint`
- `pnpm --filter @hypequery/serve test` — 27 test files, 487 tests passed
- targeted protocol-adapter and semantic integration coverage for inherited global auth, explicit public endpoints, and role-protected semantic entries
