### PR TITLE
Add active runtime materialization

### DIFF
--- a/.changeset/deployment-runtime-materialization.md
+++ b/.changeset/deployment-runtime-materialization.md
@@ -1,0 +1,7 @@
+---
+'@hypequery/deployment': minor
+---
+
+Add active-release runtime materialization with closed-bundle revalidation,
+copy-on-read artifacts, deterministic query bindings, and activation stability
+checks.

--- a/packages/deployment/README.md
+++ b/packages/deployment/README.md
@@ -184,4 +184,29 @@ current state, and bounded cursor history. It returns stable, bounded JSON error
 codes and suppresses internal provider and filesystem details. The HTTP
 contract is specified in `specs/deployment/0003-control-plane-http.md`.
 
+## Runtime materialization
+
+`createDeploymentRuntimeMaterializer` converts the current target activation
+into a private runtime snapshot. It revalidates the accepted release and closed
+bundle, copies and hashes each runtime artifact without following symbolic
+links, and confirms the activation revision again before returning.
+
+```ts
+import { createDeploymentRuntimeMaterializer } from '@hypequery/deployment';
+
+const materializer = createDeploymentRuntimeMaterializer({
+  activations,
+  releases: store,
+});
+
+const snapshot = await materializer.current({
+  project: 'analytics',
+  environment: 'production',
+});
+```
+
+Artifact `read()` methods return fresh byte copies, so neither callers nor later
+changes to durable storage can alter a materialized snapshot. Runtime imports,
+process lifecycle, readiness, and traffic switching remain separate concerns.
+
 The package is ESM-only and requires Node.js 20 or newer.

--- a/packages/deployment/package.json
+++ b/packages/deployment/package.json
@@ -22,7 +22,7 @@
     "dev": "tsc --project tsconfig.json --watch",
     "lint": "eslint --ext .ts \"src/**/*.ts\"",
     "test": "vitest run",
-    "types": "tsc --project tsconfig.json --noEmit"
+    "types": "tsc --project tsconfig.json --noEmit && tsc --project tsconfig.test.json"
   },
   "dependencies": {
     "@hypequery/protocol": "workspace:*"

--- a/packages/deployment/src/activation.test.ts
+++ b/packages/deployment/src/activation.test.ts
@@ -335,10 +335,12 @@ describe('filesystem deployment activation registry', () => {
     ]);
 
     expect(results.map(result => result.status).sort()).toEqual(['activated', 'conflict']);
+    const activated = results.find(result => result.status === 'activated');
+    if (!activated || activated.status === 'conflict') {
+      throw new Error('Expected one concurrent activation to succeed.');
+    }
     const current = await registry.current(target);
-    expect(current?.releaseIdentity).toBe(
-      results.find(result => result.status === 'activated')!.activation.releaseIdentity,
-    );
+    expect(current?.releaseIdentity).toBe(activated.activation.releaseIdentity);
     expect(await registry.history(target)).toHaveLength(1);
   });
 

--- a/packages/deployment/src/activation.test.ts
+++ b/packages/deployment/src/activation.test.ts
@@ -22,6 +22,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createFileSystemDeploymentActivationRegistry,
   DeploymentActivationError,
+  validateDeploymentActivationRecord,
 } from './activation.js';
 import { verifyDeploymentBundle } from './bundle.js';
 import { createFileSystemDeploymentSubmissionStore } from './filesystem-store.js';
@@ -147,6 +148,22 @@ async function targetDirectory(root: string): Promise<string> {
 }
 
 describe('filesystem deployment activation registry', () => {
+  it('validates standalone activation records by recomputing their revision', async () => {
+    const { first, registry } = await setup();
+    const result = await registry.activate({
+      target,
+      releaseIdentity: first.submission.releaseIdentity,
+      expectedRevision: null,
+    });
+    if (result.status !== 'activated') throw new Error('Expected activation.');
+
+    expect(validateDeploymentActivationRecord(result.activation)).toEqual(result.activation);
+    expect(() => validateDeploymentActivationRecord({
+      ...result.activation,
+      revision: '0'.repeat(64),
+    })).toThrow(/revision/);
+  });
+
   it('returns no current record before the first successful comparison', async () => {
     const { first, registry } = await setup();
 

--- a/packages/deployment/src/activation.ts
+++ b/packages/deployment/src/activation.ts
@@ -274,20 +274,12 @@ function requireRecord(input: unknown): Record<string, unknown> {
   return value;
 }
 
-function validateStoredActivation(
-  input: unknown,
-  expectedTarget: ProtocolDeploymentReleaseTarget,
-  expectedPreviousRevision: string | null,
-  expectedPreviousReleaseIdentity: string | null,
-): PreparedActivation {
+function prepareValidatedActivation(input: unknown): PreparedActivation {
   const value = requireRecord(input);
   if (value.kind !== 'hypequery-deployment-activation' || value.version !== 1) {
     throw new Error('Activation record kind or version is invalid.');
   }
   const target = validateTarget(value.target, 'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE');
-  if (!targetsEqual(target, expectedTarget)) {
-    throw new Error('Activation record target is inconsistent.');
-  }
   const releaseIdentity = requireIdentity(
     value.releaseIdentity,
     'Stored release identity',
@@ -303,9 +295,7 @@ function validateStoredActivation(
     'Stored previous release identity',
     'HQ_DEPLOYMENT_ACTIVATION_CORRUPT_STATE',
   );
-  if (previousRevision !== expectedPreviousRevision
-    || previousReleaseIdentity !== expectedPreviousReleaseIdentity
-    || (previousRevision === null) !== (previousReleaseIdentity === null)) {
+  if ((previousRevision === null) !== (previousReleaseIdentity === null)) {
     throw new Error('Activation record predecessor is inconsistent.');
   }
   if (typeof value.activatedAt !== 'string') {
@@ -324,6 +314,28 @@ function validateStoredActivation(
   });
   if (value.revision !== prepared.record.revision) {
     throw new Error('Activation revision does not match its contents.');
+  }
+  return prepared;
+}
+
+/** Validate and recompute an immutable deployment activation record. */
+export function validateDeploymentActivationRecord(input: unknown): DeploymentActivationRecord {
+  return prepareValidatedActivation(input).record;
+}
+
+function validateStoredActivation(
+  input: unknown,
+  expectedTarget: ProtocolDeploymentReleaseTarget,
+  expectedPreviousRevision: string | null,
+  expectedPreviousReleaseIdentity: string | null,
+): PreparedActivation {
+  const prepared = prepareValidatedActivation(input);
+  if (!targetsEqual(prepared.record.target, expectedTarget)) {
+    throw new Error('Activation record target is inconsistent.');
+  }
+  if (prepared.record.previousRevision !== expectedPreviousRevision
+    || prepared.record.previousReleaseIdentity !== expectedPreviousReleaseIdentity) {
+    throw new Error('Activation record predecessor is inconsistent.');
   }
   return prepared;
 }

--- a/packages/deployment/src/control-plane.test.ts
+++ b/packages/deployment/src/control-plane.test.ts
@@ -3,13 +3,18 @@ import {
   DeploymentActivationError,
   type DeploymentActivationRecord,
   type DeploymentActivationRegistry,
+  type DeploymentActivationResult,
 } from './activation.js';
-import { createDeploymentControlPlane } from './control-plane.js';
+import {
+  createDeploymentControlPlane,
+  type DeploymentControlPlaneAuthorizationInput,
+} from './control-plane.js';
 import {
   DEFAULT_DEPLOYMENT_CONTROL_PLANE_LIMITS,
   resolveDeploymentControlPlaneLimits,
 } from './control-plane-limits.js';
 import type {
+  DeploymentAuthenticationInput,
   DeploymentIntake,
   DeploymentIntakeResponse,
 } from './types.js';
@@ -56,15 +61,20 @@ function parsed(response: DeploymentIntakeResponse): any {
 }
 
 function fixture(overrides: {
-  readonly authenticate?: () => Promise<string | null>;
-  readonly authorize?: () => Promise<boolean>;
+  readonly authenticate?: (input: DeploymentAuthenticationInput) => Promise<string | null>;
+  readonly authorize?: (
+    input: DeploymentControlPlaneAuthorizationInput<string>
+  ) => Promise<boolean>;
   readonly registry?: Partial<DeploymentActivationRegistry>;
   readonly intake?: DeploymentIntake;
   readonly limits?: { readonly maxActivationRequestBytes?: number; readonly maxHistoryPageSize?: number };
 } = {}) {
   const defaultActivation = activation(REVISION_ONE);
   const registry: DeploymentActivationRegistry = {
-    activate: vi.fn(async () => ({ status: 'activated', activation: defaultActivation })),
+    activate: vi.fn(async (): Promise<DeploymentActivationResult> => ({
+      status: 'activated',
+      activation: defaultActivation,
+    })),
     current: vi.fn(async () => defaultActivation),
     history: vi.fn(async () => [defaultActivation]),
     historyPage: vi.fn(async () => ({

--- a/packages/deployment/src/filesystem-store.test.ts
+++ b/packages/deployment/src/filesystem-store.test.ts
@@ -297,7 +297,10 @@ describe('filesystem deployment submission store', () => {
     const prototype = Object.getPrototypeOf(probe) as FileHandle;
     const originalRead = prototype.read;
     await probe.close();
-    const read = vi.spyOn(prototype, 'read').mockImplementationOnce(async function (...args) {
+    const read = vi.spyOn(prototype, 'read').mockImplementationOnce(async function (
+      this: FileHandle,
+      ...args
+    ) {
       await appendFile(releasePath, Buffer.alloc(16 * 1024));
       return originalRead.apply(this, args);
     });

--- a/packages/deployment/src/index.ts
+++ b/packages/deployment/src/index.ts
@@ -1,6 +1,7 @@
 export {
   createFileSystemDeploymentActivationRegistry,
   DeploymentActivationError,
+  validateDeploymentActivationRecord,
 } from './activation.js';
 export type {
   DeploymentActivationErrorCode,
@@ -68,6 +69,20 @@ export {
   resolveDeploymentIntakeLimits,
 } from './limits.js';
 export type { DeploymentIntakeLimits } from './limits.js';
+export {
+  createDeploymentRuntimeMaterializer,
+  DeploymentRuntimeMaterializationError,
+} from './runtime-materialization.js';
+export type {
+  DeploymentRuntimeArtifactSnapshot,
+  DeploymentRuntimeMaterializationErrorCode,
+  DeploymentRuntimeMaterializer,
+  DeploymentRuntimeMaterializerOptions,
+  DeploymentRuntimeQueryBinding,
+  DeploymentRuntimeRelease,
+  DeploymentRuntimeReleaseReader,
+  DeploymentRuntimeSnapshot,
+} from './runtime-materialization.js';
 export type {
   DeploymentAuthenticationInput,
   DeploymentAuthenticator,

--- a/packages/deployment/src/runtime-materialization.test.ts
+++ b/packages/deployment/src/runtime-materialization.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { constants } from 'node:fs';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -144,6 +145,7 @@ function registry(
     current,
     activate: async () => { throw new Error('not used'); },
     history: async () => [],
+    historyPage: async () => ({ activations: [], nextBefore: null }),
   };
 }
 
@@ -217,6 +219,21 @@ describe('deployment runtime materialization', () => {
     expect(current).toHaveBeenCalledTimes(4);
   });
 
+  it('returns no snapshot when the activation disappears during materialization', async () => {
+    const fixture = await releaseFixture('export const version=1;\n');
+    const active = activation(fixture.stored.releaseIdentity);
+    const current = vi.fn()
+      .mockResolvedValueOnce(active)
+      .mockResolvedValueOnce(undefined);
+    const materializer = createDeploymentRuntimeMaterializer({
+      activations: registry(current),
+      releases: { read: async () => fixture.stored },
+    });
+
+    await expect(materializer.current(TARGET)).resolves.toBeUndefined();
+    expect(current).toHaveBeenCalledTimes(2);
+  });
+
   it('fails closed when the accepted release or closed bundle is inconsistent', async () => {
     const fixture = await releaseFixture('export const value=true;\n');
     const active = activation(fixture.stored.releaseIdentity);
@@ -276,4 +293,16 @@ describe('deployment runtime materialization', () => {
       maxStabilityAttempts: 17,
     })).toThrow(DeploymentRuntimeMaterializationError);
   });
+
+  it.skipIf(Boolean(constants.O_NOFOLLOW))(
+    'fails closed when the platform cannot open artifacts without following links',
+    () => {
+      expect(() => createDeploymentRuntimeMaterializer({
+        activations: registry(async () => undefined),
+        releases: { read: async () => undefined },
+      })).toThrow(expect.objectContaining({
+        code: 'HQ_RUNTIME_MATERIALIZATION_CONFIGURATION',
+      }));
+    },
+  );
 });

--- a/packages/deployment/src/runtime-materialization.test.ts
+++ b/packages/deployment/src/runtime-materialization.test.ts
@@ -1,0 +1,279 @@
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  prepareProtocolDeploymentBundleManifest,
+  prepareProtocolDeploymentContract,
+  prepareProtocolDeploymentReleaseEnvelope,
+} from '@hypequery/protocol';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  DeploymentActivationRecord,
+  DeploymentActivationRegistry,
+} from './activation.js';
+import {
+  DEPLOYMENT_BUNDLE_CONTRACT,
+  DEPLOYMENT_BUNDLE_MANIFEST,
+  verifyDeploymentBundle,
+} from './bundle.js';
+import {
+  createDeploymentRuntimeMaterializer,
+  DeploymentRuntimeMaterializationError,
+  type DeploymentRuntimeRelease,
+} from './runtime-materialization.js';
+
+const TARGET = Object.freeze({ project: 'analytics', environment: 'production' });
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(directory => (
+    rm(directory, { force: true, recursive: true })
+  )));
+});
+
+function sha256(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+async function releaseFixture(source: string): Promise<{
+  readonly stored: DeploymentRuntimeRelease;
+  readonly artifactPath: string;
+  readonly artifactBytes: Uint8Array;
+}> {
+  const directory = await mkdtemp(path.join(tmpdir(), 'hypequery-runtime-materialization-'));
+  temporaryDirectories.push(directory);
+  const artifactBytes = Buffer.from(source);
+  const artifactSha256 = sha256(artifactBytes);
+  const preparedDeployment = prepareProtocolDeploymentContract({
+    kind: 'hypequery-deployment',
+    version: 1,
+    datasets: [],
+    queries: [{
+      name: 'handler',
+      input: { kind: 'any' },
+      output: { kind: 'any' },
+      implementation: {
+        kind: 'runtime-reference',
+        runtime: 'node',
+        artifactSha256,
+        entrypoint: 'queries.handler',
+      },
+      endpoint: {
+        access: { kind: 'public' },
+        tenant: { kind: 'not-required' },
+        method: 'POST',
+        path: '/handler',
+      },
+      tags: [],
+    }],
+    artifacts: [{ runtime: 'node', artifactSha256 }],
+  });
+  const deploymentBytes = Buffer.from(`${preparedDeployment.canonical}\n`);
+  const artifactPath = `artifacts/${artifactSha256}.mjs`;
+  const preparedManifest = prepareProtocolDeploymentBundleManifest({
+    kind: 'hypequery-deployment-bundle',
+    version: 1,
+    deployment: {
+      path: DEPLOYMENT_BUNDLE_CONTRACT,
+      identity: preparedDeployment.identity,
+      sha256: sha256(deploymentBytes),
+      byteLength: deploymentBytes.byteLength,
+    },
+    artifacts: [{
+      runtime: 'node',
+      path: artifactPath,
+      sha256: artifactSha256,
+      byteLength: artifactBytes.byteLength,
+    }],
+  });
+  await mkdir(path.join(directory, 'artifacts'));
+  await writeFile(path.join(directory, DEPLOYMENT_BUNDLE_CONTRACT), deploymentBytes);
+  await writeFile(path.join(directory, artifactPath), artifactBytes);
+  await writeFile(path.join(directory, DEPLOYMENT_BUNDLE_MANIFEST), `${preparedManifest.canonical}\n`);
+  const bundle = await verifyDeploymentBundle(directory);
+  const preparedRelease = prepareProtocolDeploymentReleaseEnvelope({
+    kind: 'hypequery-deployment-release',
+    version: 1,
+    bundleIdentity: bundle.identity,
+    target: TARGET,
+  });
+  return {
+    stored: Object.freeze({
+      release: preparedRelease.release,
+      releaseIdentity: preparedRelease.identity,
+      bundle,
+    }),
+    artifactPath: path.join(directory, artifactPath),
+    artifactBytes: Uint8Array.from(artifactBytes),
+  };
+}
+
+function activation(
+  releaseIdentity: string,
+): DeploymentActivationRecord {
+  const activatedAt = '2026-07-19T12:00:00.000Z';
+  const payload = JSON.stringify({
+    kind: 'hypequery-deployment-activation',
+    version: 1,
+    target: TARGET,
+    releaseIdentity,
+    previousRevision: null,
+    previousReleaseIdentity: null,
+    activatedAt,
+  });
+  return Object.freeze({
+    kind: 'hypequery-deployment-activation',
+    version: 1,
+    revision: createHash('sha256')
+      .update('hypequery:deployment-activation:v1\0')
+      .update(payload)
+      .digest('hex'),
+    target: TARGET,
+    releaseIdentity,
+    previousRevision: null,
+    previousReleaseIdentity: null,
+    activatedAt,
+  });
+}
+
+function registry(
+  current: DeploymentActivationRegistry['current'],
+): DeploymentActivationRegistry {
+  return {
+    current,
+    activate: async () => { throw new Error('not used'); },
+    history: async () => [],
+  };
+}
+
+describe('deployment runtime materialization', () => {
+  it('creates an immutable copy-on-read snapshot bound to the active revision', async () => {
+    const fixture = await releaseFixture('export const queries={handler:()=>"v1"};\n');
+    const active = activation(fixture.stored.releaseIdentity);
+    const materializer = createDeploymentRuntimeMaterializer({
+      activations: registry(async () => active),
+      releases: { read: async () => fixture.stored },
+    });
+
+    const snapshot = await materializer.current(TARGET);
+
+    expect(snapshot).toMatchObject({
+      target: TARGET,
+      activation: active,
+      releaseIdentity: fixture.stored.releaseIdentity,
+      bundleIdentity: fixture.stored.bundle.identity,
+      queries: [{
+        query: 'handler',
+        runtime: 'node',
+        artifactSha256: sha256(fixture.artifactBytes),
+        entrypoint: 'queries.handler',
+      }],
+    });
+    expect(snapshot?.artifacts[0]?.entrypoints).toEqual(['queries.handler']);
+    const firstRead = snapshot!.artifacts[0]!.read();
+    firstRead.fill(0);
+    expect(snapshot!.artifacts[0]!.read()).toEqual(fixture.artifactBytes);
+    expect(Object.isFrozen(snapshot)).toBe(true);
+  });
+
+  it('keeps materialized bytes stable after durable storage changes', async () => {
+    const fixture = await releaseFixture('export const value="original";\n');
+    const active = activation(fixture.stored.releaseIdentity);
+    const materializer = createDeploymentRuntimeMaterializer({
+      activations: registry(async () => active),
+      releases: { read: async () => fixture.stored },
+    });
+    const snapshot = await materializer.current(TARGET);
+
+    await writeFile(fixture.artifactPath, 'tampered after materialization');
+
+    expect(snapshot!.artifacts[0]!.read()).toEqual(fixture.artifactBytes);
+  });
+
+  it('retries when activation changes and returns only a confirmed current snapshot', async () => {
+    const first = await releaseFixture('export const version=1;\n');
+    const second = await releaseFixture('export const version=2;\n');
+    const activationOne = activation(first.stored.releaseIdentity);
+    const activationTwo = activation(second.stored.releaseIdentity);
+    const current = vi.fn()
+      .mockResolvedValueOnce(activationOne)
+      .mockResolvedValueOnce(activationTwo)
+      .mockResolvedValueOnce(activationTwo)
+      .mockResolvedValueOnce(activationTwo);
+    const releases = new Map([
+      [first.stored.releaseIdentity, first.stored],
+      [second.stored.releaseIdentity, second.stored],
+    ]);
+    const materializer = createDeploymentRuntimeMaterializer({
+      activations: registry(current),
+      releases: { read: async identity => releases.get(identity) },
+    });
+
+    const snapshot = await materializer.current(TARGET);
+
+    expect(snapshot?.activation).toEqual(activationTwo);
+    expect(snapshot?.artifacts[0]?.read()).toEqual(second.artifactBytes);
+    expect(current).toHaveBeenCalledTimes(4);
+  });
+
+  it('fails closed when the accepted release or closed bundle is inconsistent', async () => {
+    const fixture = await releaseFixture('export const value=true;\n');
+    const active = activation(fixture.stored.releaseIdentity);
+    const missing = createDeploymentRuntimeMaterializer({
+      activations: registry(async () => active),
+      releases: { read: async () => undefined },
+    });
+    await expect(missing.current(TARGET)).rejects.toMatchObject({
+      code: 'HQ_RUNTIME_MATERIALIZATION_RELEASE_NOT_FOUND',
+    });
+
+    await writeFile(fixture.artifactPath, 'tampered');
+    const invalid = createDeploymentRuntimeMaterializer({
+      activations: registry(async () => active),
+      releases: { read: async () => fixture.stored },
+    });
+    await expect(invalid.current(TARGET)).rejects.toMatchObject({
+      code: 'HQ_RUNTIME_MATERIALIZATION_RELEASE_INVALID',
+    });
+
+    const invalidActivation = createDeploymentRuntimeMaterializer({
+      activations: registry(async () => ({ ...active, revision: '0'.repeat(64) })),
+      releases: { read: async () => fixture.stored },
+    });
+    await expect(invalidActivation.current(TARGET)).rejects.toMatchObject({
+      code: 'HQ_RUNTIME_MATERIALIZATION_ACTIVATION_UNAVAILABLE',
+    });
+  });
+
+  it('bounds activation churn and validates its stability configuration', async () => {
+    const first = await releaseFixture('export const version=1;\n');
+    const second = await releaseFixture('export const version=2;\n');
+    const values = [
+      activation(first.stored.releaseIdentity),
+      activation(second.stored.releaseIdentity),
+    ];
+    let index = 0;
+    const releases = new Map([
+      [first.stored.releaseIdentity, first.stored],
+      [second.stored.releaseIdentity, second.stored],
+    ]);
+    const materializer = createDeploymentRuntimeMaterializer({
+      activations: registry(async () => values[index++ % 2]),
+      releases: { read: async identity => releases.get(identity) },
+      maxStabilityAttempts: 2,
+    });
+
+    await expect(materializer.current(TARGET)).rejects.toBeInstanceOf(
+      DeploymentRuntimeMaterializationError,
+    );
+    await expect(materializer.current(TARGET)).rejects.toMatchObject({
+      code: 'HQ_RUNTIME_MATERIALIZATION_UNSTABLE_ACTIVATION',
+    });
+    expect(() => createDeploymentRuntimeMaterializer({
+      activations: registry(async () => undefined),
+      releases: { read: async () => undefined },
+      maxStabilityAttempts: 17,
+    })).toThrow(DeploymentRuntimeMaterializationError);
+  });
+});

--- a/packages/deployment/src/runtime-materialization.ts
+++ b/packages/deployment/src/runtime-materialization.ts
@@ -286,6 +286,12 @@ export function createDeploymentRuntimeMaterializer(
   options: DeploymentRuntimeMaterializerOptions,
 ): DeploymentRuntimeMaterializer {
   const maximumAttempts = stabilityAttempts(options.maxStabilityAttempts);
+  if (!constants.O_NOFOLLOW) {
+    throw materializationError(
+      'HQ_RUNTIME_MATERIALIZATION_CONFIGURATION',
+      'Runtime materialization requires filesystem no-follow support.',
+    );
+  }
 
   async function currentActivation(
     target: ProtocolDeploymentReleaseTarget,
@@ -316,7 +322,8 @@ export function createDeploymentRuntimeMaterializer(
         if (!activation) return undefined;
         const snapshot = await materializeActivation(activation, options.releases);
         const confirmed = await currentActivation(target);
-        if (confirmed?.revision === activation.revision) return snapshot;
+        if (!confirmed) return undefined;
+        if (confirmed.revision === activation.revision) return snapshot;
       }
       throw materializationError(
         'HQ_RUNTIME_MATERIALIZATION_UNSTABLE_ACTIVATION',

--- a/packages/deployment/src/runtime-materialization.ts
+++ b/packages/deployment/src/runtime-materialization.ts
@@ -1,0 +1,327 @@
+import { createHash } from 'node:crypto';
+import { constants } from 'node:fs';
+import { lstat, open } from 'node:fs/promises';
+import path from 'node:path';
+import type {
+  ProtocolDeploymentContract,
+  ProtocolDeploymentReleaseEnvelope,
+  ProtocolDeploymentReleaseTarget,
+} from '@hypequery/protocol';
+import { prepareProtocolDeploymentReleaseEnvelope } from '@hypequery/protocol';
+import { validateDeploymentActivationRecord } from './activation.js';
+import type {
+  DeploymentActivationRecord,
+  DeploymentActivationRegistry,
+} from './activation.js';
+import {
+  verifyDeploymentBundle,
+  type VerifiedDeploymentBundle,
+} from './bundle.js';
+
+const DEFAULT_STABILITY_ATTEMPTS = 4;
+const MAX_STABILITY_ATTEMPTS = 16;
+
+export type DeploymentRuntimeMaterializationErrorCode =
+  | 'HQ_RUNTIME_MATERIALIZATION_CONFIGURATION'
+  | 'HQ_RUNTIME_MATERIALIZATION_ACTIVATION_UNAVAILABLE'
+  | 'HQ_RUNTIME_MATERIALIZATION_RELEASE_NOT_FOUND'
+  | 'HQ_RUNTIME_MATERIALIZATION_RELEASE_INVALID'
+  | 'HQ_RUNTIME_MATERIALIZATION_ARTIFACT_INVALID'
+  | 'HQ_RUNTIME_MATERIALIZATION_UNSTABLE_ACTIVATION';
+
+export class DeploymentRuntimeMaterializationError extends Error {
+  readonly code: DeploymentRuntimeMaterializationErrorCode;
+
+  constructor(
+    code: DeploymentRuntimeMaterializationErrorCode,
+    message: string,
+    options: { readonly cause?: unknown } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'DeploymentRuntimeMaterializationError';
+    this.code = code;
+  }
+}
+
+export interface DeploymentRuntimeRelease {
+  readonly release: ProtocolDeploymentReleaseEnvelope;
+  readonly releaseIdentity: string;
+  readonly bundle: VerifiedDeploymentBundle;
+}
+
+export interface DeploymentRuntimeReleaseReader {
+  /** Return only a fully revalidated accepted release and its closed bundle. */
+  read(releaseIdentity: string): Promise<DeploymentRuntimeRelease | undefined>;
+}
+
+export interface DeploymentRuntimeArtifactSnapshot {
+  readonly runtime: 'node' | 'python';
+  readonly artifactSha256: string;
+  readonly byteLength: number;
+  readonly entrypoints: readonly string[];
+  /** Returns a fresh copy so callers cannot mutate the materialized bytes. */
+  read(): Uint8Array;
+}
+
+export interface DeploymentRuntimeQueryBinding {
+  readonly query: string;
+  readonly runtime: 'node' | 'python';
+  readonly artifactSha256: string;
+  readonly entrypoint: string;
+}
+
+export interface DeploymentRuntimeSnapshot {
+  readonly target: ProtocolDeploymentReleaseTarget;
+  readonly activation: DeploymentActivationRecord;
+  readonly release: ProtocolDeploymentReleaseEnvelope;
+  readonly releaseIdentity: string;
+  readonly bundleIdentity: string;
+  readonly deployment: ProtocolDeploymentContract;
+  readonly artifacts: readonly DeploymentRuntimeArtifactSnapshot[];
+  readonly queries: readonly DeploymentRuntimeQueryBinding[];
+}
+
+export interface DeploymentRuntimeMaterializer {
+  /**
+   * Materialize the current activation and confirm it remained current while
+   * its bytes were copied. Returns undefined when the target has no activation.
+   */
+  current(target: ProtocolDeploymentReleaseTarget): Promise<DeploymentRuntimeSnapshot | undefined>;
+}
+
+export interface DeploymentRuntimeMaterializerOptions {
+  readonly activations: DeploymentActivationRegistry;
+  readonly releases: DeploymentRuntimeReleaseReader;
+  /** Activation-stability attempts from 1 through 16. */
+  readonly maxStabilityAttempts?: number;
+}
+
+function materializationError(
+  code: DeploymentRuntimeMaterializationErrorCode,
+  message: string,
+  cause?: unknown,
+): DeploymentRuntimeMaterializationError {
+  return new DeploymentRuntimeMaterializationError(code, message, { cause });
+}
+
+function sameTarget(
+  left: ProtocolDeploymentReleaseTarget,
+  right: ProtocolDeploymentReleaseTarget,
+): boolean {
+  return left.project === right.project && left.environment === right.environment;
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+async function readArtifact(
+  bundleDirectory: string,
+  artifact: { readonly path: string; readonly sha256: string; readonly byteLength: number },
+): Promise<Uint8Array> {
+  const artifactPath = path.join(bundleDirectory, ...artifact.path.split('/'));
+  let handle;
+  try {
+    const initial = await lstat(artifactPath);
+    if (initial.isSymbolicLink() || !initial.isFile() || initial.size !== artifact.byteLength) {
+      throw new Error('Runtime artifact is not the declared bounded regular file.');
+    }
+    handle = await open(artifactPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size !== artifact.byteLength) {
+      throw new Error('Runtime artifact changed before materialization.');
+    }
+    const bytes = await handle.readFile();
+    if (bytes.byteLength !== artifact.byteLength || sha256(bytes) !== artifact.sha256) {
+      throw new Error('Runtime artifact bytes do not match the closed bundle manifest.');
+    }
+    await handle.close();
+    handle = undefined;
+    return Uint8Array.from(bytes);
+  } catch (error) {
+    try {
+      await handle?.close();
+    } catch {
+      // Preserve the validation failure that made this artifact unusable.
+    }
+    throw materializationError(
+      'HQ_RUNTIME_MATERIALIZATION_ARTIFACT_INVALID',
+      'A deployment runtime artifact could not be materialized.',
+      error,
+    );
+  }
+}
+
+function artifactSnapshot(
+  input: {
+    readonly runtime: 'node' | 'python';
+    readonly artifactSha256: string;
+    readonly entrypoints: readonly string[];
+  },
+  bytes: Uint8Array,
+): DeploymentRuntimeArtifactSnapshot {
+  const materialized = Uint8Array.from(bytes);
+  return Object.freeze({
+    runtime: input.runtime,
+    artifactSha256: input.artifactSha256,
+    byteLength: materialized.byteLength,
+    entrypoints: Object.freeze([...input.entrypoints]),
+    read: () => Uint8Array.from(materialized),
+  });
+}
+
+async function materializeActivation(
+  activation: DeploymentActivationRecord,
+  releases: DeploymentRuntimeReleaseReader,
+): Promise<DeploymentRuntimeSnapshot> {
+  let stored: DeploymentRuntimeRelease | undefined;
+  try {
+    stored = await releases.read(activation.releaseIdentity);
+  } catch (error) {
+    throw materializationError(
+      'HQ_RUNTIME_MATERIALIZATION_RELEASE_INVALID',
+      'The active deployment release could not be revalidated.',
+      error,
+    );
+  }
+  if (!stored) {
+    throw materializationError(
+      'HQ_RUNTIME_MATERIALIZATION_RELEASE_NOT_FOUND',
+      'The active deployment release was not found.',
+    );
+  }
+  let release: ProtocolDeploymentReleaseEnvelope;
+  let releaseIdentity: string;
+  try {
+    const prepared = prepareProtocolDeploymentReleaseEnvelope(stored.release);
+    release = prepared.release;
+    releaseIdentity = prepared.identity;
+  } catch (error) {
+    throw materializationError(
+      'HQ_RUNTIME_MATERIALIZATION_RELEASE_INVALID',
+      'The active deployment release envelope is invalid.',
+      error,
+    );
+  }
+  if (stored.releaseIdentity !== activation.releaseIdentity
+    || releaseIdentity !== activation.releaseIdentity
+    || !sameTarget(release.target, activation.target)
+    || release.bundleIdentity !== stored.bundle.identity) {
+    throw materializationError(
+      'HQ_RUNTIME_MATERIALIZATION_RELEASE_INVALID',
+      'The active deployment release is inconsistent with its activation or bundle.',
+    );
+  }
+
+  let bundle: VerifiedDeploymentBundle;
+  try {
+    bundle = await verifyDeploymentBundle(stored.bundle.directory);
+  } catch (error) {
+    throw materializationError(
+      'HQ_RUNTIME_MATERIALIZATION_RELEASE_INVALID',
+      'The active deployment bundle could not be revalidated.',
+      error,
+    );
+  }
+  if (bundle.identity !== stored.bundle.identity
+    || bundle.identity !== release.bundleIdentity) {
+    throw materializationError(
+      'HQ_RUNTIME_MATERIALIZATION_RELEASE_INVALID',
+      'The active deployment bundle identity is inconsistent.',
+    );
+  }
+
+  const entrypoints = new Map<string, string[]>();
+  const queries: DeploymentRuntimeQueryBinding[] = [];
+  for (const query of bundle.contract.queries) {
+    const implementation = query.implementation;
+    if (implementation.kind !== 'runtime-reference') continue;
+    const names = entrypoints.get(implementation.artifactSha256) ?? [];
+    names.push(implementation.entrypoint);
+    entrypoints.set(implementation.artifactSha256, names);
+    queries.push(Object.freeze({
+      query: query.name,
+      runtime: implementation.runtime,
+      artifactSha256: implementation.artifactSha256,
+      entrypoint: implementation.entrypoint,
+    }));
+  }
+
+  const artifacts: DeploymentRuntimeArtifactSnapshot[] = [];
+  for (const artifact of bundle.manifest.artifacts) {
+    const bytes = await readArtifact(bundle.directory, artifact);
+    artifacts.push(artifactSnapshot({
+      runtime: artifact.runtime,
+      artifactSha256: artifact.sha256,
+      entrypoints: [...new Set(entrypoints.get(artifact.sha256) ?? [])].sort(),
+    }, bytes));
+  }
+  artifacts.sort((left, right) => left.artifactSha256.localeCompare(right.artifactSha256));
+  queries.sort((left, right) => left.query.localeCompare(right.query));
+
+  return Object.freeze({
+    target: activation.target,
+    activation,
+    release,
+    releaseIdentity,
+    bundleIdentity: bundle.identity,
+    deployment: bundle.contract,
+    artifacts: Object.freeze(artifacts),
+    queries: Object.freeze(queries),
+  });
+}
+
+function stabilityAttempts(input: number | undefined): number {
+  const value = input ?? DEFAULT_STABILITY_ATTEMPTS;
+  if (!Number.isSafeInteger(value) || value < 1 || value > MAX_STABILITY_ATTEMPTS) {
+    throw materializationError(
+      'HQ_RUNTIME_MATERIALIZATION_CONFIGURATION',
+      `maxStabilityAttempts must be between 1 and ${MAX_STABILITY_ATTEMPTS}.`,
+    );
+  }
+  return value;
+}
+
+export function createDeploymentRuntimeMaterializer(
+  options: DeploymentRuntimeMaterializerOptions,
+): DeploymentRuntimeMaterializer {
+  const maximumAttempts = stabilityAttempts(options.maxStabilityAttempts);
+
+  async function currentActivation(
+    target: ProtocolDeploymentReleaseTarget,
+  ): Promise<DeploymentActivationRecord | undefined> {
+    try {
+      const activation = await options.activations.current(target);
+      if (!activation) return undefined;
+      const validated = validateDeploymentActivationRecord(activation);
+      if (!sameTarget(validated.target, target)) {
+        throw new Error('Deployment activation target does not match the requested target.');
+      }
+      return validated;
+    } catch (error) {
+      throw materializationError(
+        'HQ_RUNTIME_MATERIALIZATION_ACTIVATION_UNAVAILABLE',
+        'Deployment activation state could not be read.',
+        error,
+      );
+    }
+  }
+
+  return Object.freeze({
+    async current(
+      target: ProtocolDeploymentReleaseTarget,
+    ): Promise<DeploymentRuntimeSnapshot | undefined> {
+      for (let attempt = 0; attempt < maximumAttempts; attempt += 1) {
+        const activation = await currentActivation(target);
+        if (!activation) return undefined;
+        const snapshot = await materializeActivation(activation, options.releases);
+        const confirmed = await currentActivation(target);
+        if (confirmed?.revision === activation.revision) return snapshot;
+      }
+      throw materializationError(
+        'HQ_RUNTIME_MATERIALIZATION_UNSTABLE_ACTIVATION',
+        'Deployment activation changed repeatedly during runtime materialization.',
+      );
+    },
+  });
+}

--- a/packages/deployment/tsconfig.test.json
+++ b/packages/deployment/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/specs/deployment/0004-runtime-materialization.md
+++ b/specs/deployment/0004-runtime-materialization.md
@@ -1,0 +1,76 @@
+# Deployment runtime 0004: Active-release materialization
+
+- Status: Proposed
+- Version: deployment runtime materialization 1
+
+## Summary
+
+This specification defines the boundary between target activation and runtime
+startup. Materialization resolves the currently active release, completely
+revalidates its closed bundle, copies every referenced runtime artifact into an
+immutable snapshot, and confirms that the activation did not change while the
+copy was made.
+
+Materialization does not import, execute, supervise, or route traffic to runtime
+code.
+
+## Inputs and trust boundaries
+
+A materializer requires:
+
+- an activation registry implementing specification 0002;
+- a release reader that returns only accepted releases whose release envelope
+  and closed bundle were completely revalidated;
+- a target expressed using the release-target v1 constraints.
+
+The release reader is a provider boundary. The materializer MUST independently
+revalidate the returned bundle directory before copying runtime bytes. Release
+identity, release target, release bundle identity, and recomputed bundle
+identity MUST all agree with the activation.
+
+## Snapshot construction
+
+For each manifest-declared runtime artifact, materialization MUST:
+
+1. open the declared path without following symbolic links;
+2. require a regular file with the exact declared byte length;
+3. read no more than the closed bundle limits;
+4. recompute and compare SHA-256;
+5. retain a private copy that cannot be mutated through the public snapshot.
+
+The resulting snapshot contains:
+
+- the exact activation record and target;
+- the release and release identity;
+- the bundle identity and validated deployment contract;
+- runtime, digest, byte length, and entrypoints for each artifact;
+- the deterministic mapping from named queries to runtime references.
+
+Artifact reads from the snapshot MUST return independent copies. Changing a
+returned byte array or the durable bundle after materialization cannot alter
+the snapshot.
+
+## Activation stability
+
+The materializer reads the current activation before constructing the snapshot
+and reads it again afterward. The snapshot may be returned only when both reads
+have the same activation revision. If the revision changed, the intermediate
+snapshot is discarded and materialization retries from the new activation.
+
+Retries are bounded. Repeated activation churn fails with a stable
+`HQ_RUNTIME_MATERIALIZATION_UNSTABLE_ACTIVATION` error rather than returning a
+snapshot that was never confirmed current. A target with no activation returns
+no snapshot and is not an error.
+
+## Fail-closed behavior
+
+Missing releases, invalid release-to-target bindings, bundle identity
+mismatches, revalidation failures, symbolic links, changed artifact lengths,
+and digest mismatches fail closed. No partially materialized snapshot is
+returned.
+
+## Out of scope
+
+This version does not define module loading, worker or process isolation,
+readiness checks, request execution, traffic switching, draining, automatic
+rollback, retention, or garbage collection.

--- a/specs/deployment/0004-runtime-materialization.md
+++ b/specs/deployment/0004-runtime-materialization.md
@@ -38,6 +38,10 @@ For each manifest-declared runtime artifact, materialization MUST:
 4. recompute and compare SHA-256;
 5. retain a private copy that cannot be mutated through the public snapshot.
 
+Materialization fails with `HQ_RUNTIME_MATERIALIZATION_CONFIGURATION` when the
+host cannot open files with a no-follow primitive. An `lstat`-then-open sequence
+alone is insufficient because a path can be replaced between those operations.
+
 The resulting snapshot contains:
 
 - the exact activation record and target;
@@ -56,6 +60,8 @@ The materializer reads the current activation before constructing the snapshot
 and reads it again afterward. The snapshot may be returned only when both reads
 have the same activation revision. If the revision changed, the intermediate
 snapshot is discarded and materialization retries from the new activation.
+If either read finds no activation, the intermediate snapshot is discarded and
+no snapshot is returned.
 
 Retries are bounded. Repeated activation churn fails with a stable
 `HQ_RUNTIME_MATERIALIZATION_UNSTABLE_ACTIVATION` error rather than returning a

--- a/specs/deployment/README.md
+++ b/specs/deployment/README.md
@@ -16,3 +16,5 @@ Current specifications:
   compare-and-swap behavior;
 - `0003-control-plane-http.md` binds submission and activation to provider-neutral
   HTTP routes and adapters.
+- `0004-runtime-materialization.md` converts a confirmed current activation into
+  an immutable, fully revalidated runtime snapshot.


### PR DESCRIPTION
## Summary

- materialize the currently active release into an immutable runtime snapshot
- independently revalidate release identities, declared artifact bytes, and digests
- retry when activation changes during snapshot construction and fail closed on inconsistent state
- document deployment runtime contract 0004 and export the materializer APIs

## Why

Runtime loaders need a stable, verified snapshot that cannot be changed by later durable-store mutations. This layer intentionally stops before importing or executing runtime code.

## Stack

Depends on #319.

## Validation

- `pnpm types`
- `pnpm lint`
- `pnpm test`
- `pnpm build`