### PR TITLE
Add provider-neutral deployment intake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
           ---
           "@hypequery/clickhouse": patch
           "@hypequery/datasets": patch
+          "@hypequery/deployment": patch
           "@hypequery/serve": patch
           "@hypequery/cli": patch
           "@hypequery/mcp": patch
@@ -132,6 +133,8 @@ jobs:
               packages/clickhouse/package.json \
               packages/clickhouse/CHANGELOG.md \
               packages/datasets/package.json \
+              packages/deployment/package.json \
+              packages/deployment/CHANGELOG.md \
               packages/serve/package.json \
               packages/serve/CHANGELOG.md \
               packages/cli/package.json \

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "packages/cli",
     "packages/clickhouse",
     "packages/datasets",
+    "packages/deployment",
     "packages/mcp-server",
     "packages/protocol",
     "packages/react",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@clickhouse/client": "^1.18.3",
+    "@hypequery/deployment": "workspace:*",
     "@hypequery/protocol": "workspace:*",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",

--- a/packages/cli/src/utils/deployment-bundle.ts
+++ b/packages/cli/src/utils/deployment-bundle.ts
@@ -5,7 +5,6 @@ import {
   mkdir,
   mkdtemp,
   open,
-  readdir,
   rename,
   rm,
   writeFile,
@@ -14,16 +13,24 @@ import path from 'node:path';
 import {
   DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS,
   prepareProtocolDeploymentBundleManifest,
-  prepareProtocolDeploymentContract,
   type PreparedProtocolDeploymentContract,
-  type ProtocolDeploymentBundleArtifact,
   type ProtocolDeploymentBundleManifest,
   type ProtocolDeploymentContract,
 } from '@hypequery/protocol';
+import {
+  DEPLOYMENT_BUNDLE_CONTRACT,
+  DEPLOYMENT_BUNDLE_MANIFEST,
+  verifyDeploymentBundle,
+} from '@hypequery/deployment';
+import type { VerifiedDeploymentBundle } from '@hypequery/deployment';
 import { logger } from './logger.js';
 
-export const DEPLOYMENT_BUNDLE_MANIFEST = 'bundle.json';
-export const DEPLOYMENT_BUNDLE_CONTRACT = 'deployment.json';
+export {
+  DEPLOYMENT_BUNDLE_CONTRACT,
+  DEPLOYMENT_BUNDLE_MANIFEST,
+  verifyDeploymentBundle,
+};
+export type { VerifiedDeploymentBundle };
 
 export interface DeploymentBundleRuntimeFile {
   readonly runtime: 'node' | 'python';
@@ -38,8 +45,6 @@ export interface WrittenDeploymentBundle {
   readonly contract: ProtocolDeploymentContract;
 }
 
-export type VerifiedDeploymentBundle = WrittenDeploymentBundle;
-const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 const utf8Encoder = new TextEncoder();
 
 function sha256(bytes: Uint8Array): string {
@@ -250,182 +255,10 @@ async function readBoundedAbsoluteRegularFile(
   }
 }
 
-async function readBoundedRegularFile(
-  root: string,
-  relativePath: string,
-  maximum: number,
-): Promise<Uint8Array> {
-  return readBoundedAbsoluteRegularFile(
-    path.join(root, ...relativePath.split('/')),
-    relativePath,
-    maximum,
-  );
-}
-
 export async function readDeploymentRuntimeFile(filePath: string): Promise<Uint8Array> {
   return readBoundedAbsoluteRegularFile(
     path.resolve(filePath),
     filePath,
     DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxArtifactBytes,
   );
-}
-
-function expectedDirectories(files: readonly string[]): ReadonlySet<string> {
-  const result = new Set<string>();
-  for (const file of files) {
-    const segments = file.split('/');
-    for (let index = 1; index < segments.length; index += 1) {
-      result.add(segments.slice(0, index).join('/'));
-    }
-  }
-  return result;
-}
-
-async function verifyExactEntries(
-  root: string,
-  manifest: ProtocolDeploymentBundleManifest,
-): Promise<void> {
-  const expectedFiles = new Set([
-    DEPLOYMENT_BUNDLE_MANIFEST,
-    manifest.deployment.path,
-    ...manifest.artifacts.map(artifact => artifact.path),
-  ]);
-  const expectedDirectoryPaths = expectedDirectories([...expectedFiles]);
-  const seenFiles = new Set<string>();
-  const seenDirectories = new Set<string>();
-  async function visit(relativeDirectory: string): Promise<void> {
-    const absoluteDirectory = relativeDirectory
-      ? path.join(root, ...relativeDirectory.split('/'))
-      : root;
-    const names = await readdir(absoluteDirectory);
-    names.sort();
-    for (const name of names) {
-      const relativePath = relativeDirectory ? `${relativeDirectory}/${name}` : name;
-      const stat = await lstat(path.join(absoluteDirectory, name));
-      if (stat.isSymbolicLink()) {
-        throw new Error(`Bundle entries must not be symbolic links: ${relativePath}`);
-      }
-      if (stat.isDirectory()) {
-        if (!expectedDirectoryPaths.has(relativePath)) {
-          throw new Error(`Deployment bundle contains an undeclared directory: ${relativePath}`);
-        }
-        seenDirectories.add(relativePath);
-        await visit(relativePath);
-      } else if (stat.isFile()) {
-        if (!expectedFiles.has(relativePath)) {
-          throw new Error(`Deployment bundle contains an undeclared file: ${relativePath}`);
-        }
-        seenFiles.add(relativePath);
-      } else {
-        throw new Error(`Bundle entry is not a regular file or directory: ${relativePath}`);
-      }
-    }
-  }
-  await visit('');
-  const missingFiles = [...expectedFiles].filter(file => !seenFiles.has(file)).sort();
-  if (missingFiles.length > 0) {
-    throw new Error(`Deployment bundle is missing files: ${missingFiles.join(', ')}`);
-  }
-  const missingDirectories = [...expectedDirectoryPaths]
-    .filter(directory => !seenDirectories.has(directory))
-    .sort();
-  if (missingDirectories.length > 0) {
-    throw new Error(`Deployment bundle is missing directories: ${missingDirectories.join(', ')}`);
-  }
-}
-
-function verifyFile(bytes: Uint8Array, file: { path: string; sha256: string; byteLength: number }): void {
-  if (bytes.byteLength !== file.byteLength) {
-    throw new Error(`Bundle entry byte length does not match the manifest: ${file.path}`);
-  }
-  if (sha256(bytes) !== file.sha256) {
-    throw new Error(`Bundle entry SHA-256 does not match the manifest: ${file.path}`);
-  }
-}
-
-function verifyRuntimeReferences(
-  contract: ProtocolDeploymentContract,
-  artifacts: readonly ProtocolDeploymentBundleArtifact[],
-): void {
-  requireClosedContractArtifactSet(contract);
-  const declared = new Map(
-    contract.artifacts.map(artifact => [artifact.artifactSha256, artifact.runtime]),
-  );
-  if (declared.size !== artifacts.length) {
-    throw new Error('Bundle runtime artifacts do not match the deployment contract.');
-  }
-  for (const artifact of artifacts) {
-    if (declared.get(artifact.sha256) !== artifact.runtime) {
-      throw new Error(
-        `Bundle artifact ${artifact.sha256} does not match a deployment runtime reference.`,
-      );
-    }
-  }
-}
-
-export async function verifyDeploymentBundle(
-  bundleDirectory: string,
-): Promise<VerifiedDeploymentBundle> {
-  const root = path.resolve(bundleDirectory);
-  const rootStat = await lstat(root);
-  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
-    throw new Error(`Deployment bundle path must be a regular directory: ${bundleDirectory}`);
-  }
-  const manifestBytes = await readBoundedRegularFile(
-    root,
-    DEPLOYMENT_BUNDLE_MANIFEST,
-    1024 * 1024,
-  );
-  let input: unknown;
-  try {
-    input = JSON.parse(utf8Decoder.decode(manifestBytes));
-  } catch (error) {
-    throw new Error(
-      `Invalid deployment bundle manifest: ${path.join(root, DEPLOYMENT_BUNDLE_MANIFEST)}\n\n`
-      + (error instanceof Error ? error.message : String(error)),
-    );
-  }
-  const preparedManifest = prepareProtocolDeploymentBundleManifest(input);
-  const expectedManifestBytes = utf8Encoder.encode(`${preparedManifest.canonical}\n`);
-  if (!Buffer.from(manifestBytes).equals(Buffer.from(expectedManifestBytes))) {
-    throw new Error('Deployment bundle manifest must contain canonical JSON followed by one newline.');
-  }
-  await verifyExactEntries(root, preparedManifest.manifest);
-
-  const deployment = preparedManifest.manifest.deployment;
-  const deploymentBytes = await readBoundedRegularFile(
-    root,
-    deployment.path,
-    DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxDeploymentBytes,
-  );
-  verifyFile(deploymentBytes, deployment);
-  let contractInput: unknown;
-  try {
-    contractInput = JSON.parse(utf8Decoder.decode(deploymentBytes));
-  } catch (error) {
-    throw new Error(
-      `Invalid deployment JSON in bundle: ${deployment.path}\n\n`
-      + (error instanceof Error ? error.message : String(error)),
-    );
-  }
-  const preparedContract = prepareProtocolDeploymentContract(contractInput);
-  if (preparedContract.identity !== deployment.identity) {
-    throw new Error('Deployment identity does not match the bundle manifest.');
-  }
-
-  for (const artifact of preparedManifest.manifest.artifacts) {
-    const bytes = await readBoundedRegularFile(
-      root,
-      artifact.path,
-      DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxArtifactBytes,
-    );
-    verifyFile(bytes, artifact);
-  }
-  verifyRuntimeReferences(preparedContract.contract, preparedManifest.manifest.artifacts);
-  return Object.freeze({
-    directory: root,
-    manifest: preparedManifest.manifest,
-    identity: preparedManifest.identity,
-    contract: preparedContract.contract,
-  });
 }

--- a/packages/cli/src/utils/deployment-upload.test.ts
+++ b/packages/cli/src/utils/deployment-upload.test.ts
@@ -5,6 +5,7 @@ import {
   prepareProtocolDeploymentContract,
   prepareProtocolDeploymentReleaseEnvelope,
 } from '@hypequery/protocol';
+import { createDeploymentIntake } from '@hypequery/deployment';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   verifyDeploymentBundle,
@@ -98,6 +99,48 @@ function jsonResponse(input: unknown, status = 200, statusText = 'OK'): Response
 }
 
 describe('deployment upload transport', () => {
+  it('is wire-compatible with the provider-neutral deployment intake', async () => {
+    const bundle = await verifiedBundle();
+    const release = releaseFor(bundle.identity);
+    const intake = createDeploymentIntake({
+      authenticator: { authenticate: async ({ token }) => (
+        token === 'secret-token' ? 'principal' : null
+      ) },
+      authorizer: { authorize: async ({ target }) => (
+        target.project === 'project-1' && target.environment === 'production'
+      ) },
+      store: {
+        accept: async submission => {
+          expect(await readFile(
+            path.join(submission.bundle.directory, 'deployment.json'),
+            'utf8',
+          )).toContain('hypequery-deployment');
+          return 'accepted';
+        },
+      },
+    });
+    const fetch = vi.fn<DeploymentFetch>(async (_endpoint, init) => {
+      const response = await intake.handle({
+        headers: init.headers,
+        body: init.body,
+        signal: init.signal,
+      });
+      return new Response(response.body, {
+        status: response.status,
+        headers: response.headers,
+      });
+    });
+    const transport = createHttpDeploymentUploadTransport({
+      endpoint: 'https://deploy.example.test/v1/releases',
+      token: 'secret-token',
+      fetch,
+    });
+
+    await expect(transport.submit(bundle, release)).resolves.toEqual(
+      submission(bundle.identity, release.identity),
+    );
+  });
+
   it('streams a verified bundle with authenticated identity headers', async () => {
     const bundle = await verifiedBundle();
     const release = releaseFor(bundle.identity);

--- a/packages/cli/src/utils/deployment-upload.ts
+++ b/packages/cli/src/utils/deployment-upload.ts
@@ -12,6 +12,9 @@ import {
   DEPLOYMENT_BUNDLE_MANIFEST,
   type VerifiedDeploymentBundle,
 } from './deployment-bundle.js';
+import type { DeploymentSubmissionResponse } from '@hypequery/deployment';
+
+export type { DeploymentSubmissionResponse } from '@hypequery/deployment';
 
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
 const MAX_RESPONSE_BYTES = 64 * 1024;
@@ -37,14 +40,6 @@ export class DeploymentUploadError extends Error {
     this.code = code;
     if (status !== undefined) this.status = status;
   }
-}
-
-export interface DeploymentSubmissionResponse {
-  readonly kind: 'hypequery-deployment-submission';
-  readonly version: 1;
-  readonly status: 'accepted' | 'already-exists';
-  readonly releaseIdentity: string;
-  readonly bundleIdentity: string;
 }
 
 export interface DeploymentHttpResponse {

--- a/packages/deployment/README.md
+++ b/packages/deployment/README.md
@@ -1,0 +1,68 @@
+# @hypequery/deployment
+
+Provider-neutral verification and receiving-side intake for Hypequery deployment
+bundles.
+
+The package accepts the authenticated multipart transport emitted by
+`hypequery deploy`, reconstructs only manifest-declared files in temporary
+storage, and revalidates the release, bundle manifest, file hashes, deployment
+identity, and runtime references before handing the submission to a store. It
+does not activate or execute a release.
+
+## Intake adapters
+
+`createDeploymentIntake` is independent of an HTTP framework. Adapt an incoming
+request into a case-insensitive header record and an `AsyncIterable<Uint8Array>`
+body, then map the returned status, headers, and JSON body onto the framework's
+response.
+
+Three provider-owned adapters are required:
+
+- `DeploymentAuthenticator` validates the bearer token before request bytes are
+  consumed;
+- `DeploymentAuthorizer` authorizes the canonical project and environment once
+  the release envelope has been validated;
+- `DeploymentSubmissionStore` atomically persists or recognizes the fully
+  verified release identity.
+
+The store receives a verified bundle whose directory is temporary. It must copy
+or persist every required byte before `accept` resolves. Returning
+`already-exists` is valid only for an authorized replay of the same deterministic
+release identity.
+
+```ts
+import { createDeploymentIntake } from '@hypequery/deployment';
+
+const intake = createDeploymentIntake({
+  authenticator: {
+    async authenticate({ token }) {
+      return authenticateToken(token);
+    },
+  },
+  authorizer: {
+    async authorize({ principal, target }) {
+      return canDeploy(principal, target.project, target.environment);
+    },
+  },
+  store: {
+    async accept(submission) {
+      return persistVerifiedSubmission(submission);
+    },
+  },
+});
+```
+
+New submissions return HTTP status `202` and `status: "accepted"`; verified
+idempotent replays return HTTP status `200` and `status: "already-exists"`.
+Malformed, unauthorized, oversized, or inconsistent submissions fail closed
+with a bounded JSON error response. Temporary upload data is removed on success
+and failure.
+
+## Bundle verification
+
+`verifyDeploymentBundle(directory)` verifies a closed bundle directly from the
+filesystem. It rejects symbolic links and undeclared entries, enforces byte
+limits, recomputes every hash and identity, and returns an immutable verified
+snapshot.
+
+The package is ESM-only and requires Node.js 20 or newer.

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@hypequery/deployment",
+  "version": "0.1.0",
+  "description": "Provider-neutral deployment verification and intake for Hypequery",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "dev": "tsc --project tsconfig.json --watch",
+    "lint": "eslint --ext .ts \"src/**/*.ts\"",
+    "test": "vitest run",
+    "types": "tsc --project tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@hypequery/protocol": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.6"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hypequery/hypequery.git",
+    "directory": "packages/deployment"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/deployment/src/bundle.ts
+++ b/packages/deployment/src/bundle.ts
@@ -1,0 +1,251 @@
+import { createHash } from 'node:crypto';
+import {
+  constants,
+  lstat,
+  open,
+  readdir,
+} from 'node:fs/promises';
+import path from 'node:path';
+import {
+  DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS,
+  prepareProtocolDeploymentBundleManifest,
+  prepareProtocolDeploymentContract,
+  type ProtocolDeploymentBundleArtifact,
+  type ProtocolDeploymentBundleManifest,
+  type ProtocolDeploymentContract,
+} from '@hypequery/protocol';
+
+export const DEPLOYMENT_BUNDLE_MANIFEST = 'bundle.json';
+export const DEPLOYMENT_BUNDLE_CONTRACT = 'deployment.json';
+
+export interface VerifiedDeploymentBundle {
+  readonly directory: string;
+  readonly manifest: ProtocolDeploymentBundleManifest;
+  readonly identity: string;
+  readonly contract: ProtocolDeploymentContract;
+}
+
+const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
+const utf8Encoder = new TextEncoder();
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code)
+    : undefined;
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+async function readBoundedRegularFile(
+  root: string,
+  relativePath: string,
+  maximum: number,
+): Promise<Uint8Array> {
+  const absolutePath = path.join(root, ...relativePath.split('/'));
+  let handle;
+  try {
+    const initialStat = await lstat(absolutePath);
+    if (initialStat.isSymbolicLink()) {
+      throw new Error(`Bundle entry must not be a symbolic link: ${relativePath}`);
+    }
+    if (!initialStat.isFile()) {
+      throw new Error(`Bundle entry is not a regular file: ${relativePath}`);
+    }
+    if (initialStat.size < 1 || initialStat.size > maximum) {
+      throw new Error(`Bundle entry exceeds its byte limit: ${relativePath}`);
+    }
+    handle = await open(absolutePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const stat = await handle.stat();
+    if (!stat.isFile()) throw new Error(`Bundle entry is not a regular file: ${relativePath}`);
+    if (stat.size < 1 || stat.size > maximum) {
+      throw new Error(`Bundle entry exceeds its byte limit: ${relativePath}`);
+    }
+    return await handle.readFile();
+  } catch (error) {
+    if (errorCode(error) === 'ELOOP') {
+      throw new Error(`Bundle entry must not be a symbolic link: ${relativePath}`);
+    }
+    throw error;
+  } finally {
+    await handle?.close();
+  }
+}
+
+function expectedDirectories(files: readonly string[]): ReadonlySet<string> {
+  const result = new Set<string>();
+  for (const file of files) {
+    const segments = file.split('/');
+    for (let index = 1; index < segments.length; index += 1) {
+      result.add(segments.slice(0, index).join('/'));
+    }
+  }
+  return result;
+}
+
+async function verifyExactEntries(
+  root: string,
+  manifest: ProtocolDeploymentBundleManifest,
+): Promise<void> {
+  const expectedFiles = new Set([
+    DEPLOYMENT_BUNDLE_MANIFEST,
+    manifest.deployment.path,
+    ...manifest.artifacts.map(artifact => artifact.path),
+  ]);
+  const expectedDirectoryPaths = expectedDirectories([...expectedFiles]);
+  const seenFiles = new Set<string>();
+  const seenDirectories = new Set<string>();
+  async function visit(relativeDirectory: string): Promise<void> {
+    const absoluteDirectory = relativeDirectory
+      ? path.join(root, ...relativeDirectory.split('/'))
+      : root;
+    const names = await readdir(absoluteDirectory);
+    names.sort();
+    for (const name of names) {
+      const relativePath = relativeDirectory ? `${relativeDirectory}/${name}` : name;
+      const stat = await lstat(path.join(absoluteDirectory, name));
+      if (stat.isSymbolicLink()) {
+        throw new Error(`Bundle entries must not be symbolic links: ${relativePath}`);
+      }
+      if (stat.isDirectory()) {
+        if (!expectedDirectoryPaths.has(relativePath)) {
+          throw new Error(`Deployment bundle contains an undeclared directory: ${relativePath}`);
+        }
+        seenDirectories.add(relativePath);
+        await visit(relativePath);
+      } else if (stat.isFile()) {
+        if (!expectedFiles.has(relativePath)) {
+          throw new Error(`Deployment bundle contains an undeclared file: ${relativePath}`);
+        }
+        seenFiles.add(relativePath);
+      } else {
+        throw new Error(`Bundle entry is not a regular file or directory: ${relativePath}`);
+      }
+    }
+  }
+  await visit('');
+  const missingFiles = [...expectedFiles].filter(file => !seenFiles.has(file)).sort();
+  if (missingFiles.length > 0) {
+    throw new Error(`Deployment bundle is missing files: ${missingFiles.join(', ')}`);
+  }
+  const missingDirectories = [...expectedDirectoryPaths]
+    .filter(directory => !seenDirectories.has(directory)).sort();
+  if (missingDirectories.length > 0) {
+    throw new Error(`Deployment bundle is missing directories: ${missingDirectories.join(', ')}`);
+  }
+}
+
+function verifyFile(
+  bytes: Uint8Array,
+  file: { path: string; sha256: string; byteLength: number },
+): void {
+  if (bytes.byteLength !== file.byteLength) {
+    throw new Error(`Bundle entry byte length does not match the manifest: ${file.path}`);
+  }
+  if (sha256(bytes) !== file.sha256) {
+    throw new Error(`Bundle entry SHA-256 does not match the manifest: ${file.path}`);
+  }
+}
+
+function requireClosedContractArtifactSet(contract: ProtocolDeploymentContract): void {
+  const referenced = new Map<string, 'node' | 'python'>();
+  for (const query of contract.queries) {
+    if (query.implementation.kind === 'runtime-reference') {
+      referenced.set(query.implementation.artifactSha256, query.implementation.runtime);
+    }
+  }
+  if (referenced.size !== contract.artifacts.length) {
+    throw new Error('Deployment contract contains missing or unreferenced runtime artifacts.');
+  }
+  for (const artifact of contract.artifacts) {
+    if (referenced.get(artifact.artifactSha256) !== artifact.runtime) {
+      throw new Error(
+        `Deployment runtime artifact ${artifact.artifactSha256} is not referenced by a named query.`,
+      );
+    }
+  }
+}
+
+function verifyRuntimeReferences(
+  contract: ProtocolDeploymentContract,
+  artifacts: readonly ProtocolDeploymentBundleArtifact[],
+): void {
+  requireClosedContractArtifactSet(contract);
+  const declared = new Map(
+    contract.artifacts.map(artifact => [artifact.artifactSha256, artifact.runtime]),
+  );
+  if (declared.size !== artifacts.length) {
+    throw new Error('Bundle runtime artifacts do not match the deployment contract.');
+  }
+  for (const artifact of artifacts) {
+    if (declared.get(artifact.sha256) !== artifact.runtime) {
+      throw new Error(
+        `Bundle artifact ${artifact.sha256} does not match a deployment runtime reference.`,
+      );
+    }
+  }
+}
+
+export async function verifyDeploymentBundle(
+  bundleDirectory: string,
+): Promise<VerifiedDeploymentBundle> {
+  const root = path.resolve(bundleDirectory);
+  const rootStat = await lstat(root);
+  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+    throw new Error(`Deployment bundle path must be a regular directory: ${bundleDirectory}`);
+  }
+  const manifestBytes = await readBoundedRegularFile(root, DEPLOYMENT_BUNDLE_MANIFEST, 1024 * 1024);
+  let input: unknown;
+  try {
+    input = JSON.parse(utf8Decoder.decode(manifestBytes));
+  } catch (error) {
+    throw new Error(
+      `Invalid deployment bundle manifest: ${path.join(root, DEPLOYMENT_BUNDLE_MANIFEST)}\n\n`
+      + (error instanceof Error ? error.message : String(error)),
+    );
+  }
+  const preparedManifest = prepareProtocolDeploymentBundleManifest(input);
+  const expectedManifestBytes = utf8Encoder.encode(`${preparedManifest.canonical}\n`);
+  if (!Buffer.from(manifestBytes).equals(Buffer.from(expectedManifestBytes))) {
+    throw new Error('Deployment bundle manifest must contain canonical JSON followed by one newline.');
+  }
+  await verifyExactEntries(root, preparedManifest.manifest);
+
+  const deployment = preparedManifest.manifest.deployment;
+  const deploymentBytes = await readBoundedRegularFile(
+    root,
+    deployment.path,
+    DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxDeploymentBytes,
+  );
+  verifyFile(deploymentBytes, deployment);
+  let contractInput: unknown;
+  try {
+    contractInput = JSON.parse(utf8Decoder.decode(deploymentBytes));
+  } catch (error) {
+    throw new Error(
+      `Invalid deployment JSON in bundle: ${deployment.path}\n\n`
+      + (error instanceof Error ? error.message : String(error)),
+    );
+  }
+  const preparedContract = prepareProtocolDeploymentContract(contractInput);
+  if (preparedContract.identity !== deployment.identity) {
+    throw new Error('Deployment identity does not match the bundle manifest.');
+  }
+
+  for (const artifact of preparedManifest.manifest.artifacts) {
+    const bytes = await readBoundedRegularFile(
+      root,
+      artifact.path,
+      DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxArtifactBytes,
+    );
+    verifyFile(bytes, artifact);
+  }
+  verifyRuntimeReferences(preparedContract.contract, preparedManifest.manifest.artifacts);
+  return Object.freeze({
+    directory: root,
+    manifest: preparedManifest.manifest,
+    identity: preparedManifest.identity,
+    contract: preparedContract.contract,
+  });
+}

--- a/packages/deployment/src/errors.ts
+++ b/packages/deployment/src/errors.ts
@@ -1,0 +1,42 @@
+export type DeploymentIntakeErrorCode =
+  | 'HQ_INTAKE_BAD_REQUEST'
+  | 'HQ_INTAKE_UNAUTHENTICATED'
+  | 'HQ_INTAKE_FORBIDDEN'
+  | 'HQ_INTAKE_TOO_LARGE'
+  | 'HQ_INTAKE_CONFLICT'
+  | 'HQ_INTAKE_INTERNAL';
+
+const ERROR_STATUS: Readonly<Record<DeploymentIntakeErrorCode, number>> = Object.freeze({
+  HQ_INTAKE_BAD_REQUEST: 400,
+  HQ_INTAKE_UNAUTHENTICATED: 401,
+  HQ_INTAKE_FORBIDDEN: 403,
+  HQ_INTAKE_TOO_LARGE: 413,
+  HQ_INTAKE_CONFLICT: 409,
+  HQ_INTAKE_INTERNAL: 500,
+});
+
+export class DeploymentIntakeError extends Error {
+  readonly code: DeploymentIntakeErrorCode;
+  readonly status: number;
+  readonly expose: boolean;
+
+  constructor(
+    code: DeploymentIntakeErrorCode,
+    message: string,
+    options: { readonly expose?: boolean; readonly cause?: unknown } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'DeploymentIntakeError';
+    this.code = code;
+    this.status = ERROR_STATUS[code];
+    this.expose = options.expose ?? this.status < 500;
+  }
+}
+
+export function badRequest(message: string, cause?: unknown): DeploymentIntakeError {
+  return new DeploymentIntakeError('HQ_INTAKE_BAD_REQUEST', message, { cause });
+}
+
+export function tooLarge(message: string): DeploymentIntakeError {
+  return new DeploymentIntakeError('HQ_INTAKE_TOO_LARGE', message);
+}

--- a/packages/deployment/src/index.ts
+++ b/packages/deployment/src/index.ts
@@ -1,0 +1,31 @@
+export {
+  DEPLOYMENT_BUNDLE_CONTRACT,
+  DEPLOYMENT_BUNDLE_MANIFEST,
+  verifyDeploymentBundle,
+} from './bundle.js';
+export type { VerifiedDeploymentBundle } from './bundle.js';
+export {
+  DeploymentIntakeError,
+} from './errors.js';
+export type { DeploymentIntakeErrorCode } from './errors.js';
+export {
+  createDeploymentIntake,
+} from './intake.js';
+export {
+  DEFAULT_DEPLOYMENT_INTAKE_LIMITS,
+  resolveDeploymentIntakeLimits,
+} from './limits.js';
+export type { DeploymentIntakeLimits } from './limits.js';
+export type {
+  DeploymentAuthenticationInput,
+  DeploymentAuthenticator,
+  DeploymentAuthorizationInput,
+  DeploymentAuthorizer,
+  DeploymentIntake,
+  DeploymentIntakeOptions,
+  DeploymentIntakeRequest,
+  DeploymentIntakeResponse,
+  DeploymentSubmissionResponse,
+  DeploymentSubmissionStore,
+  VerifiedDeploymentSubmission,
+} from './types.js';

--- a/packages/deployment/src/intake.test.ts
+++ b/packages/deployment/src/intake.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import {
+  chmod,
   mkdtemp,
   readFile,
   readdir,
@@ -272,6 +273,26 @@ describe('deployment intake', () => {
     expect(accept).not.toHaveBeenCalled();
   });
 
+  it('rejects non-ASCII multipart header bytes without lossy decoding', async () => {
+    const fixture = submissionFixture();
+    const body = Buffer.from(fixture.body);
+    const headerValue = body.indexOf('application/json');
+    if (headerValue < 0) throw new Error('Expected multipart content type header.');
+    body[headerValue] = 0x80;
+    const request = fixture.request();
+    const accept = vi.fn<DeploymentSubmissionStore<string>['accept']>();
+    const intake = createDeploymentIntake({
+      authenticator: { authenticate: async () => 'principal' },
+      authorizer: { authorize: async () => true },
+      store: { accept },
+    });
+
+    const response = await intake.handle({ ...request, body: chunks(body) });
+
+    expect(response.status).toBe(400);
+    expect(accept).not.toHaveBeenCalled();
+  });
+
   it('rejects undeclared parts and truncated bodies', async () => {
     const extra: Part = {
       name: 'bundle',
@@ -309,6 +330,35 @@ describe('deployment intake', () => {
     expect(response.status).toBe(400);
     expect(accept).not.toHaveBeenCalled();
   });
+
+  it.each(['../outside.json', 'nested//outside.json', 'nested/./outside.json'])(
+    'rejects unsafe manifest path %s before creating temporary files',
+    async unsafePath => {
+      const fixture = submissionFixture();
+      const temporary = await temporaryDirectory();
+      const body = Buffer.from(
+        fixture.body.toString('utf8').replaceAll('deployment.json', unsafePath),
+      );
+      const request = fixture.request();
+      const accept = vi.fn<DeploymentSubmissionStore<string>['accept']>();
+      const intake = createDeploymentIntake({
+        authenticator: { authenticate: async () => 'principal' },
+        authorizer: { authorize: async () => true },
+        store: { accept },
+        temporaryDirectory: temporary,
+      });
+
+      const response = await intake.handle({
+        ...request,
+        headers: { ...request.headers, 'Content-Length': String(body.byteLength) },
+        body: chunks(body),
+      });
+
+      expect(response.status).toBe(400);
+      expect(accept).not.toHaveBeenCalled();
+      expect(await readdir(temporary)).toEqual([]);
+    },
+  );
 
   it('preflights request limits without consuming the body', async () => {
     const fixture = submissionFixture();
@@ -365,4 +415,30 @@ describe('deployment intake', () => {
     expect(response.body).not.toContain('database secret');
     expect(await readdir(temporary)).toEqual([]);
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'does not turn a successful persist into a failure when cleanup fails',
+    async () => {
+      const fixture = submissionFixture();
+      const temporary = await temporaryDirectory();
+      const accept = vi.fn<DeploymentSubmissionStore<string>['accept']>(async () => {
+        await chmod(temporary, 0o500);
+        return 'accepted';
+      });
+      const intake = createDeploymentIntake({
+        authenticator: { authenticate: async () => 'principal' },
+        authorizer: { authorize: async () => true },
+        store: { accept },
+        temporaryDirectory: temporary,
+      });
+
+      const response = await intake.handle(fixture.request());
+      await chmod(temporary, 0o700);
+
+      expect(response.status).toBe(202);
+      expect((responseBody(response) as { status: string }).status).toBe('accepted');
+      expect(accept).toHaveBeenCalledOnce();
+      expect(await readdir(temporary)).toHaveLength(1);
+    },
+  );
 });

--- a/packages/deployment/src/intake.test.ts
+++ b/packages/deployment/src/intake.test.ts
@@ -1,0 +1,368 @@
+import { createHash } from 'node:crypto';
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  prepareProtocolDeploymentBundleManifest,
+  prepareProtocolDeploymentContract,
+  prepareProtocolDeploymentReleaseEnvelope,
+} from '@hypequery/protocol';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createDeploymentIntake } from './intake.js';
+import type {
+  DeploymentIntakeRequest,
+  DeploymentSubmissionStore,
+} from './types.js';
+
+interface Part {
+  readonly name: 'release' | 'bundle';
+  readonly filename: string;
+  readonly contentType: string;
+  readonly bundlePath?: string;
+  readonly bytes: Uint8Array;
+}
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), 'hypequery-intake-test-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(directory => (
+    rm(directory, { force: true, recursive: true })
+  )));
+});
+
+function sha256(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function multipart(boundary: string, parts: readonly Part[]): Buffer {
+  const values: Buffer[] = [];
+  for (const part of parts) {
+    values.push(Buffer.from([
+      `--${boundary}`,
+      `Content-Disposition: form-data; name="${part.name}"; filename="${part.filename}"`,
+      `Content-Type: ${part.contentType}`,
+      ...(part.bundlePath ? [`X-HypeQuery-Bundle-Path: ${part.bundlePath}`] : []),
+      '',
+      '',
+    ].join('\r\n')));
+    values.push(Buffer.from(part.bytes), Buffer.from('\r\n'));
+  }
+  values.push(Buffer.from(`--${boundary}--\r\n`));
+  return Buffer.concat(values);
+}
+
+async function* chunks(bytes: Uint8Array, size = 17): AsyncGenerator<Uint8Array> {
+  for (let offset = 0; offset < bytes.byteLength; offset += size) {
+    yield bytes.subarray(offset, Math.min(offset + size, bytes.byteLength));
+  }
+}
+
+function deployment() {
+  return {
+    kind: 'hypequery-deployment' as const,
+    version: 1 as const,
+    datasets: [],
+    queries: [],
+    artifacts: [],
+  };
+}
+
+function submissionFixture(
+  extraParts: readonly Part[] = [],
+  deploymentPath = 'deployment.json',
+) {
+  const preparedDeployment = prepareProtocolDeploymentContract(deployment());
+  const deploymentBytes = Buffer.from(`${preparedDeployment.canonical}\n`);
+  const preparedManifest = prepareProtocolDeploymentBundleManifest({
+    kind: 'hypequery-deployment-bundle',
+    version: 1,
+    deployment: {
+      path: deploymentPath,
+      identity: preparedDeployment.identity,
+      sha256: sha256(deploymentBytes),
+      byteLength: deploymentBytes.byteLength,
+    },
+    artifacts: [],
+  });
+  const release = prepareProtocolDeploymentReleaseEnvelope({
+    kind: 'hypequery-deployment-release',
+    version: 1,
+    bundleIdentity: preparedManifest.identity,
+    target: { project: 'analytics', environment: 'production' },
+  });
+  const parts: Part[] = [
+    {
+      name: 'release',
+      filename: 'release.json',
+      contentType: 'application/json',
+      bytes: release.bytes,
+    },
+    {
+      name: 'bundle',
+      filename: 'bundle.json',
+      contentType: 'application/json',
+      bundlePath: 'bundle.json',
+      bytes: Buffer.from(`${preparedManifest.canonical}\n`),
+    },
+    {
+      name: 'bundle',
+      filename: path.basename(deploymentPath),
+      contentType: 'application/json',
+      bundlePath: deploymentPath,
+      bytes: deploymentBytes,
+    },
+    ...extraParts,
+  ];
+  const boundary = 'hypequery-test-boundary';
+  const body = multipart(boundary, parts);
+  const request = (): DeploymentIntakeRequest => ({
+    headers: {
+      Authorization: 'Bearer secret-token',
+      'Content-Type': `multipart/form-data; boundary=${boundary}`,
+      'Content-Length': String(body.byteLength),
+      'Idempotency-Key': release.identity,
+      'X-HypeQuery-Release-Identity': release.identity,
+      'X-HypeQuery-Bundle-Identity': preparedManifest.identity,
+    },
+    body: chunks(body),
+  });
+  return { body, boundary, deploymentBytes, preparedManifest, release, request };
+}
+
+function responseBody(response: { readonly body: string }): unknown {
+  return JSON.parse(response.body) as unknown;
+}
+
+describe('deployment intake', () => {
+  it('authenticates, authorizes, fully verifies, persists, and cleans the upload', async () => {
+    const fixture = submissionFixture();
+    const temporary = await temporaryDirectory();
+    const authenticate = vi.fn(async () => 'principal');
+    const authorize = vi.fn(async () => true);
+    const accept = vi.fn<DeploymentSubmissionStore<string>['accept']>(async submission => {
+      expect(submission.principal).toBe('principal');
+      expect(submission.releaseCanonical).toBe(fixture.release.canonical);
+      expect(submission.bundle.identity).toBe(fixture.preparedManifest.identity);
+      expect(await readFile(
+        path.join(submission.bundle.directory, 'deployment.json'),
+      )).toEqual(fixture.deploymentBytes);
+      return 'accepted';
+    });
+    const intake = createDeploymentIntake({
+      authenticator: { authenticate },
+      authorizer: { authorize },
+      store: { accept },
+      temporaryDirectory: temporary,
+    });
+
+    const response = await intake.handle(fixture.request());
+
+    expect(response.status).toBe(202);
+    expect(responseBody(response)).toEqual({
+      kind: 'hypequery-deployment-submission',
+      version: 1,
+      status: 'accepted',
+      releaseIdentity: fixture.release.identity,
+      bundleIdentity: fixture.preparedManifest.identity,
+    });
+    expect(authenticate).toHaveBeenCalledWith({ token: 'secret-token', signal: undefined });
+    expect(authorize).toHaveBeenCalledWith({
+      principal: 'principal',
+      target: { project: 'analytics', environment: 'production' },
+      releaseIdentity: fixture.release.identity,
+      bundleIdentity: fixture.preparedManifest.identity,
+      signal: undefined,
+    });
+    expect(accept).toHaveBeenCalledOnce();
+    expect(await readdir(temporary)).toEqual([]);
+  });
+
+  it('returns the store idempotency result after complete revalidation', async () => {
+    const fixture = submissionFixture();
+    const seen = new Set<string>();
+    const accept = vi.fn<DeploymentSubmissionStore<string>['accept']>(async submission => {
+      if (seen.has(submission.releaseIdentity)) return 'already-exists';
+      seen.add(submission.releaseIdentity);
+      return 'accepted';
+    });
+    const intake = createDeploymentIntake({
+      authenticator: { authenticate: async () => 'principal' },
+      authorizer: { authorize: async () => true },
+      store: { accept },
+    });
+
+    expect((responseBody(await intake.handle(fixture.request())) as { status: string }).status)
+      .toBe('accepted');
+    const replay = await intake.handle(fixture.request());
+    expect(replay.status).toBe(200);
+    expect((responseBody(replay) as { status: string }).status).toBe('already-exists');
+    expect(accept).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects unauthenticated requests before consuming body bytes', async () => {
+    let consumed = false;
+    const fixture = submissionFixture();
+    const request = fixture.request();
+    const intake = createDeploymentIntake({
+      authenticator: { authenticate: async () => null },
+      authorizer: { authorize: async () => true },
+      store: { accept: async () => 'accepted' },
+    });
+
+    const response = await intake.handle({
+      ...request,
+      body: (async function* () {
+        consumed = true;
+        yield fixture.body;
+      })(),
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers['www-authenticate']).toBe('Bearer');
+    expect(consumed).toBe(false);
+  });
+
+  it('authorizes the canonical target before receiving bundle files', async () => {
+    const fixture = submissionFixture();
+    const accept = vi.fn<DeploymentSubmissionStore<string>['accept']>();
+    const intake = createDeploymentIntake({
+      authenticator: { authenticate: async () => 'principal' },
+      authorizer: { authorize: async () => false },
+      store: { accept },
+    });
+
+    const response = await intake.handle(fixture.request());
+
+    expect(response.status).toBe(403);
+    expect(accept).not.toHaveBeenCalled();
+  });
+
+  it('rejects tampered file bytes and never calls the store', async () => {
+    const fixture = submissionFixture();
+    const tampered = Buffer.from(fixture.body);
+    const location = tampered.indexOf(fixture.deploymentBytes);
+    tampered[location] = tampered[location]! ^ 1;
+    const request = fixture.request();
+    const accept = vi.fn<DeploymentSubmissionStore<string>['accept']>();
+    const intake = createDeploymentIntake({
+      authenticator: { authenticate: async () => 'principal' },
+      authorizer: { authorize: async () => true },
+      store: { accept },
+    });
+
+    const response = await intake.handle({
+      ...request,
+      headers: { ...request.headers, 'Content-Length': String(tampered.byteLength) },
+      body: chunks(tampered),
+    });
+
+    expect(response.status).toBe(400);
+    expect(responseBody(response)).toMatchObject({ error: { code: 'HQ_INTAKE_BAD_REQUEST' } });
+    expect(accept).not.toHaveBeenCalled();
+  });
+
+  it('rejects undeclared parts and truncated bodies', async () => {
+    const extra: Part = {
+      name: 'bundle',
+      filename: 'extra.bin',
+      contentType: 'application/octet-stream',
+      bundlePath: 'extra.bin',
+      bytes: Buffer.from('extra'),
+    };
+    const withExtra = submissionFixture([extra]);
+    const intake = createDeploymentIntake({
+      authenticator: { authenticate: async () => 'principal' },
+      authorizer: { authorize: async () => true },
+      store: { accept: async () => 'accepted' },
+    });
+
+    expect((await intake.handle(withExtra.request())).status).toBe(400);
+    const fixture = submissionFixture();
+    const request = fixture.request();
+    const truncated = fixture.body.subarray(0, fixture.body.byteLength - 8);
+    const response = await intake.handle({ ...request, body: chunks(truncated) });
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects a declared file that collides with the bundle manifest path', async () => {
+    const fixture = submissionFixture([], 'bundle.json');
+    const accept = vi.fn<DeploymentSubmissionStore<string>['accept']>();
+    const intake = createDeploymentIntake({
+      authenticator: { authenticate: async () => 'principal' },
+      authorizer: { authorize: async () => true },
+      store: { accept },
+    });
+
+    const response = await intake.handle(fixture.request());
+
+    expect(response.status).toBe(400);
+    expect(accept).not.toHaveBeenCalled();
+  });
+
+  it('preflights request limits without consuming the body', async () => {
+    const fixture = submissionFixture();
+    const request = fixture.request();
+    let consumed = false;
+    const intake = createDeploymentIntake({
+      authenticator: { authenticate: async () => 'principal' },
+      authorizer: { authorize: async () => true },
+      store: { accept: async () => 'accepted' },
+      limits: { maxRequestBytes: fixture.body.byteLength - 1 },
+    });
+
+    const response = await intake.handle({
+      ...request,
+      body: (async function* () {
+        consumed = true;
+        yield fixture.body;
+      })(),
+    });
+
+    expect(response.status).toBe(413);
+    expect(consumed).toBe(false);
+  });
+
+  it('accepts explicitly undefined limits and rejects raised safety ceilings', () => {
+    const options = {
+      authenticator: { authenticate: async () => 'principal' },
+      authorizer: { authorize: async () => true },
+      store: { accept: async () => 'accepted' as const },
+    };
+    expect(() => createDeploymentIntake({
+      ...options,
+      limits: { maxRequestBytes: undefined },
+    })).not.toThrow();
+    expect(() => createDeploymentIntake({
+      ...options,
+      limits: { maxRequestBytes: (258 * 1024 * 1024) + 1 },
+    })).toThrow(/deployment intake v1 maximum/);
+  });
+
+  it('cleans temporary bytes when persistence fails without exposing the error', async () => {
+    const fixture = submissionFixture();
+    const temporary = await temporaryDirectory();
+    const intake = createDeploymentIntake({
+      authenticator: { authenticate: async () => 'principal' },
+      authorizer: { authorize: async () => true },
+      store: { accept: async () => { throw new Error('database secret'); } },
+      temporaryDirectory: temporary,
+    });
+
+    const response = await intake.handle(fixture.request());
+
+    expect(response.status).toBe(500);
+    expect(response.body).not.toContain('database secret');
+    expect(await readdir(temporary)).toEqual([]);
+  });
+});

--- a/packages/deployment/src/intake.ts
+++ b/packages/deployment/src/intake.ts
@@ -153,6 +153,10 @@ function requireReconstructablePaths(manifest: PreparedProtocolDeploymentBundleM
   }
   for (const file of files) {
     const segments = file.split('/');
+    if (file.includes('\\')
+      || segments.some(segment => segment === '' || segment === '.' || segment === '..')) {
+      throw badRequest('Bundle file paths must be safe relative paths.');
+    }
     for (let index = 1; index < segments.length; index += 1) {
       if (fileSet.has(segments.slice(0, index).join('/'))) {
         throw badRequest('A bundle file path cannot also be a parent directory.');
@@ -243,7 +247,12 @@ async function receiveBundleFile(
     contentType,
     bundlePath: file.path,
   });
-  const absolutePath = path.join(root, ...file.path.split('/'));
+  const absolutePath = path.resolve(root, ...file.path.split('/'));
+  const relativePath = path.relative(root, absolutePath);
+  if (relativePath === '' || relativePath === '..'
+    || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
+    throw badRequest('Bundle file paths must remain within the temporary bundle directory.');
+  }
   await mkdir(path.dirname(absolutePath), { recursive: true });
   const handle = await open(absolutePath, 'wx');
   const digest = createHash('sha256');
@@ -428,8 +437,8 @@ export function createDeploymentIntake<Principal>(
         releaseIdentity: release.identity,
         bundleIdentity: bundle.identity,
       });
-      await removeTemporaryDirectory(temporaryRoot);
       cleaned = true;
+      await removeTemporaryDirectory(temporaryRoot, true);
       return jsonResponse(status === 'accepted' ? 202 : 200, response);
     } finally {
       if (!cleaned) await removeTemporaryDirectory(temporaryRoot, true);

--- a/packages/deployment/src/intake.ts
+++ b/packages/deployment/src/intake.ts
@@ -1,0 +1,448 @@
+import { createHash } from 'node:crypto';
+import {
+  mkdir,
+  mkdtemp,
+  open,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  prepareProtocolDeploymentBundleManifest,
+  prepareProtocolDeploymentReleaseEnvelope,
+  type PreparedProtocolDeploymentBundleManifest,
+  type PreparedProtocolDeploymentReleaseEnvelope,
+  type ProtocolDeploymentBundleFile,
+} from '@hypequery/protocol';
+import {
+  DEPLOYMENT_BUNDLE_MANIFEST,
+  verifyDeploymentBundle,
+} from './bundle.js';
+import {
+  badRequest,
+  DeploymentIntakeError,
+  tooLarge,
+} from './errors.js';
+import { resolveDeploymentIntakeLimits } from './limits.js';
+import {
+  BoundedMultipartReader,
+  type MultipartPartHeaders,
+} from './multipart.js';
+import type {
+  DeploymentIntake,
+  DeploymentIntakeOptions,
+  DeploymentIntakeRequest,
+  DeploymentIntakeResponse,
+  DeploymentSubmissionResponse,
+} from './types.js';
+
+const BOUNDARY_PATTERN = /^[A-Za-z0-9-]{1,70}$/;
+const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+const textDecoder = new TextDecoder('utf-8', { fatal: true });
+
+function requestHeader(
+  headers: Readonly<Record<string, string | undefined>>,
+  expectedName: string,
+): string | undefined {
+  const matches = Object.entries(headers)
+    .filter(([name, value]) => value !== undefined && name.toLowerCase() === expectedName)
+    .map(([, value]) => value!);
+  if (matches.length > 1) throw badRequest(`Duplicate ${expectedName} request header.`);
+  return matches[0];
+}
+
+function requireIdentityHeader(
+  headers: Readonly<Record<string, string | undefined>>,
+  name: string,
+): string {
+  const value = requestHeader(headers, name);
+  if (!value || !DIGEST_PATTERN.test(value)) {
+    throw badRequest(`The ${name} request header is invalid.`);
+  }
+  return value;
+}
+
+function bearerToken(headers: Readonly<Record<string, string | undefined>>): string {
+  const authorization = requestHeader(headers, 'authorization');
+  const token = authorization?.startsWith('Bearer ') ? authorization.slice(7) : '';
+  if (token.length < 1 || token.length > 4096 || token.trim() !== token
+    || [...token].some(character => {
+      const code = character.charCodeAt(0);
+      return code < 0x21 || code > 0x7e;
+    })) {
+    throw new DeploymentIntakeError(
+      'HQ_INTAKE_UNAUTHENTICATED',
+      'A valid bearer credential is required.',
+    );
+  }
+  return token;
+}
+
+function contentLength(
+  headers: Readonly<Record<string, string | undefined>>,
+  maximum: number,
+): number {
+  const input = requestHeader(headers, 'content-length');
+  if (!input || !/^[1-9][0-9]*$/.test(input)) {
+    throw badRequest('An exact Content-Length request header is required.');
+  }
+  const value = Number(input);
+  if (!Number.isSafeInteger(value)) throw tooLarge('The deployment request is too large.');
+  if (value > maximum) throw tooLarge('The deployment request exceeds its byte limit.');
+  return value;
+}
+
+function multipartBoundary(headers: Readonly<Record<string, string | undefined>>): string {
+  const contentType = requestHeader(headers, 'content-type');
+  const match = contentType?.match(/^multipart\/form-data; boundary=([^; ]+)$/);
+  if (!match || !BOUNDARY_PATTERN.test(match[1]!)) {
+    throw badRequest('Content-Type must declare a valid multipart boundary.');
+  }
+  return match[1]!;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw badRequest('The deployment request was aborted.', signal.reason);
+}
+
+async function bufferedPart(
+  reader: BoundedMultipartReader,
+  maximum: number,
+): Promise<{ readonly bytes: Buffer; readonly final: boolean }> {
+  const chunks: Buffer[] = [];
+  const result = await reader.readPartBody(maximum, chunk => {
+    chunks.push(Buffer.from(chunk));
+  });
+  return Object.freeze({ bytes: Buffer.concat(chunks, result.byteLength), final: result.final });
+}
+
+function requirePart(
+  headers: MultipartPartHeaders,
+  expected: {
+    readonly name: 'release' | 'bundle';
+    readonly filename: string;
+    readonly contentType: 'application/json' | 'application/octet-stream';
+    readonly bundlePath?: string;
+  },
+): void {
+  if (headers.name !== expected.name
+    || headers.filename !== expected.filename
+    || headers.contentType !== expected.contentType
+    || headers.bundlePath !== expected.bundlePath) {
+    throw badRequest('Multipart parts do not match the deployment submission contract.');
+  }
+}
+
+function decodeJson(bytes: Uint8Array, description: string): unknown {
+  try {
+    return JSON.parse(textDecoder.decode(bytes));
+  } catch (error) {
+    throw badRequest(`${description} is not valid UTF-8 JSON.`, error);
+  }
+}
+
+function requireReconstructablePaths(manifest: PreparedProtocolDeploymentBundleManifest): void {
+  const files = [
+    manifest.manifest.deployment.path,
+    ...manifest.manifest.artifacts.map(artifact => artifact.path),
+  ];
+  const fileSet = new Set(files);
+  if (fileSet.has(DEPLOYMENT_BUNDLE_MANIFEST)) {
+    throw badRequest('The bundle manifest path is reserved.');
+  }
+  for (const file of files) {
+    const segments = file.split('/');
+    for (let index = 1; index < segments.length; index += 1) {
+      if (fileSet.has(segments.slice(0, index).join('/'))) {
+        throw badRequest('A bundle file path cannot also be a parent directory.');
+      }
+    }
+  }
+}
+
+async function readRelease(
+  reader: BoundedMultipartReader,
+  maximum: number,
+): Promise<PreparedProtocolDeploymentReleaseEnvelope> {
+  requirePart(await reader.readPartHeaders(), {
+    name: 'release',
+    filename: 'release.json',
+    contentType: 'application/json',
+  });
+  const part = await bufferedPart(reader, maximum);
+  if (part.final) throw badRequest('The deployment submission is missing its bundle.');
+  let prepared: PreparedProtocolDeploymentReleaseEnvelope;
+  try {
+    prepared = prepareProtocolDeploymentReleaseEnvelope(
+      decodeJson(part.bytes, 'The deployment release'),
+    );
+  } catch (error) {
+    if (error instanceof DeploymentIntakeError) throw error;
+    throw badRequest('The deployment release is invalid.', error);
+  }
+  if (!part.bytes.equals(Buffer.from(prepared.bytes))) {
+    throw badRequest('The deployment release must use canonical JSON without trailing bytes.');
+  }
+  return prepared;
+}
+
+async function readManifest(
+  reader: BoundedMultipartReader,
+  maximum: number,
+): Promise<{
+  readonly prepared: PreparedProtocolDeploymentBundleManifest;
+  readonly bytes: Buffer;
+}> {
+  requirePart(await reader.readPartHeaders(), {
+    name: 'bundle',
+    filename: DEPLOYMENT_BUNDLE_MANIFEST,
+    contentType: 'application/json',
+    bundlePath: DEPLOYMENT_BUNDLE_MANIFEST,
+  });
+  const part = await bufferedPart(reader, maximum);
+  if (part.final) throw badRequest('The deployment submission is missing bundle files.');
+  let prepared: PreparedProtocolDeploymentBundleManifest;
+  try {
+    prepared = prepareProtocolDeploymentBundleManifest(
+      decodeJson(part.bytes, 'The deployment bundle manifest'),
+    );
+  } catch (error) {
+    if (error instanceof DeploymentIntakeError) throw error;
+    throw badRequest('The deployment bundle manifest is invalid.', error);
+  }
+  const canonical = Buffer.from(`${prepared.canonical}\n`);
+  if (!part.bytes.equals(canonical)) {
+    throw badRequest(
+      'The deployment bundle manifest must use canonical JSON followed by one newline.',
+    );
+  }
+  requireReconstructablePaths(prepared);
+  return Object.freeze({ prepared, bytes: canonical });
+}
+
+async function writeChunk(handle: Awaited<ReturnType<typeof open>>, chunk: Uint8Array): Promise<void> {
+  let offset = 0;
+  while (offset < chunk.byteLength) {
+    const result = await handle.write(chunk, offset, chunk.byteLength - offset);
+    if (result.bytesWritten < 1) throw new Error('Could not write deployment bundle bytes.');
+    offset += result.bytesWritten;
+  }
+}
+
+async function receiveBundleFile(
+  reader: BoundedMultipartReader,
+  root: string,
+  file: ProtocolDeploymentBundleFile,
+  contentType: 'application/json' | 'application/octet-stream',
+  expectFinal: boolean,
+): Promise<void> {
+  requirePart(await reader.readPartHeaders(), {
+    name: 'bundle',
+    filename: path.basename(file.path),
+    contentType,
+    bundlePath: file.path,
+  });
+  const absolutePath = path.join(root, ...file.path.split('/'));
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  const handle = await open(absolutePath, 'wx');
+  const digest = createHash('sha256');
+  let result: { readonly final: boolean; readonly byteLength: number };
+  try {
+    result = await reader.readPartBody(file.byteLength, async chunk => {
+      digest.update(chunk);
+      await writeChunk(handle, chunk);
+    });
+  } finally {
+    await handle.close();
+  }
+  if (result.byteLength !== file.byteLength || digest.digest('hex') !== file.sha256) {
+    throw badRequest(`Uploaded bundle bytes do not match the manifest: ${file.path}`);
+  }
+  if (result.final !== expectFinal) {
+    throw badRequest(expectFinal
+      ? 'The deployment submission contains undeclared bundle parts.'
+      : 'The deployment submission is missing declared bundle parts.');
+  }
+}
+
+function jsonResponse(
+  status: number,
+  body: unknown,
+  additionalHeaders: Readonly<Record<string, string>> = {},
+): DeploymentIntakeResponse {
+  const encoded = `${JSON.stringify(body)}\n`;
+  return Object.freeze({
+    status,
+    headers: Object.freeze({
+      'content-type': 'application/json; charset=utf-8',
+      'content-length': String(Buffer.byteLength(encoded)),
+      'cache-control': 'no-store',
+      ...additionalHeaders,
+    }),
+    body: encoded,
+  });
+}
+
+function errorResponse(error: unknown): DeploymentIntakeResponse {
+  const intakeError = error instanceof DeploymentIntakeError
+    ? error
+    : new DeploymentIntakeError(
+      'HQ_INTAKE_INTERNAL',
+      'The deployment submission could not be processed.',
+      { expose: false, cause: error },
+    );
+  const unsafeMessage = intakeError.expose
+    ? intakeError.message
+    : 'The deployment submission could not be processed.';
+  const message = [...unsafeMessage].map(character => {
+    const code = character.codePointAt(0) ?? 0;
+    return code < 0x20 || code === 0x7f ? ' ' : character;
+  }).join('').slice(0, 1024).trim() || 'The deployment submission was rejected.';
+  return jsonResponse(intakeError.status, {
+    error: { code: intakeError.code, message },
+  }, intakeError.status === 401 ? { 'www-authenticate': 'Bearer' } : {});
+}
+
+async function removeTemporaryDirectory(directory: string, suppressError = false): Promise<void> {
+  try {
+    await rm(directory, { force: true, recursive: true });
+  } catch (cleanupError) {
+    if (!suppressError) {
+      throw new DeploymentIntakeError(
+        'HQ_INTAKE_INTERNAL',
+        'The deployment submission could not be cleaned up.',
+        { expose: false, cause: cleanupError },
+      );
+    }
+  }
+}
+
+export function createDeploymentIntake<Principal>(
+  options: DeploymentIntakeOptions<Principal>,
+): DeploymentIntake {
+  const limits = resolveDeploymentIntakeLimits(options.limits);
+
+  async function process(request: DeploymentIntakeRequest): Promise<DeploymentIntakeResponse> {
+    throwIfAborted(request.signal);
+    const token = bearerToken(request.headers);
+    const principal = await options.authenticator.authenticate({ token, signal: request.signal });
+    if (principal === null) {
+      throw new DeploymentIntakeError(
+        'HQ_INTAKE_UNAUTHENTICATED',
+        'The bearer credential was not accepted.',
+      );
+    }
+    throwIfAborted(request.signal);
+
+    const releaseHeader = requireIdentityHeader(request.headers, 'x-hypequery-release-identity');
+    const bundleHeader = requireIdentityHeader(request.headers, 'x-hypequery-bundle-identity');
+    const idempotencyKey = requireIdentityHeader(request.headers, 'idempotency-key');
+    const declaredLength = contentLength(request.headers, limits.maxRequestBytes);
+    const boundary = multipartBoundary(request.headers);
+    const reader = new BoundedMultipartReader(
+      request.body,
+      boundary,
+      declaredLength,
+      limits.maxRequestBytes,
+      limits.maxPartHeaderBytes,
+      request.signal,
+    );
+    await reader.start();
+    const release = await readRelease(reader, limits.maxReleaseBytes);
+    if (release.identity !== releaseHeader || release.identity !== idempotencyKey
+      || release.release.bundleIdentity !== bundleHeader) {
+      throw badRequest('Deployment release identities do not match the uploaded release.');
+    }
+    const authorized = await options.authorizer.authorize({
+      principal,
+      target: release.release.target,
+      releaseIdentity: release.identity,
+      bundleIdentity: release.release.bundleIdentity,
+      signal: request.signal,
+    });
+    if (!authorized) {
+      throw new DeploymentIntakeError(
+        'HQ_INTAKE_FORBIDDEN',
+        'The caller is not authorized for the deployment target.',
+      );
+    }
+    throwIfAborted(request.signal);
+
+    const manifest = await readManifest(reader, limits.maxManifestBytes);
+    if (manifest.prepared.identity !== bundleHeader
+      || manifest.prepared.identity !== release.release.bundleIdentity) {
+      throw badRequest('Deployment bundle identities do not match the uploaded manifest.');
+    }
+
+    const temporaryRoot = await mkdtemp(path.join(options.temporaryDirectory ?? tmpdir(), 'hypequery-intake-'));
+    let cleaned = false;
+    try {
+      const bundleRoot = path.join(temporaryRoot, 'bundle');
+      await mkdir(bundleRoot);
+      await writeFile(path.join(bundleRoot, DEPLOYMENT_BUNDLE_MANIFEST), manifest.bytes, { flag: 'wx' });
+      const files = [
+        manifest.prepared.manifest.deployment,
+        ...manifest.prepared.manifest.artifacts,
+      ];
+      for (let index = 0; index < files.length; index += 1) {
+        await receiveBundleFile(
+          reader,
+          bundleRoot,
+          files[index]!,
+          index === 0 ? 'application/json' : 'application/octet-stream',
+          index === files.length - 1,
+        );
+      }
+      await reader.finish();
+      throwIfAborted(request.signal);
+
+      let bundle;
+      try {
+        bundle = await verifyDeploymentBundle(bundleRoot);
+      } catch (error) {
+        throw badRequest('The reconstructed deployment bundle is invalid.', error);
+      }
+      if (bundle.identity !== manifest.prepared.identity
+        || bundle.identity !== release.release.bundleIdentity) {
+        throw badRequest('The reconstructed deployment bundle identity is inconsistent.');
+      }
+      const status = await options.store.accept(Object.freeze({
+        principal,
+        release: release.release,
+        releaseCanonical: release.canonical,
+        releaseIdentity: release.identity,
+        bundle,
+      }));
+      if (status !== 'accepted' && status !== 'already-exists') {
+        throw new DeploymentIntakeError(
+          'HQ_INTAKE_INTERNAL',
+          'The deployment store returned an invalid status.',
+          { expose: false },
+        );
+      }
+      const response: DeploymentSubmissionResponse = Object.freeze({
+        kind: 'hypequery-deployment-submission',
+        version: 1,
+        status,
+        releaseIdentity: release.identity,
+        bundleIdentity: bundle.identity,
+      });
+      await removeTemporaryDirectory(temporaryRoot);
+      cleaned = true;
+      return jsonResponse(status === 'accepted' ? 202 : 200, response);
+    } finally {
+      if (!cleaned) await removeTemporaryDirectory(temporaryRoot, true);
+    }
+  }
+
+  return Object.freeze({
+    async handle(request: DeploymentIntakeRequest): Promise<DeploymentIntakeResponse> {
+      try {
+        return await process(request);
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  });
+}

--- a/packages/deployment/src/limits.ts
+++ b/packages/deployment/src/limits.ts
@@ -1,0 +1,34 @@
+import { DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS } from '@hypequery/protocol';
+
+export interface DeploymentIntakeLimits {
+  readonly maxRequestBytes: number;
+  readonly maxReleaseBytes: number;
+  readonly maxManifestBytes: number;
+  readonly maxPartHeaderBytes: number;
+}
+
+export const DEFAULT_DEPLOYMENT_INTAKE_LIMITS: Readonly<DeploymentIntakeLimits> = Object.freeze({
+  maxRequestBytes: DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxTotalBytes + (2 * 1024 * 1024),
+  maxReleaseBytes: 16 * 1024,
+  maxManifestBytes: 1024 * 1024,
+  maxPartHeaderBytes: 8 * 1024,
+});
+
+export function resolveDeploymentIntakeLimits(
+  input: Partial<DeploymentIntakeLimits> = {},
+): Readonly<DeploymentIntakeLimits> {
+  const result = { ...DEFAULT_DEPLOYMENT_INTAKE_LIMITS };
+  for (const key of Object.keys(result) as (keyof DeploymentIntakeLimits)[]) {
+    const value = input[key];
+    if (value === undefined) continue;
+    if (!Number.isSafeInteger(value) || value < 1
+      || value > DEFAULT_DEPLOYMENT_INTAKE_LIMITS[key]) {
+      throw new RangeError(
+        `${key} must be a positive safe integer no greater than `
+        + `${DEFAULT_DEPLOYMENT_INTAKE_LIMITS[key]} (the deployment intake v1 maximum)`,
+      );
+    }
+    result[key] = value;
+  }
+  return Object.freeze(result);
+}

--- a/packages/deployment/src/multipart.ts
+++ b/packages/deployment/src/multipart.ts
@@ -93,10 +93,11 @@ export class BoundedMultipartReader {
         if (index > maximum) throw tooLarge('Multipart part headers exceed their byte limit.');
         const bytes = this.#buffer.subarray(0, index);
         this.#buffer = this.#buffer.subarray(index + CRLF.length);
-        if (!HEADER_VALUE.test(bytes.toString('latin1'))) {
+        const value = bytes.toString('latin1');
+        if (!HEADER_VALUE.test(value)) {
           throw badRequest('Multipart headers must contain printable ASCII.');
         }
-        return bytes.toString('ascii');
+        return value;
       }
       if (this.#buffer.length > maximum) {
         throw tooLarge('Multipart part headers exceed their byte limit.');

--- a/packages/deployment/src/multipart.ts
+++ b/packages/deployment/src/multipart.ts
@@ -1,0 +1,208 @@
+import { badRequest, tooLarge } from './errors.js';
+
+const CRLF = Buffer.from('\r\n');
+const HEADER_NAME = /^[A-Za-z0-9-]+$/;
+const HEADER_VALUE = /^[\x20-\x7e]*$/;
+
+export interface MultipartPartHeaders {
+  readonly name: string;
+  readonly filename: string;
+  readonly contentType: string;
+  readonly bundlePath?: string;
+}
+
+export class BoundedMultipartReader {
+  readonly #iterator: AsyncIterator<Uint8Array>;
+  readonly #boundary: Buffer;
+  readonly #declaredLength: number;
+  readonly #maximumLength: number;
+  readonly #maximumHeaderBytes: number;
+  readonly #signal?: AbortSignal;
+  #buffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+  #received = 0;
+  #finished = false;
+  #started = false;
+
+  constructor(
+    body: AsyncIterable<Uint8Array>,
+    boundary: string,
+    declaredLength: number,
+    maximumLength: number,
+    maximumHeaderBytes: number,
+    signal?: AbortSignal,
+  ) {
+    this.#iterator = body[Symbol.asyncIterator]();
+    this.#boundary = Buffer.from(`--${boundary}`);
+    this.#declaredLength = declaredLength;
+    this.#maximumLength = maximumLength;
+    this.#maximumHeaderBytes = maximumHeaderBytes;
+    this.#signal = signal;
+  }
+
+  #throwIfAborted(): void {
+    if (this.#signal?.aborted) {
+      throw badRequest('The deployment request was aborted.', this.#signal.reason);
+    }
+  }
+
+  async #fill(): Promise<boolean> {
+    while (!this.#finished) {
+      this.#throwIfAborted();
+      let item: IteratorResult<Uint8Array>;
+      try {
+        item = await this.#iterator.next();
+      } catch (error) {
+        throw badRequest('The deployment request body could not be read.', error);
+      }
+      if (item.done) {
+        this.#finished = true;
+        return false;
+      }
+      if (!(item.value instanceof Uint8Array)) {
+        throw badRequest('The deployment request body yielded a non-byte chunk.');
+      }
+      if (item.value.byteLength === 0) continue;
+      this.#received += item.value.byteLength;
+      if (this.#received > this.#declaredLength) {
+        throw badRequest('The deployment request body exceeds its Content-Length.');
+      }
+      if (this.#received > this.#maximumLength) {
+        throw tooLarge('The deployment request exceeds its byte limit.');
+      }
+      const chunk = Buffer.from(item.value.buffer, item.value.byteOffset, item.value.byteLength);
+      this.#buffer = this.#buffer.length === 0 ? chunk : Buffer.concat([this.#buffer, chunk]);
+      return true;
+    }
+    return false;
+  }
+
+  async #readBytes(length: number): Promise<Buffer> {
+    while (this.#buffer.length < length && await this.#fill()) {
+      // Fill until the requested framing bytes are available.
+    }
+    if (this.#buffer.length < length) throw badRequest('The multipart request is truncated.');
+    const value = this.#buffer.subarray(0, length);
+    this.#buffer = this.#buffer.subarray(length);
+    return value;
+  }
+
+  async #readLine(maximum: number): Promise<string> {
+    for (;;) {
+      const index = this.#buffer.indexOf(CRLF);
+      if (index >= 0) {
+        if (index > maximum) throw tooLarge('Multipart part headers exceed their byte limit.');
+        const bytes = this.#buffer.subarray(0, index);
+        this.#buffer = this.#buffer.subarray(index + CRLF.length);
+        if (!HEADER_VALUE.test(bytes.toString('latin1'))) {
+          throw badRequest('Multipart headers must contain printable ASCII.');
+        }
+        return bytes.toString('ascii');
+      }
+      if (this.#buffer.length > maximum) {
+        throw tooLarge('Multipart part headers exceed their byte limit.');
+      }
+      if (!await this.#fill()) throw badRequest('The multipart request is truncated.');
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this.#started) throw new Error('Multipart reader has already started.');
+    this.#started = true;
+    const opening = await this.#readBytes(this.#boundary.length + CRLF.length);
+    if (!opening.equals(Buffer.concat([this.#boundary, CRLF]))) {
+      throw badRequest('The multipart body does not begin with its declared boundary.');
+    }
+  }
+
+  async readPartHeaders(): Promise<MultipartPartHeaders> {
+    if (!this.#started) throw new Error('Multipart reader has not started.');
+    const headers = new Map<string, string>();
+    let consumed = 0;
+    for (;;) {
+      const line = await this.#readLine(this.#maximumHeaderBytes - consumed);
+      consumed += Buffer.byteLength(line) + CRLF.length;
+      if (consumed > this.#maximumHeaderBytes) {
+        throw tooLarge('Multipart part headers exceed their byte limit.');
+      }
+      if (line === '') break;
+      if (/^[ \t]/.test(line)) throw badRequest('Folded multipart headers are not supported.');
+      const separator = line.indexOf(':');
+      if (separator < 1) throw badRequest('Multipart part header syntax is invalid.');
+      const name = line.slice(0, separator);
+      const value = line.slice(separator + 1).trim();
+      const normalized = name.toLowerCase();
+      if (!HEADER_NAME.test(name) || headers.has(normalized)) {
+        throw badRequest('Multipart part headers contain an invalid or duplicate field.');
+      }
+      headers.set(normalized, value);
+    }
+    const allowed = new Set([
+      'content-disposition',
+      'content-type',
+      'x-hypequery-bundle-path',
+    ]);
+    if ([...headers.keys()].some(name => !allowed.has(name))) {
+      throw badRequest('Multipart parts contain an unsupported header.');
+    }
+    const disposition = headers.get('content-disposition');
+    const match = disposition?.match(/^form-data; name="(release|bundle)"; filename="([^"\r\n]+)"$/);
+    const contentType = headers.get('content-type');
+    if (!match || !contentType) throw badRequest('Multipart part headers are incomplete.');
+    return Object.freeze({
+      name: match[1]!,
+      filename: match[2]!,
+      contentType,
+      ...(headers.has('x-hypequery-bundle-path')
+        ? { bundlePath: headers.get('x-hypequery-bundle-path')! }
+        : {}),
+    });
+  }
+
+  /** Returns true when this was the final part. */
+  async readPartBody(
+    maximum: number,
+    consume: (chunk: Uint8Array) => void | Promise<void>,
+  ): Promise<{ readonly final: boolean; readonly byteLength: number }> {
+    const marker = Buffer.concat([CRLF, this.#boundary]);
+    const retained = marker.length - 1;
+    let byteLength = 0;
+    const emit = async (chunk: Buffer): Promise<void> => {
+      if (chunk.length === 0) return;
+      this.#throwIfAborted();
+      byteLength += chunk.length;
+      if (byteLength > maximum) throw tooLarge('A multipart part exceeds its byte limit.');
+      await consume(chunk);
+    };
+    for (;;) {
+      const index = this.#buffer.indexOf(marker);
+      if (index >= 0) {
+        await emit(this.#buffer.subarray(0, index));
+        this.#buffer = this.#buffer.subarray(index + marker.length);
+        break;
+      }
+      if (this.#buffer.length > retained) {
+        const flushLength = this.#buffer.length - retained;
+        await emit(this.#buffer.subarray(0, flushLength));
+        this.#buffer = this.#buffer.subarray(flushLength);
+      }
+      if (!await this.#fill()) throw badRequest('The multipart request is truncated.');
+    }
+    const suffix = await this.#readBytes(2);
+    if (suffix.equals(CRLF)) return Object.freeze({ final: false, byteLength });
+    if (!suffix.equals(Buffer.from('--'))) throw badRequest('The multipart boundary is invalid.');
+    if (!(await this.#readBytes(2)).equals(CRLF)) {
+      throw badRequest('The final multipart boundary is invalid.');
+    }
+    return Object.freeze({ final: true, byteLength });
+  }
+
+  async finish(): Promise<void> {
+    if (this.#buffer.length > 0) throw badRequest('The multipart request has trailing bytes.');
+    while (await this.#fill()) {
+      if (this.#buffer.length > 0) throw badRequest('The multipart request has trailing bytes.');
+    }
+    if (this.#received !== this.#declaredLength) {
+      throw badRequest('The deployment request body does not match its Content-Length.');
+    }
+  }
+}

--- a/packages/deployment/src/types.ts
+++ b/packages/deployment/src/types.ts
@@ -1,0 +1,79 @@
+import type {
+  ProtocolDeploymentReleaseEnvelope,
+  ProtocolDeploymentReleaseTarget,
+} from '@hypequery/protocol';
+import type { VerifiedDeploymentBundle } from './bundle.js';
+import type { DeploymentIntakeLimits } from './limits.js';
+
+export interface DeploymentSubmissionResponse {
+  readonly kind: 'hypequery-deployment-submission';
+  readonly version: 1;
+  readonly status: 'accepted' | 'already-exists';
+  readonly releaseIdentity: string;
+  readonly bundleIdentity: string;
+}
+
+export interface DeploymentIntakeRequest {
+  readonly headers: Readonly<Record<string, string | undefined>>;
+  readonly body: AsyncIterable<Uint8Array>;
+  readonly signal?: AbortSignal;
+}
+
+export interface DeploymentIntakeResponse {
+  readonly status: number;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: string;
+}
+
+export interface DeploymentAuthenticationInput {
+  readonly token: string;
+  readonly signal?: AbortSignal;
+}
+
+export interface DeploymentAuthenticator<Principal> {
+  authenticate(input: DeploymentAuthenticationInput): Promise<Principal | null>;
+}
+
+export interface DeploymentAuthorizationInput<Principal> {
+  readonly principal: Principal;
+  readonly target: ProtocolDeploymentReleaseTarget;
+  readonly releaseIdentity: string;
+  /** Declared by the canonical release; the bundle bytes are verified after authorization. */
+  readonly bundleIdentity: string;
+  readonly signal?: AbortSignal;
+}
+
+export interface DeploymentAuthorizer<Principal> {
+  authorize(input: DeploymentAuthorizationInput<Principal>): Promise<boolean>;
+}
+
+/**
+ * A completely revalidated submission. The bundle directory is temporary and
+ * exists only for the duration of `DeploymentSubmissionStore.accept`.
+ */
+export interface VerifiedDeploymentSubmission<Principal> {
+  readonly principal: Principal;
+  readonly release: ProtocolDeploymentReleaseEnvelope;
+  readonly releaseCanonical: string;
+  readonly releaseIdentity: string;
+  readonly bundle: VerifiedDeploymentBundle;
+}
+
+export interface DeploymentSubmissionStore<Principal> {
+  /** Persist all required bytes before this promise resolves. */
+  accept(
+    submission: VerifiedDeploymentSubmission<Principal>,
+  ): Promise<'accepted' | 'already-exists'>;
+}
+
+export interface DeploymentIntakeOptions<Principal> {
+  readonly authenticator: DeploymentAuthenticator<Principal>;
+  readonly authorizer: DeploymentAuthorizer<Principal>;
+  readonly store: DeploymentSubmissionStore<Principal>;
+  readonly limits?: Partial<DeploymentIntakeLimits>;
+  readonly temporaryDirectory?: string;
+}
+
+export interface DeploymentIntake {
+  handle(request: DeploymentIntakeRequest): Promise<DeploymentIntakeResponse>;
+}

--- a/packages/deployment/tsconfig.json
+++ b/packages/deployment/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "composite": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"],
+  "references": [
+    { "path": "../protocol" }
+  ]
+}

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -80,12 +80,13 @@ with the deployment-v1 domain-separated SHA-256 digest.
 The proposed deployment-bundle surface validates the portable manifest that
 binds a deployment identity to exact deployment and runtime artifact files. It
 provides canonical encoding and a separate bundle-v1 identity. Filesystem-safe
-writing and byte verification remain in the CLI because this package performs
-no I/O.
+writing remains in the CLI, while reusable filesystem verification and
+receiving-side intake live in `@hypequery/deployment`; this package performs no
+I/O.
 
 The proposed deployment-release surface binds one verified bundle identity to
-an explicit project and environment. Its deterministic identity can serve as an
-idempotency key for a future authenticated upload API without putting
+an explicit project and environment. Its deterministic identity serves as the
+idempotency key for authenticated deployment submission without putting
 credentials, timestamps, release state, or provider behavior into the envelope.
 
 ## Runtime compatibility

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@clickhouse/client':
         specifier: ^1.18.3
         version: 1.18.3
+      '@hypequery/deployment':
+        specifier: workspace:*
+        version: link:../deployment
       '@hypequery/protocol':
         specifier: workspace:*
         version: link:../protocol
@@ -174,6 +177,22 @@ importers:
       vitest:
         specifier: ^3.2.6
         version: 3.2.6(@edge-runtime/vm@3.2.0)(@types/node@18.19.130)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/deployment:
+    dependencies:
+      '@hypequery/protocol':
+        specifier: workspace:*
+        version: link:../protocol
+    devDependencies:
+      '@types/node':
+        specifier: ^22.5.0
+        version: 22.20.1
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@edge-runtime/vm@3.2.0)(@types/node@22.20.1)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/gateway:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - 'packages/clickhouse'
   - 'packages/react'
   - 'packages/datasets'
+  - 'packages/deployment'
   - 'packages/gateway'
   - 'packages/serve'
   - 'packages/studio'

--- a/specs/deployment/0001-authenticated-deployment-submission.md
+++ b/specs/deployment/0001-authenticated-deployment-submission.md
@@ -82,6 +82,25 @@ MUST match the request after server-side recomputation. Unknown response fields,
 invalid UTF-8 or JSON, responses larger than 64 KiB, and identity mismatches fail
 closed on the client.
 
+A newly persisted submission returns HTTP `202`. An authorized, fully verified
+idempotent replay returns HTTP `200`. Neither response activates or executes the
+release.
+
+## Reference receiver
+
+`@hypequery/deployment` provides the framework-neutral TypeScript reference
+receiver. Its request adapter accepts a header record and streaming byte body;
+its response adapter returns an HTTP status, headers, and bounded JSON body.
+Authentication, target authorization, and atomic persistence are deliberately
+pluggable provider responsibilities.
+
+The reference receiver authenticates before consuming body bytes, authorizes
+after validating the canonical release, streams only manifest-declared bundle
+paths into a unique temporary directory, then invokes the same complete bundle
+filesystem verifier used by the CLI. The persistence callback must copy every
+required byte before it resolves because the temporary directory is removed on
+both success and failure.
+
 ## Rejection and client errors
 
 Non-success HTTP statuses reject the submission. A service may return a bounded


### PR DESCRIPTION
## Summary

- add `@hypequery/deployment`, a provider-neutral package for deployment bundle verification and receiving-side intake
- authenticate before consuming request bytes and authorize the validated release target before receiving bundle files
- stream a bounded multipart submission into temporary storage, reconstruct only manifest-declared files, and revalidate release, bundle, file, identity, and runtime references
- hand fully verified submissions to a pluggable idempotent store and return stable accepted or already-exists responses
- share the filesystem bundle verifier with the CLI and add an end-to-end CLI-to-intake compatibility test

## Why

PR #312 adds the authenticated deployment upload client. A receiving service needs the matching fail-closed acceptance boundary without depending on the CLI or adding filesystem, authentication, and persistence concerns to `@hypequery/protocol`.

This PR intentionally stops at verified persistence. It does not activate, execute, or promote a release.

## Impact

Framework and provider integrations supply authentication, target authorization, and persistence adapters. The persistence callback receives a fully verified temporary bundle and must copy required bytes before returning.

This is stacked on PR #312 and should be reviewed or merged after it.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm types`
