### PR TITLE
Add deployment control plane HTTP adapters

### DIFF
--- a/.changeset/deployment-control-plane-http.md
+++ b/.changeset/deployment-control-plane-http.md
@@ -1,0 +1,7 @@
+---
+'@hypequery/deployment': minor
+---
+
+Add a provider-neutral deployment HTTP control plane with authenticated target
+activation, current-state and bounded-history reads, and streaming Fetch and
+Node adapters.

--- a/packages/deployment/README.md
+++ b/packages/deployment/README.md
@@ -1,7 +1,7 @@
 # @hypequery/deployment
 
-Provider-neutral verification and receiving-side intake for Hypequery deployment
-bundles.
+Provider-neutral verification, intake, activation, and HTTP control-plane
+building blocks for Hypequery deployment bundles.
 
 The package accepts the authenticated multipart transport emitted by
 `hypequery deploy`, reconstructs only manifest-declared files in temporary
@@ -151,5 +151,37 @@ record for every transition and derives the current release by verifying the
 append-only chain. It has no mutable pointer file or persistent lock to become
 stale after a crash. Activation does not load runtime code, route traffic,
 perform health checks, or authorize callers; those remain provider concerns.
+
+## HTTP control plane
+
+`createDeploymentControlPlane` combines intake and activation behind closed v1
+routes. Activation reads and writes use a separate target-scoped authorizer;
+write authorization completes before the small JSON request body is consumed.
+The Fetch and Node adapters preserve streaming multipart submission bodies.
+
+```ts
+import {
+  createDeploymentControlPlane,
+  createDeploymentControlPlaneNodeHandler,
+} from '@hypequery/deployment';
+
+const controlPlane = createDeploymentControlPlane({
+  intake,
+  activations,
+  authenticator,
+  authorizer: {
+    async authorize({ principal, action, target }) {
+      return canControlDeployment(principal, action, target);
+    },
+  },
+});
+
+const nodeHandler = createDeploymentControlPlaneNodeHandler(controlPlane);
+```
+
+The control plane exposes release submission, compare-and-swap activation,
+current state, and bounded cursor history. It returns stable, bounded JSON error
+codes and suppresses internal provider and filesystem details. The HTTP
+contract is specified in `specs/deployment/0003-control-plane-http.md`.
 
 The package is ESM-only and requires Node.js 20 or newer.

--- a/packages/deployment/src/activation.test.ts
+++ b/packages/deployment/src/activation.test.ts
@@ -266,6 +266,23 @@ describe('filesystem deployment activation registry', () => {
       second.submission.releaseIdentity,
       first.submission.releaseIdentity,
     ]);
+    const newest = await registry.historyPage(target, { limit: 1 });
+    const older = await registry.historyPage(target, {
+      limit: 1,
+      before: newest.nextBefore!,
+    });
+    const oldest = await registry.historyPage(target, {
+      limit: 1,
+      before: older.nextBefore!,
+    });
+    expect(newest).toEqual({ activations: [rollback.activation], nextBefore: rollback.activation.revision });
+    expect(older).toEqual({ activations: [forward.activation], nextBefore: forward.activation.revision });
+    expect(oldest).toEqual({ activations: [initial.activation], nextBefore: null });
+    expect(Object.isFrozen(newest.activations)).toBe(true);
+    await expectActivationCode(
+      registry.historyPage(target, { limit: 1, before: 'f'.repeat(64) }),
+      'HQ_DEPLOYMENT_ACTIVATION_INVALID_REQUEST',
+    );
   });
 
   it('returns the current record on a compare-and-swap conflict', async () => {

--- a/packages/deployment/src/activation.ts
+++ b/packages/deployment/src/activation.ts
@@ -81,6 +81,16 @@ export type DeploymentActivationResult =
     readonly current: DeploymentActivationRecord | null;
   };
 
+export interface DeploymentActivationHistoryQuery {
+  readonly limit: number;
+  readonly before?: string;
+}
+
+export interface DeploymentActivationHistoryPage {
+  readonly activations: readonly DeploymentActivationRecord[];
+  readonly nextBefore: string | null;
+}
+
 export interface DeploymentActivationRelease {
   readonly release: ProtocolDeploymentReleaseEnvelope;
   readonly releaseIdentity: string;
@@ -105,6 +115,10 @@ export interface DeploymentActivationRegistry {
   history(
     target: ProtocolDeploymentReleaseTarget,
   ): Promise<readonly DeploymentActivationRecord[]>;
+  historyPage(
+    target: ProtocolDeploymentReleaseTarget,
+    query: DeploymentActivationHistoryQuery,
+  ): Promise<DeploymentActivationHistoryPage>;
 }
 
 interface PreparedActivation {
@@ -516,10 +530,11 @@ async function readStoredActivation(
   return prepared;
 }
 
-async function resolveHistory(
+async function visitHistory(
   targetDirectory: string,
   target: ProtocolDeploymentReleaseTarget,
-): Promise<readonly DeploymentActivationRecord[]> {
+  visitor: (record: DeploymentActivationRecord) => void,
+): Promise<void> {
   try {
     await readCanonicalTarget(targetDirectory, target);
     const claimsDirectory = path.join(targetDirectory, CLAIMS_DIRECTORY);
@@ -531,7 +546,6 @@ async function resolveHistory(
     }
     const remaining = new Set(claimNames);
     const revisions = new Set<string>();
-    const history: DeploymentActivationRecord[] = [];
     let previousRevision: string | null = null;
     let previousReleaseIdentity: string | null = null;
     // Following predecessor-named claims derives the head without trusting a
@@ -549,14 +563,13 @@ async function resolveHistory(
         throw new Error('Deployment activation history contains a cycle.');
       }
       revisions.add(prepared.record.revision);
-      history.push(prepared.record);
+      visitor(prepared.record);
       previousRevision = prepared.record.revision;
       previousReleaseIdentity = prepared.record.releaseIdentity;
     }
     if (remaining.size > 0) {
       throw new Error('Deployment activation history contains unreachable claims.');
     }
-    return Object.freeze(history);
   } catch (error) {
     if (error instanceof DeploymentActivationError) throw error;
     if (isOperationalFileSystemError(error)) throw error;
@@ -568,10 +581,71 @@ async function resolveHistory(
   }
 }
 
-function currentActivation(
-  history: readonly DeploymentActivationRecord[],
-): DeploymentActivationRecord | undefined {
-  return history[history.length - 1];
+async function resolveHistory(
+  targetDirectory: string,
+  target: ProtocolDeploymentReleaseTarget,
+): Promise<readonly DeploymentActivationRecord[]> {
+  const history: DeploymentActivationRecord[] = [];
+  await visitHistory(targetDirectory, target, record => { history.push(record); });
+  return Object.freeze(history);
+}
+
+async function resolveCurrent(
+  targetDirectory: string,
+  target: ProtocolDeploymentReleaseTarget,
+): Promise<DeploymentActivationRecord | undefined> {
+  let current: DeploymentActivationRecord | undefined;
+  await visitHistory(targetDirectory, target, record => { current = record; });
+  return current;
+}
+
+function validateHistoryQuery(
+  input: DeploymentActivationHistoryQuery,
+): DeploymentActivationHistoryQuery {
+  if (!Number.isSafeInteger(input?.limit) || input.limit < 1
+    || (input.before !== undefined && !IDENTITY_PATTERN.test(input.before))) {
+    throw activationError(
+      'HQ_DEPLOYMENT_ACTIVATION_INVALID_REQUEST',
+      'Deployment activation history query is invalid.',
+    );
+  }
+  return Object.freeze({
+    limit: input.limit,
+    ...(input.before === undefined ? {} : { before: input.before }),
+  });
+}
+
+async function resolveHistoryPage(
+  targetDirectory: string,
+  target: ProtocolDeploymentReleaseTarget,
+  query: DeploymentActivationHistoryQuery,
+): Promise<DeploymentActivationHistoryPage> {
+  const retained: DeploymentActivationRecord[] = [];
+  let beforeFound = query.before === undefined;
+  let beforeReached = false;
+  await visitHistory(targetDirectory, target, record => {
+    if (record.revision === query.before) {
+      beforeFound = true;
+      beforeReached = true;
+      return;
+    }
+    if (beforeReached) return;
+    retained.push(record);
+    if (retained.length > query.limit + 1) retained.shift();
+  });
+  if (!beforeFound) {
+    throw activationError(
+      'HQ_DEPLOYMENT_ACTIVATION_INVALID_REQUEST',
+      'Deployment activation history cursor was not found.',
+    );
+  }
+  const hasOlder = retained.length > query.limit;
+  if (hasOlder) retained.shift();
+  const activations = Object.freeze(retained);
+  return Object.freeze({
+    activations,
+    nextBefore: hasOlder ? activations[0]!.revision : null,
+  });
 }
 
 export function createFileSystemDeploymentActivationRegistry(
@@ -644,9 +718,45 @@ export function createFileSystemDeploymentActivationRegistry(
   }
 
   async function current(
-    target: ProtocolDeploymentReleaseTarget,
+    targetInput: ProtocolDeploymentReleaseTarget,
   ): Promise<DeploymentActivationRecord | undefined> {
-    return currentActivation(await history(target));
+    const target = validateTarget(targetInput, 'HQ_DEPLOYMENT_ACTIVATION_INVALID_REQUEST');
+    try {
+      const key = sha256(TARGET_IDENTITY_DOMAIN, targetCanonical(target));
+      const targetDirectory = path.join(await activationRoot(), key);
+      if (!await pathExists(targetDirectory)) return undefined;
+      return await resolveCurrent(targetDirectory, target);
+    } catch (error) {
+      if (error instanceof DeploymentActivationError) throw error;
+      throw activationError(
+        'HQ_DEPLOYMENT_ACTIVATION_IO',
+        'Could not read the current deployment activation.',
+        error,
+      );
+    }
+  }
+
+  async function historyPage(
+    targetInput: ProtocolDeploymentReleaseTarget,
+    queryInput: DeploymentActivationHistoryQuery,
+  ): Promise<DeploymentActivationHistoryPage> {
+    const target = validateTarget(targetInput, 'HQ_DEPLOYMENT_ACTIVATION_INVALID_REQUEST');
+    const query = validateHistoryQuery(queryInput);
+    try {
+      const key = sha256(TARGET_IDENTITY_DOMAIN, targetCanonical(target));
+      const targetDirectory = path.join(await activationRoot(), key);
+      if (!await pathExists(targetDirectory)) {
+        return Object.freeze({ activations: Object.freeze([]), nextBefore: null });
+      }
+      return await resolveHistoryPage(targetDirectory, target, query);
+    } catch (error) {
+      if (error instanceof DeploymentActivationError) throw error;
+      throw activationError(
+        'HQ_DEPLOYMENT_ACTIVATION_IO',
+        'Could not read deployment activation history.',
+        error,
+      );
+    }
   }
 
   async function activate(
@@ -706,8 +816,7 @@ export function createFileSystemDeploymentActivationRegistry(
     try {
       const activations = await activationRoot();
       const targetDirectory = await ensureTargetDirectory(activations, target);
-      const existingHistory = await resolveHistory(targetDirectory, target);
-      const existing = currentActivation(existingHistory);
+      const existing = await resolveCurrent(targetDirectory, target);
       if (existing?.releaseIdentity === releaseIdentity) {
         return Object.freeze({ status: 'already-active', activation: existing });
       }
@@ -757,7 +866,7 @@ export function createFileSystemDeploymentActivationRegistry(
       if (published) {
         return Object.freeze({ status: 'activated', activation: prepared.record });
       }
-      const resolved = currentActivation(await resolveHistory(targetDirectory, target));
+      const resolved = await resolveCurrent(targetDirectory, target);
       if (resolved?.releaseIdentity === releaseIdentity) {
         return Object.freeze({ status: 'already-active', activation: resolved });
       }
@@ -772,5 +881,5 @@ export function createFileSystemDeploymentActivationRegistry(
     }
   }
 
-  return Object.freeze({ activate, current, history });
+  return Object.freeze({ activate, current, history, historyPage });
 }

--- a/packages/deployment/src/control-plane-adapters.test.ts
+++ b/packages/deployment/src/control-plane-adapters.test.ts
@@ -1,0 +1,109 @@
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createDeploymentControlPlaneFetchHandler,
+  createDeploymentControlPlaneNodeHandler,
+} from './control-plane-adapters.js';
+import type { DeploymentControlPlane } from './control-plane.js';
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(server => new Promise<void>((resolve, reject) => {
+    server.close(error => { if (error) reject(error); else resolve(); });
+  })));
+});
+
+function success(body = '{"ok":true}\n') {
+  return Object.freeze({
+    status: 200,
+    headers: Object.freeze({
+      'content-type': 'application/json; charset=utf-8',
+      'x-control-plane': 'true',
+    }),
+    body,
+  });
+}
+
+describe('deployment control-plane HTTP adapters', () => {
+  it('streams Fetch request bytes and preserves duplicate query parameters', async () => {
+    let handlerStarted = false;
+    let streamPulledBeforeHandler = false;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (!handlerStarted) streamPulledBeforeHandler = true;
+        controller.enqueue(Buffer.from('streamed-fetch-body'));
+        controller.close();
+      },
+    });
+    const handle = vi.fn<DeploymentControlPlane['handle']>(async request => {
+      handlerStarted = true;
+      const chunks: Uint8Array[] = [];
+      for await (const chunk of request.body) chunks.push(chunk);
+      expect(Buffer.concat(chunks).toString()).toBe('streamed-fetch-body');
+      expect(request.query?.limit).toEqual(['1', '2']);
+      expect(request.query?.__proto__).toBe('value');
+      expect(request.hasBody).toBe(true);
+      return success();
+    });
+    const fetchHandler = createDeploymentControlPlaneFetchHandler({ handle });
+    const request = new Request('https://deploy.example/v1/test?limit=1&limit=2&__proto__=value', {
+      method: 'POST',
+      body: stream,
+      duplex: 'half',
+    } as RequestInit & { duplex: 'half' });
+
+    const response = await fetchHandler(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-control-plane')).toBe('true');
+    expect(await response.json()).toEqual({ ok: true });
+    expect(handle).toHaveBeenCalledOnce();
+    expect(streamPulledBeforeHandler).toBe(false);
+  });
+
+  it('streams Node request bytes and writes the exact control-plane response', async () => {
+    const handle = vi.fn<DeploymentControlPlane['handle']>(async request => {
+      const chunks: Uint8Array[] = [];
+      for await (const chunk of request.body) chunks.push(chunk);
+      expect(Buffer.concat(chunks).toString()).toBe('streamed-node-body');
+      expect(request.path).toBe('/v1/test');
+      expect(request.query).toEqual({ cursor: ['a', 'b'] });
+      expect(request.hasBody).toBe(true);
+      return success('{"transport":"node"}\n');
+    });
+    const server = createServer(createDeploymentControlPlaneNodeHandler({ handle }));
+    servers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const { port } = server.address() as AddressInfo;
+
+    const response = await fetch(`http://127.0.0.1:${port}/v1/test?cursor=a&cursor=b`, {
+      method: 'POST',
+      body: 'streamed-node-body',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-control-plane')).toBe('true');
+    expect(await response.json()).toEqual({ transport: 'node' });
+    expect(handle).toHaveBeenCalledOnce();
+  });
+
+  it('contains unexpected adapter and custom-handler failures', async () => {
+    const fetchHandler = createDeploymentControlPlaneFetchHandler({
+      handle: async () => { throw new Error('sensitive fetch failure'); },
+    });
+    const response = await fetchHandler(new Request('https://deploy.example/v1/test'));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: {
+        code: 'HQ_CONTROL_INTERNAL',
+        message: 'The deployment control-plane request could not be processed.',
+      },
+    });
+  });
+});

--- a/packages/deployment/src/control-plane-adapters.test.ts
+++ b/packages/deployment/src/control-plane-adapters.test.ts
@@ -92,6 +92,26 @@ describe('deployment control-plane HTTP adapters', () => {
     expect(handle).toHaveBeenCalledOnce();
   });
 
+  it('preserves potential duplicate Fetch singleton headers for core rejection', async () => {
+    const headers = new Headers();
+    headers.append('authorization', 'Bearer first');
+    headers.append('authorization', 'Bearer second');
+    const handle = vi.fn<DeploymentControlPlane['handle']>(async request => {
+      expect(Object.keys(request.headers).filter(name => (
+        name.toLowerCase() === 'authorization'
+      ))).toHaveLength(2);
+      return success();
+    });
+    const fetchHandler = createDeploymentControlPlaneFetchHandler({ handle });
+
+    const response = await fetchHandler(new Request('https://deploy.example/v1/test', {
+      headers,
+    }));
+
+    expect(response.status).toBe(200);
+    expect(handle).toHaveBeenCalledOnce();
+  });
+
   it('contains unexpected adapter and custom-handler failures', async () => {
     const fetchHandler = createDeploymentControlPlaneFetchHandler({
       handle: async () => { throw new Error('sensitive fetch failure'); },

--- a/packages/deployment/src/control-plane-adapters.ts
+++ b/packages/deployment/src/control-plane-adapters.ts
@@ -1,0 +1,162 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type {
+  DeploymentControlPlane,
+  DeploymentControlPlaneRequest,
+  DeploymentControlPlaneResponse,
+} from './control-plane.js';
+
+export type DeploymentControlPlaneFetchHandler = (request: Request) => Promise<Response>;
+export type DeploymentControlPlaneNodeHandler = (
+  request: IncomingMessage,
+  response: ServerResponse,
+) => Promise<void>;
+
+type ControlPlaneQuery = NonNullable<DeploymentControlPlaneRequest['query']>;
+
+const INTERNAL_BODY = '{"error":{"code":"HQ_CONTROL_INTERNAL","message":"The deployment control-plane request could not be processed."}}\n';
+const INTERNAL_RESPONSE: DeploymentControlPlaneResponse = Object.freeze({
+  status: 500,
+  headers: Object.freeze({
+    'content-type': 'application/json; charset=utf-8',
+    'content-length': String(Buffer.byteLength(INTERNAL_BODY)),
+    'cache-control': 'no-store',
+  }),
+  body: INTERNAL_BODY,
+});
+
+function queryParameters(search: URLSearchParams): ControlPlaneQuery {
+  const query = Object.create(null) as Record<string, string | readonly string[]>;
+  for (const [name, value] of search) {
+    const current = query[name];
+    if (current === undefined) {
+      query[name] = value;
+    } else if (typeof current === 'string') {
+      query[name] = Object.freeze([current, value]);
+    } else {
+      query[name] = Object.freeze([...current, value]);
+    }
+  }
+  return Object.freeze(query);
+}
+
+function fetchHeaders(input: Headers): Readonly<Record<string, string>> {
+  return Object.freeze(Object.fromEntries(input.entries()));
+}
+
+async function* fetchBody(input: ReadableStream<Uint8Array> | null): AsyncGenerator<Uint8Array> {
+  if (input === null) return;
+  const reader = input.getReader();
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) return;
+      yield result.value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function nodeHeaders(request: IncomingMessage): Readonly<Record<string, string>> {
+  const headers = Object.create(null) as Record<string, string>;
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    const name = request.rawHeaders[index]!.toLowerCase();
+    const value = request.rawHeaders[index + 1]!;
+    if (headers[name] === undefined) {
+      headers[name] = value;
+    } else {
+      // Keep a second case-insensitive entry so the core duplicate-header guard
+      // observes duplicates instead of accepting Node's comma-joined value.
+      headers[name.toUpperCase()] = value;
+    }
+  }
+  return Object.freeze(headers);
+}
+
+async function* nodeBody(request: IncomingMessage): AsyncGenerator<Uint8Array> {
+  for await (const chunk of request) {
+    yield chunk instanceof Uint8Array ? chunk : Buffer.from(chunk as string);
+  }
+}
+
+function nodeHasBody(headers: Readonly<Record<string, string>>): boolean {
+  return Object.entries(headers).some(([name, value]) => {
+    const normalized = name.toLowerCase();
+    return normalized === 'transfer-encoding'
+      || (normalized === 'content-length' && value !== '0');
+  });
+}
+
+function internalFetchResponse(): Response {
+  return new Response(INTERNAL_RESPONSE.body, {
+    status: INTERNAL_RESPONSE.status,
+    headers: INTERNAL_RESPONSE.headers,
+  });
+}
+
+function sendNodeResponse(
+  response: ServerResponse,
+  controlResponse: DeploymentControlPlaneResponse,
+): void {
+  if (response.writableEnded || response.headersSent) return;
+  response.statusCode = controlResponse.status;
+  for (const [name, value] of Object.entries(controlResponse.headers)) {
+    response.setHeader(name, value);
+  }
+  response.end(controlResponse.body);
+}
+
+export function createDeploymentControlPlaneFetchHandler(
+  controlPlane: DeploymentControlPlane,
+): DeploymentControlPlaneFetchHandler {
+  return async request => {
+    try {
+      const url = new URL(request.url);
+      const response = await controlPlane.handle({
+        method: request.method,
+        path: url.pathname,
+        query: queryParameters(url.searchParams),
+        headers: fetchHeaders(request.headers),
+        body: fetchBody(request.body),
+        hasBody: request.body !== null,
+        signal: request.signal,
+      });
+      return new Response(response.body, { status: response.status, headers: response.headers });
+    } catch {
+      return internalFetchResponse();
+    }
+  };
+}
+
+export function createDeploymentControlPlaneNodeHandler(
+  controlPlane: DeploymentControlPlane,
+): DeploymentControlPlaneNodeHandler {
+  return async (request, response) => {
+    const abort = new AbortController();
+    const abortRequest = () => abort.abort(new Error('The request was aborted.'));
+    const abortResponse = () => {
+      if (!response.writableEnded) abort.abort(new Error('The response connection was closed.'));
+    };
+    request.once('aborted', abortRequest);
+    response.once('close', abortResponse);
+    try {
+      const url = new URL(request.url ?? '/', 'http://deployment-control-plane.invalid');
+      const headers = nodeHeaders(request);
+      const controlResponse = await controlPlane.handle({
+        method: request.method ?? 'GET',
+        path: url.pathname,
+        query: queryParameters(url.searchParams),
+        headers,
+        body: nodeBody(request),
+        hasBody: nodeHasBody(headers),
+        signal: abort.signal,
+      });
+      sendNodeResponse(response, controlResponse);
+    } catch {
+      sendNodeResponse(response, INTERNAL_RESPONSE);
+    } finally {
+      request.off('aborted', abortRequest);
+      response.off('close', abortResponse);
+    }
+  };
+}

--- a/packages/deployment/src/control-plane-adapters.ts
+++ b/packages/deployment/src/control-plane-adapters.ts
@@ -23,6 +23,14 @@ const INTERNAL_RESPONSE: DeploymentControlPlaneResponse = Object.freeze({
   }),
   body: INTERNAL_BODY,
 });
+const FETCH_SINGLETON_HEADERS = new Set([
+  'authorization',
+  'content-length',
+  'content-type',
+  'idempotency-key',
+  'x-hypequery-bundle-identity',
+  'x-hypequery-release-identity',
+]);
 
 function queryParameters(search: URLSearchParams): ControlPlaneQuery {
   const query = Object.create(null) as Record<string, string | readonly string[]>;
@@ -40,7 +48,16 @@ function queryParameters(search: URLSearchParams): ControlPlaneQuery {
 }
 
 function fetchHeaders(input: Headers): Readonly<Record<string, string>> {
-  return Object.freeze(Object.fromEntries(input.entries()));
+  const headers = Object.create(null) as Record<string, string>;
+  for (const [name, value] of input.entries()) {
+    headers[name] = value;
+    if (FETCH_SINGLETON_HEADERS.has(name) && value.includes(',')) {
+      // Fetch combines duplicate header lines before exposing Headers. Reify a
+      // second case-insensitive entry so the core singleton guard rejects it.
+      headers[name.toUpperCase()] = value;
+    }
+  }
+  return Object.freeze(headers);
 }
 
 async function* fetchBody(input: ReadableStream<Uint8Array> | null): AsyncGenerator<Uint8Array> {
@@ -133,12 +150,15 @@ export function createDeploymentControlPlaneNodeHandler(
 ): DeploymentControlPlaneNodeHandler {
   return async (request, response) => {
     const abort = new AbortController();
-    const abortRequest = () => abort.abort(new Error('The request was aborted.'));
+    const abortRequest = () => {
+      if (!request.complete) abort.abort(new Error('The request connection was closed.'));
+    };
     const abortResponse = () => {
       if (!response.writableEnded) abort.abort(new Error('The response connection was closed.'));
     };
-    request.once('aborted', abortRequest);
+    request.socket.once('close', abortRequest);
     response.once('close', abortResponse);
+    if (request.destroyed && !request.complete) abortRequest();
     try {
       const url = new URL(request.url ?? '/', 'http://deployment-control-plane.invalid');
       const headers = nodeHeaders(request);
@@ -155,7 +175,7 @@ export function createDeploymentControlPlaneNodeHandler(
     } catch {
       sendNodeResponse(response, INTERNAL_RESPONSE);
     } finally {
-      request.off('aborted', abortRequest);
+      request.socket.off('close', abortRequest);
       response.off('close', abortResponse);
     }
   };

--- a/packages/deployment/src/control-plane-limits.ts
+++ b/packages/deployment/src/control-plane-limits.ts
@@ -1,0 +1,28 @@
+export interface DeploymentControlPlaneLimits {
+  readonly maxActivationRequestBytes: number;
+  readonly maxHistoryPageSize: number;
+}
+
+export const DEFAULT_DEPLOYMENT_CONTROL_PLANE_LIMITS:
+Readonly<DeploymentControlPlaneLimits> = Object.freeze({
+  maxActivationRequestBytes: 16 * 1024,
+  maxHistoryPageSize: 100,
+});
+
+export function resolveDeploymentControlPlaneLimits(
+  input: Partial<DeploymentControlPlaneLimits> = {},
+): Readonly<DeploymentControlPlaneLimits> {
+  const limits = { ...DEFAULT_DEPLOYMENT_CONTROL_PLANE_LIMITS };
+  for (const key of Object.keys(limits) as (keyof DeploymentControlPlaneLimits)[]) {
+    const value = input[key];
+    if (value === undefined) continue;
+    if (!Number.isSafeInteger(value) || value < 1
+      || value > DEFAULT_DEPLOYMENT_CONTROL_PLANE_LIMITS[key]) {
+      throw new RangeError(
+        `${key} must be a positive safe integer no greater than the control-plane v1 maximum`,
+      );
+    }
+    limits[key] = value;
+  }
+  return Object.freeze(limits);
+}

--- a/packages/deployment/src/control-plane.test.ts
+++ b/packages/deployment/src/control-plane.test.ts
@@ -67,6 +67,10 @@ function fixture(overrides: {
     activate: vi.fn(async () => ({ status: 'activated', activation: defaultActivation })),
     current: vi.fn(async () => defaultActivation),
     history: vi.fn(async () => [defaultActivation]),
+    historyPage: vi.fn(async () => ({
+      activations: Object.freeze([defaultActivation]),
+      nextBefore: null,
+    })),
     ...overrides.registry,
   };
   const intake = overrides.intake ?? {
@@ -196,8 +200,14 @@ describe('deployment control plane', () => {
   it('reads current activation and bounded cursor history', async () => {
     const first = activation(REVISION_ONE);
     const second = activation(REVISION_TWO, REVISION_ONE);
+    const historyPage = vi.fn(async (
+      _target: typeof TARGET,
+      query: { readonly limit: number; readonly before?: string },
+    ) => query.before === undefined
+      ? { activations: Object.freeze([second]), nextBefore: REVISION_TWO }
+      : { activations: Object.freeze([first]), nextBefore: null });
     const { controlPlane, authorize } = fixture({
-      registry: { current: async () => undefined, history: async () => [first, second] },
+      registry: { current: async () => undefined, historyPage },
       limits: { maxHistoryPageSize: 1 },
     });
 
@@ -219,6 +229,11 @@ describe('deployment control plane', () => {
       'read-activation-history',
       'read-activation-history',
     ]);
+    expect(historyPage).toHaveBeenNthCalledWith(1, TARGET, { limit: 1 });
+    expect(historyPage).toHaveBeenNthCalledWith(2, TARGET, {
+      limit: 1,
+      before: REVISION_TWO,
+    });
   });
 
   it('rejects duplicate, unknown, and out-of-range history query parameters', async () => {
@@ -236,6 +251,28 @@ describe('deployment control plane', () => {
       expect(response.status).toBe(400);
       expect(parsed(response).error.code).toBe('HQ_CONTROL_BAD_REQUEST');
     }
+  });
+
+  it('maps a history cursor missing from storage to a bad request', async () => {
+    const { controlPlane } = fixture({
+      registry: {
+        historyPage: async () => {
+          throw new DeploymentActivationError(
+            'HQ_DEPLOYMENT_ACTIVATION_INVALID_REQUEST',
+            'cursor missing',
+          );
+        },
+      },
+    });
+
+    const response = await controlPlane.handle(request({
+      path: '/v1/deployments/targets/analytics/production/activations',
+      query: { before: REVISION_ONE },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(parsed(response).error.code).toBe('HQ_CONTROL_BAD_REQUEST');
+    expect(response.body).not.toContain('cursor missing');
   });
 
   it('rejects invalid activation bodies and enforces the configured byte limit', async () => {
@@ -337,7 +374,7 @@ describe('deployment control plane', () => {
 
     expect(unknown.status).toBe(404);
     expect(wrongMethod.status).toBe(405);
-    expect(wrongMethod.headers.allow).toBe('PUT');
+    expect(wrongMethod.headers.allow).toBe('GET, PUT');
   });
 });
 

--- a/packages/deployment/src/control-plane.test.ts
+++ b/packages/deployment/src/control-plane.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DeploymentActivationError,
+  type DeploymentActivationRecord,
+  type DeploymentActivationRegistry,
+} from './activation.js';
+import { createDeploymentControlPlane } from './control-plane.js';
+import {
+  DEFAULT_DEPLOYMENT_CONTROL_PLANE_LIMITS,
+  resolveDeploymentControlPlaneLimits,
+} from './control-plane-limits.js';
+import type {
+  DeploymentIntake,
+  DeploymentIntakeResponse,
+} from './types.js';
+
+const RELEASE = '1'.repeat(64);
+const REVISION_ONE = '2'.repeat(64);
+const REVISION_TWO = '3'.repeat(64);
+const TARGET = Object.freeze({ project: 'analytics', environment: 'production' });
+
+async function* noBody(): AsyncGenerator<Uint8Array> {}
+
+async function* body(value: string, onRead?: () => void): AsyncGenerator<Uint8Array> {
+  onRead?.();
+  yield Buffer.from(value);
+}
+
+function activation(
+  revision: string,
+  previousRevision: string | null = null,
+): DeploymentActivationRecord {
+  return Object.freeze({
+    kind: 'hypequery-deployment-activation',
+    version: 1,
+    revision,
+    target: TARGET,
+    releaseIdentity: RELEASE,
+    previousRevision,
+    previousReleaseIdentity: previousRevision === null ? null : RELEASE,
+    activatedAt: '2026-07-19T12:00:00.000Z',
+  });
+}
+
+function activationRequest(expectedRevision: string | null = null): string {
+  return JSON.stringify({
+    kind: 'hypequery-deployment-activation-request',
+    version: 1,
+    releaseIdentity: RELEASE,
+    expectedRevision,
+  });
+}
+
+function parsed(response: DeploymentIntakeResponse): any {
+  return JSON.parse(response.body);
+}
+
+function fixture(overrides: {
+  readonly authenticate?: () => Promise<string | null>;
+  readonly authorize?: () => Promise<boolean>;
+  readonly registry?: Partial<DeploymentActivationRegistry>;
+  readonly intake?: DeploymentIntake;
+  readonly limits?: { readonly maxActivationRequestBytes?: number; readonly maxHistoryPageSize?: number };
+} = {}) {
+  const defaultActivation = activation(REVISION_ONE);
+  const registry: DeploymentActivationRegistry = {
+    activate: vi.fn(async () => ({ status: 'activated', activation: defaultActivation })),
+    current: vi.fn(async () => defaultActivation),
+    history: vi.fn(async () => [defaultActivation]),
+    ...overrides.registry,
+  };
+  const intake = overrides.intake ?? {
+    handle: vi.fn(async () => ({
+      status: 202,
+      headers: Object.freeze({ 'content-type': 'application/json' }),
+      body: '{"status":"accepted"}\n',
+    })),
+  };
+  const authenticate = vi.fn(overrides.authenticate ?? (async () => 'operator'));
+  const authorize = vi.fn(overrides.authorize ?? (async () => true));
+  const controlPlane = createDeploymentControlPlane({
+    intake,
+    activations: registry,
+    authenticator: { authenticate },
+    authorizer: { authorize },
+    limits: overrides.limits,
+  });
+  return { controlPlane, registry, intake, authenticate, authorize };
+}
+
+function request(overrides: Record<string, unknown> = {}) {
+  return {
+    method: 'GET',
+    path: '/v1/deployments/targets/analytics/production/activation',
+    query: {},
+    headers: { authorization: 'Bearer secret' },
+    body: noBody(),
+    hasBody: false,
+    ...overrides,
+  };
+}
+
+describe('deployment control plane', () => {
+  it('delegates the streaming submission route to deployment intake', async () => {
+    const { controlPlane, intake, authenticate } = fixture();
+    const submission = request({
+      method: 'POST',
+      path: '/v1/deployments/submissions',
+      headers: { 'content-type': 'multipart/form-data' },
+    });
+
+    const response = await controlPlane.handle(submission);
+
+    expect(response.status).toBe(202);
+    expect(intake.handle).toHaveBeenCalledWith(submission);
+    expect(authenticate).not.toHaveBeenCalled();
+  });
+
+  it('authenticates and authorizes before reading an activation body', async () => {
+    let consumed = false;
+    const { controlPlane, authorize } = fixture({ authorize: async () => false });
+
+    const response = await controlPlane.handle(request({
+      method: 'PUT',
+      headers: { authorization: 'Bearer secret', 'content-type': 'application/json' },
+      body: body(activationRequest(), () => { consumed = true; }),
+      hasBody: true,
+    }));
+
+    expect(response.status).toBe(403);
+    expect(parsed(response).error.code).toBe('HQ_CONTROL_FORBIDDEN');
+    expect(authorize).toHaveBeenCalledWith({
+      principal: 'operator',
+      action: 'activate',
+      target: TARGET,
+      signal: undefined,
+    });
+    expect(consumed).toBe(false);
+  });
+
+  it('activates a release with compare-and-swap semantics', async () => {
+    const record = activation(REVISION_TWO, REVISION_ONE);
+    const activate = vi.fn(async () => ({ status: 'activated' as const, activation: record }));
+    const { controlPlane } = fixture({ registry: { activate } });
+    const encoded = activationRequest(REVISION_ONE);
+
+    const response = await controlPlane.handle(request({
+      method: 'PUT',
+      headers: {
+        authorization: 'Bearer secret',
+        'content-type': 'application/json; charset=utf-8',
+        'content-length': String(Buffer.byteLength(encoded)),
+      },
+      body: body(encoded),
+      hasBody: true,
+    }));
+
+    expect(response.status).toBe(201);
+    expect(parsed(response)).toEqual({
+      kind: 'hypequery-deployment-activation-response',
+      version: 1,
+      status: 'activated',
+      activation: record,
+    });
+    expect(activate).toHaveBeenCalledWith({
+      target: TARGET,
+      releaseIdentity: RELEASE,
+      expectedRevision: REVISION_ONE,
+    });
+  });
+
+  it('returns conflicts and already-active results without losing current state', async () => {
+    const current = activation(REVISION_ONE);
+    const conflict = fixture({
+      registry: { activate: async () => ({ status: 'conflict', current }) },
+    });
+    const already = fixture({
+      registry: { activate: async () => ({ status: 'already-active', activation: current }) },
+    });
+    const activationHttpRequest = () => request({
+      method: 'PUT',
+      headers: { authorization: 'Bearer secret', 'content-type': 'application/json' },
+      body: body(activationRequest()),
+      hasBody: true,
+    });
+
+    const conflictResponse = await conflict.controlPlane.handle(activationHttpRequest());
+    const alreadyResponse = await already.controlPlane.handle(activationHttpRequest());
+
+    expect(conflictResponse.status).toBe(409);
+    expect(parsed(conflictResponse).current).toEqual(current);
+    expect(alreadyResponse.status).toBe(200);
+    expect(parsed(alreadyResponse).status).toBe('already-active');
+  });
+
+  it('reads current activation and bounded cursor history', async () => {
+    const first = activation(REVISION_ONE);
+    const second = activation(REVISION_TWO, REVISION_ONE);
+    const { controlPlane, authorize } = fixture({
+      registry: { current: async () => undefined, history: async () => [first, second] },
+      limits: { maxHistoryPageSize: 1 },
+    });
+
+    const current = await controlPlane.handle(request());
+    const newest = await controlPlane.handle(request({
+      path: '/v1/deployments/targets/analytics/production/activations',
+      query: {},
+    }));
+    const older = await controlPlane.handle(request({
+      path: '/v1/deployments/targets/analytics/production/activations',
+      query: { before: parsed(newest).nextBefore },
+    }));
+
+    expect(parsed(current).activation).toBeNull();
+    expect(parsed(newest)).toMatchObject({ activations: [second], nextBefore: REVISION_TWO });
+    expect(parsed(older)).toMatchObject({ activations: [first], nextBefore: null });
+    expect(authorize.mock.calls.map(call => call[0].action)).toEqual([
+      'read-current-activation',
+      'read-activation-history',
+      'read-activation-history',
+    ]);
+  });
+
+  it('rejects duplicate, unknown, and out-of-range history query parameters', async () => {
+    const { controlPlane } = fixture({ limits: { maxHistoryPageSize: 2 } });
+    const historyPath = '/v1/deployments/targets/analytics/production/activations';
+
+    for (const query of [
+      { limit: ['1', '2'] },
+      { before: [REVISION_ONE, REVISION_TWO] },
+      { limit: '3' },
+      { unknown: 'value' },
+      { __proto__: null, constructor: 'value' },
+    ]) {
+      const response = await controlPlane.handle(request({ path: historyPath, query }));
+      expect(response.status).toBe(400);
+      expect(parsed(response).error.code).toBe('HQ_CONTROL_BAD_REQUEST');
+    }
+  });
+
+  it('rejects invalid activation bodies and enforces the configured byte limit', async () => {
+    const { controlPlane } = fixture({ limits: { maxActivationRequestBytes: 512 } });
+    const base = {
+      method: 'PUT',
+      headers: { authorization: 'Bearer secret', 'content-type': 'application/json' },
+      hasBody: true,
+    };
+
+    const oversized = await controlPlane.handle(request({
+      ...base,
+      headers: { ...base.headers, 'content-length': '513' },
+      body: body('x'.repeat(513)),
+    }));
+    const openShape = await controlPlane.handle(request({
+      ...base,
+      body: body(JSON.stringify({
+        ...JSON.parse(activationRequest()),
+        extra: true,
+      })),
+    }));
+
+    expect(oversized.status).toBe(413);
+    expect(parsed(oversized).error.code).toBe('HQ_CONTROL_TOO_LARGE');
+    expect(openShape.status).toBe(400);
+  });
+
+  it('rejects bodies on read routes without consuming them', async () => {
+    let consumed = false;
+    const { controlPlane, authenticate } = fixture();
+    const response = await controlPlane.handle(request({
+      body: body('unexpected', () => { consumed = true; }),
+      hasBody: true,
+    }));
+
+    expect(response.status).toBe(400);
+    expect(consumed).toBe(false);
+    expect(authenticate).not.toHaveBeenCalled();
+  });
+
+  it('maps activation storage errors to stable, non-leaking HTTP errors', async () => {
+    const { controlPlane } = fixture({
+      registry: {
+        current: async () => {
+          throw new DeploymentActivationError(
+            'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE',
+            'sensitive filesystem detail',
+          );
+        },
+      },
+    });
+
+    const response = await controlPlane.handle(request());
+
+    expect(response.status).toBe(500);
+    expect(parsed(response)).toEqual({
+      error: {
+        code: 'HQ_CONTROL_INTERNAL',
+        message: 'The deployment control-plane request could not be processed.',
+      },
+    });
+    expect(response.body).not.toContain('filesystem');
+  });
+
+  it('does not expose custom registry details for expected release failures', async () => {
+    const { controlPlane } = fixture({
+      registry: {
+        activate: async () => {
+          throw new DeploymentActivationError(
+            'HQ_DEPLOYMENT_ACTIVATION_RELEASE_NOT_FOUND',
+            'sensitive provider detail',
+          );
+        },
+      },
+    });
+
+    const response = await controlPlane.handle(request({
+      method: 'PUT',
+      headers: { authorization: 'Bearer secret', 'content-type': 'application/json' },
+      body: body(activationRequest()),
+      hasBody: true,
+    }));
+
+    expect(response.status).toBe(404);
+    expect(parsed(response).error).toEqual({
+      code: 'HQ_CONTROL_RELEASE_NOT_FOUND',
+      message: 'The deployment release was not found.',
+    });
+    expect(response.body).not.toContain('provider');
+  });
+
+  it('returns strict route and method errors', async () => {
+    const { controlPlane } = fixture();
+    const unknown = await controlPlane.handle(request({
+      path: '/v1/deployments/targets/%/production/unknown',
+    }));
+    const wrongMethod = await controlPlane.handle(request({ method: 'POST' }));
+
+    expect(unknown.status).toBe(404);
+    expect(wrongMethod.status).toBe(405);
+    expect(wrongMethod.headers.allow).toBe('PUT');
+  });
+});
+
+describe('deployment control-plane limits', () => {
+  it('accepts explicit undefined overrides and rejects limits above the v1 maxima', () => {
+    expect(resolveDeploymentControlPlaneLimits({
+      maxActivationRequestBytes: undefined,
+      maxHistoryPageSize: 25,
+    })).toEqual({
+      maxActivationRequestBytes:
+        DEFAULT_DEPLOYMENT_CONTROL_PLANE_LIMITS.maxActivationRequestBytes,
+      maxHistoryPageSize: 25,
+    });
+    expect(() => resolveDeploymentControlPlaneLimits({
+      maxHistoryPageSize: DEFAULT_DEPLOYMENT_CONTROL_PLANE_LIMITS.maxHistoryPageSize + 1,
+    })).toThrow(RangeError);
+  });
+});

--- a/packages/deployment/src/control-plane.ts
+++ b/packages/deployment/src/control-plane.ts
@@ -1,0 +1,596 @@
+import {
+  prepareProtocolDeploymentReleaseEnvelope,
+  type ProtocolDeploymentReleaseTarget,
+} from '@hypequery/protocol';
+import {
+  DeploymentActivationError,
+  type DeploymentActivationRecord,
+  type DeploymentActivationRegistry,
+} from './activation.js';
+import {
+  resolveDeploymentControlPlaneLimits,
+  type DeploymentControlPlaneLimits,
+} from './control-plane-limits.js';
+import type {
+  DeploymentAuthenticator,
+  DeploymentIntake,
+  DeploymentIntakeRequest,
+  DeploymentIntakeResponse,
+} from './types.js';
+
+const IDENTITY_PATTERN = /^[0-9a-f]{64}$/;
+const JSON_CONTENT_TYPE = /^application\/json(?:;\s*charset=utf-8)?$/i;
+const textDecoder = new TextDecoder('utf-8', { fatal: true });
+
+export type DeploymentControlPlaneAction =
+  | 'activate'
+  | 'read-current-activation'
+  | 'read-activation-history';
+
+export interface DeploymentControlPlaneAuthorizationInput<Principal> {
+  readonly principal: Principal;
+  readonly action: DeploymentControlPlaneAction;
+  readonly target: ProtocolDeploymentReleaseTarget;
+  readonly signal?: AbortSignal;
+}
+
+export interface DeploymentControlPlaneAuthorizer<Principal> {
+  authorize(input: DeploymentControlPlaneAuthorizationInput<Principal>): Promise<boolean>;
+}
+
+export interface DeploymentControlPlaneRequest extends DeploymentIntakeRequest {
+  readonly method: string;
+  readonly path: string;
+  readonly query?: Readonly<Record<string, string | readonly string[] | undefined>>;
+  /** Set by transport adapters without consuming the request stream. */
+  readonly hasBody?: boolean;
+}
+
+export type DeploymentControlPlaneResponse = DeploymentIntakeResponse;
+
+export interface DeploymentControlPlane {
+  handle(request: DeploymentControlPlaneRequest): Promise<DeploymentControlPlaneResponse>;
+}
+
+export interface DeploymentControlPlaneOptions<Principal> {
+  readonly intake: DeploymentIntake;
+  readonly activations: DeploymentActivationRegistry;
+  readonly authenticator: DeploymentAuthenticator<Principal>;
+  readonly authorizer: DeploymentControlPlaneAuthorizer<Principal>;
+  readonly limits?: Partial<DeploymentControlPlaneLimits>;
+}
+
+export type DeploymentControlPlaneErrorCode =
+  | 'HQ_CONTROL_BAD_REQUEST'
+  | 'HQ_CONTROL_UNAUTHENTICATED'
+  | 'HQ_CONTROL_FORBIDDEN'
+  | 'HQ_CONTROL_NOT_FOUND'
+  | 'HQ_CONTROL_METHOD_NOT_ALLOWED'
+  | 'HQ_CONTROL_TOO_LARGE'
+  | 'HQ_CONTROL_RELEASE_NOT_FOUND'
+  | 'HQ_CONTROL_RELEASE_UNAVAILABLE'
+  | 'HQ_CONTROL_INTERNAL';
+
+const ERROR_STATUS: Readonly<Record<DeploymentControlPlaneErrorCode, number>> = Object.freeze({
+  HQ_CONTROL_BAD_REQUEST: 400,
+  HQ_CONTROL_UNAUTHENTICATED: 401,
+  HQ_CONTROL_FORBIDDEN: 403,
+  HQ_CONTROL_NOT_FOUND: 404,
+  HQ_CONTROL_METHOD_NOT_ALLOWED: 405,
+  HQ_CONTROL_TOO_LARGE: 413,
+  HQ_CONTROL_RELEASE_NOT_FOUND: 404,
+  HQ_CONTROL_RELEASE_UNAVAILABLE: 503,
+  HQ_CONTROL_INTERNAL: 500,
+});
+
+class ControlPlaneError extends Error {
+  readonly code: DeploymentControlPlaneErrorCode;
+  readonly status: number;
+  readonly expose: boolean;
+  readonly headers: Readonly<Record<string, string>>;
+
+  constructor(
+    code: DeploymentControlPlaneErrorCode,
+    message: string,
+    options: {
+      readonly expose?: boolean;
+      readonly cause?: unknown;
+      readonly headers?: Readonly<Record<string, string>>;
+    } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'DeploymentControlPlaneError';
+    this.code = code;
+    this.status = ERROR_STATUS[code];
+    this.expose = options.expose ?? this.status < 500;
+    this.headers = Object.freeze({ ...options.headers });
+  }
+}
+
+interface ActivationBody {
+  readonly releaseIdentity: string;
+  readonly expectedRevision: string | null;
+}
+
+interface ParsedRoute {
+  readonly kind: 'submission' | 'activation' | 'history';
+  readonly target?: ProtocolDeploymentReleaseTarget;
+}
+
+function requestHeader(
+  headers: Readonly<Record<string, string | undefined>>,
+  expectedName: string,
+): string | undefined {
+  const values = Object.entries(headers)
+    .filter(([name, value]) => value !== undefined && name.toLowerCase() === expectedName)
+    .map(([, value]) => value!);
+  if (values.length > 1) {
+    throw new ControlPlaneError('HQ_CONTROL_BAD_REQUEST', `Duplicate ${expectedName} header.`);
+  }
+  return values[0];
+}
+
+function bearerToken(headers: Readonly<Record<string, string | undefined>>): string {
+  const authorization = requestHeader(headers, 'authorization');
+  const token = authorization?.startsWith('Bearer ') ? authorization.slice(7) : '';
+  if (token.length < 1 || token.length > 4096 || token.trim() !== token
+    || [...token].some(character => {
+      const code = character.charCodeAt(0);
+      return code < 0x21 || code > 0x7e;
+    })) {
+    throw new ControlPlaneError(
+      'HQ_CONTROL_UNAUTHENTICATED',
+      'A valid bearer credential is required.',
+      { headers: { 'www-authenticate': 'Bearer' } },
+    );
+  }
+  return token;
+}
+
+function jsonResponse(
+  status: number,
+  body: unknown,
+  headers: Readonly<Record<string, string>> = {},
+): DeploymentControlPlaneResponse {
+  const encoded = `${JSON.stringify(body)}\n`;
+  return Object.freeze({
+    status,
+    headers: Object.freeze({
+      'content-type': 'application/json; charset=utf-8',
+      'content-length': String(Buffer.byteLength(encoded)),
+      'cache-control': 'no-store',
+      ...headers,
+    }),
+    body: encoded,
+  });
+}
+
+function sanitizeMessage(input: string): string {
+  return [...input].map(character => {
+    const code = character.codePointAt(0) ?? 0;
+    return code < 0x20 || code === 0x7f ? ' ' : character;
+  }).join('').slice(0, 1024).trim() || 'The deployment control-plane request was rejected.';
+}
+
+function errorResponse(error: unknown): DeploymentControlPlaneResponse {
+  const value = error instanceof ControlPlaneError
+    ? error
+    : new ControlPlaneError(
+      'HQ_CONTROL_INTERNAL',
+      'The deployment control-plane request could not be processed.',
+      { expose: false, cause: error },
+    );
+  return jsonResponse(value.status, {
+    error: {
+      code: value.code,
+      message: sanitizeMessage(value.expose
+        ? value.message
+        : 'The deployment control-plane request could not be processed.'),
+    },
+  }, value.headers);
+}
+
+function decodeTargetSegment(input: string): string {
+  try {
+    return decodeURIComponent(input);
+  } catch (error) {
+    throw new ControlPlaneError(
+      'HQ_CONTROL_BAD_REQUEST',
+      'Deployment target path encoding is invalid.',
+      { cause: error },
+    );
+  }
+}
+
+function validatedTarget(project: string, environment: string): ProtocolDeploymentReleaseTarget {
+  try {
+    return prepareProtocolDeploymentReleaseEnvelope({
+      kind: 'hypequery-deployment-release',
+      version: 1,
+      bundleIdentity: '0'.repeat(64),
+      target: {
+        project: decodeTargetSegment(project),
+        environment: decodeTargetSegment(environment),
+      },
+    }).release.target;
+  } catch (error) {
+    if (error instanceof ControlPlaneError) throw error;
+    throw new ControlPlaneError(
+      'HQ_CONTROL_BAD_REQUEST',
+      'Deployment target path is invalid.',
+      { cause: error },
+    );
+  }
+}
+
+function parseRoute(path: string): ParsedRoute | undefined {
+  if (path === '/v1/deployments/submissions') return Object.freeze({ kind: 'submission' });
+  const segments = path.split('/');
+  if (segments.length !== 7 || segments[0] !== '' || segments[1] !== 'v1'
+    || segments[2] !== 'deployments' || segments[3] !== 'targets') return undefined;
+  if (segments[6] !== 'activation' && segments[6] !== 'activations') return undefined;
+  const target = validatedTarget(segments[4]!, segments[5]!);
+  if (segments[6] === 'activation') return Object.freeze({ kind: 'activation', target });
+  if (segments[6] === 'activations') return Object.freeze({ kind: 'history', target });
+  return undefined;
+}
+
+function requireMethod(method: string, expected: string): void {
+  if (method !== expected) {
+    throw new ControlPlaneError(
+      'HQ_CONTROL_METHOD_NOT_ALLOWED',
+      `This deployment control-plane route requires ${expected}.`,
+      { headers: { allow: expected } },
+    );
+  }
+}
+
+function requireNoQuery(request: DeploymentControlPlaneRequest): void {
+  if (request.query && Object.keys(request.query).length > 0) {
+    throw new ControlPlaneError(
+      'HQ_CONTROL_BAD_REQUEST',
+      'This deployment control-plane route does not accept query parameters.',
+    );
+  }
+}
+
+function requireNoBody(request: DeploymentControlPlaneRequest): void {
+  const length = requestHeader(request.headers, 'content-length');
+  const transferEncoding = requestHeader(request.headers, 'transfer-encoding');
+  if (request.hasBody || transferEncoding !== undefined || (length !== undefined && length !== '0')) {
+    throw new ControlPlaneError(
+      'HQ_CONTROL_BAD_REQUEST',
+      'This deployment control-plane route does not accept a request body.',
+    );
+  }
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new ControlPlaneError(
+      'HQ_CONTROL_BAD_REQUEST',
+      'The deployment control-plane request was aborted.',
+      { cause: signal.reason },
+    );
+  }
+}
+
+async function readBoundedBody(
+  request: DeploymentControlPlaneRequest,
+  maximum: number,
+): Promise<Buffer> {
+  const declared = requestHeader(request.headers, 'content-length');
+  let declaredLength: number | undefined;
+  if (declared !== undefined) {
+    if (!/^(?:0|[1-9][0-9]*)$/.test(declared)) {
+      throw new ControlPlaneError(
+        'HQ_CONTROL_BAD_REQUEST',
+        'Content-Length must be a non-negative decimal integer.',
+      );
+    }
+    declaredLength = Number(declared);
+    if (!Number.isSafeInteger(declaredLength) || declaredLength > maximum) {
+      throw new ControlPlaneError(
+        'HQ_CONTROL_TOO_LARGE',
+        'The activation request exceeds its byte limit.',
+      );
+    }
+  }
+  const chunks: Buffer[] = [];
+  let total = 0;
+  try {
+    for await (const chunk of request.body) {
+      throwIfAborted(request.signal);
+      if (!(chunk instanceof Uint8Array)) {
+        throw new ControlPlaneError(
+          'HQ_CONTROL_BAD_REQUEST',
+          'The activation request body yielded a non-byte chunk.',
+        );
+      }
+      total += chunk.byteLength;
+      if (total > maximum) {
+        throw new ControlPlaneError(
+          'HQ_CONTROL_TOO_LARGE',
+          'The activation request exceeds its byte limit.',
+        );
+      }
+      if (declaredLength !== undefined && total > declaredLength) {
+        throw new ControlPlaneError(
+          'HQ_CONTROL_BAD_REQUEST',
+          'The activation request body does not match Content-Length.',
+        );
+      }
+      chunks.push(Buffer.from(chunk));
+    }
+  } catch (error) {
+    if (error instanceof ControlPlaneError) throw error;
+    throw new ControlPlaneError(
+      'HQ_CONTROL_BAD_REQUEST',
+      'The activation request body could not be read.',
+      { cause: error },
+    );
+  }
+  throwIfAborted(request.signal);
+  if (declaredLength !== undefined && total !== declaredLength) {
+    throw new ControlPlaneError(
+      'HQ_CONTROL_BAD_REQUEST',
+      'The activation request body does not match Content-Length.',
+    );
+  }
+  return Buffer.concat(chunks, total);
+}
+
+function parseActivationBody(bytes: Uint8Array): ActivationBody {
+  let input: unknown;
+  try {
+    input = JSON.parse(textDecoder.decode(bytes));
+  } catch (error) {
+    throw new ControlPlaneError(
+      'HQ_CONTROL_BAD_REQUEST',
+      'The activation request must be valid UTF-8 JSON.',
+      { cause: error },
+    );
+  }
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new ControlPlaneError('HQ_CONTROL_BAD_REQUEST', 'The activation request is invalid.');
+  }
+  const value = input as Record<string, unknown>;
+  const expected = ['expectedRevision', 'kind', 'releaseIdentity', 'version'];
+  if (Object.keys(value).sort().join('\0') !== expected.join('\0')
+    || value.kind !== 'hypequery-deployment-activation-request' || value.version !== 1
+    || typeof value.releaseIdentity !== 'string'
+    || !IDENTITY_PATTERN.test(value.releaseIdentity)
+    || (value.expectedRevision !== null
+      && (typeof value.expectedRevision !== 'string'
+        || !IDENTITY_PATTERN.test(value.expectedRevision)))) {
+    throw new ControlPlaneError('HQ_CONTROL_BAD_REQUEST', 'The activation request is invalid.');
+  }
+  return Object.freeze({
+    releaseIdentity: value.releaseIdentity,
+    expectedRevision: value.expectedRevision as string | null,
+  });
+}
+
+function activationError(error: DeploymentActivationError): never {
+  switch (error.code) {
+    case 'HQ_DEPLOYMENT_ACTIVATION_INVALID_REQUEST':
+      throw new ControlPlaneError(
+        'HQ_CONTROL_BAD_REQUEST',
+        'The deployment activation request is invalid.',
+        { cause: error },
+      );
+    case 'HQ_DEPLOYMENT_ACTIVATION_TARGET_MISMATCH':
+      throw new ControlPlaneError(
+        'HQ_CONTROL_BAD_REQUEST',
+        'The deployment release does not match the requested target.',
+        { cause: error },
+      );
+    case 'HQ_DEPLOYMENT_ACTIVATION_RELEASE_NOT_FOUND':
+      throw new ControlPlaneError(
+        'HQ_CONTROL_RELEASE_NOT_FOUND',
+        'The deployment release was not found.',
+        { cause: error },
+      );
+    case 'HQ_DEPLOYMENT_ACTIVATION_RELEASE_UNAVAILABLE':
+      throw new ControlPlaneError(
+        'HQ_CONTROL_RELEASE_UNAVAILABLE',
+        'The deployment release is temporarily unavailable.',
+        { cause: error },
+      );
+    default:
+      throw new ControlPlaneError(
+        'HQ_CONTROL_INTERNAL',
+        'The deployment activation state could not be processed.',
+        { expose: false, cause: error },
+      );
+  }
+}
+
+async function activationCall<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof DeploymentActivationError) activationError(error);
+    throw error;
+  }
+}
+
+function activationResponse(
+  status: 'activated' | 'already-active',
+  activation: DeploymentActivationRecord,
+): DeploymentControlPlaneResponse {
+  return jsonResponse(status === 'activated' ? 201 : 200, {
+    kind: 'hypequery-deployment-activation-response',
+    version: 1,
+    status,
+    activation,
+  });
+}
+
+function validatedHistoryQuery(
+  query: Readonly<Record<string, string | readonly string[] | undefined>> | undefined,
+  maximum: number,
+): { readonly limit: number; readonly before?: string } {
+  const values = query ?? {};
+  if (Object.keys(values).some(key => key !== 'limit' && key !== 'before')) {
+    throw new ControlPlaneError('HQ_CONTROL_BAD_REQUEST', 'History query parameters are invalid.');
+  }
+  const limitInput = values.limit;
+  if (limitInput !== undefined && typeof limitInput !== 'string') {
+    throw new ControlPlaneError('HQ_CONTROL_BAD_REQUEST', 'History limit is invalid.');
+  }
+  const limit = limitInput === undefined ? maximum : Number(limitInput);
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > maximum
+    || (limitInput !== undefined && String(limit) !== limitInput)) {
+    throw new ControlPlaneError('HQ_CONTROL_BAD_REQUEST', 'History limit is invalid.');
+  }
+  const before = values.before;
+  if (before !== undefined && typeof before !== 'string') {
+    throw new ControlPlaneError('HQ_CONTROL_BAD_REQUEST', 'History cursor is invalid.');
+  }
+  if (before !== undefined) {
+    if (!IDENTITY_PATTERN.test(before)) {
+      throw new ControlPlaneError('HQ_CONTROL_BAD_REQUEST', 'History cursor is invalid.');
+    }
+  }
+  return Object.freeze({ limit, ...(before === undefined ? {} : { before }) });
+}
+
+function historyPage(
+  history: readonly DeploymentActivationRecord[],
+  query: { readonly limit: number; readonly before?: string },
+): {
+  readonly activations: readonly DeploymentActivationRecord[];
+  readonly nextBefore: string | null;
+} {
+  let end = history.length;
+  if (query.before !== undefined) {
+    const before = query.before;
+    end = history.findIndex(record => record.revision === before);
+    if (end < 0) {
+      throw new ControlPlaneError('HQ_CONTROL_BAD_REQUEST', 'History cursor was not found.');
+    }
+  }
+  const start = Math.max(0, end - query.limit);
+  return Object.freeze({
+    activations: Object.freeze(history.slice(start, end)),
+    nextBefore: start > 0 ? history[start]!.revision : null,
+  });
+}
+
+export function createDeploymentControlPlane<Principal>(
+  options: DeploymentControlPlaneOptions<Principal>,
+): DeploymentControlPlane {
+  const limits = resolveDeploymentControlPlaneLimits(options.limits);
+
+  async function authenticateAndAuthorize(
+    request: DeploymentControlPlaneRequest,
+    action: DeploymentControlPlaneAction,
+    target: ProtocolDeploymentReleaseTarget,
+  ): Promise<void> {
+    throwIfAborted(request.signal);
+    const token = bearerToken(request.headers);
+    const principal = await options.authenticator.authenticate({ token, signal: request.signal });
+    if (principal === null) {
+      throw new ControlPlaneError(
+        'HQ_CONTROL_UNAUTHENTICATED',
+        'The bearer credential is invalid.',
+        { headers: { 'www-authenticate': 'Bearer' } },
+      );
+    }
+    throwIfAborted(request.signal);
+    const allowed = await options.authorizer.authorize({
+      principal,
+      action,
+      target,
+      signal: request.signal,
+    });
+    if (!allowed) {
+      throw new ControlPlaneError(
+        'HQ_CONTROL_FORBIDDEN',
+        'The caller is not authorized for the deployment target.',
+      );
+    }
+    throwIfAborted(request.signal);
+  }
+
+  async function process(
+    request: DeploymentControlPlaneRequest,
+  ): Promise<DeploymentControlPlaneResponse> {
+    const method = request.method.toUpperCase();
+    const route = parseRoute(request.path);
+    if (!route) {
+      throw new ControlPlaneError('HQ_CONTROL_NOT_FOUND', 'Deployment route not found.');
+    }
+    if (route.kind === 'submission') {
+      requireMethod(method, 'POST');
+      requireNoQuery(request);
+      return options.intake.handle(request);
+    }
+    const target = route.target!;
+    if (route.kind === 'activation') {
+      if (method === 'GET') {
+        requireNoQuery(request);
+        requireNoBody(request);
+        await authenticateAndAuthorize(request, 'read-current-activation', target);
+        const current = await activationCall(() => options.activations.current(target));
+        return jsonResponse(200, {
+          kind: 'hypequery-deployment-current-activation',
+          version: 1,
+          target,
+          activation: current ?? null,
+        });
+      }
+      requireMethod(method, 'PUT');
+      requireNoQuery(request);
+      await authenticateAndAuthorize(request, 'activate', target);
+      const contentType = requestHeader(request.headers, 'content-type');
+      if (!contentType || !JSON_CONTENT_TYPE.test(contentType)) {
+        throw new ControlPlaneError(
+          'HQ_CONTROL_BAD_REQUEST',
+          'Activation requests require application/json with UTF-8 encoding.',
+        );
+      }
+      const body = parseActivationBody(
+        await readBoundedBody(request, limits.maxActivationRequestBytes),
+      );
+      const result = await activationCall(() => options.activations.activate({
+        target,
+        releaseIdentity: body.releaseIdentity,
+        expectedRevision: body.expectedRevision,
+      }));
+      if (result.status === 'conflict') {
+        return jsonResponse(409, {
+          kind: 'hypequery-deployment-activation-response',
+          version: 1,
+          status: 'conflict',
+          current: result.current,
+        });
+      }
+      return activationResponse(result.status, result.activation);
+    }
+    requireMethod(method, 'GET');
+    requireNoBody(request);
+    await authenticateAndAuthorize(request, 'read-activation-history', target);
+    const historyQuery = validatedHistoryQuery(request.query, limits.maxHistoryPageSize);
+    const history = await activationCall(() => options.activations.history(target));
+    const page = historyPage(history, historyQuery);
+    return jsonResponse(200, {
+      kind: 'hypequery-deployment-activation-history',
+      version: 1,
+      target,
+      activations: page.activations,
+      nextBefore: page.nextBefore,
+    });
+  }
+
+  return Object.freeze({
+    async handle(request: DeploymentControlPlaneRequest): Promise<DeploymentControlPlaneResponse> {
+      try {
+        return await process(request);
+      } catch (error) {
+        return errorResponse(error);
+      }
+    },
+  });
+}

--- a/packages/deployment/src/control-plane.ts
+++ b/packages/deployment/src/control-plane.ts
@@ -1,5 +1,5 @@
 import {
-  prepareProtocolDeploymentReleaseEnvelope,
+  validateProtocolDeploymentReleaseTarget,
   type ProtocolDeploymentReleaseTarget,
 } from '@hypequery/protocol';
 import {
@@ -204,15 +204,10 @@ function decodeTargetSegment(input: string): string {
 
 function validatedTarget(project: string, environment: string): ProtocolDeploymentReleaseTarget {
   try {
-    return prepareProtocolDeploymentReleaseEnvelope({
-      kind: 'hypequery-deployment-release',
-      version: 1,
-      bundleIdentity: '0'.repeat(64),
-      target: {
-        project: decodeTargetSegment(project),
-        environment: decodeTargetSegment(environment),
-      },
-    }).release.target;
+    return validateProtocolDeploymentReleaseTarget({
+      project: decodeTargetSegment(project),
+      environment: decodeTargetSegment(environment),
+    });
   } catch (error) {
     if (error instanceof ControlPlaneError) throw error;
     throw new ControlPlaneError(
@@ -235,12 +230,13 @@ function parseRoute(path: string): ParsedRoute | undefined {
   return undefined;
 }
 
-function requireMethod(method: string, expected: string): void {
-  if (method !== expected) {
+function requireMethod(method: string, ...expected: readonly string[]): void {
+  if (!expected.includes(method)) {
+    const allowed = expected.join(', ');
     throw new ControlPlaneError(
       'HQ_CONTROL_METHOD_NOT_ALLOWED',
-      `This deployment control-plane route requires ${expected}.`,
-      { headers: { allow: expected } },
+      `This deployment control-plane route requires ${allowed}.`,
+      { headers: { allow: allowed } },
     );
   }
 }
@@ -456,28 +452,6 @@ function validatedHistoryQuery(
   return Object.freeze({ limit, ...(before === undefined ? {} : { before }) });
 }
 
-function historyPage(
-  history: readonly DeploymentActivationRecord[],
-  query: { readonly limit: number; readonly before?: string },
-): {
-  readonly activations: readonly DeploymentActivationRecord[];
-  readonly nextBefore: string | null;
-} {
-  let end = history.length;
-  if (query.before !== undefined) {
-    const before = query.before;
-    end = history.findIndex(record => record.revision === before);
-    if (end < 0) {
-      throw new ControlPlaneError('HQ_CONTROL_BAD_REQUEST', 'History cursor was not found.');
-    }
-  }
-  const start = Math.max(0, end - query.limit);
-  return Object.freeze({
-    activations: Object.freeze(history.slice(start, end)),
-    nextBefore: start > 0 ? history[start]!.revision : null,
-  });
-}
-
 export function createDeploymentControlPlane<Principal>(
   options: DeploymentControlPlaneOptions<Principal>,
 ): DeploymentControlPlane {
@@ -541,7 +515,7 @@ export function createDeploymentControlPlane<Principal>(
           activation: current ?? null,
         });
       }
-      requireMethod(method, 'PUT');
+      requireMethod(method, 'GET', 'PUT');
       requireNoQuery(request);
       await authenticateAndAuthorize(request, 'activate', target);
       const contentType = requestHeader(request.headers, 'content-type');
@@ -573,8 +547,9 @@ export function createDeploymentControlPlane<Principal>(
     requireNoBody(request);
     await authenticateAndAuthorize(request, 'read-activation-history', target);
     const historyQuery = validatedHistoryQuery(request.query, limits.maxHistoryPageSize);
-    const history = await activationCall(() => options.activations.history(target));
-    const page = historyPage(history, historyQuery);
+    const page = await activationCall(() => (
+      options.activations.historyPage(target, historyQuery)
+    ));
     return jsonResponse(200, {
       kind: 'hypequery-deployment-activation-history',
       version: 1,

--- a/packages/deployment/src/index.ts
+++ b/packages/deployment/src/index.ts
@@ -36,6 +36,32 @@ export {
   createDeploymentIntake,
 } from './intake.js';
 export {
+  createDeploymentControlPlaneFetchHandler,
+  createDeploymentControlPlaneNodeHandler,
+} from './control-plane-adapters.js';
+export type {
+  DeploymentControlPlaneFetchHandler,
+  DeploymentControlPlaneNodeHandler,
+} from './control-plane-adapters.js';
+export {
+  createDeploymentControlPlane,
+} from './control-plane.js';
+export type {
+  DeploymentControlPlane,
+  DeploymentControlPlaneAction,
+  DeploymentControlPlaneAuthorizationInput,
+  DeploymentControlPlaneAuthorizer,
+  DeploymentControlPlaneErrorCode,
+  DeploymentControlPlaneOptions,
+  DeploymentControlPlaneRequest,
+  DeploymentControlPlaneResponse,
+} from './control-plane.js';
+export {
+  DEFAULT_DEPLOYMENT_CONTROL_PLANE_LIMITS,
+  resolveDeploymentControlPlaneLimits,
+} from './control-plane-limits.js';
+export type { DeploymentControlPlaneLimits } from './control-plane-limits.js';
+export {
   DEFAULT_DEPLOYMENT_INTAKE_LIMITS,
   resolveDeploymentIntakeLimits,
 } from './limits.js';

--- a/packages/deployment/src/index.ts
+++ b/packages/deployment/src/index.ts
@@ -4,6 +4,8 @@ export {
 } from './activation.js';
 export type {
   DeploymentActivationErrorCode,
+  DeploymentActivationHistoryPage,
+  DeploymentActivationHistoryQuery,
   DeploymentActivationRegistry,
   DeploymentActivationRelease,
   DeploymentActivationRecord,

--- a/specs/deployment/0002-target-activation.md
+++ b/specs/deployment/0002-target-activation.md
@@ -66,6 +66,12 @@ Rollback uses the same activation operation with an older accepted release
 identity. There is no special rollback mutation and no historical record is
 rewritten.
 
+Registries expose bounded history pages using a positive `limit` and an
+optional `before` revision. Providers SHOULD apply that cursor and limit while
+reading storage rather than materializing the complete history. Returned
+records remain chronological and strictly precede `before`; `nextBefore` is
+the first returned revision when older records remain, otherwise `null`.
+
 ## Reference filesystem registry
 
 The reference registry uses this layout beneath the deployment store root:

--- a/specs/deployment/0003-control-plane-http.md
+++ b/specs/deployment/0003-control-plane-http.md
@@ -1,0 +1,119 @@
+# Deployment control plane 0003: HTTP transport
+
+- Status: Proposed
+- Version: deployment control-plane HTTP 1
+
+## Summary
+
+This specification exposes authenticated release submission and target
+activation through a provider-neutral HTTP control plane. It binds the intake
+contract from specification 0001 and the activation contract from specification
+0002 to closed routes and JSON messages without defining runtime loading,
+traffic switching, or provider credentials.
+
+## Routes
+
+The v1 routes are:
+
+| Method | Path | Action |
+| --- | --- | --- |
+| `POST` | `/v1/deployments/submissions` | Submit one release and closed bundle using the multipart contract from specification 0001. |
+| `PUT` | `/v1/deployments/targets/{project}/{environment}/activation` | Compare-and-swap the target's active release. |
+| `GET` | `/v1/deployments/targets/{project}/{environment}/activation` | Read the current activation, or `null`. |
+| `GET` | `/v1/deployments/targets/{project}/{environment}/activations` | Read bounded activation history. |
+
+Project and environment path segments are percent-decoded exactly once and
+then validated with the release-target v1 constraints. Unknown routes return
+`404`; a known route with the wrong method returns `405` and an `Allow` header.
+
+Submission requests are delegated unchanged to deployment intake. In
+particular, the control plane MUST NOT buffer or pre-consume their multipart
+body.
+
+## Authentication and authorization
+
+Every activation read or write requires one strict `Authorization: Bearer
+<credential>` header. The provider authenticator maps the opaque credential to
+a principal. The provider authorizer receives that principal, the validated
+target, and one of these actions:
+
+- `activate`;
+- `read-current-activation`;
+- `read-activation-history`.
+
+Authentication and authorization MUST complete before an activation write body
+is read. A missing or invalid credential returns `401`; a valid principal that
+cannot perform the action returns `403`. Submission authentication and
+authorization retain the ordering defined by specification 0001.
+
+## Activation write
+
+An activation write requires `application/json` and this exact object shape:
+
+```json
+{
+  "kind": "hypequery-deployment-activation-request",
+  "version": 1,
+  "releaseIdentity": "<64 lowercase hexadecimal characters>",
+  "expectedRevision": null
+}
+```
+
+`expectedRevision` may instead be a 64-character activation revision. Unknown
+properties, invalid UTF-8, duplicate query parameters, unsupported media types,
+and bodies over the configured limit are rejected. A declared `Content-Length`
+is checked against both the limit and the received byte count.
+
+A committed transition returns `201` with status `activated`. An idempotent
+request for the already-active release returns `200` with status
+`already-active`. A failed compare-and-swap returns `409`, status `conflict`,
+and the current activation without changing state.
+
+## Activation reads
+
+The current route accepts no query parameters or request body and returns the
+validated target plus `activation`, which is an activation record or `null`.
+
+The history route accepts only:
+
+- `limit`: a canonical positive decimal integer no greater than the configured
+  page-size limit;
+- `before`: an activation revision previously returned as `nextBefore`.
+
+History records are returned in chronological order. A page contains records
+strictly before its `before` cursor. `nextBefore` is the cursor for the next
+older page or `null` when no older record remains. Repeated parameters and
+unknown cursors fail closed.
+
+## Responses and errors
+
+Control-plane JSON responses are UTF-8, use `Cache-Control: no-store`, and have
+a trailing line feed. Errors have this bounded shape:
+
+```json
+{
+  "error": {
+    "code": "HQ_CONTROL_BAD_REQUEST",
+    "message": "The activation request is invalid."
+  }
+}
+```
+
+Stable control-plane codes distinguish malformed requests, authentication,
+authorization, missing routes, method mismatches, size limits, missing or
+temporarily unavailable releases, and internal failures. Internal storage and
+provider error details MUST NOT appear in a response.
+
+## Transport adapters
+
+The reference Fetch and Node adapters translate URL, method, headers, query,
+abort state, and response metadata. Both expose request bodies as
+`AsyncIterable<Uint8Array>` and MUST preserve streaming for multipart
+submissions. Core limits remain authoritative; adapters do not introduce a
+second buffering limit or parse payloads themselves.
+
+## Out of scope
+
+This version does not define credential issuance, CORS, service discovery,
+runtime materialization, health checks, traffic routing, automatic rollback,
+retention, or garbage collection.

--- a/specs/deployment/README.md
+++ b/specs/deployment/README.md
@@ -7,3 +7,12 @@ Unlike `specs/security-protocol`, these specifications may describe HTTP,
 authentication, authorization, idempotent persistence, and service responses.
 They must not weaken or replace the validation, identity, or closed-content
 requirements of the referenced immutable artifacts.
+
+Current specifications:
+
+- `0001-authenticated-deployment-submission.md` defines streaming authenticated
+  release intake;
+- `0002-target-activation.md` defines immutable target activation and
+  compare-and-swap behavior;
+- `0003-control-plane-http.md` binds submission and activation to provider-neutral
+  HTTP routes and adapters.


### PR DESCRIPTION
## Summary

- add a provider-neutral HTTP control plane for release intake and target-scoped activation
- add Fetch and Node transport adapters with strict request and response limits
- document deployment control-plane contract 0003 and export the new APIs

## Why

This supplies the authenticated control-plane boundary that build and deployment clients use without coupling the deployment core to a specific HTTP framework.

## Validation

- `pnpm types`
- `pnpm lint`
- `pnpm test`
- `pnpm build`