### PR TITLE
Add atomic deployment activation registry

### DIFF
--- a/.changeset/atomic-deployment-activation.md
+++ b/.changeset/atomic-deployment-activation.md
@@ -1,5 +1,6 @@
 ---
 '@hypequery/deployment': minor
+'@hypequery/protocol': minor
 ---
 
 Add target-scoped deployment activation with immutable history, atomic

--- a/.changeset/atomic-deployment-activation.md
+++ b/.changeset/atomic-deployment-activation.md
@@ -1,0 +1,7 @@
+---
+'@hypequery/deployment': minor
+---
+
+Add target-scoped deployment activation with immutable history, atomic
+compare-and-swap semantics, rollback support, and a filesystem reference
+registry.

--- a/packages/deployment/README.md
+++ b/packages/deployment/README.md
@@ -110,4 +110,46 @@ store does not provide remote replication, activation, lifecycle state, or
 protection from an administrator modifying its files. `read(releaseIdentity)`
 returns only a completely revalidated stored submission.
 
+## Activation registry
+
+`createFileSystemDeploymentActivationRegistry` adds explicit target activation
+without changing accepted release or bundle bytes. The registry requires a
+release reader that completely revalidates an accepted release and its closed
+bundle before returning it; the filesystem submission store satisfies that
+contract directly.
+
+```ts
+import {
+  createFileSystemDeploymentActivationRegistry,
+  createFileSystemDeploymentSubmissionStore,
+} from '@hypequery/deployment';
+
+const directory = '/var/lib/hypequery/deployments';
+const releases = createFileSystemDeploymentSubmissionStore({ directory });
+const activations = createFileSystemDeploymentActivationRegistry({
+  directory,
+  releases,
+});
+
+const target = { project: 'analytics', environment: 'production' };
+const current = await activations.current(target);
+const result = await activations.activate({
+  target,
+  releaseIdentity,
+  expectedRevision: current?.revision ?? null,
+});
+```
+
+`expectedRevision` is a compare-and-swap precondition. A different active
+revision returns `conflict`; requesting the release that is already active
+returns `already-active`. Activating an older accepted release performs a
+rollback through the same operation and produces a new revision, so stale
+pre-rollback callers cannot pass the comparison after an ABA sequence.
+
+The filesystem implementation stores an immutable, domain-separated activation
+record for every transition and derives the current release by verifying the
+append-only chain. It has no mutable pointer file or persistent lock to become
+stale after a crash. Activation does not load runtime code, route traffic,
+perform health checks, or authorize callers; those remain provider concerns.
+
 The package is ESM-only and requires Node.js 20 or newer.

--- a/packages/deployment/src/activation.test.ts
+++ b/packages/deployment/src/activation.test.ts
@@ -2,10 +2,12 @@ import { createHash } from 'node:crypto';
 import {
   mkdir,
   mkdtemp,
+  open,
   readFile,
   readdir,
   rm,
   symlink,
+  type FileHandle,
   writeFile,
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -16,7 +18,7 @@ import {
   prepareProtocolDeploymentReleaseEnvelope,
   type ProtocolDeploymentReleaseTarget,
 } from '@hypequery/protocol';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createFileSystemDeploymentActivationRegistry,
   DeploymentActivationError,
@@ -157,6 +159,32 @@ describe('filesystem deployment activation registry', () => {
     })).resolves.toEqual({ status: 'conflict', current: null });
     await expect(registry.current(target)).resolves.toBeUndefined();
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'syncs newly created activation directories only once',
+    async () => {
+      const root = await temporaryDirectory('hypequery-activation-store-');
+      const probe = await open(root, 'r');
+      const prototype = Object.getPrototypeOf(probe) as FileHandle;
+      await probe.close();
+      const sync = vi.spyOn(prototype, 'sync');
+      const registry = createFileSystemDeploymentActivationRegistry({
+        directory: root,
+        releases: { read: async () => undefined },
+      });
+
+      try {
+        await registry.current(target);
+        const initializationSyncs = sync.mock.calls.length;
+        expect(initializationSyncs).toBeGreaterThan(0);
+
+        await registry.history(target);
+        expect(sync).toHaveBeenCalledTimes(initializationSyncs);
+      } finally {
+        sync.mockRestore();
+      }
+    },
+  );
 
   it('activates an accepted release with an immutable target-scoped record', async () => {
     const { first, registry, root } = await setup();

--- a/packages/deployment/src/activation.test.ts
+++ b/packages/deployment/src/activation.test.ts
@@ -1,0 +1,462 @@
+import { createHash } from 'node:crypto';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  prepareProtocolDeploymentBundleManifest,
+  prepareProtocolDeploymentContract,
+  prepareProtocolDeploymentReleaseEnvelope,
+  type ProtocolDeploymentReleaseTarget,
+} from '@hypequery/protocol';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createFileSystemDeploymentActivationRegistry,
+  DeploymentActivationError,
+} from './activation.js';
+import { verifyDeploymentBundle } from './bundle.js';
+import { createFileSystemDeploymentSubmissionStore } from './filesystem-store.js';
+import type { VerifiedDeploymentSubmission } from './types.js';
+
+const target: ProtocolDeploymentReleaseTarget = Object.freeze({
+  project: 'analytics',
+  environment: 'production',
+});
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(prefix: string): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(directory => (
+    rm(directory, { force: true, recursive: true })
+  )));
+});
+
+function sha256(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+async function submissionFixture(
+  name: string,
+  releaseTarget = target,
+): Promise<{
+  readonly deploymentPath: string;
+  readonly submission: VerifiedDeploymentSubmission<string>;
+}> {
+  const source = await temporaryDirectory('hypequery-activation-source-');
+  const deploymentPath = 'contract/deployment.json';
+  const deployment = prepareProtocolDeploymentContract({
+    kind: 'hypequery-deployment',
+    version: 1,
+    datasets: [{
+      name,
+      source: name,
+      tenant: { kind: 'not-required' },
+      dimensions: [],
+      measures: [],
+      filters: [],
+      metrics: [],
+      relationships: [],
+    }],
+    queries: [],
+    artifacts: [],
+  });
+  const deploymentBytes = Buffer.from(`${deployment.canonical}\n`);
+  const manifest = prepareProtocolDeploymentBundleManifest({
+    kind: 'hypequery-deployment-bundle',
+    version: 1,
+    deployment: {
+      path: deploymentPath,
+      identity: deployment.identity,
+      sha256: sha256(deploymentBytes),
+      byteLength: deploymentBytes.byteLength,
+    },
+    artifacts: [],
+  });
+  await mkdir(path.join(source, 'contract'), { recursive: true });
+  await writeFile(path.join(source, 'bundle.json'), `${manifest.canonical}\n`);
+  await writeFile(path.join(source, deploymentPath), deploymentBytes);
+  const bundle = await verifyDeploymentBundle(source);
+  const release = prepareProtocolDeploymentReleaseEnvelope({
+    kind: 'hypequery-deployment-release',
+    version: 1,
+    bundleIdentity: bundle.identity,
+    target: releaseTarget,
+  });
+  return {
+    deploymentPath,
+    submission: {
+      principal: 'principal',
+      release: release.release,
+      releaseCanonical: release.canonical,
+      releaseIdentity: release.identity,
+      bundle,
+    },
+  };
+}
+
+async function setup() {
+  const root = await temporaryDirectory('hypequery-activation-store-');
+  const releases = createFileSystemDeploymentSubmissionStore<string>({ directory: root });
+  const first = await submissionFixture('orders');
+  const second = await submissionFixture('customers');
+  await releases.accept(first.submission);
+  await releases.accept(second.submission);
+  let tick = 0;
+  const registry = createFileSystemDeploymentActivationRegistry({
+    directory: root,
+    releases,
+    clock: () => new Date(Date.UTC(2026, 0, 1, 0, 0, tick++)),
+  });
+  const otherRegistry = createFileSystemDeploymentActivationRegistry({
+    directory: root,
+    releases,
+    clock: () => new Date(Date.UTC(2026, 0, 2)),
+  });
+  return { first, second, registry, otherRegistry, releases, root };
+}
+
+function expectActivationCode(
+  promise: Promise<unknown>,
+  code: DeploymentActivationError['code'],
+): Promise<void> {
+  return expect(promise).rejects.toMatchObject({
+    name: 'DeploymentActivationError',
+    code,
+  });
+}
+
+async function targetDirectory(root: string): Promise<string> {
+  const entries = await readdir(path.join(root, 'activations'));
+  const key = entries.find(entry => /^[0-9a-f]{64}$/.test(entry));
+  if (!key) throw new Error('Expected an activation target directory.');
+  return path.join(root, 'activations', key);
+}
+
+describe('filesystem deployment activation registry', () => {
+  it('returns no current record before the first successful comparison', async () => {
+    const { first, registry } = await setup();
+
+    await expect(registry.current(target)).resolves.toBeUndefined();
+    await expect(registry.history(target)).resolves.toEqual([]);
+    await expect(registry.activate({
+      target,
+      releaseIdentity: first.submission.releaseIdentity,
+      expectedRevision: '0'.repeat(64),
+    })).resolves.toEqual({ status: 'conflict', current: null });
+    await expect(registry.current(target)).resolves.toBeUndefined();
+  });
+
+  it('activates an accepted release with an immutable target-scoped record', async () => {
+    const { first, registry, root } = await setup();
+
+    const result = await registry.activate({
+      target,
+      releaseIdentity: first.submission.releaseIdentity,
+      expectedRevision: null,
+    });
+
+    expect(result.status).toBe('activated');
+    if (result.status !== 'activated') throw new Error('Expected activation.');
+    expect(result.activation).toMatchObject({
+      kind: 'hypequery-deployment-activation',
+      version: 1,
+      target,
+      releaseIdentity: first.submission.releaseIdentity,
+      previousRevision: null,
+      previousReleaseIdentity: null,
+      activatedAt: '2026-01-01T00:00:00.000Z',
+    });
+    expect(result.activation.revision).toMatch(/^[0-9a-f]{64}$/);
+    expect(Object.isFrozen(result.activation)).toBe(true);
+    await expect(registry.current(target)).resolves.toEqual(result.activation);
+    const history = await registry.history(target);
+    expect(history).toEqual([result.activation]);
+    expect(Object.isFrozen(history)).toBe(true);
+    expect(await readdir(path.join(await targetDirectory(root), 'claims'))).toEqual(['initial']);
+  });
+
+  it('treats an already-active release as idempotent regardless of a stale expectation', async () => {
+    const { first, registry } = await setup();
+    const activated = await registry.activate({
+      target,
+      releaseIdentity: first.submission.releaseIdentity,
+      expectedRevision: null,
+    });
+    if (activated.status !== 'activated') throw new Error('Expected activation.');
+
+    const replay = await registry.activate({
+      target,
+      releaseIdentity: first.submission.releaseIdentity,
+      expectedRevision: '0'.repeat(64),
+    });
+
+    expect(replay).toEqual({ status: 'already-active', activation: activated.activation });
+    expect(await registry.history(target)).toHaveLength(1);
+  });
+
+  it('supports forward activation and rollback without an ABA revision', async () => {
+    const { first, second, registry } = await setup();
+    const initial = await registry.activate({
+      target,
+      releaseIdentity: first.submission.releaseIdentity,
+      expectedRevision: null,
+    });
+    if (initial.status !== 'activated') throw new Error('Expected activation.');
+    const forward = await registry.activate({
+      target,
+      releaseIdentity: second.submission.releaseIdentity,
+      expectedRevision: initial.activation.revision,
+    });
+    if (forward.status !== 'activated') throw new Error('Expected activation.');
+
+    const rollback = await registry.activate({
+      target,
+      releaseIdentity: first.submission.releaseIdentity,
+      expectedRevision: forward.activation.revision,
+    });
+
+    expect(rollback.status).toBe('activated');
+    if (rollback.status !== 'activated') throw new Error('Expected rollback.');
+    expect(rollback.activation.previousRevision).toBe(forward.activation.revision);
+    expect(rollback.activation.previousReleaseIdentity)
+      .toBe(second.submission.releaseIdentity);
+    expect(rollback.activation.revision).not.toBe(initial.activation.revision);
+    expect((await registry.history(target)).map(record => record.releaseIdentity)).toEqual([
+      first.submission.releaseIdentity,
+      second.submission.releaseIdentity,
+      first.submission.releaseIdentity,
+    ]);
+  });
+
+  it('returns the current record on a compare-and-swap conflict', async () => {
+    const { first, second, registry } = await setup();
+    const initial = await registry.activate({
+      target,
+      releaseIdentity: first.submission.releaseIdentity,
+      expectedRevision: null,
+    });
+    if (initial.status !== 'activated') throw new Error('Expected activation.');
+
+    await expect(registry.activate({
+      target,
+      releaseIdentity: second.submission.releaseIdentity,
+      expectedRevision: null,
+    })).resolves.toEqual({ status: 'conflict', current: initial.activation });
+  });
+
+  it('allows exactly one of two concurrent transitions from the same revision', async () => {
+    const { first, second, registry, otherRegistry } = await setup();
+
+    const results = await Promise.all([
+      otherRegistry.activate({
+        target,
+        releaseIdentity: first.submission.releaseIdentity,
+        expectedRevision: null,
+      }),
+      registry.activate({
+        target,
+        releaseIdentity: second.submission.releaseIdentity,
+        expectedRevision: null,
+      }),
+    ]);
+
+    expect(results.map(result => result.status).sort()).toEqual(['activated', 'conflict']);
+    const current = await registry.current(target);
+    expect(current?.releaseIdentity).toBe(
+      results.find(result => result.status === 'activated')!.activation.releaseIdentity,
+    );
+    expect(await registry.history(target)).toHaveLength(1);
+  });
+
+  it('coalesces concurrent requests for the same release', async () => {
+    const { first, registry, otherRegistry } = await setup();
+
+    const results = await Promise.all([
+      otherRegistry.activate({
+        target,
+        releaseIdentity: first.submission.releaseIdentity,
+        expectedRevision: null,
+      }),
+      registry.activate({
+        target,
+        releaseIdentity: first.submission.releaseIdentity,
+        expectedRevision: null,
+      }),
+    ]);
+
+    expect(results.map(result => result.status).sort())
+      .toEqual(['activated', 'already-active']);
+    expect(await registry.history(target)).toHaveLength(1);
+  });
+
+  it('requires the release to exist and match the requested target', async () => {
+    const { first, registry, releases, root } = await setup();
+    await expectActivationCode(
+      registry.activate({
+        target,
+        releaseIdentity: '0'.repeat(64),
+        expectedRevision: null,
+      }),
+      'HQ_DEPLOYMENT_ACTIVATION_RELEASE_NOT_FOUND',
+    );
+    const otherTarget = Object.freeze({ project: 'analytics', environment: 'staging' });
+    await expectActivationCode(
+      registry.activate({
+        target: otherTarget,
+        releaseIdentity: first.submission.releaseIdentity,
+        expectedRevision: null,
+      }),
+      'HQ_DEPLOYMENT_ACTIVATION_TARGET_MISMATCH',
+    );
+
+    const storedDeployment = path.join(
+      root,
+      'bundles',
+      first.submission.bundle.identity,
+      ...first.deploymentPath.split('/'),
+    );
+    await writeFile(storedDeployment, 'corrupt');
+    const unavailable = createFileSystemDeploymentActivationRegistry({
+      directory: root,
+      releases,
+    });
+    await expectActivationCode(
+      unavailable.activate({
+        target,
+        releaseIdentity: first.submission.releaseIdentity,
+        expectedRevision: null,
+      }),
+      'HQ_DEPLOYMENT_ACTIVATION_RELEASE_UNAVAILABLE',
+    );
+
+    const inconsistent = createFileSystemDeploymentActivationRegistry({
+      directory: await temporaryDirectory('hypequery-activation-inconsistent-'),
+      releases: {
+        read: async () => ({
+          release: first.submission.release,
+          releaseIdentity: 'f'.repeat(64),
+        }),
+      },
+    });
+    await expectActivationCode(
+      inconsistent.activate({
+        target,
+        releaseIdentity: first.submission.releaseIdentity,
+        expectedRevision: null,
+      }),
+      'HQ_DEPLOYMENT_ACTIVATION_RELEASE_UNAVAILABLE',
+    );
+  });
+
+  it('rejects malformed request identities before touching state', async () => {
+    const { first, registry } = await setup();
+
+    await expectActivationCode(
+      registry.activate({
+        target,
+        releaseIdentity: first.submission.releaseIdentity,
+        expectedRevision: undefined as unknown as string,
+      }),
+      'HQ_DEPLOYMENT_ACTIVATION_INVALID_REQUEST',
+    );
+  });
+
+  it('detects non-canonical or tampered activation records', async () => {
+    const { first, registry, root } = await setup();
+    await registry.activate({
+      target,
+      releaseIdentity: first.submission.releaseIdentity,
+      expectedRevision: null,
+    });
+    const activationFile = path.join(
+      await targetDirectory(root),
+      'claims',
+      'initial',
+      'activation.json',
+    );
+    const value = JSON.parse(await readFile(activationFile, 'utf8')) as Record<string, unknown>;
+    await writeFile(activationFile, JSON.stringify({ ...value, revision: '0'.repeat(64) }));
+
+    await expectActivationCode(
+      registry.current(target),
+      'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE',
+    );
+  });
+
+  it('detects unreachable claims instead of silently choosing a head', async () => {
+    const { first, registry, root } = await setup();
+    await registry.activate({
+      target,
+      releaseIdentity: first.submission.releaseIdentity,
+      expectedRevision: null,
+    });
+    await mkdir(path.join(
+      await targetDirectory(root),
+      'claims',
+      'f'.repeat(64),
+    ));
+
+    await expectActivationCode(
+      registry.history(target),
+      'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE',
+    );
+  });
+
+  it('ignores an uncommitted staging directory left by an interrupted writer', async () => {
+    const { first, registry, root } = await setup();
+    const activated = await registry.activate({
+      target,
+      releaseIdentity: first.submission.releaseIdentity,
+      expectedRevision: null,
+    });
+    await mkdir(path.join(root, 'activations', '.activation-staging-interrupted'));
+
+    await expect(registry.current(target)).resolves.toEqual(
+      activated.status === 'activated' ? activated.activation : undefined,
+    );
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects a symbolic-link claim in the committed history',
+    async () => {
+      const { first, second, registry, root } = await setup();
+      const activated = await registry.activate({
+        target,
+        releaseIdentity: first.submission.releaseIdentity,
+        expectedRevision: null,
+      });
+      if (activated.status !== 'activated') throw new Error('Expected activation.');
+      const external = await temporaryDirectory('hypequery-activation-external-');
+      await symlink(
+        external,
+        path.join(
+          await targetDirectory(root),
+          'claims',
+          activated.activation.revision,
+        ),
+        'dir',
+      );
+
+      await expectActivationCode(
+        registry.activate({
+          target,
+          releaseIdentity: second.submission.releaseIdentity,
+          expectedRevision: activated.activation.revision,
+        }),
+        'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE',
+      );
+    },
+  );
+});

--- a/packages/deployment/src/activation.ts
+++ b/packages/deployment/src/activation.ts
@@ -1,0 +1,759 @@
+import { createHash } from 'node:crypto';
+import { constants } from 'node:fs';
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  readdir,
+  rename,
+  rm,
+} from 'node:fs/promises';
+import path from 'node:path';
+import {
+  prepareProtocolDeploymentReleaseEnvelope,
+  type ProtocolDeploymentReleaseEnvelope,
+  type ProtocolDeploymentReleaseTarget,
+} from '@hypequery/protocol';
+
+const ACTIVATION_FILE = 'activation.json';
+const CLAIMS_DIRECTORY = 'claims';
+// Each predecessor has one filesystem slot for its successor. Renaming a
+// complete record into that slot is the cross-process compare-and-swap.
+const INITIAL_CLAIM = 'initial';
+const TARGET_FILE = 'target.json';
+const MAX_ACTIVATION_BYTES = 4096;
+const MAX_TARGET_BYTES = 1024;
+const IDENTITY_PATTERN = /^[0-9a-f]{64}$/;
+const ACTIVATION_IDENTITY_DOMAIN = 'hypequery:deployment-activation:v1\0';
+const TARGET_IDENTITY_DOMAIN = 'hypequery:deployment-target:v1\0';
+const textDecoder = new TextDecoder('utf-8', { fatal: true });
+
+export type DeploymentActivationErrorCode =
+  | 'HQ_DEPLOYMENT_ACTIVATION_CONFIGURATION'
+  | 'HQ_DEPLOYMENT_ACTIVATION_INVALID_REQUEST'
+  | 'HQ_DEPLOYMENT_ACTIVATION_RELEASE_NOT_FOUND'
+  | 'HQ_DEPLOYMENT_ACTIVATION_RELEASE_UNAVAILABLE'
+  | 'HQ_DEPLOYMENT_ACTIVATION_TARGET_MISMATCH'
+  | 'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE'
+  | 'HQ_DEPLOYMENT_ACTIVATION_IO';
+
+export class DeploymentActivationError extends Error {
+  readonly code: DeploymentActivationErrorCode;
+
+  constructor(
+    code: DeploymentActivationErrorCode,
+    message: string,
+    options: { readonly cause?: unknown } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'DeploymentActivationError';
+    this.code = code;
+  }
+}
+
+export interface DeploymentActivationRecord {
+  readonly kind: 'hypequery-deployment-activation';
+  readonly version: 1;
+  readonly revision: string;
+  readonly target: ProtocolDeploymentReleaseTarget;
+  readonly releaseIdentity: string;
+  readonly previousRevision: string | null;
+  readonly previousReleaseIdentity: string | null;
+  readonly activatedAt: string;
+}
+
+export interface DeploymentActivationRequest {
+  readonly target: ProtocolDeploymentReleaseTarget;
+  readonly releaseIdentity: string;
+  /** `null` means the caller expects this target to have no active release. */
+  readonly expectedRevision: string | null;
+}
+
+export type DeploymentActivationResult =
+  | {
+    readonly status: 'activated' | 'already-active';
+    readonly activation: DeploymentActivationRecord;
+  }
+  | {
+    readonly status: 'conflict';
+    readonly current: DeploymentActivationRecord | null;
+  };
+
+export interface DeploymentActivationRelease {
+  readonly release: ProtocolDeploymentReleaseEnvelope;
+  readonly releaseIdentity: string;
+}
+
+export interface DeploymentReleaseReader {
+  /** Return only accepted releases whose release and closed bundle remain completely valid. */
+  read(releaseIdentity: string): Promise<DeploymentActivationRelease | undefined>;
+}
+
+export interface FileSystemDeploymentActivationRegistryOptions {
+  readonly directory: string;
+  readonly releases: DeploymentReleaseReader;
+  readonly clock?: () => Date;
+}
+
+export interface DeploymentActivationRegistry {
+  activate(request: DeploymentActivationRequest): Promise<DeploymentActivationResult>;
+  current(
+    target: ProtocolDeploymentReleaseTarget,
+  ): Promise<DeploymentActivationRecord | undefined>;
+  history(
+    target: ProtocolDeploymentReleaseTarget,
+  ): Promise<readonly DeploymentActivationRecord[]>;
+}
+
+interface PreparedActivation {
+  readonly record: DeploymentActivationRecord;
+  readonly canonical: string;
+  readonly bytes: Uint8Array;
+}
+
+function activationError(
+  code: DeploymentActivationErrorCode,
+  message: string,
+  cause?: unknown,
+): DeploymentActivationError {
+  return new DeploymentActivationError(code, message, { cause });
+}
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code)
+    : undefined;
+}
+
+function isOperationalFileSystemError(error: unknown): boolean {
+  const code = errorCode(error);
+  return code !== undefined && !['EISDIR', 'ELOOP', 'ENOENT', 'ENOTDIR'].includes(code);
+}
+
+function sha256(domain: string, value: string): string {
+  return createHash('sha256').update(domain).update(value).digest('hex');
+}
+
+function targetCanonical(target: ProtocolDeploymentReleaseTarget): string {
+  return JSON.stringify({ project: target.project, environment: target.environment });
+}
+
+function targetsEqual(
+  left: ProtocolDeploymentReleaseTarget,
+  right: ProtocolDeploymentReleaseTarget,
+): boolean {
+  return left.project === right.project && left.environment === right.environment;
+}
+
+function validateTarget(
+  input: unknown,
+  code: DeploymentActivationErrorCode,
+): ProtocolDeploymentReleaseTarget {
+  try {
+    return prepareProtocolDeploymentReleaseEnvelope({
+      kind: 'hypequery-deployment-release',
+      version: 1,
+      bundleIdentity: '0'.repeat(64),
+      target: input,
+    }).release.target;
+  } catch (error) {
+    throw activationError(code, 'Deployment activation target is invalid.', error);
+  }
+}
+
+function requireIdentity(
+  input: unknown,
+  description: string,
+  code: DeploymentActivationErrorCode,
+): string {
+  if (typeof input !== 'string' || !IDENTITY_PATTERN.test(input)) {
+    throw activationError(code, `${description} must be 64 lowercase hexadecimal characters.`);
+  }
+  return input;
+}
+
+function requireNullableIdentity(
+  input: unknown,
+  description: string,
+  code: DeploymentActivationErrorCode,
+): string | null {
+  return input === null ? null : requireIdentity(input, description, code);
+}
+
+function activationPayloadCanonical(input: {
+  readonly target: ProtocolDeploymentReleaseTarget;
+  readonly releaseIdentity: string;
+  readonly previousRevision: string | null;
+  readonly previousReleaseIdentity: string | null;
+  readonly activatedAt: string;
+}): string {
+  // Every value has already been reduced to a closed primitive shape, so this
+  // fixed construction order is also the canonical byte order persisted below.
+  return JSON.stringify({
+    kind: 'hypequery-deployment-activation',
+    version: 1,
+    target: {
+      project: input.target.project,
+      environment: input.target.environment,
+    },
+    releaseIdentity: input.releaseIdentity,
+    previousRevision: input.previousRevision,
+    previousReleaseIdentity: input.previousReleaseIdentity,
+    activatedAt: input.activatedAt,
+  });
+}
+
+function activationCanonical(record: DeploymentActivationRecord): string {
+  return JSON.stringify({
+    kind: record.kind,
+    version: record.version,
+    revision: record.revision,
+    target: {
+      project: record.target.project,
+      environment: record.target.environment,
+    },
+    releaseIdentity: record.releaseIdentity,
+    previousRevision: record.previousRevision,
+    previousReleaseIdentity: record.previousReleaseIdentity,
+    activatedAt: record.activatedAt,
+  });
+}
+
+function prepareActivation(input: {
+  readonly target: ProtocolDeploymentReleaseTarget;
+  readonly releaseIdentity: string;
+  readonly previousRevision: string | null;
+  readonly previousReleaseIdentity: string | null;
+  readonly activatedAt: string;
+}): PreparedActivation {
+  const payload = activationPayloadCanonical(input);
+  const revision = sha256(ACTIVATION_IDENTITY_DOMAIN, payload);
+  const record: DeploymentActivationRecord = Object.freeze({
+    kind: 'hypequery-deployment-activation',
+    version: 1,
+    revision,
+    target: input.target,
+    releaseIdentity: input.releaseIdentity,
+    previousRevision: input.previousRevision,
+    previousReleaseIdentity: input.previousReleaseIdentity,
+    activatedAt: input.activatedAt,
+  });
+  const canonical = activationCanonical(record);
+  return Object.freeze({ record, canonical, bytes: Buffer.from(canonical) });
+}
+
+function requireRecord(input: unknown): Record<string, unknown> {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new Error('Activation record must be an object.');
+  }
+  const value = input as Record<string, unknown>;
+  const expected = [
+    'activatedAt',
+    'kind',
+    'previousReleaseIdentity',
+    'previousRevision',
+    'releaseIdentity',
+    'revision',
+    'target',
+    'version',
+  ];
+  if (Object.keys(value).sort().join('\0') !== expected.join('\0')) {
+    throw new Error('Activation record fields are inconsistent.');
+  }
+  return value;
+}
+
+function validateStoredActivation(
+  input: unknown,
+  expectedTarget: ProtocolDeploymentReleaseTarget,
+  expectedPreviousRevision: string | null,
+  expectedPreviousReleaseIdentity: string | null,
+): PreparedActivation {
+  const value = requireRecord(input);
+  if (value.kind !== 'hypequery-deployment-activation' || value.version !== 1) {
+    throw new Error('Activation record kind or version is invalid.');
+  }
+  const target = validateTarget(value.target, 'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE');
+  if (!targetsEqual(target, expectedTarget)) {
+    throw new Error('Activation record target is inconsistent.');
+  }
+  const releaseIdentity = requireIdentity(
+    value.releaseIdentity,
+    'Stored release identity',
+    'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE',
+  );
+  const previousRevision = requireNullableIdentity(
+    value.previousRevision,
+    'Stored previous revision',
+    'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE',
+  );
+  const previousReleaseIdentity = requireNullableIdentity(
+    value.previousReleaseIdentity,
+    'Stored previous release identity',
+    'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE',
+  );
+  if (previousRevision !== expectedPreviousRevision
+    || previousReleaseIdentity !== expectedPreviousReleaseIdentity
+    || (previousRevision === null) !== (previousReleaseIdentity === null)) {
+    throw new Error('Activation record predecessor is inconsistent.');
+  }
+  if (typeof value.activatedAt !== 'string') {
+    throw new Error('Activation timestamp is invalid.');
+  }
+  const timestamp = new Date(value.activatedAt);
+  if (!Number.isFinite(timestamp.valueOf()) || timestamp.toISOString() !== value.activatedAt) {
+    throw new Error('Activation timestamp is not a canonical ISO timestamp.');
+  }
+  const prepared = prepareActivation({
+    target,
+    releaseIdentity,
+    previousRevision,
+    previousReleaseIdentity,
+    activatedAt: value.activatedAt,
+  });
+  if (value.revision !== prepared.record.revision) {
+    throw new Error('Activation revision does not match its contents.');
+  }
+  return prepared;
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await lstat(filePath);
+    return true;
+  } catch (error) {
+    if (errorCode(error) === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+async function requireRegularDirectory(directory: string, description: string): Promise<void> {
+  const stat = await lstat(directory);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw activationError(
+      'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE',
+      `${description} must be a regular directory: ${directory}`,
+    );
+  }
+}
+
+async function ensureRegularDirectory(directory: string, description: string): Promise<void> {
+  try {
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    if (errorCode(error) !== 'EEXIST') throw error;
+  }
+  await requireRegularDirectory(directory, description);
+}
+
+async function syncDirectory(directory: string): Promise<void> {
+  if (process.platform === 'win32') return;
+  const handle = await open(directory, constants.O_RDONLY);
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function writeExclusiveFile(filePath: string, bytes: Uint8Array): Promise<void> {
+  const handle = await open(filePath, 'wx', 0o600);
+  try {
+    let offset = 0;
+    while (offset < bytes.byteLength) {
+      const result = await handle.write(bytes, offset, bytes.byteLength - offset);
+      if (result.bytesWritten < 1) throw new Error('Filesystem write made no progress.');
+      offset += result.bytesWritten;
+    }
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readRegularFile(filePath: string, maximumBytes: number): Promise<Uint8Array> {
+  const initial = await lstat(filePath);
+  if (initial.isSymbolicLink() || !initial.isFile()
+    || initial.size < 1 || initial.size > maximumBytes) {
+    throw new Error(`Stored entry is not a bounded regular file: ${filePath}`);
+  }
+  const handle = await open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size < 1 || stat.size > maximumBytes) {
+      throw new Error(`Stored entry is not a bounded regular file: ${filePath}`);
+    }
+    return await handle.readFile();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function withStagingDirectory<T>(
+  root: string,
+  prefix: string,
+  action: (directory: string) => Promise<T>,
+): Promise<T> {
+  const staging = await mkdtemp(path.join(root, prefix));
+  let result: T | undefined;
+  let failure: { readonly error: unknown } | undefined;
+  try {
+    result = await action(staging);
+  } catch (error) {
+    failure = { error };
+  }
+  try {
+    await rm(staging, { force: true, recursive: true });
+  } catch (error) {
+    throw activationError(
+      'HQ_DEPLOYMENT_ACTIVATION_IO',
+      `Could not clean deployment activation staging directory: ${staging}`,
+      failure ? new AggregateError([failure.error, error]) : error,
+    );
+  }
+  if (failure) throw failure.error;
+  return result as T;
+}
+
+async function readCanonicalTarget(
+  targetDirectory: string,
+  expectedTarget: ProtocolDeploymentReleaseTarget,
+): Promise<void> {
+  try {
+    await requireRegularDirectory(targetDirectory, 'Deployment activation target');
+    const entries = (await readdir(targetDirectory)).sort();
+    if (entries.join('\0') !== `${CLAIMS_DIRECTORY}\0${TARGET_FILE}`) {
+      throw new Error('Deployment activation target contains undeclared or missing entries.');
+    }
+    await requireRegularDirectory(
+      path.join(targetDirectory, CLAIMS_DIRECTORY),
+      'Deployment activation claims',
+    );
+    const bytes = await readRegularFile(path.join(targetDirectory, TARGET_FILE), MAX_TARGET_BYTES);
+    let input: unknown;
+    try {
+      input = JSON.parse(textDecoder.decode(bytes));
+    } catch (error) {
+      throw new Error('Stored deployment activation target is invalid JSON.', { cause: error });
+    }
+    const target = validateTarget(input, 'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE');
+    if (!targetsEqual(target, expectedTarget)
+      || !Buffer.from(bytes).equals(Buffer.from(targetCanonical(target)))) {
+      throw new Error('Stored deployment activation target is inconsistent.');
+    }
+  } catch (error) {
+    if (error instanceof DeploymentActivationError) throw error;
+    if (isOperationalFileSystemError(error)) throw error;
+    throw activationError(
+      'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE',
+      'Stored deployment activation target is invalid.',
+      error,
+    );
+  }
+}
+
+async function ensureTargetDirectory(
+  activationsRoot: string,
+  target: ProtocolDeploymentReleaseTarget,
+): Promise<string> {
+  const canonical = targetCanonical(target);
+  const targetKey = sha256(TARGET_IDENTITY_DOMAIN, canonical);
+  const destination = path.join(activationsRoot, targetKey);
+  if (await pathExists(destination)) {
+    await readCanonicalTarget(destination, target);
+    return destination;
+  }
+  await withStagingDirectory(activationsRoot, '.target-staging-', async staging => {
+    await mkdir(path.join(staging, CLAIMS_DIRECTORY), { mode: 0o700 });
+    await writeExclusiveFile(path.join(staging, TARGET_FILE), Buffer.from(canonical));
+    await syncDirectory(path.join(staging, CLAIMS_DIRECTORY));
+    await syncDirectory(staging);
+    try {
+      await rename(staging, destination);
+    } catch (error) {
+      if (!await pathExists(destination)) throw error;
+      await readCanonicalTarget(destination, target);
+      return;
+    }
+    await syncDirectory(activationsRoot);
+  });
+  await readCanonicalTarget(destination, target);
+  return destination;
+}
+
+async function readStoredActivation(
+  claimDirectory: string,
+  target: ProtocolDeploymentReleaseTarget,
+  previousRevision: string | null,
+  previousReleaseIdentity: string | null,
+): Promise<PreparedActivation> {
+  await requireRegularDirectory(claimDirectory, 'Deployment activation claim');
+  const entries = await readdir(claimDirectory);
+  if (entries.length !== 1 || entries[0] !== ACTIVATION_FILE) {
+    throw new Error('Deployment activation claim contains undeclared or missing entries.');
+  }
+  const bytes = await readRegularFile(
+    path.join(claimDirectory, ACTIVATION_FILE),
+    MAX_ACTIVATION_BYTES,
+  );
+  let input: unknown;
+  try {
+    input = JSON.parse(textDecoder.decode(bytes));
+  } catch (error) {
+    throw new Error('Stored deployment activation is invalid JSON.', { cause: error });
+  }
+  const prepared = validateStoredActivation(
+    input,
+    target,
+    previousRevision,
+    previousReleaseIdentity,
+  );
+  if (!Buffer.from(bytes).equals(Buffer.from(prepared.bytes))) {
+    throw new Error('Stored deployment activation is not canonical JSON.');
+  }
+  return prepared;
+}
+
+async function resolveHistory(
+  targetDirectory: string,
+  target: ProtocolDeploymentReleaseTarget,
+): Promise<readonly DeploymentActivationRecord[]> {
+  try {
+    await readCanonicalTarget(targetDirectory, target);
+    const claimsDirectory = path.join(targetDirectory, CLAIMS_DIRECTORY);
+    const claimNames = (await readdir(claimsDirectory)).sort();
+    for (const name of claimNames) {
+      if (name !== INITIAL_CLAIM && !IDENTITY_PATTERN.test(name)) {
+        throw new Error(`Deployment activation claim name is invalid: ${name}`);
+      }
+    }
+    const remaining = new Set(claimNames);
+    const revisions = new Set<string>();
+    const history: DeploymentActivationRecord[] = [];
+    let previousRevision: string | null = null;
+    let previousReleaseIdentity: string | null = null;
+    // Following predecessor-named claims derives the head without trusting a
+    // mutable pointer. The remaining-set check rejects orphaned branches.
+    for (;;) {
+      const claimName = previousRevision ?? INITIAL_CLAIM;
+      if (!remaining.delete(claimName)) break;
+      const prepared = await readStoredActivation(
+        path.join(claimsDirectory, claimName),
+        target,
+        previousRevision,
+        previousReleaseIdentity,
+      );
+      if (revisions.has(prepared.record.revision)) {
+        throw new Error('Deployment activation history contains a cycle.');
+      }
+      revisions.add(prepared.record.revision);
+      history.push(prepared.record);
+      previousRevision = prepared.record.revision;
+      previousReleaseIdentity = prepared.record.releaseIdentity;
+    }
+    if (remaining.size > 0) {
+      throw new Error('Deployment activation history contains unreachable claims.');
+    }
+    return Object.freeze(history);
+  } catch (error) {
+    if (error instanceof DeploymentActivationError) throw error;
+    if (isOperationalFileSystemError(error)) throw error;
+    throw activationError(
+      'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE',
+      'Stored deployment activation history is invalid.',
+      error,
+    );
+  }
+}
+
+function currentActivation(
+  history: readonly DeploymentActivationRecord[],
+): DeploymentActivationRecord | undefined {
+  return history[history.length - 1];
+}
+
+export function createFileSystemDeploymentActivationRegistry(
+  options: FileSystemDeploymentActivationRegistryOptions,
+): DeploymentActivationRegistry {
+  if (typeof options.directory !== 'string' || options.directory.length < 1) {
+    throw activationError(
+      'HQ_DEPLOYMENT_ACTIVATION_CONFIGURATION',
+      'Deployment activation directory is required.',
+    );
+  }
+  if (typeof options.releases?.read !== 'function') {
+    throw activationError(
+      'HQ_DEPLOYMENT_ACTIVATION_CONFIGURATION',
+      'A deployment release reader is required.',
+    );
+  }
+  const root = path.resolve(options.directory);
+  if (root === path.parse(root).root) {
+    throw activationError(
+      'HQ_DEPLOYMENT_ACTIVATION_CONFIGURATION',
+      'Deployment activation directory cannot be a filesystem root.',
+    );
+  }
+  const clock = options.clock ?? (() => new Date());
+
+  async function activationRoot(): Promise<string> {
+    await ensureRegularDirectory(root, 'Deployment store root');
+    const activations = path.join(root, 'activations');
+    await ensureRegularDirectory(activations, 'Deployment activation store');
+    await syncDirectory(root);
+    await syncDirectory(path.dirname(root));
+    return activations;
+  }
+
+  async function history(
+    targetInput: ProtocolDeploymentReleaseTarget,
+  ): Promise<readonly DeploymentActivationRecord[]> {
+    const target = validateTarget(targetInput, 'HQ_DEPLOYMENT_ACTIVATION_INVALID_REQUEST');
+    try {
+      const activations = await activationRoot();
+      const key = sha256(TARGET_IDENTITY_DOMAIN, targetCanonical(target));
+      const targetDirectory = path.join(activations, key);
+      if (!await pathExists(targetDirectory)) return Object.freeze([]);
+      return await resolveHistory(targetDirectory, target);
+    } catch (error) {
+      if (error instanceof DeploymentActivationError) throw error;
+      throw activationError(
+        'HQ_DEPLOYMENT_ACTIVATION_IO',
+        'Could not read deployment activation history.',
+        error,
+      );
+    }
+  }
+
+  async function current(
+    target: ProtocolDeploymentReleaseTarget,
+  ): Promise<DeploymentActivationRecord | undefined> {
+    return currentActivation(await history(target));
+  }
+
+  async function activate(
+    request: DeploymentActivationRequest,
+  ): Promise<DeploymentActivationResult> {
+    const target = validateTarget(request.target, 'HQ_DEPLOYMENT_ACTIVATION_INVALID_REQUEST');
+    const releaseIdentity = requireIdentity(
+      request.releaseIdentity,
+      'Deployment release identity',
+      'HQ_DEPLOYMENT_ACTIVATION_INVALID_REQUEST',
+    );
+    const expectedRevision = requireNullableIdentity(
+      request.expectedRevision,
+      'Expected deployment activation revision',
+      'HQ_DEPLOYMENT_ACTIVATION_INVALID_REQUEST',
+    );
+    let storedRelease: DeploymentActivationRelease | undefined;
+    try {
+      storedRelease = await options.releases.read(releaseIdentity);
+    } catch (error) {
+      throw activationError(
+        'HQ_DEPLOYMENT_ACTIVATION_RELEASE_UNAVAILABLE',
+        `Could not verify deployment release before activation: ${releaseIdentity}`,
+        error,
+      );
+    }
+    if (!storedRelease) {
+      throw activationError(
+        'HQ_DEPLOYMENT_ACTIVATION_RELEASE_NOT_FOUND',
+        `Deployment release is not stored: ${releaseIdentity}`,
+      );
+    }
+    let verifiedRelease;
+    try {
+      verifiedRelease = prepareProtocolDeploymentReleaseEnvelope(storedRelease.release);
+    } catch (error) {
+      throw activationError(
+        'HQ_DEPLOYMENT_ACTIVATION_RELEASE_UNAVAILABLE',
+        `Stored deployment release is invalid: ${releaseIdentity}`,
+        error,
+      );
+    }
+    if (storedRelease.releaseIdentity !== releaseIdentity
+      || verifiedRelease.identity !== releaseIdentity) {
+      throw activationError(
+        'HQ_DEPLOYMENT_ACTIVATION_RELEASE_UNAVAILABLE',
+        `Stored deployment release identity is inconsistent: ${releaseIdentity}`,
+      );
+    }
+    if (!targetsEqual(verifiedRelease.release.target, target)) {
+      throw activationError(
+        'HQ_DEPLOYMENT_ACTIVATION_TARGET_MISMATCH',
+        'Deployment release target does not match the activation target.',
+      );
+    }
+
+    try {
+      const activations = await activationRoot();
+      const targetDirectory = await ensureTargetDirectory(activations, target);
+      const existingHistory = await resolveHistory(targetDirectory, target);
+      const existing = currentActivation(existingHistory);
+      if (existing?.releaseIdentity === releaseIdentity) {
+        return Object.freeze({ status: 'already-active', activation: existing });
+      }
+      if ((existing?.revision ?? null) !== expectedRevision) {
+        return Object.freeze({ status: 'conflict', current: existing ?? null });
+      }
+
+      let now: Date;
+      try {
+        now = clock();
+        if (!(now instanceof Date) || !Number.isFinite(now.valueOf())) throw new Error('Invalid date.');
+      } catch (error) {
+        throw activationError(
+          'HQ_DEPLOYMENT_ACTIVATION_CONFIGURATION',
+          'Deployment activation clock returned an invalid value.',
+          error,
+        );
+      }
+      const prepared = prepareActivation({
+        target,
+        releaseIdentity,
+        previousRevision: existing?.revision ?? null,
+        previousReleaseIdentity: existing?.releaseIdentity ?? null,
+        activatedAt: now.toISOString(),
+      });
+      const claimsDirectory = path.join(targetDirectory, CLAIMS_DIRECTORY);
+      const claimName = existing?.revision ?? INITIAL_CLAIM;
+      const destination = path.join(claimsDirectory, claimName);
+      const published = await withStagingDirectory(
+        // Staging lives outside the exact target directory, so interrupted
+        // writers are invisible to history readers until the atomic rename.
+        activations,
+        '.activation-staging-',
+        async staging => {
+          await writeExclusiveFile(path.join(staging, ACTIVATION_FILE), prepared.bytes);
+          await syncDirectory(staging);
+          try {
+            await rename(staging, destination);
+          } catch (error) {
+            if (!await pathExists(destination)) throw error;
+            return false;
+          }
+          await syncDirectory(claimsDirectory);
+          return true;
+        },
+      );
+      if (published) {
+        return Object.freeze({ status: 'activated', activation: prepared.record });
+      }
+      const resolved = currentActivation(await resolveHistory(targetDirectory, target));
+      if (resolved?.releaseIdentity === releaseIdentity) {
+        return Object.freeze({ status: 'already-active', activation: resolved });
+      }
+      return Object.freeze({ status: 'conflict', current: resolved ?? null });
+    } catch (error) {
+      if (error instanceof DeploymentActivationError) throw error;
+      throw activationError(
+        'HQ_DEPLOYMENT_ACTIVATION_IO',
+        'Could not update deployment activation state.',
+        error,
+      );
+    }
+  }
+
+  return Object.freeze({ activate, current, history });
+}

--- a/packages/deployment/src/activation.ts
+++ b/packages/deployment/src/activation.ts
@@ -12,6 +12,7 @@ import {
 import path from 'node:path';
 import {
   prepareProtocolDeploymentReleaseEnvelope,
+  validateProtocolDeploymentReleaseTarget,
   type ProtocolDeploymentReleaseEnvelope,
   type ProtocolDeploymentReleaseTarget,
 } from '@hypequery/protocol';
@@ -151,12 +152,7 @@ function validateTarget(
   code: DeploymentActivationErrorCode,
 ): ProtocolDeploymentReleaseTarget {
   try {
-    return prepareProtocolDeploymentReleaseEnvelope({
-      kind: 'hypequery-deployment-release',
-      version: 1,
-      bundleIdentity: '0'.repeat(64),
-      target: input,
-    }).release.target;
+    return validateProtocolDeploymentReleaseTarget(input);
   } catch (error) {
     throw activationError(code, 'Deployment activation target is invalid.', error);
   }
@@ -338,13 +334,18 @@ async function requireRegularDirectory(directory: string, description: string): 
   }
 }
 
-async function ensureRegularDirectory(directory: string, description: string): Promise<void> {
+async function ensureRegularDirectory(
+  directory: string,
+  description: string,
+): Promise<boolean> {
+  let created = false;
   try {
-    await mkdir(directory, { recursive: true, mode: 0o700 });
+    created = await mkdir(directory, { recursive: true, mode: 0o700 }) !== undefined;
   } catch (error) {
     if (errorCode(error) !== 'EEXIST') throw error;
   }
   await requireRegularDirectory(directory, description);
+  return created;
 }
 
 async function syncDirectory(directory: string): Promise<void> {
@@ -596,13 +597,29 @@ export function createFileSystemDeploymentActivationRegistry(
     );
   }
   const clock = options.clock ?? (() => new Date());
+  const activations = path.join(root, 'activations');
+  let initializationPromise: Promise<void> | undefined;
+
+  async function initializeActivationRoot(): Promise<void> {
+    const rootCreated = await ensureRegularDirectory(root, 'Deployment store root');
+    const activationsCreated = await ensureRegularDirectory(
+      activations,
+      'Deployment activation store',
+    );
+    if (activationsCreated) await syncDirectory(root);
+    if (rootCreated) await syncDirectory(path.dirname(root));
+  }
 
   async function activationRoot(): Promise<string> {
-    await ensureRegularDirectory(root, 'Deployment store root');
-    const activations = path.join(root, 'activations');
-    await ensureRegularDirectory(activations, 'Deployment activation store');
-    await syncDirectory(root);
-    await syncDirectory(path.dirname(root));
+    const pending = initializationPromise ??= initializeActivationRoot();
+    try {
+      await pending;
+    } catch (error) {
+      if (initializationPromise === pending) initializationPromise = undefined;
+      throw error;
+    }
+    await requireRegularDirectory(root, 'Deployment store root');
+    await requireRegularDirectory(activations, 'Deployment activation store');
     return activations;
   }
 

--- a/packages/deployment/src/index.ts
+++ b/packages/deployment/src/index.ts
@@ -1,4 +1,18 @@
 export {
+  createFileSystemDeploymentActivationRegistry,
+  DeploymentActivationError,
+} from './activation.js';
+export type {
+  DeploymentActivationErrorCode,
+  DeploymentActivationRegistry,
+  DeploymentActivationRelease,
+  DeploymentActivationRecord,
+  DeploymentActivationRequest,
+  DeploymentActivationResult,
+  DeploymentReleaseReader,
+  FileSystemDeploymentActivationRegistryOptions,
+} from './activation.js';
+export {
   DEPLOYMENT_BUNDLE_CONTRACT,
   DEPLOYMENT_BUNDLE_MANIFEST,
   verifyDeploymentBundle,

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -50,6 +50,7 @@ describe('@hypequery/protocol public surface', () => {
       'validateProtocolDeploymentBundleManifest',
       'validateProtocolDeploymentContract',
       'validateProtocolDeploymentReleaseEnvelope',
+      'validateProtocolDeploymentReleaseTarget',
       'validateProtocolExpression',
       'validateProtocolQueryImplementation',
       'validateProtocolSchema',

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -106,6 +106,7 @@ export {
   hashProtocolDeploymentReleaseEnvelope,
   prepareProtocolDeploymentReleaseEnvelope,
   validateProtocolDeploymentReleaseEnvelope,
+  validateProtocolDeploymentReleaseTarget,
 } from './releases/index.js';
 
 export type {

--- a/packages/protocol/src/releases/index.ts
+++ b/packages/protocol/src/releases/index.ts
@@ -8,7 +8,10 @@ export {
 } from './codec.js';
 export type { PreparedProtocolDeploymentReleaseEnvelope } from './codec.js';
 export { DEFAULT_PROTOCOL_DEPLOYMENT_RELEASE_LIMITS } from './limits.js';
-export { validateProtocolDeploymentReleaseEnvelope } from './validate.js';
+export {
+  validateProtocolDeploymentReleaseEnvelope,
+  validateProtocolDeploymentReleaseTarget,
+} from './validate.js';
 export type {
   ProtocolDeploymentReleaseEnvelope,
   ProtocolDeploymentReleaseErrorCode,

--- a/packages/protocol/src/releases/releases.test.ts
+++ b/packages/protocol/src/releases/releases.test.ts
@@ -10,6 +10,7 @@ import {
   PROTOCOL_DEPLOYMENT_RELEASE_IDENTITY_DOMAIN,
   ProtocolDeploymentReleaseError,
   validateProtocolDeploymentReleaseEnvelope,
+  validateProtocolDeploymentReleaseTarget,
 } from './index.js';
 
 interface SuccessFixture { id: string; value: unknown }
@@ -133,6 +134,17 @@ describe('deployment release envelope v1', () => {
       }),
       'HQ_RELEASE_INVALID_VALUE',
       '$.target.project',
+    );
+  });
+
+  it('validates release targets independently as immutable snapshots', () => {
+    const target = validateProtocolDeploymentReleaseTarget(baseRelease().target);
+    expect(target).toEqual(baseRelease().target);
+    expect(Object.isFrozen(target)).toBe(true);
+    expectReleaseError(
+      () => validateProtocolDeploymentReleaseTarget({ ...target, extra: true }),
+      'HQ_RELEASE_UNKNOWN_FIELD',
+      '$.target.extra',
     );
   });
 

--- a/packages/protocol/src/releases/validate.ts
+++ b/packages/protocol/src/releases/validate.ts
@@ -53,7 +53,7 @@ function targetToken(value: unknown, path: string, maximum: number): string {
   return value;
 }
 
-function validateTarget(
+function validateTargetWithMaximum(
   input: unknown,
   maximum: number,
 ): ProtocolDeploymentReleaseTarget {
@@ -63,6 +63,16 @@ function validateTarget(
     project: targetToken(value.project, '$.target.project', maximum),
     environment: targetToken(value.environment, '$.target.environment', maximum),
   }) as unknown as ProtocolDeploymentReleaseTarget;
+}
+
+export function validateProtocolDeploymentReleaseTarget(
+  input: unknown,
+  options: ProtocolDeploymentReleaseOptions = {},
+): ProtocolDeploymentReleaseTarget {
+  return validateTargetWithMaximum(
+    input,
+    resolveDeploymentReleaseLimits(options).maxTargetBytes,
+  );
 }
 
 export function validateProtocolDeploymentReleaseEnvelope(
@@ -90,6 +100,6 @@ export function validateProtocolDeploymentReleaseEnvelope(
     kind: 'hypequery-deployment-release',
     version: 1,
     bundleIdentity: value.bundleIdentity,
-    target: validateTarget(value.target, limits.maxTargetBytes),
+    target: validateTargetWithMaximum(value.target, limits.maxTargetBytes),
   }) as unknown as ProtocolDeploymentReleaseEnvelope;
 }

--- a/specs/deployment/0002-target-activation.md
+++ b/specs/deployment/0002-target-activation.md
@@ -1,0 +1,103 @@
+# Deployment control plane 0002: Target activation
+
+- Status: Proposed
+- Version: deployment activation 1
+
+## Summary
+
+This specification defines how an accepted deployment release becomes the
+active release for one project and environment. Activation changes only
+control-plane state. It does not alter the immutable release, bundle, deployment
+contract, or runtime artifacts, and it does not prescribe runtime loading or
+traffic routing.
+
+## Preconditions
+
+Before attempting an activation, an implementation MUST:
+
+1. validate the target and release identity using the release-envelope v1
+   constraints;
+2. locate the accepted release by its recomputed release identity;
+3. completely revalidate the accepted release and its closed bundle;
+4. require the release target to equal the requested project and environment;
+5. authorize the caller for that target at the provider boundary.
+
+An activation MUST fail closed if the release is missing, its stored content is
+unavailable or invalid, or its target differs. An active pointer does not replace
+stored-content validation.
+
+## Compare-and-swap request
+
+An activation request contains:
+
+- `target`: the exact `project` and `environment`;
+- `releaseIdentity`: the accepted release to activate;
+- `expectedRevision`: the currently observed activation revision, or `null` if
+  the caller observed no active release.
+
+The revision, rather than only the release identity, is the concurrency token.
+Every successful transition creates a new revision, including a rollback to a
+previously active release. This prevents an ABA sequence from satisfying a
+stale caller's comparison.
+
+If the requested release is already active, the operation is idempotent and
+returns `already-active`, regardless of `expectedRevision`. Otherwise, if the
+current revision does not equal `expectedRevision`, the operation returns
+`conflict` with the current record and makes no change. A successful comparison
+atomically commits one new record and returns `activated`.
+
+## Activation record
+
+Each committed record is immutable and contains:
+
+- kind `hypequery-deployment-activation` and version `1`;
+- a domain-separated SHA-256 revision of the complete transition payload;
+- the exact target and new release identity;
+- the previous activation revision and release identity, or `null` for the
+  first activation;
+- a receiver-generated canonical UTC timestamp.
+
+The timestamp is operational metadata and is not a concurrency token or proof
+of ordering. Chain position defines ordering. History readers MUST reject
+non-canonical records, revision mismatches, invalid predecessor links, cycles,
+branches, and unreachable records.
+
+Rollback uses the same activation operation with an older accepted release
+identity. There is no special rollback mutation and no historical record is
+rewritten.
+
+## Reference filesystem registry
+
+The reference registry uses this layout beneath the deployment store root:
+
+```text
+activations/
+  <target identity>/
+    target.json
+    claims/
+      initial/activation.json
+      <previous activation revision>/activation.json
+```
+
+The target identity is a domain-separated hash of the canonical target. The
+stored `target.json` is checked on every read so a path collision or misplaced
+directory fails closed.
+
+Each claim directory is named for the revision it replaces. The first
+activation claims `initial`; later activations claim the current revision.
+Publishing a complete claim directory with an atomic rename is the commit point.
+Only one writer can claim a predecessor, providing compare-and-swap across
+processes without a mutable current file or a lock that can remain stale after a
+crash.
+
+Files and directories are synced before and after publication where the host
+platform exposes those operations. A crash before rename may leave an ignored
+staging directory. A crash after rename leaves a complete committed record that
+history traversal discovers. Unknown, symbolic-link, partial, conflicting, or
+unreachable committed state fails closed.
+
+## Out of scope
+
+This version does not define HTTP routes, authentication mechanisms, runtime
+materialization, traffic switching, health checks, automatic rollback,
+deactivation, retention, or garbage collection.


### PR DESCRIPTION
## Summary

- define a provider-neutral, target-scoped deployment activation contract
- add immutable activation records with domain-separated revisions
- implement filesystem-backed atomic compare-and-swap without a mutable pointer or persistent lock
- support idempotent activation, explicit conflicts, history, and rollback without ABA races
- revalidate accepted release identity, target, and closed-bundle availability before activation
- add deployment control-plane specification 0002 and package documentation

## Why

Submission acceptance and durable storage do not decide which release serves a project and environment. This adds that control-plane boundary while keeping HTTP transport, runtime loading, traffic routing, health checks, and authorization adapters out of scope.

## Filesystem model

Each predecessor revision owns one successor claim path. A complete activation record is staged, synced, and atomically renamed into that path. Exactly one concurrent writer can claim a predecessor. Readers derive the active release by validating the append-only chain, which avoids a mutable current pointer and stale crash locks.

## Validation

- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm types`
- `pnpm --filter @hypequery/deployment pack --pack-destination /tmp/hypequery-deployment-activation-pack`

The activation suite covers empty state, first activation, stale comparisons, concurrent same/different releases, idempotency, rollback, ABA protection, target mismatch, missing/corrupt releases, tampered records, unreachable claims, symlinks, and interrupted staging.