### PR TITLE
Add durable deployment filesystem store

### DIFF
--- a/.changeset/durable-deployment-store.md
+++ b/.changeset/durable-deployment-store.md
@@ -1,0 +1,6 @@
+---
+'@hypequery/deployment': minor
+---
+
+Add a content-addressed filesystem submission store with atomic publication,
+safe idempotent replay, stored-state verification, and partial-write recovery.

--- a/packages/deployment/README.md
+++ b/packages/deployment/README.md
@@ -65,4 +65,49 @@ filesystem. It rejects symbolic links and undeclared entries, enforces byte
 limits, recomputes every hash and identity, and returns an immutable verified
 snapshot.
 
+## Filesystem store
+
+`createFileSystemDeploymentSubmissionStore` is the reference durable store for
+a single host. It copies verified bundle bytes out of temporary intake storage,
+revalidates the copy, and atomically publishes the release only after its bundle
+is durable. Replaying the same release returns `already-exists` after the stored
+state has been fully revalidated.
+
+```ts
+import {
+  createDeploymentIntake,
+  createFileSystemDeploymentSubmissionStore,
+} from '@hypequery/deployment';
+
+const store = createFileSystemDeploymentSubmissionStore({
+  directory: '/var/lib/hypequery/deployments',
+});
+
+const intake = createDeploymentIntake({
+  authenticator,
+  authorizer,
+  store,
+});
+```
+
+The closed layout is content-addressed:
+
+```text
+<directory>/
+  bundles/<bundle identity>/...
+  releases/<release identity>/release.json
+```
+
+Bundle directories are published before release directories. A crash can leave
+an unreferenced bundle that a later submission safely reuses, but cannot expose
+a release whose bundle is incomplete. Files and directories are opened without
+following symbolic links where Node exposes that facility, file contents and
+directory entries are revalidated on reads and replays, and temporary staging
+directories are removed after success or failure.
+
+The configured directory is an operator-controlled local trust boundary. This
+store does not provide remote replication, activation, lifecycle state, or
+protection from an administrator modifying its files. `read(releaseIdentity)`
+returns only a completely revalidated stored submission.
+
 The package is ESM-only and requires Node.js 20 or newer.

--- a/packages/deployment/src/filesystem-store.test.ts
+++ b/packages/deployment/src/filesystem-store.test.ts
@@ -1,11 +1,14 @@
 import { createHash } from 'node:crypto';
 import {
+  appendFile,
   mkdir,
   mkdtemp,
+  open,
   readFile,
   readdir,
   rm,
   symlink,
+  type FileHandle,
   writeFile,
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -15,7 +18,7 @@ import {
   prepareProtocolDeploymentContract,
   prepareProtocolDeploymentReleaseEnvelope,
 } from '@hypequery/protocol';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { verifyDeploymentBundle } from './bundle.js';
 import {
   createFileSystemDeploymentSubmissionStore,
@@ -158,6 +161,29 @@ describe('filesystem deployment submission store', () => {
     await expect(store.read('0'.repeat(64))).resolves.toBeUndefined();
   });
 
+  it.skipIf(process.platform === 'win32')(
+    'initializes and syncs the store layout only once',
+    async () => {
+      const root = await temporaryDirectory('hypequery-store-');
+      const probe = await open(root, 'r');
+      const prototype = Object.getPrototypeOf(probe) as FileHandle;
+      await probe.close();
+      const sync = vi.spyOn(prototype, 'sync');
+      const store = createFileSystemDeploymentSubmissionStore({ directory: root });
+
+      try {
+        await store.read('0'.repeat(64));
+        const initializationSyncs = sync.mock.calls.length;
+        expect(initializationSyncs).toBeGreaterThan(0);
+
+        await store.read('1'.repeat(64));
+        expect(sync).toHaveBeenCalledTimes(initializationSyncs);
+      } finally {
+        sync.mockRestore();
+      }
+    },
+  );
+
   it('rejects inconsistent submission metadata before writing store state', async () => {
     const fixture = await submissionFixture();
     const root = await temporaryDirectory('hypequery-store-');
@@ -254,6 +280,37 @@ describe('filesystem deployment submission store', () => {
       store.accept(fixture.submission),
       'HQ_DEPLOYMENT_STORE_CORRUPT_STATE',
     );
+  });
+
+  it('enforces the release byte ceiling if the file grows after stat', async () => {
+    const fixture = await submissionFixture();
+    const root = await temporaryDirectory('hypequery-store-');
+    const store = createFileSystemDeploymentSubmissionStore<string>({ directory: root });
+    await store.accept(fixture.submission);
+    const releasePath = path.join(
+      root,
+      'releases',
+      fixture.submission.releaseIdentity,
+      'release.json',
+    );
+    const probe = await open(releasePath, 'r');
+    const prototype = Object.getPrototypeOf(probe) as FileHandle;
+    const originalRead = prototype.read;
+    await probe.close();
+    const read = vi.spyOn(prototype, 'read').mockImplementationOnce(async function (...args) {
+      await appendFile(releasePath, Buffer.alloc(16 * 1024));
+      return originalRead.apply(this, args);
+    });
+
+    try {
+      await expectStoreCode(
+        store.read(fixture.submission.releaseIdentity),
+        'HQ_DEPLOYMENT_STORE_CORRUPT_STATE',
+      );
+      expect(read).toHaveBeenCalled();
+    } finally {
+      read.mockRestore();
+    }
   });
 
   it('recovers a missing release record from an already-published bundle', async () => {

--- a/packages/deployment/src/filesystem-store.test.ts
+++ b/packages/deployment/src/filesystem-store.test.ts
@@ -1,0 +1,308 @@
+import { createHash } from 'node:crypto';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  prepareProtocolDeploymentBundleManifest,
+  prepareProtocolDeploymentContract,
+  prepareProtocolDeploymentReleaseEnvelope,
+} from '@hypequery/protocol';
+import { afterEach, describe, expect, it } from 'vitest';
+import { verifyDeploymentBundle } from './bundle.js';
+import {
+  createFileSystemDeploymentSubmissionStore,
+  FileSystemDeploymentStoreError,
+} from './filesystem-store.js';
+import type { VerifiedDeploymentSubmission } from './types.js';
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(prefix: string): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(directory => (
+    rm(directory, { force: true, recursive: true })
+  )));
+});
+
+function sha256(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+async function submissionFixture(): Promise<{
+  readonly source: string;
+  readonly deploymentPath: string;
+  readonly submission: VerifiedDeploymentSubmission<string>;
+}> {
+  const source = await temporaryDirectory('hypequery-store-source-');
+  const deploymentPath = 'contract/deployment.json';
+  const deployment = prepareProtocolDeploymentContract({
+    kind: 'hypequery-deployment',
+    version: 1,
+    datasets: [],
+    queries: [],
+    artifacts: [],
+  });
+  const deploymentBytes = Buffer.from(`${deployment.canonical}\n`);
+  const manifest = prepareProtocolDeploymentBundleManifest({
+    kind: 'hypequery-deployment-bundle',
+    version: 1,
+    deployment: {
+      path: deploymentPath,
+      identity: deployment.identity,
+      sha256: sha256(deploymentBytes),
+      byteLength: deploymentBytes.byteLength,
+    },
+    artifacts: [],
+  });
+  await mkdir(path.join(source, 'contract'), { recursive: true });
+  await writeFile(path.join(source, 'bundle.json'), `${manifest.canonical}\n`);
+  await writeFile(path.join(source, deploymentPath), deploymentBytes);
+  const bundle = await verifyDeploymentBundle(source);
+  const release = prepareProtocolDeploymentReleaseEnvelope({
+    kind: 'hypequery-deployment-release',
+    version: 1,
+    bundleIdentity: bundle.identity,
+    target: { project: 'analytics', environment: 'production' },
+  });
+  return {
+    source,
+    deploymentPath,
+    submission: {
+      principal: 'principal',
+      release: release.release,
+      releaseCanonical: release.canonical,
+      releaseIdentity: release.identity,
+      bundle,
+    },
+  };
+}
+
+function expectStoreCode(
+  promise: Promise<unknown>,
+  code: FileSystemDeploymentStoreError['code'],
+): Promise<void> {
+  return expect(promise).rejects.toMatchObject({
+    name: 'FileSystemDeploymentStoreError',
+    code,
+  });
+}
+
+describe('filesystem deployment submission store', () => {
+  it('atomically persists a submission independently of its temporary source', async () => {
+    const fixture = await submissionFixture();
+    const root = await temporaryDirectory('hypequery-store-');
+    const store = createFileSystemDeploymentSubmissionStore<string>({ directory: root });
+
+    await expect(store.accept(fixture.submission)).resolves.toBe('accepted');
+    await rm(fixture.source, { force: true, recursive: true });
+
+    const stored = await store.read(fixture.submission.releaseIdentity);
+    expect(stored?.release).toEqual(fixture.submission.release);
+    expect(stored?.bundle.identity).toBe(fixture.submission.bundle.identity);
+    expect(await readFile(path.join(
+      stored!.bundle.directory,
+      ...fixture.deploymentPath.split('/'),
+    ), 'utf8')).toBe(`${prepareProtocolDeploymentContract(stored!.bundle.contract).canonical}\n`);
+    expect(await readdir(root)).toEqual(['bundles', 'releases']);
+    expect(await readdir(path.join(root, 'releases', fixture.submission.releaseIdentity)))
+      .toEqual(['release.json']);
+    expect(await readFile(path.join(
+      root,
+      'releases',
+      fixture.submission.releaseIdentity,
+      'release.json',
+    ), 'utf8')).toBe(fixture.submission.releaseCanonical);
+  });
+
+  it('returns already-exists without rereading an already-stored source bundle', async () => {
+    const fixture = await submissionFixture();
+    const root = await temporaryDirectory('hypequery-store-');
+    const store = createFileSystemDeploymentSubmissionStore<string>({ directory: root });
+    await store.accept(fixture.submission);
+    await rm(fixture.source, { force: true, recursive: true });
+
+    await expect(store.accept(fixture.submission)).resolves.toBe('already-exists');
+  });
+
+  it('serializes concurrent idempotent submissions through atomic publication', async () => {
+    const fixture = await submissionFixture();
+    const root = await temporaryDirectory('hypequery-store-');
+    const store = createFileSystemDeploymentSubmissionStore<string>({ directory: root });
+
+    const statuses = await Promise.all([
+      store.accept(fixture.submission),
+      store.accept(fixture.submission),
+    ]);
+
+    expect(statuses.sort()).toEqual(['accepted', 'already-exists']);
+    await expect(store.read(fixture.submission.releaseIdentity)).resolves.toBeDefined();
+  });
+
+  it('returns undefined for a well-formed identity that is not stored', async () => {
+    const root = await temporaryDirectory('hypequery-store-');
+    const store = createFileSystemDeploymentSubmissionStore({ directory: root });
+
+    await expect(store.read('0'.repeat(64))).resolves.toBeUndefined();
+  });
+
+  it('rejects inconsistent submission metadata before writing store state', async () => {
+    const fixture = await submissionFixture();
+    const root = await temporaryDirectory('hypequery-store-');
+    const store = createFileSystemDeploymentSubmissionStore<string>({ directory: root });
+    const submission = {
+      ...fixture.submission,
+      releaseIdentity: '0'.repeat(64),
+    };
+
+    await expectStoreCode(
+      store.accept(submission),
+      'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+    );
+    expect(await readdir(root)).toEqual([]);
+  });
+
+  it('rejects and cleans staging when a verified source changes before persistence', async () => {
+    const fixture = await submissionFixture();
+    const root = await temporaryDirectory('hypequery-store-');
+    const store = createFileSystemDeploymentSubmissionStore<string>({ directory: root });
+    const deploymentFile = path.join(fixture.source, fixture.deploymentPath);
+    const bytes = await readFile(deploymentFile);
+    bytes[0] = bytes[0]! ^ 1;
+    await writeFile(deploymentFile, bytes);
+
+    await expectStoreCode(
+      store.accept(fixture.submission),
+      'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+    );
+    expect((await readdir(root)).filter(name => name.includes('staging'))).toEqual([]);
+    await expect(store.read(fixture.submission.releaseIdentity)).resolves.toBeUndefined();
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'does not follow a source entry replaced with a symbolic link',
+    async () => {
+      const fixture = await submissionFixture();
+      const root = await temporaryDirectory('hypequery-store-');
+      const store = createFileSystemDeploymentSubmissionStore<string>({ directory: root });
+      const deploymentFile = path.join(fixture.source, fixture.deploymentPath);
+      const external = path.join(await temporaryDirectory('hypequery-store-external-'), 'data');
+      await writeFile(external, await readFile(deploymentFile));
+      await rm(deploymentFile);
+      await symlink(external, deploymentFile);
+
+      await expectStoreCode(
+        store.accept(fixture.submission),
+        'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+      );
+      expect((await readdir(root)).filter(name => name.includes('staging'))).toEqual([]);
+    },
+  );
+
+  it('detects corrupt stored bundle bytes on reads and replays', async () => {
+    const fixture = await submissionFixture();
+    const root = await temporaryDirectory('hypequery-store-');
+    const store = createFileSystemDeploymentSubmissionStore<string>({ directory: root });
+    await store.accept(fixture.submission);
+    const storedDeployment = path.join(
+      root,
+      'bundles',
+      fixture.submission.bundle.identity,
+      ...fixture.deploymentPath.split('/'),
+    );
+    await writeFile(storedDeployment, 'corrupt');
+
+    await expectStoreCode(
+      store.read(fixture.submission.releaseIdentity),
+      'HQ_DEPLOYMENT_STORE_CORRUPT_STATE',
+    );
+    await expectStoreCode(
+      store.accept(fixture.submission),
+      'HQ_DEPLOYMENT_STORE_CORRUPT_STATE',
+    );
+  });
+
+  it('detects undeclared state in an existing release directory', async () => {
+    const fixture = await submissionFixture();
+    const root = await temporaryDirectory('hypequery-store-');
+    const store = createFileSystemDeploymentSubmissionStore<string>({ directory: root });
+    await store.accept(fixture.submission);
+    await writeFile(path.join(
+      root,
+      'releases',
+      fixture.submission.releaseIdentity,
+      'unexpected',
+    ), 'data');
+
+    await expectStoreCode(
+      store.read(fixture.submission.releaseIdentity),
+      'HQ_DEPLOYMENT_STORE_CORRUPT_STATE',
+    );
+    await expectStoreCode(
+      store.accept(fixture.submission),
+      'HQ_DEPLOYMENT_STORE_CORRUPT_STATE',
+    );
+  });
+
+  it('recovers a missing release record from an already-published bundle', async () => {
+    const fixture = await submissionFixture();
+    const root = await temporaryDirectory('hypequery-store-');
+    const store = createFileSystemDeploymentSubmissionStore<string>({ directory: root });
+    await store.accept(fixture.submission);
+    await rm(path.join(root, 'releases', fixture.submission.releaseIdentity), {
+      recursive: true,
+    });
+    await rm(fixture.source, { recursive: true });
+
+    await expect(store.accept(fixture.submission)).resolves.toBe('accepted');
+    await expect(store.read(fixture.submission.releaseIdentity)).resolves.toBeDefined();
+  });
+
+  it('rejects conflicting reserved store entries as corrupt state', async () => {
+    const fixture = await submissionFixture();
+    const root = await temporaryDirectory('hypequery-store-');
+    await writeFile(path.join(root, 'bundles'), 'not a directory');
+    const store = createFileSystemDeploymentSubmissionStore<string>({ directory: root });
+
+    await expectStoreCode(
+      store.accept(fixture.submission),
+      'HQ_DEPLOYMENT_STORE_CORRUPT_STATE',
+    );
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects a store root that is a symbolic link',
+    async () => {
+      const parent = await temporaryDirectory('hypequery-store-parent-');
+      const target = await temporaryDirectory('hypequery-store-target-');
+      const linkedRoot = path.join(parent, 'store');
+      await symlink(target, linkedRoot, 'dir');
+      const store = createFileSystemDeploymentSubmissionStore({ directory: linkedRoot });
+
+      await expectStoreCode(
+        store.read('0'.repeat(64)),
+        'HQ_DEPLOYMENT_STORE_CORRUPT_STATE',
+      );
+    },
+  );
+
+  it('rejects filesystem-root configuration', () => {
+    expect(() => createFileSystemDeploymentSubmissionStore({
+      directory: path.parse(path.resolve('.')).root,
+    })).toThrow(expect.objectContaining({
+      code: 'HQ_DEPLOYMENT_STORE_CONFIGURATION',
+    }));
+  });
+});

--- a/packages/deployment/src/filesystem-store.ts
+++ b/packages/deployment/src/filesystem-store.ts
@@ -1,0 +1,580 @@
+import { constants } from 'node:fs';
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  readdir,
+  rename,
+  rm,
+} from 'node:fs/promises';
+import path from 'node:path';
+import {
+  prepareProtocolDeploymentReleaseEnvelope,
+  type ProtocolDeploymentReleaseEnvelope,
+} from '@hypequery/protocol';
+import {
+  DEPLOYMENT_BUNDLE_MANIFEST,
+  verifyDeploymentBundle,
+  type VerifiedDeploymentBundle,
+} from './bundle.js';
+import type {
+  DeploymentSubmissionStore,
+  VerifiedDeploymentSubmission,
+} from './types.js';
+
+const RELEASE_FILE = 'release.json';
+const MAX_MANIFEST_BYTES = 1024 * 1024;
+const MAX_RELEASE_BYTES = 16 * 1024;
+const COPY_BUFFER_BYTES = 64 * 1024;
+const IDENTITY_PATTERN = /^[0-9a-f]{64}$/;
+const textDecoder = new TextDecoder('utf-8', { fatal: true });
+
+export type FileSystemDeploymentStoreErrorCode =
+  | 'HQ_DEPLOYMENT_STORE_CONFIGURATION'
+  | 'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION'
+  | 'HQ_DEPLOYMENT_STORE_CORRUPT_STATE'
+  | 'HQ_DEPLOYMENT_STORE_IO';
+
+export class FileSystemDeploymentStoreError extends Error {
+  readonly code: FileSystemDeploymentStoreErrorCode;
+
+  constructor(
+    code: FileSystemDeploymentStoreErrorCode,
+    message: string,
+    options: { readonly cause?: unknown } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'FileSystemDeploymentStoreError';
+    this.code = code;
+  }
+}
+
+export interface FileSystemDeploymentSubmissionStoreOptions {
+  readonly directory: string;
+}
+
+export interface StoredDeploymentSubmission {
+  readonly releaseDirectory: string;
+  readonly release: ProtocolDeploymentReleaseEnvelope;
+  readonly releaseCanonical: string;
+  readonly releaseIdentity: string;
+  readonly bundle: VerifiedDeploymentBundle;
+}
+
+export interface FileSystemDeploymentSubmissionStore<Principal>
+  extends DeploymentSubmissionStore<Principal> {
+  read(releaseIdentity: string): Promise<StoredDeploymentSubmission | undefined>;
+}
+
+function storeError(
+  code: FileSystemDeploymentStoreErrorCode,
+  message: string,
+  cause?: unknown,
+): FileSystemDeploymentStoreError {
+  return new FileSystemDeploymentStoreError(code, message, { cause });
+}
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code)
+    : undefined;
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await lstat(filePath);
+    return true;
+  } catch (error) {
+    if (errorCode(error) === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+async function requireRegularDirectory(
+  directory: string,
+  description: string,
+  code: FileSystemDeploymentStoreErrorCode = 'HQ_DEPLOYMENT_STORE_CORRUPT_STATE',
+): Promise<void> {
+  const stat = await lstat(directory);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw storeError(
+      code,
+      `${description} must be a regular directory: ${directory}`,
+    );
+  }
+}
+
+async function ensureRegularStoreDirectory(directory: string, description: string): Promise<void> {
+  try {
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    if (errorCode(error) !== 'EEXIST') throw error;
+  }
+  await requireRegularDirectory(directory, description);
+}
+
+async function ensureStoreDirectories(root: string): Promise<{
+  readonly bundles: string;
+  readonly releases: string;
+}> {
+  await ensureRegularStoreDirectory(root, 'Deployment store root');
+  const bundles = path.join(root, 'bundles');
+  const releases = path.join(root, 'releases');
+  await ensureRegularStoreDirectory(bundles, 'Deployment bundle store');
+  await ensureRegularStoreDirectory(releases, 'Deployment release store');
+  await syncDirectory(root);
+  await syncDirectory(path.dirname(root));
+  return Object.freeze({ bundles, releases });
+}
+
+async function syncDirectory(directory: string): Promise<void> {
+  if (process.platform === 'win32') return;
+  const handle = await open(directory, constants.O_RDONLY);
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function writeAll(
+  handle: Awaited<ReturnType<typeof open>>,
+  bytes: Uint8Array,
+): Promise<void> {
+  let offset = 0;
+  while (offset < bytes.byteLength) {
+    const result = await handle.write(bytes, offset, bytes.byteLength - offset);
+    if (result.bytesWritten < 1) throw new Error('Filesystem write made no progress.');
+    offset += result.bytesWritten;
+  }
+}
+
+async function writeExclusiveFile(filePath: string, bytes: Uint8Array): Promise<void> {
+  const handle = await open(filePath, 'wx', 0o600);
+  try {
+    await writeAll(handle, bytes);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function copyRegularFile(
+  sourcePath: string,
+  destinationPath: string,
+  maximumBytes: number,
+  expectedBytes?: number,
+): Promise<void> {
+  const initial = await lstat(sourcePath);
+  if (initial.isSymbolicLink() || !initial.isFile()) {
+    throw storeError(
+      'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+      `Verified bundle entry is no longer a regular file: ${sourcePath}`,
+    );
+  }
+  if (initial.size < 1 || initial.size > maximumBytes
+    || (expectedBytes !== undefined && initial.size !== expectedBytes)) {
+    throw storeError(
+      'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+      `Verified bundle entry changed before persistence: ${sourcePath}`,
+    );
+  }
+
+  let source;
+  let destination;
+  try {
+    source = await open(sourcePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const stat = await source.stat();
+    if (!stat.isFile() || stat.size < 1 || stat.size > maximumBytes
+      || (expectedBytes !== undefined && stat.size !== expectedBytes)) {
+      throw storeError(
+        'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+        `Verified bundle entry changed before persistence: ${sourcePath}`,
+      );
+    }
+    destination = await open(destinationPath, 'wx', 0o600);
+    const buffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
+    let total = 0;
+    for (;;) {
+      const { bytesRead } = await source.read(buffer, 0, buffer.byteLength, null);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+      if (total > maximumBytes || (expectedBytes !== undefined && total > expectedBytes)) {
+        throw storeError(
+          'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+          `Verified bundle entry changed before persistence: ${sourcePath}`,
+        );
+      }
+      await writeAll(destination, buffer.subarray(0, bytesRead));
+    }
+    if (expectedBytes !== undefined && total !== expectedBytes) {
+      throw storeError(
+        'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+        `Verified bundle entry changed before persistence: ${sourcePath}`,
+      );
+    }
+    await destination.sync();
+  } catch (error) {
+    if (errorCode(error) === 'ELOOP') {
+      throw storeError(
+        'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+        `Verified bundle entry became a symbolic link: ${sourcePath}`,
+        error,
+      );
+    }
+    throw error;
+  } finally {
+    await destination?.close();
+    await source?.close();
+  }
+}
+
+function bundleFilePaths(bundle: VerifiedDeploymentBundle): readonly {
+  readonly path: string;
+  readonly byteLength?: number;
+}[] {
+  return Object.freeze([
+    { path: DEPLOYMENT_BUNDLE_MANIFEST },
+    {
+      path: bundle.manifest.deployment.path,
+      byteLength: bundle.manifest.deployment.byteLength,
+    },
+    ...bundle.manifest.artifacts.map(artifact => ({
+      path: artifact.path,
+      byteLength: artifact.byteLength,
+    })),
+  ]);
+}
+
+async function syncBundleDirectories(
+  bundleRoot: string,
+  files: readonly { readonly path: string }[],
+): Promise<void> {
+  const directories = new Set<string>([bundleRoot]);
+  for (const file of files) {
+    const segments = file.path.split('/');
+    for (let index = 1; index < segments.length; index += 1) {
+      directories.add(path.join(bundleRoot, ...segments.slice(0, index)));
+    }
+  }
+  const ordered = [...directories].sort((left, right) => (
+    right.split(path.sep).length - left.split(path.sep).length
+  ));
+  for (const directory of ordered) await syncDirectory(directory);
+}
+
+async function copyBundleToStaging(
+  bundle: VerifiedDeploymentBundle,
+  staging: string,
+): Promise<VerifiedDeploymentBundle> {
+  await requireRegularDirectory(
+    bundle.directory,
+    'Verified deployment bundle',
+    'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+  );
+  const files = bundleFilePaths(bundle);
+  for (const file of files) {
+    const destination = path.join(staging, ...file.path.split('/'));
+    await mkdir(path.dirname(destination), { recursive: true, mode: 0o700 });
+    await copyRegularFile(
+      path.join(bundle.directory, ...file.path.split('/')),
+      destination,
+      file.byteLength ?? MAX_MANIFEST_BYTES,
+      file.byteLength,
+    );
+  }
+  await syncBundleDirectories(staging, files);
+  let verified: VerifiedDeploymentBundle;
+  try {
+    verified = await verifyDeploymentBundle(staging);
+  } catch (error) {
+    throw storeError(
+      'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+      'Deployment bundle changed before it could be persisted.',
+      error,
+    );
+  }
+  if (verified.identity !== bundle.identity) {
+    throw storeError(
+      'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+      'Persisted bundle identity does not match the verified submission.',
+    );
+  }
+  return verified;
+}
+
+async function readRegularFile(filePath: string, maximumBytes: number): Promise<Uint8Array> {
+  const initial = await lstat(filePath);
+  if (initial.isSymbolicLink() || !initial.isFile()
+    || initial.size < 1 || initial.size > maximumBytes) {
+    throw new Error(`Stored entry is not a bounded regular file: ${filePath}`);
+  }
+  const handle = await open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size < 1 || stat.size > maximumBytes) {
+      throw new Error(`Stored entry is not a bounded regular file: ${filePath}`);
+    }
+    return await handle.readFile();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readStoredRelease(
+  releaseDirectory: string,
+  expectedIdentity: string,
+): Promise<{
+  readonly release: ProtocolDeploymentReleaseEnvelope;
+  readonly canonical: string;
+}> {
+  await requireRegularDirectory(releaseDirectory, 'Stored deployment release');
+  const entries = (await readdir(releaseDirectory)).sort();
+  if (entries.length !== 1 || entries[0] !== RELEASE_FILE) {
+    throw new Error('Stored deployment release contains undeclared or missing entries.');
+  }
+  const bytes = await readRegularFile(path.join(releaseDirectory, RELEASE_FILE), MAX_RELEASE_BYTES);
+  let input: unknown;
+  try {
+    input = JSON.parse(textDecoder.decode(bytes));
+  } catch (error) {
+    throw new Error('Stored deployment release is not valid UTF-8 JSON.', { cause: error });
+  }
+  const prepared = prepareProtocolDeploymentReleaseEnvelope(input);
+  if (prepared.identity !== expectedIdentity
+    || !Buffer.from(bytes).equals(Buffer.from(prepared.bytes))) {
+    throw new Error('Stored deployment release identity or canonical bytes do not match.');
+  }
+  return Object.freeze({ release: prepared.release, canonical: prepared.canonical });
+}
+
+async function verifyStoredBundle(
+  bundleDirectory: string,
+  expectedIdentity: string,
+): Promise<VerifiedDeploymentBundle> {
+  let bundle: VerifiedDeploymentBundle;
+  try {
+    bundle = await verifyDeploymentBundle(bundleDirectory);
+  } catch (error) {
+    throw storeError(
+      'HQ_DEPLOYMENT_STORE_CORRUPT_STATE',
+      `Stored deployment bundle is invalid: ${expectedIdentity}`,
+      error,
+    );
+  }
+  if (bundle.identity !== expectedIdentity) {
+    throw storeError(
+      'HQ_DEPLOYMENT_STORE_CORRUPT_STATE',
+      `Stored deployment bundle identity is inconsistent: ${expectedIdentity}`,
+    );
+  }
+  return bundle;
+}
+
+async function ensureStoredBundle(
+  root: string,
+  bundlesDirectory: string,
+  bundle: VerifiedDeploymentBundle,
+): Promise<void> {
+  const destination = path.join(bundlesDirectory, bundle.identity);
+  if (await pathExists(destination)) {
+    await verifyStoredBundle(destination, bundle.identity);
+    return;
+  }
+  await withStagingDirectory(root, '.bundle-staging-', async staging => {
+    await copyBundleToStaging(bundle, staging);
+    await publishDirectory(
+      staging,
+      destination,
+      bundlesDirectory,
+      async () => { await verifyStoredBundle(destination, bundle.identity); },
+    );
+  });
+}
+
+async function publishDirectory(
+  staging: string,
+  destination: string,
+  parent: string,
+  verifyExisting: () => Promise<void>,
+): Promise<boolean> {
+  if (await pathExists(destination)) {
+    await verifyExisting();
+    return false;
+  }
+  try {
+    await rename(staging, destination);
+  } catch (error) {
+    if (!await pathExists(destination)) throw error;
+    await verifyExisting();
+    return false;
+  }
+  await syncDirectory(parent);
+  return true;
+}
+
+async function withStagingDirectory<T>(
+  root: string,
+  prefix: string,
+  action: (directory: string) => Promise<T>,
+): Promise<T> {
+  const staging = await mkdtemp(path.join(root, prefix));
+  let result: T | undefined;
+  let failure: { readonly error: unknown } | undefined;
+  try {
+    result = await action(staging);
+  } catch (error) {
+    failure = { error };
+  }
+  try {
+    await rm(staging, { force: true, recursive: true });
+  } catch (error) {
+    throw storeError(
+      'HQ_DEPLOYMENT_STORE_IO',
+      `Could not clean deployment store staging directory: ${staging}`,
+      failure ? new AggregateError([failure.error, error]) : error,
+    );
+  }
+  if (failure) throw failure.error;
+  return result as T;
+}
+
+function prepareSubmission<Principal>(submission: VerifiedDeploymentSubmission<Principal>) {
+  let prepared;
+  try {
+    prepared = prepareProtocolDeploymentReleaseEnvelope(submission.release);
+  } catch (error) {
+    throw storeError(
+      'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+      'Deployment release is invalid.',
+      error,
+    );
+  }
+  if (prepared.identity !== submission.releaseIdentity
+    || prepared.canonical !== submission.releaseCanonical
+    || prepared.release.bundleIdentity !== submission.bundle.identity) {
+    throw storeError(
+      'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+      'Deployment submission identities or canonical release bytes are inconsistent.',
+    );
+  }
+  return prepared;
+}
+
+function requireIdentity(input: string): string {
+  if (!IDENTITY_PATTERN.test(input)) {
+    throw storeError(
+      'HQ_DEPLOYMENT_STORE_INVALID_SUBMISSION',
+      'Deployment release identity must be 64 lowercase hexadecimal characters.',
+    );
+  }
+  return input;
+}
+
+export function createFileSystemDeploymentSubmissionStore<Principal = unknown>(
+  options: FileSystemDeploymentSubmissionStoreOptions,
+): FileSystemDeploymentSubmissionStore<Principal> {
+  if (typeof options.directory !== 'string' || options.directory.length < 1) {
+    throw storeError(
+      'HQ_DEPLOYMENT_STORE_CONFIGURATION',
+      'Deployment store directory is required.',
+    );
+  }
+  const root = path.resolve(options.directory);
+  if (root === path.parse(root).root) {
+    throw storeError(
+      'HQ_DEPLOYMENT_STORE_CONFIGURATION',
+      'Deployment store directory cannot be a filesystem root.',
+    );
+  }
+
+  async function read(releaseIdentity: string): Promise<StoredDeploymentSubmission | undefined> {
+    const identity = requireIdentity(releaseIdentity);
+    let directories;
+    try {
+      directories = await ensureStoreDirectories(root);
+      const releaseDirectory = path.join(directories.releases, identity);
+      if (!await pathExists(releaseDirectory)) return undefined;
+      let storedRelease;
+      try {
+        storedRelease = await readStoredRelease(releaseDirectory, identity);
+      } catch (error) {
+        if (error instanceof FileSystemDeploymentStoreError) throw error;
+        throw storeError(
+          'HQ_DEPLOYMENT_STORE_CORRUPT_STATE',
+          `Stored deployment release is invalid: ${identity}`,
+          error,
+        );
+      }
+      const bundle = await verifyStoredBundle(
+        path.join(directories.bundles, storedRelease.release.bundleIdentity),
+        storedRelease.release.bundleIdentity,
+      );
+      return Object.freeze({
+        releaseDirectory,
+        release: storedRelease.release,
+        releaseCanonical: storedRelease.canonical,
+        releaseIdentity: identity,
+        bundle,
+      });
+    } catch (error) {
+      if (error instanceof FileSystemDeploymentStoreError) throw error;
+      throw storeError(
+        'HQ_DEPLOYMENT_STORE_IO',
+        `Could not read deployment release from ${root}.`,
+        error,
+      );
+    }
+  }
+
+  async function accept(
+    submission: VerifiedDeploymentSubmission<Principal>,
+  ): Promise<'accepted' | 'already-exists'> {
+    const prepared = prepareSubmission(submission);
+    try {
+      const directories = await ensureStoreDirectories(root);
+      await ensureStoredBundle(root, directories.bundles, submission.bundle);
+
+      const releaseDestination = path.join(directories.releases, submission.releaseIdentity);
+      const published = await withStagingDirectory(root, '.release-staging-', async staging => {
+        await writeExclusiveFile(path.join(staging, RELEASE_FILE), prepared.bytes);
+        await syncDirectory(staging);
+        return publishDirectory(
+          staging,
+          releaseDestination,
+          directories.releases,
+          async () => {
+            let existing;
+            try {
+              existing = await readStoredRelease(releaseDestination, submission.releaseIdentity);
+            } catch (error) {
+              throw storeError(
+                'HQ_DEPLOYMENT_STORE_CORRUPT_STATE',
+                `Stored deployment release is invalid: ${submission.releaseIdentity}`,
+                error,
+              );
+            }
+            if (existing.canonical !== prepared.canonical
+              || existing.release.bundleIdentity !== submission.bundle.identity) {
+              throw storeError(
+                'HQ_DEPLOYMENT_STORE_CORRUPT_STATE',
+                `Stored deployment release conflicts with its identity: ${submission.releaseIdentity}`,
+              );
+            }
+          },
+        );
+      });
+      return published ? 'accepted' : 'already-exists';
+    } catch (error) {
+      if (error instanceof FileSystemDeploymentStoreError) throw error;
+      throw storeError(
+        'HQ_DEPLOYMENT_STORE_IO',
+        `Could not persist deployment submission in ${root}.`,
+        error,
+      );
+    }
+  }
+
+  return Object.freeze({ accept, read });
+}

--- a/packages/deployment/src/filesystem-store.ts
+++ b/packages/deployment/src/filesystem-store.ts
@@ -105,26 +105,31 @@ async function requireRegularDirectory(
   }
 }
 
-async function ensureRegularStoreDirectory(directory: string, description: string): Promise<void> {
+async function ensureRegularStoreDirectory(
+  directory: string,
+  description: string,
+): Promise<boolean> {
+  let created = false;
   try {
-    await mkdir(directory, { recursive: true, mode: 0o700 });
+    created = await mkdir(directory, { recursive: true, mode: 0o700 }) !== undefined;
   } catch (error) {
     if (errorCode(error) !== 'EEXIST') throw error;
   }
   await requireRegularDirectory(directory, description);
+  return created;
 }
 
 async function ensureStoreDirectories(root: string): Promise<{
   readonly bundles: string;
   readonly releases: string;
 }> {
-  await ensureRegularStoreDirectory(root, 'Deployment store root');
+  const rootCreated = await ensureRegularStoreDirectory(root, 'Deployment store root');
   const bundles = path.join(root, 'bundles');
   const releases = path.join(root, 'releases');
-  await ensureRegularStoreDirectory(bundles, 'Deployment bundle store');
-  await ensureRegularStoreDirectory(releases, 'Deployment release store');
-  await syncDirectory(root);
-  await syncDirectory(path.dirname(root));
+  const bundlesCreated = await ensureRegularStoreDirectory(bundles, 'Deployment bundle store');
+  const releasesCreated = await ensureRegularStoreDirectory(releases, 'Deployment release store');
+  if (bundlesCreated || releasesCreated) await syncDirectory(root);
+  if (rootCreated) await syncDirectory(path.dirname(root));
   return Object.freeze({ bundles, releases });
 }
 
@@ -225,8 +230,11 @@ async function copyRegularFile(
     }
     throw error;
   } finally {
-    await destination?.close();
-    await source?.close();
+    try {
+      await destination?.close();
+    } finally {
+      await source?.close();
+    }
   }
 }
 
@@ -316,7 +324,28 @@ async function readRegularFile(filePath: string, maximumBytes: number): Promise<
     if (!stat.isFile() || stat.size < 1 || stat.size > maximumBytes) {
       throw new Error(`Stored entry is not a bounded regular file: ${filePath}`);
     }
-    return await handle.readFile();
+    const buffer = Buffer.allocUnsafe(Math.min(COPY_BUFFER_BYTES, maximumBytes + 1));
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (total <= maximumBytes) {
+      const remaining = maximumBytes + 1 - total;
+      const { bytesRead } = await handle.read(
+        buffer,
+        0,
+        Math.min(buffer.byteLength, remaining),
+        null,
+      );
+      if (bytesRead === 0) break;
+      total += bytesRead;
+      if (total > maximumBytes) {
+        throw new Error(`Stored entry is not a bounded regular file: ${filePath}`);
+      }
+      chunks.push(Buffer.from(buffer.subarray(0, bytesRead)));
+    }
+    if (total < 1) {
+      throw new Error(`Stored entry is not a bounded regular file: ${filePath}`);
+    }
+    return Buffer.concat(chunks, total);
   } finally {
     await handle.close();
   }
@@ -488,12 +517,23 @@ export function createFileSystemDeploymentSubmissionStore<Principal = unknown>(
       'Deployment store directory cannot be a filesystem root.',
     );
   }
+  let directoriesPromise: ReturnType<typeof ensureStoreDirectories> | undefined;
+
+  async function storeDirectories(): ReturnType<typeof ensureStoreDirectories> {
+    const pending = directoriesPromise ??= ensureStoreDirectories(root);
+    try {
+      return await pending;
+    } catch (error) {
+      if (directoriesPromise === pending) directoriesPromise = undefined;
+      throw error;
+    }
+  }
 
   async function read(releaseIdentity: string): Promise<StoredDeploymentSubmission | undefined> {
     const identity = requireIdentity(releaseIdentity);
     let directories;
     try {
-      directories = await ensureStoreDirectories(root);
+      directories = await storeDirectories();
       const releaseDirectory = path.join(directories.releases, identity);
       if (!await pathExists(releaseDirectory)) return undefined;
       let storedRelease;
@@ -533,7 +573,7 @@ export function createFileSystemDeploymentSubmissionStore<Principal = unknown>(
   ): Promise<'accepted' | 'already-exists'> {
     const prepared = prepareSubmission(submission);
     try {
-      const directories = await ensureStoreDirectories(root);
+      const directories = await storeDirectories();
       await ensureStoredBundle(root, directories.bundles, submission.bundle);
 
       const releaseDestination = path.join(directories.releases, submission.releaseIdentity);

--- a/packages/deployment/src/index.ts
+++ b/packages/deployment/src/index.ts
@@ -9,6 +9,16 @@ export {
 } from './errors.js';
 export type { DeploymentIntakeErrorCode } from './errors.js';
 export {
+  createFileSystemDeploymentSubmissionStore,
+  FileSystemDeploymentStoreError,
+} from './filesystem-store.js';
+export type {
+  FileSystemDeploymentStoreErrorCode,
+  FileSystemDeploymentSubmissionStore,
+  FileSystemDeploymentSubmissionStoreOptions,
+  StoredDeploymentSubmission,
+} from './filesystem-store.js';
+export {
   createDeploymentIntake,
 } from './intake.js';
 export {

--- a/specs/deployment/0001-authenticated-deployment-submission.md
+++ b/specs/deployment/0001-authenticated-deployment-submission.md
@@ -101,6 +101,14 @@ filesystem verifier used by the CLI. The persistence callback must copy every
 required byte before it resolves because the temporary directory is removed on
 both success and failure.
 
+The package also includes an optional single-host filesystem store. It copies
+and revalidates the closed bundle into a content-addressed bundle directory,
+syncs it, and only then atomically publishes the canonical release record under
+its release identity. An interruption may leave an unreferenced bundle for a
+later retry to reuse, but never a visible release that references an incomplete
+bundle. Reads and idempotent replays revalidate both stored objects. The store
+does not activate releases or define provider lifecycle state.
+
 ## Rejection and client errors
 
 Non-success HTTP statuses reject the submission. A service may return a bounded


### PR DESCRIPTION
## Summary

- add a reference filesystem-backed `DeploymentSubmissionStore`
- persist closed bundles and canonical releases in a content-addressed layout
- publish bundles before releases with exclusive writes, fsyncs, and atomic directory renames
- fully revalidate stored state on reads and idempotent replays
- fail closed on source mutation, symlinks, path collisions, conflicting state, and partial writes
- document the storage and crash-recovery contract

## Why

The provider-neutral intake introduced in the base PR hands verified submissions to a pluggable store, but its upload directory is temporary. This gives single-host receivers a durable reference implementation that copies every required byte before intake cleanup while keeping activation and provider lifecycle concerns out of scope.

## Storage contract

- `bundles/<bundleIdentity>` is published first and contains the closed verified bundle.
- `releases/<releaseIdentity>/release.json` is the atomic acceptance record.
- a crash may leave a reusable unreferenced bundle, but never a visible release backed by an incomplete bundle.
- a replay returns `already-exists` only after both stored objects pass complete revalidation.

## Validation

- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm types`
- `pnpm --filter @hypequery/deployment pack --pack-destination /tmp/hypequery-deployment-pack-test`

The new store suite covers persistence after temporary-source deletion, concurrent replay, source mutation and symlink replacement, corrupt state, reserved-path collisions, canonical release bytes, staging cleanup, and partial-publication recovery.