### PR TITLE
Add deployment runtime supervision

### DIFF
--- a/.changeset/deployment-runtime-supervisor.md
+++ b/.changeset/deployment-runtime-supervisor.md
@@ -1,0 +1,6 @@
+---
+'@hypequery/deployment': minor
+---
+
+Add readiness-gated runtime supervision with atomic generation switching,
+in-flight draining, named-query invocation, and a reference Node worker factory.

--- a/packages/deployment/README.md
+++ b/packages/deployment/README.md
@@ -209,4 +209,40 @@ Artifact `read()` methods return fresh byte copies, so neither callers nor later
 changes to durable storage can alter a materialized snapshot. Runtime imports,
 process lifecycle, readiness, and traffic switching remain separate concerns.
 
+## Runtime supervision
+
+`createDeploymentRuntimeSupervisor` starts materialized snapshots through a
+runtime factory, checks candidate readiness, confirms activation again, and
+atomically changes the generation used for new named-query invocations. Failed
+or superseded candidates never displace a healthy generation.
+
+```ts
+import {
+  createDeploymentRuntimeSupervisor,
+  createNodeWorkerDeploymentRuntimeFactory,
+} from '@hypequery/deployment';
+
+const supervisor = createDeploymentRuntimeSupervisor({
+  materializer,
+  factory: createNodeWorkerDeploymentRuntimeFactory(),
+});
+
+await supervisor.reconcile({ project: 'analytics', environment: 'production' });
+const result = await supervisor.invoke({
+  target: { project: 'analytics', environment: 'production' },
+  query: 'orders',
+  argument: { input, ctx: { tenantId } },
+});
+```
+
+Calls already assigned to an old generation may finish after cutover. That
+generation receives no new calls and closes when its in-flight work reaches
+zero or the drain deadline expires. The reference Node factory loads exact
+materialized bytes in worker threads and removes their temporary files on
+shutdown. Provider factories can implement Python, process, container, or
+remote-sandbox isolation behind the same lifecycle interface.
+
+The reference worker is a lifecycle boundary, not a hostile-code security
+sandbox. Only trusted deployment code should use it directly.
+
 The package is ESM-only and requires Node.js 20 or newer.

--- a/packages/deployment/src/index.ts
+++ b/packages/deployment/src/index.ts
@@ -70,6 +70,14 @@ export {
 } from './limits.js';
 export type { DeploymentIntakeLimits } from './limits.js';
 export {
+  createNodeWorkerDeploymentRuntimeFactory,
+  NodeDeploymentRuntimeError,
+} from './node-runtime-factory.js';
+export type {
+  NodeDeploymentRuntimeErrorCode,
+  NodeDeploymentRuntimeFactoryOptions,
+} from './node-runtime-factory.js';
+export {
   createDeploymentRuntimeMaterializer,
   DeploymentRuntimeMaterializationError,
 } from './runtime-materialization.js';
@@ -83,6 +91,21 @@ export type {
   DeploymentRuntimeReleaseReader,
   DeploymentRuntimeSnapshot,
 } from './runtime-materialization.js';
+export {
+  createDeploymentRuntimeSupervisor,
+  DeploymentRuntimeSupervisorError,
+} from './runtime-supervisor.js';
+export type {
+  DeploymentRuntimeFactory,
+  DeploymentRuntimeInstance,
+  DeploymentRuntimeInstanceInvocation,
+  DeploymentRuntimeInvocation,
+  DeploymentRuntimeReconcileResult,
+  DeploymentRuntimeStatus,
+  DeploymentRuntimeSupervisor,
+  DeploymentRuntimeSupervisorErrorCode,
+  DeploymentRuntimeSupervisorOptions,
+} from './runtime-supervisor.js';
 export type {
   DeploymentAuthenticationInput,
   DeploymentAuthenticator,

--- a/packages/deployment/src/node-runtime-factory.test.ts
+++ b/packages/deployment/src/node-runtime-factory.test.ts
@@ -1,0 +1,183 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { prepareProtocolDeploymentContract } from '@hypequery/protocol';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createNodeWorkerDeploymentRuntimeFactory,
+  NodeDeploymentRuntimeError,
+} from './node-runtime-factory.js';
+import type { DeploymentRuntimeSnapshot } from './runtime-materialization.js';
+import type { DeploymentRuntimeInstance } from './runtime-supervisor.js';
+
+const TARGET = Object.freeze({ project: 'analytics', environment: 'production' });
+const temporaryDirectories: string[] = [];
+const instances: DeploymentRuntimeInstance[] = [];
+
+afterEach(async () => {
+  await Promise.allSettled(instances.splice(0).map(instance => instance.close()));
+  await Promise.all(temporaryDirectories.splice(0).map(directory => (
+    rm(directory, { force: true, recursive: true })
+  )));
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), 'hypequery-node-worker-test-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function snapshot(
+  source: string,
+  options: { readonly runtime?: 'node' | 'python'; readonly entrypoint?: string; readonly digest?: string } = {},
+): DeploymentRuntimeSnapshot {
+  const bytes = Buffer.from(source);
+  const runtime = options.runtime ?? 'node';
+  const artifactSha256 = options.digest ?? sha256(bytes);
+  const entrypoint = options.entrypoint ?? 'queries.handler';
+  const binding = Object.freeze({
+    query: 'handler',
+    runtime,
+    artifactSha256,
+    entrypoint,
+  });
+  const deployment = prepareProtocolDeploymentContract({
+    kind: 'hypequery-deployment',
+    version: 1,
+    datasets: [],
+    queries: [{
+      name: 'handler',
+      input: { kind: 'any' },
+      output: { kind: 'any' },
+      implementation: {
+        kind: 'runtime-reference',
+        runtime,
+        artifactSha256,
+        entrypoint,
+      },
+      endpoint: {
+        access: { kind: 'public' },
+        tenant: { kind: 'not-required' },
+        method: 'POST',
+        path: '/handler',
+      },
+      tags: [],
+    }],
+    artifacts: [{ runtime, artifactSha256 }],
+  }).contract;
+  return Object.freeze({
+    target: TARGET,
+    activation: Object.freeze({
+      kind: 'hypequery-deployment-activation',
+      version: 1,
+      revision: '1'.repeat(64),
+      target: TARGET,
+      releaseIdentity: '2'.repeat(64),
+      previousRevision: null,
+      previousReleaseIdentity: null,
+      activatedAt: '2026-07-19T12:00:00.000Z',
+    }),
+    release: Object.freeze({
+      kind: 'hypequery-deployment-release',
+      version: 1,
+      bundleIdentity: '3'.repeat(64),
+      target: TARGET,
+    }),
+    releaseIdentity: '2'.repeat(64),
+    bundleIdentity: '3'.repeat(64),
+    deployment,
+    artifacts: [Object.freeze({
+      runtime,
+      artifactSha256,
+      byteLength: bytes.byteLength,
+      entrypoints: Object.freeze([entrypoint]),
+      read: () => Uint8Array.from(bytes),
+    })],
+    queries: [binding],
+  });
+}
+
+describe('Node worker deployment runtime factory', () => {
+  it('imports materialized modules in a worker and invokes qualified entrypoints', async () => {
+    const directory = await temporaryDirectory();
+    const deployed = snapshot([
+      'export const queries = {',
+      '  handler: async ({ value, delay = 0 }) => {',
+      '    await new Promise(resolve => setTimeout(resolve, delay));',
+      '    return { doubled: value * 2 };',
+      '  },',
+      '};',
+      '',
+    ].join('\n'));
+    const factory = createNodeWorkerDeploymentRuntimeFactory({ temporaryDirectory: directory });
+    const instance = await factory.start(deployed, {});
+    instances.push(instance);
+
+    await expect(instance.healthCheck({})).resolves.toBeUndefined();
+    await expect(instance.invoke({
+      query: 'handler',
+      binding: deployed.queries[0]!,
+      argument: { value: 21 },
+    })).resolves.toEqual({ doubled: 42 });
+
+    const dispatchedAbort = new AbortController();
+    const dispatched = instance.invoke({
+      query: 'handler',
+      binding: deployed.queries[0]!,
+      argument: { value: 2, delay: 20 },
+      signal: dispatchedAbort.signal,
+    });
+    dispatchedAbort.abort();
+    await expect(dispatched).resolves.toEqual({ doubled: 4 });
+
+    const preDispatchAbort = new AbortController();
+    preDispatchAbort.abort();
+    await expect(instance.invoke({
+      query: 'handler',
+      binding: deployed.queries[0]!,
+      argument: { value: 1 },
+      signal: preDispatchAbort.signal,
+    })).rejects.toMatchObject({ code: 'HQ_NODE_RUNTIME_ABORTED' });
+
+    await instance.close();
+    expect(await readdir(directory)).toEqual([]);
+    await expect(instance.invoke({
+      query: 'handler',
+      binding: deployed.queries[0]!,
+      argument: { value: 1 },
+    })).rejects.toMatchObject({ code: 'HQ_NODE_RUNTIME_CLOSED' });
+  });
+
+  it('fails startup for missing entrypoints and removes temporary bytes', async () => {
+    const directory = await temporaryDirectory();
+    const deployed = snapshot('export const queries = {};\n');
+    const factory = createNodeWorkerDeploymentRuntimeFactory({ temporaryDirectory: directory });
+
+    await expect(factory.start(deployed, {})).rejects.toMatchObject({
+      code: 'HQ_NODE_RUNTIME_START_FAILED',
+    });
+    expect(await readdir(directory)).toEqual([]);
+  });
+
+  it('rejects unsupported or identity-mismatched artifacts before execution', async () => {
+    const directory = await temporaryDirectory();
+    const factory = createNodeWorkerDeploymentRuntimeFactory({ temporaryDirectory: directory });
+    const python = snapshot('print("hello")\n', { runtime: 'python' });
+    const mismatched = snapshot('export const queries = {};\n', { digest: 'f'.repeat(64) });
+
+    await expect(factory.start(python, {})).rejects.toMatchObject({
+      code: 'HQ_NODE_RUNTIME_UNSUPPORTED_ARTIFACT',
+    });
+    await expect(factory.start(mismatched, {})).rejects.toMatchObject({
+      code: 'HQ_NODE_RUNTIME_INVALID_ARTIFACT',
+    });
+    expect(await readdir(directory)).toEqual([]);
+    expect(() => createNodeWorkerDeploymentRuntimeFactory({ startupTimeoutMs: 0 }))
+      .toThrow(NodeDeploymentRuntimeError);
+  });
+});

--- a/packages/deployment/src/node-runtime-factory.test.ts
+++ b/packages/deployment/src/node-runtime-factory.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { chmod, mkdtemp, readdir, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { prepareProtocolDeploymentContract } from '@hypequery/protocol';
@@ -163,6 +163,23 @@ describe('Node worker deployment runtime factory', () => {
     });
     expect(await readdir(directory)).toEqual([]);
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'seals generated runtime directories before writing artifacts',
+    async () => {
+      const directory = await temporaryDirectory();
+      await chmod(directory, 0o755);
+      const deployed = snapshot('export const queries = { handler: () => true };\n');
+      const factory = createNodeWorkerDeploymentRuntimeFactory({ temporaryDirectory: directory });
+
+      const instance = await factory.start(deployed, {});
+      instances.push(instance);
+      const entries = await readdir(directory);
+
+      expect(entries).toHaveLength(1);
+      expect((await stat(path.join(directory, entries[0]!))).mode & 0o777).toBe(0o700);
+    },
+  );
 
   it('rejects unsupported or identity-mismatched artifacts before execution', async () => {
     const directory = await temporaryDirectory();

--- a/packages/deployment/src/node-runtime-factory.ts
+++ b/packages/deployment/src/node-runtime-factory.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { lstat, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, lstat, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { Worker } from 'node:worker_threads';
@@ -223,7 +223,6 @@ function workerInstance(
     return new Promise((resolve, reject) => {
       const observeAbort = kind === 'health';
       const abort = () => {
-        if (!observeAbort) return;
         pending.delete(id);
         reject(nodeRuntimeError(
           'HQ_NODE_RUNTIME_ABORTED',
@@ -389,6 +388,7 @@ export function createNodeWorkerDeploymentRuntimeFactory(
       const root = await ensureTemporaryDirectory(options.temporaryDirectory);
       const directory = await mkdtemp(path.join(root, 'hypequery-node-runtime-'));
       try {
+        await chmod(directory, 0o700);
         return await startWorker(snapshot, directory, timeoutMs, input.signal);
       } catch (error) {
         try {

--- a/packages/deployment/src/node-runtime-factory.ts
+++ b/packages/deployment/src/node-runtime-factory.ts
@@ -1,0 +1,404 @@
+import { createHash } from 'node:crypto';
+import { lstat, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { Worker } from 'node:worker_threads';
+import type { DeploymentRuntimeSnapshot } from './runtime-materialization.js';
+import type {
+  DeploymentRuntimeFactory,
+  DeploymentRuntimeInstance,
+  DeploymentRuntimeInstanceInvocation,
+} from './runtime-supervisor.js';
+
+const DEFAULT_STARTUP_TIMEOUT_MS = 30_000;
+const MAX_STARTUP_TIMEOUT_MS = 5 * 60_000;
+
+const WORKER_SOURCE = [
+  "const { parentPort, workerData } = require('node:worker_threads');",
+  "const { pathToFileURL } = require('node:url');",
+  'const handlers = new Map();',
+  'function errorValue(error) {',
+  "  return { name: error instanceof Error ? error.name : 'Error',",
+  "    message: error instanceof Error ? error.message : String(error) };",
+  '}',
+  'function resolveEntrypoint(module, entrypoint) {',
+  '  let value = module;',
+  "  for (const segment of entrypoint.split('.')) value = value?.[segment];",
+  "  if (typeof value !== 'function') throw new Error(`Runtime entrypoint is unavailable: ${entrypoint}`);",
+  '  return value;',
+  '}',
+  '(async () => {',
+  '  for (const artifact of workerData.artifacts) {',
+  '    const module = await import(pathToFileURL(artifact.path).href);',
+  '    for (const entrypoint of artifact.entrypoints) {',
+  '      handlers.set(entrypoint, resolveEntrypoint(module, entrypoint));',
+  '    }',
+  '  }',
+  "  parentPort.postMessage({ kind: 'ready' });",
+  "  parentPort.on('message', async message => {",
+  "    if (message.kind === 'health') {",
+  "      parentPort.postMessage({ kind: 'result', id: message.id, value: null });",
+  '      return;',
+  '    }',
+  "    if (message.kind !== 'invoke') return;",
+  '    try {',
+  '      const handler = handlers.get(message.entrypoint);',
+  "      if (!handler) throw new Error(`Runtime entrypoint is unavailable: ${message.entrypoint}`);",
+  '      const value = await handler(message.argument);',
+  "      parentPort.postMessage({ kind: 'result', id: message.id, value });",
+  '    } catch (error) {',
+  "      parentPort.postMessage({ kind: 'failure', id: message.id, error: errorValue(error) });",
+  '    }',
+  '  });',
+  '})().catch(error => {',
+  "  parentPort.postMessage({ kind: 'fatal', error: errorValue(error) });",
+  '});',
+].join('\n');
+
+export type NodeDeploymentRuntimeErrorCode =
+  | 'HQ_NODE_RUNTIME_CONFIGURATION'
+  | 'HQ_NODE_RUNTIME_UNSUPPORTED_ARTIFACT'
+  | 'HQ_NODE_RUNTIME_INVALID_ARTIFACT'
+  | 'HQ_NODE_RUNTIME_START_FAILED'
+  | 'HQ_NODE_RUNTIME_WORKER_EXITED'
+  | 'HQ_NODE_RUNTIME_INVOCATION_FAILED'
+  | 'HQ_NODE_RUNTIME_ABORTED'
+  | 'HQ_NODE_RUNTIME_CLOSED';
+
+export class NodeDeploymentRuntimeError extends Error {
+  readonly code: NodeDeploymentRuntimeErrorCode;
+
+  constructor(
+    code: NodeDeploymentRuntimeErrorCode,
+    message: string,
+    options: { readonly cause?: unknown } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'NodeDeploymentRuntimeError';
+    this.code = code;
+  }
+}
+
+export interface NodeDeploymentRuntimeFactoryOptions {
+  readonly temporaryDirectory?: string;
+  /** Worker import deadline from 1 through 300,000 milliseconds. */
+  readonly startupTimeoutMs?: number;
+  readonly onCleanupError?: (error: unknown, directory: string) => void;
+}
+
+interface PendingCall {
+  readonly resolve: (value: unknown) => void;
+  readonly reject: (error: unknown) => void;
+  readonly cleanup: () => void;
+}
+
+interface WorkerErrorValue {
+  readonly name?: unknown;
+  readonly message?: unknown;
+}
+
+interface WorkerResponse {
+  readonly kind?: unknown;
+  readonly id?: unknown;
+  readonly value?: unknown;
+  readonly error?: WorkerErrorValue;
+}
+
+function nodeRuntimeError(
+  code: NodeDeploymentRuntimeErrorCode,
+  message: string,
+  cause?: unknown,
+): NodeDeploymentRuntimeError {
+  return new NodeDeploymentRuntimeError(code, message, { cause });
+}
+
+function startupTimeout(input: number | undefined): number {
+  const value = input ?? DEFAULT_STARTUP_TIMEOUT_MS;
+  if (!Number.isSafeInteger(value) || value < 1 || value > MAX_STARTUP_TIMEOUT_MS) {
+    throw nodeRuntimeError(
+      'HQ_NODE_RUNTIME_CONFIGURATION',
+      `startupTimeoutMs must be between 1 and ${MAX_STARTUP_TIMEOUT_MS}.`,
+    );
+  }
+  return value;
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+async function ensureTemporaryDirectory(input: string | undefined): Promise<string> {
+  const directory = path.resolve(input ?? tmpdir());
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const stat = await lstat(directory);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw nodeRuntimeError(
+      'HQ_NODE_RUNTIME_CONFIGURATION',
+      'The Node runtime temporary directory must be a regular directory.',
+    );
+  }
+  return directory;
+}
+
+function remoteError(input: WorkerErrorValue | undefined): Error {
+  const message = typeof input?.message === 'string'
+    ? input.message.slice(0, 4096)
+    : 'The runtime worker failed without an error message.';
+  const error = new Error(message);
+  if (typeof input?.name === 'string') error.name = input.name.slice(0, 128);
+  return error;
+}
+
+function workerInstance(
+  worker: Worker,
+  directory: string,
+  ready: Promise<void>,
+): DeploymentRuntimeInstance & { readonly ready: Promise<void> } {
+  const pending = new Map<number, PendingCall>();
+  let sequence = 0;
+  let closed = false;
+  let closePromise: Promise<void> | undefined;
+  let terminalError: NodeDeploymentRuntimeError | undefined;
+
+  function failPending(error: unknown): void {
+    for (const call of pending.values()) {
+      call.cleanup();
+      call.reject(error);
+    }
+    pending.clear();
+  }
+
+  worker.on('message', (message: WorkerResponse) => {
+    if ((message.kind !== 'result' && message.kind !== 'failure')
+      || !Number.isSafeInteger(message.id)) return;
+    const call = pending.get(message.id as number);
+    if (!call) return;
+    pending.delete(message.id as number);
+    call.cleanup();
+    if (message.kind === 'result') call.resolve(message.value);
+    else call.reject(nodeRuntimeError(
+      'HQ_NODE_RUNTIME_INVOCATION_FAILED',
+      'The Node deployment runtime invocation failed.',
+      remoteError(message.error),
+    ));
+  });
+  worker.on('error', error => {
+    terminalError = nodeRuntimeError(
+      'HQ_NODE_RUNTIME_WORKER_EXITED',
+      'The Node deployment runtime worker failed.',
+      error,
+    );
+    failPending(terminalError);
+  });
+  worker.on('exit', code => {
+    if (!closed) {
+      terminalError = nodeRuntimeError(
+        'HQ_NODE_RUNTIME_WORKER_EXITED',
+        `The Node deployment runtime worker exited unexpectedly with code ${code}.`,
+      );
+      failPending(terminalError);
+    }
+  });
+
+  function call(
+    kind: 'health' | 'invoke',
+    payload: Readonly<Record<string, unknown>>,
+    signal: AbortSignal | undefined,
+  ): Promise<unknown> {
+    if (closed || terminalError) {
+      return Promise.reject(terminalError ?? nodeRuntimeError(
+        'HQ_NODE_RUNTIME_CLOSED',
+        'The Node deployment runtime worker is closed.',
+      ));
+    }
+    if (signal?.aborted) {
+      return Promise.reject(nodeRuntimeError(
+        'HQ_NODE_RUNTIME_ABORTED',
+        'The Node deployment runtime invocation was aborted.',
+        signal.reason,
+      ));
+    }
+    const id = sequence;
+    sequence += 1;
+    return new Promise((resolve, reject) => {
+      const observeAbort = kind === 'health';
+      const abort = () => {
+        if (!observeAbort) return;
+        pending.delete(id);
+        reject(nodeRuntimeError(
+          'HQ_NODE_RUNTIME_ABORTED',
+          'The Node deployment runtime health check was aborted.',
+          signal?.reason,
+        ));
+      };
+      const cleanup = () => signal?.removeEventListener('abort', abort);
+      pending.set(id, { resolve, reject, cleanup });
+      if (observeAbort) signal?.addEventListener('abort', abort, { once: true });
+      try {
+        worker.postMessage({ kind, id, ...payload });
+      } catch (error) {
+        pending.delete(id);
+        cleanup();
+        reject(nodeRuntimeError(
+          'HQ_NODE_RUNTIME_INVOCATION_FAILED',
+          'The Node deployment runtime invocation could not be sent.',
+          error,
+        ));
+      }
+    });
+  }
+
+  return {
+    ready,
+    async healthCheck({ signal }): Promise<void> {
+      await call('health', {}, signal);
+    },
+    invoke(input: DeploymentRuntimeInstanceInvocation): Promise<unknown> {
+      return call('invoke', {
+        entrypoint: input.binding.entrypoint,
+        argument: input.argument,
+      }, input.signal);
+    },
+    async close(): Promise<void> {
+      if (closePromise) return closePromise;
+      closed = true;
+      const error = nodeRuntimeError(
+        'HQ_NODE_RUNTIME_CLOSED',
+        'The Node deployment runtime worker was closed.',
+      );
+      failPending(error);
+      closePromise = (async () => {
+        try {
+          await worker.terminate();
+        } finally {
+          await rm(directory, { force: true, recursive: true });
+        }
+      })();
+      return closePromise;
+    },
+  };
+}
+
+async function startWorker(
+  snapshot: DeploymentRuntimeSnapshot,
+  directory: string,
+  timeoutMs: number,
+  signal: AbortSignal | undefined,
+): Promise<DeploymentRuntimeInstance> {
+  if (signal?.aborted) {
+    throw nodeRuntimeError('HQ_NODE_RUNTIME_ABORTED', 'Node runtime startup was aborted.', signal.reason);
+  }
+  const artifacts: { readonly path: string; readonly entrypoints: readonly string[] }[] = [];
+  for (const artifact of snapshot.artifacts) {
+    if (artifact.runtime !== 'node') {
+      throw nodeRuntimeError(
+        'HQ_NODE_RUNTIME_UNSUPPORTED_ARTIFACT',
+        `The Node runtime factory cannot load a ${artifact.runtime} artifact.`,
+      );
+    }
+    const bytes = artifact.read();
+    if (bytes.byteLength !== artifact.byteLength || sha256(bytes) !== artifact.artifactSha256) {
+      throw nodeRuntimeError(
+        'HQ_NODE_RUNTIME_INVALID_ARTIFACT',
+        'Materialized Node runtime bytes do not match their identity.',
+      );
+    }
+    const artifactPath = path.join(directory, `${artifact.artifactSha256}.mjs`);
+    await writeFile(artifactPath, bytes, { flag: 'wx', mode: 0o600 });
+    artifacts.push(Object.freeze({ path: artifactPath, entrypoints: artifact.entrypoints }));
+  }
+  if (artifacts.length === 0) {
+    throw nodeRuntimeError(
+      'HQ_NODE_RUNTIME_UNSUPPORTED_ARTIFACT',
+      'The deployment snapshot contains no Node runtime artifacts.',
+    );
+  }
+
+  const worker = new Worker(WORKER_SOURCE, {
+    eval: true,
+    workerData: { artifacts },
+  });
+  let resolveReady!: () => void;
+  let rejectReady!: (error: unknown) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  const timer = setTimeout(() => {
+    rejectReady(nodeRuntimeError(
+      'HQ_NODE_RUNTIME_START_FAILED',
+      'The Node deployment runtime did not start before its deadline.',
+    ));
+  }, timeoutMs);
+  timer.unref();
+  const abort = () => rejectReady(nodeRuntimeError(
+    'HQ_NODE_RUNTIME_ABORTED',
+    'Node runtime startup was aborted.',
+    signal?.reason,
+  ));
+  signal?.addEventListener('abort', abort, { once: true });
+  const startupMessage = (message: WorkerResponse) => {
+    if (message.kind === 'ready') resolveReady();
+    if (message.kind === 'fatal') rejectReady(nodeRuntimeError(
+      'HQ_NODE_RUNTIME_START_FAILED',
+      'The Node deployment runtime could not import its artifacts.',
+      remoteError(message.error),
+    ));
+  };
+  const startupError = (error: Error) => rejectReady(nodeRuntimeError(
+    'HQ_NODE_RUNTIME_START_FAILED',
+    'The Node deployment runtime worker failed during startup.',
+    error,
+  ));
+  const startupExit = (code: number) => rejectReady(nodeRuntimeError(
+    'HQ_NODE_RUNTIME_START_FAILED',
+    `The Node deployment runtime worker exited during startup with code ${code}.`,
+  ));
+  worker.on('message', startupMessage);
+  worker.once('error', startupError);
+  worker.once('exit', startupExit);
+  const instance = workerInstance(worker, directory, ready);
+  try {
+    await ready;
+    return instance;
+  } catch (error) {
+    try {
+      await instance.close();
+    } catch {
+      // Preserve the startup failure; cleanup can be retried by the factory.
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+    signal?.removeEventListener('abort', abort);
+    worker.off('message', startupMessage);
+    worker.off('error', startupError);
+    worker.off('exit', startupExit);
+  }
+}
+
+export function createNodeWorkerDeploymentRuntimeFactory(
+  options: NodeDeploymentRuntimeFactoryOptions = {},
+): DeploymentRuntimeFactory {
+  const timeoutMs = startupTimeout(options.startupTimeoutMs);
+  return Object.freeze({
+    async start(
+      snapshot: DeploymentRuntimeSnapshot,
+      input: { readonly signal?: AbortSignal },
+    ): Promise<DeploymentRuntimeInstance> {
+      const root = await ensureTemporaryDirectory(options.temporaryDirectory);
+      const directory = await mkdtemp(path.join(root, 'hypequery-node-runtime-'));
+      try {
+        return await startWorker(snapshot, directory, timeoutMs, input.signal);
+      } catch (error) {
+        try {
+          await rm(directory, { force: true, recursive: true });
+        } catch (cleanupError) {
+          options.onCleanupError?.(cleanupError, directory);
+          // Preserve the error that prevented a runtime from starting.
+        }
+        throw error;
+      }
+    },
+  });
+}

--- a/packages/deployment/src/runtime-materialization.test.ts
+++ b/packages/deployment/src/runtime-materialization.test.ts
@@ -23,6 +23,8 @@ import {
   DeploymentRuntimeMaterializationError,
   type DeploymentRuntimeRelease,
 } from './runtime-materialization.js';
+import { createNodeWorkerDeploymentRuntimeFactory } from './node-runtime-factory.js';
+import { createDeploymentRuntimeSupervisor } from './runtime-supervisor.js';
 
 const TARGET = Object.freeze({ project: 'analytics', environment: 'production' });
 const temporaryDirectories: string[] = [];
@@ -305,4 +307,32 @@ describe('deployment runtime materialization', () => {
       }));
     },
   );
+
+  it('feeds exact materialized bytes through readiness and supervised execution', async () => {
+    const fixture = await releaseFixture([
+      'export const queries = {',
+      '  handler: async ({ input }) => ({ deployed: input }),',
+      '};',
+      '',
+    ].join('\n'));
+    const active = activation(fixture.stored.releaseIdentity);
+    const workerRoot = await mkdtemp(path.join(tmpdir(), 'hypequery-runtime-worker-'));
+    temporaryDirectories.push(workerRoot);
+    const materializer = createDeploymentRuntimeMaterializer({
+      activations: registry(async () => active),
+      releases: { read: async () => fixture.stored },
+    });
+    const supervisor = createDeploymentRuntimeSupervisor({
+      materializer,
+      factory: createNodeWorkerDeploymentRuntimeFactory({ temporaryDirectory: workerRoot }),
+    });
+
+    await expect(supervisor.reconcile(TARGET)).resolves.toMatchObject({ status: 'activated' });
+    await expect(supervisor.invoke({
+      target: TARGET,
+      query: 'handler',
+      argument: { input: 'verified-runtime' },
+    })).resolves.toEqual({ deployed: 'verified-runtime' });
+    await supervisor.close();
+  });
 });

--- a/packages/deployment/src/runtime-supervisor.test.ts
+++ b/packages/deployment/src/runtime-supervisor.test.ts
@@ -1,0 +1,326 @@
+import { prepareProtocolDeploymentContract } from '@hypequery/protocol';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  DeploymentRuntimeMaterializer,
+  DeploymentRuntimeSnapshot,
+} from './runtime-materialization.js';
+import {
+  createDeploymentRuntimeSupervisor,
+  DeploymentRuntimeSupervisorError,
+  type DeploymentRuntimeFactory,
+  type DeploymentRuntimeInstance,
+} from './runtime-supervisor.js';
+
+const TARGET = Object.freeze({ project: 'analytics', environment: 'production' });
+
+function snapshot(revisionCharacter: string, portable = false): DeploymentRuntimeSnapshot {
+  const revision = revisionCharacter.repeat(64);
+  const releaseIdentity = revisionCharacter.toUpperCase().repeat(64).toLowerCase();
+  const artifactSha256 = 'a'.repeat(64);
+  const implementation = portable
+    ? {
+        kind: 'semantic-plan' as const,
+        query: {
+          kind: 'dataset' as const,
+          dataset: 'orders',
+          dimensions: [],
+          measures: [],
+          filters: [],
+          orderBy: [],
+        },
+      }
+    : {
+        kind: 'runtime-reference' as const,
+        runtime: 'node' as const,
+        artifactSha256,
+        entrypoint: 'queries.handler',
+      };
+  const deployment = prepareProtocolDeploymentContract({
+    kind: 'hypequery-deployment' as const,
+    version: 1 as const,
+    datasets: portable ? [{
+      name: 'orders',
+      source: 'orders',
+      tenant: { kind: 'not-required' as const },
+      dimensions: [],
+      measures: [],
+      filters: [],
+      metrics: [],
+      relationships: [],
+    }] : [],
+    queries: [{
+      name: 'handler',
+      input: { kind: 'any' as const },
+      output: { kind: 'any' as const },
+      implementation,
+      endpoint: {
+        access: { kind: 'public' as const },
+        tenant: { kind: 'not-required' as const },
+        method: 'POST' as const,
+        path: '/handler',
+      },
+      tags: [],
+    }],
+    artifacts: portable ? [] : [{ runtime: 'node' as const, artifactSha256 }],
+  }).contract;
+  return Object.freeze({
+    target: TARGET,
+    activation: Object.freeze({
+      kind: 'hypequery-deployment-activation',
+      version: 1,
+      revision,
+      target: TARGET,
+      releaseIdentity,
+      previousRevision: null,
+      previousReleaseIdentity: null,
+      activatedAt: '2026-07-19T12:00:00.000Z',
+    }),
+    release: Object.freeze({
+      kind: 'hypequery-deployment-release',
+      version: 1,
+      bundleIdentity: 'b'.repeat(64),
+      target: TARGET,
+    }),
+    releaseIdentity,
+    bundleIdentity: 'b'.repeat(64),
+    deployment,
+    artifacts: portable ? [] : [Object.freeze({
+      runtime: 'node',
+      artifactSha256,
+      byteLength: 1,
+      entrypoints: Object.freeze(['queries.handler']),
+      read: () => Uint8Array.of(1),
+    })],
+    queries: portable ? [] : [Object.freeze({
+      query: 'handler',
+      runtime: 'node',
+      artifactSha256,
+      entrypoint: 'queries.handler',
+    })],
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((accept, decline) => {
+    resolve = accept;
+    reject = decline;
+  });
+  return { promise, resolve, reject };
+}
+
+function runtimeInstance(label: string) {
+  const healthCheck = vi.fn(async () => undefined);
+  const invoke = vi.fn<DeploymentRuntimeInstance['invoke']>(
+    async ({ argument }) => ({ label, argument }),
+  );
+  const close = vi.fn(async () => undefined);
+  return { instance: { healthCheck, invoke, close }, healthCheck, invoke, close };
+}
+
+function materializer(current: () => Promise<DeploymentRuntimeSnapshot | undefined>) {
+  return { current: vi.fn(current) } satisfies DeploymentRuntimeMaterializer;
+}
+
+describe('deployment runtime supervisor', () => {
+  it('starts, checks, atomically activates, and routes by named query', async () => {
+    const active = snapshot('1');
+    const runtime = runtimeInstance('v1');
+    const source = materializer(async () => active);
+    const start = vi.fn(async () => runtime.instance);
+    const supervisor = createDeploymentRuntimeSupervisor({
+      materializer: source,
+      factory: { start },
+    });
+
+    const result = await supervisor.reconcile(TARGET);
+    const response = await supervisor.invoke({ target: TARGET, query: 'handler', argument: 42 });
+
+    expect(result).toMatchObject({
+      status: 'activated',
+      runtime: { activationRevision: active.activation.revision },
+    });
+    expect(start).toHaveBeenCalledWith(active, { signal: undefined });
+    expect(runtime.healthCheck).toHaveBeenCalledOnce();
+    expect(runtime.invoke).toHaveBeenCalledWith({
+      query: 'handler',
+      binding: active.queries[0],
+      argument: 42,
+      signal: undefined,
+    });
+    expect(response).toEqual({ label: 'v1', argument: 42 });
+    expect(supervisor.status(TARGET)?.releaseIdentity).toBe(active.releaseIdentity);
+    await supervisor.close();
+  });
+
+  it('keeps the old runtime active until its in-flight work drains after cutover', async () => {
+    const first = snapshot('2');
+    const second = snapshot('3');
+    let desired = first;
+    const source = materializer(async () => desired);
+    const firstRuntime = runtimeInstance('v1');
+    const secondRuntime = runtimeInstance('v2');
+    const pending = deferred<unknown>();
+    firstRuntime.invoke.mockImplementationOnce(async () => pending.promise);
+    const start = vi.fn(async (candidate: DeploymentRuntimeSnapshot) => (
+      candidate === first ? firstRuntime.instance : secondRuntime.instance
+    ));
+    const supervisor = createDeploymentRuntimeSupervisor({
+      materializer: source,
+      factory: { start },
+    });
+    await supervisor.reconcile(TARGET);
+    const oldInvocation = supervisor.invoke({ target: TARGET, query: 'handler', argument: 'old' });
+    await vi.waitFor(() => expect(firstRuntime.invoke).toHaveBeenCalledOnce());
+
+    desired = second;
+    await expect(supervisor.reconcile(TARGET)).resolves.toMatchObject({ status: 'activated' });
+    expect(firstRuntime.close).not.toHaveBeenCalled();
+    await expect(supervisor.invoke({ target: TARGET, query: 'handler', argument: 'new' }))
+      .resolves.toEqual({ label: 'v2', argument: 'new' });
+
+    pending.resolve('old-result');
+    await expect(oldInvocation).resolves.toBe('old-result');
+    await vi.waitFor(() => expect(firstRuntime.close).toHaveBeenCalledOnce());
+    await supervisor.close();
+  });
+
+  it('keeps serving the old generation when candidate readiness fails', async () => {
+    const first = snapshot('4');
+    const second = snapshot('5');
+    let desired = first;
+    const source = materializer(async () => desired);
+    const firstRuntime = runtimeInstance('v1');
+    const failedRuntime = runtimeInstance('v2');
+    failedRuntime.healthCheck.mockRejectedValueOnce(new Error('not ready'));
+    const factory: DeploymentRuntimeFactory = {
+      start: async candidate => candidate === first ? firstRuntime.instance : failedRuntime.instance,
+    };
+    const supervisor = createDeploymentRuntimeSupervisor({ materializer: source, factory });
+    await supervisor.reconcile(TARGET);
+    desired = second;
+
+    await expect(supervisor.reconcile(TARGET)).rejects.toMatchObject({
+      code: 'HQ_RUNTIME_HEALTH_FAILED',
+    });
+    expect(supervisor.status(TARGET)?.activationRevision).toBe(first.activation.revision);
+    await expect(supervisor.invoke({ target: TARGET, query: 'handler', argument: null }))
+      .resolves.toEqual({ label: 'v1', argument: null });
+    expect(failedRuntime.close).toHaveBeenCalledOnce();
+    await supervisor.close();
+  });
+
+  it('discards a superseded candidate and retries the newly confirmed activation', async () => {
+    const stale = snapshot('6');
+    const current = snapshot('7');
+    const values = [stale, current, current, current];
+    const source = materializer(async () => values.shift() ?? current);
+    const staleRuntime = runtimeInstance('stale');
+    const currentRuntime = runtimeInstance('current');
+    const start = vi.fn(async candidate => (
+      candidate === stale ? staleRuntime.instance : currentRuntime.instance
+    ));
+    const supervisor = createDeploymentRuntimeSupervisor({
+      materializer: source,
+      factory: { start },
+      maxReconcileAttempts: 2,
+    });
+
+    await expect(supervisor.reconcile(TARGET)).resolves.toMatchObject({ status: 'activated' });
+
+    expect(staleRuntime.close).toHaveBeenCalledOnce();
+    expect(supervisor.status(TARGET)?.activationRevision).toBe(current.activation.revision);
+    expect(start).toHaveBeenCalledTimes(2);
+    await supervisor.close();
+  });
+
+  it('serializes concurrent reconciliation and deactivates absent targets', async () => {
+    const active = snapshot('8');
+    let desired: DeploymentRuntimeSnapshot | undefined = active;
+    const source = materializer(async () => desired);
+    const runtime = runtimeInstance('v1');
+    const start = vi.fn(async () => runtime.instance);
+    const supervisor = createDeploymentRuntimeSupervisor({
+      materializer: source,
+      factory: { start },
+    });
+
+    const [first, second] = await Promise.all([
+      supervisor.reconcile(TARGET),
+      supervisor.reconcile(TARGET),
+    ]);
+    expect([first.status, second.status]).toEqual(['activated', 'already-current']);
+    expect(start).toHaveBeenCalledOnce();
+
+    desired = undefined;
+    await expect(supervisor.reconcile(TARGET)).resolves.toMatchObject({ status: 'deactivated' });
+    expect(supervisor.status(TARGET)).toBeUndefined();
+    await vi.waitFor(() => expect(runtime.close).toHaveBeenCalledOnce());
+    await expect(supervisor.invoke({ target: TARGET, query: 'handler', argument: null }))
+      .rejects.toMatchObject({ code: 'HQ_RUNTIME_NOT_READY' });
+    await supervisor.close();
+  });
+
+  it('forces isolation shutdown when in-flight work exceeds the drain deadline', async () => {
+    const first = snapshot('a');
+    const second = snapshot('b');
+    let desired = first;
+    const source = materializer(async () => desired);
+    const firstRuntime = runtimeInstance('v1');
+    const secondRuntime = runtimeInstance('v2');
+    const pending = deferred<unknown>();
+    firstRuntime.invoke.mockImplementationOnce(async () => pending.promise);
+    const supervisor = createDeploymentRuntimeSupervisor({
+      materializer: source,
+      factory: {
+        start: async candidate => candidate === first
+          ? firstRuntime.instance
+          : secondRuntime.instance,
+      },
+      drainTimeoutMs: 0,
+    });
+    await supervisor.reconcile(TARGET);
+    const invocation = supervisor.invoke({ target: TARGET, query: 'handler', argument: null });
+    await vi.waitFor(() => expect(firstRuntime.invoke).toHaveBeenCalledOnce());
+
+    desired = second;
+    await supervisor.reconcile(TARGET);
+    await vi.waitFor(() => expect(firstRuntime.close).toHaveBeenCalledOnce());
+
+    pending.resolve('finished-after-deadline');
+    await expect(invocation).resolves.toBe('finished-after-deadline');
+    await supervisor.close();
+  });
+
+  it('attempts every runtime close and reports explicit shutdown failures', async () => {
+    const active = snapshot('c');
+    const runtime = runtimeInstance('v1');
+    runtime.close.mockRejectedValueOnce(new Error('close failed'));
+    const supervisor = createDeploymentRuntimeSupervisor({
+      materializer: materializer(async () => active),
+      factory: { start: async () => runtime.instance },
+    });
+    await supervisor.reconcile(TARGET);
+
+    await expect(supervisor.close()).rejects.toBeInstanceOf(AggregateError);
+    expect(runtime.close).toHaveBeenCalledOnce();
+  });
+
+  it('rejects portable queries and becomes permanently closed', async () => {
+    const active = snapshot('9', true);
+    const runtime = runtimeInstance('portable');
+    const supervisor = createDeploymentRuntimeSupervisor({
+      materializer: materializer(async () => active),
+      factory: { start: async () => runtime.instance },
+    });
+    await supervisor.reconcile(TARGET);
+
+    await expect(supervisor.invoke({ target: TARGET, query: 'handler', argument: null }))
+      .rejects.toMatchObject({ code: 'HQ_RUNTIME_QUERY_NOT_EXECUTABLE' });
+    await supervisor.close();
+    await expect(supervisor.reconcile(TARGET)).rejects.toBeInstanceOf(
+      DeploymentRuntimeSupervisorError,
+    );
+  });
+});

--- a/packages/deployment/src/runtime-supervisor.test.ts
+++ b/packages/deployment/src/runtime-supervisor.test.ts
@@ -115,7 +115,7 @@ function runtimeInstance(label: string) {
   const invoke = vi.fn<DeploymentRuntimeInstance['invoke']>(
     async ({ argument }) => ({ label, argument }),
   );
-  const close = vi.fn(async () => undefined);
+  const close = vi.fn<DeploymentRuntimeInstance['close']>(async () => undefined);
   return { instance: { healthCheck, invoke, close }, healthCheck, invoke, close };
 }
 
@@ -208,6 +208,29 @@ describe('deployment runtime supervisor', () => {
     await expect(supervisor.invoke({ target: TARGET, query: 'handler', argument: null }))
       .resolves.toEqual({ label: 'v1', argument: null });
     expect(failedRuntime.close).toHaveBeenCalledOnce();
+    await supervisor.close();
+  });
+
+  it('preserves cancellation when startup is aborted in flight', async () => {
+    const active = snapshot('d');
+    const controller = new AbortController();
+    const start = vi.fn<DeploymentRuntimeFactory['start']>(async (_candidate, { signal }) => (
+      await new Promise<DeploymentRuntimeInstance>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(new Error('startup aborted')), {
+          once: true,
+        });
+      })
+    ));
+    const supervisor = createDeploymentRuntimeSupervisor({
+      materializer: materializer(async () => active),
+      factory: { start },
+    });
+
+    const reconcile = supervisor.reconcile(TARGET, { signal: controller.signal });
+    await vi.waitFor(() => expect(start).toHaveBeenCalledOnce());
+    controller.abort('cancelled');
+
+    await expect(reconcile).rejects.toMatchObject({ code: 'HQ_RUNTIME_ABORTED' });
     await supervisor.close();
   });
 
@@ -305,6 +328,26 @@ describe('deployment runtime supervisor', () => {
 
     await expect(supervisor.close()).rejects.toBeInstanceOf(AggregateError);
     expect(runtime.close).toHaveBeenCalledOnce();
+  });
+
+  it('shares one shutdown promise across concurrent close calls', async () => {
+    const active = snapshot('e');
+    const runtime = runtimeInstance('v1');
+    const closing = deferred<void>();
+    runtime.close.mockImplementationOnce(async () => closing.promise);
+    const supervisor = createDeploymentRuntimeSupervisor({
+      materializer: materializer(async () => active),
+      factory: { start: async () => runtime.instance },
+    });
+    await supervisor.reconcile(TARGET);
+
+    const first = supervisor.close();
+    const second = supervisor.close();
+
+    expect(second).toBe(first);
+    await vi.waitFor(() => expect(runtime.close).toHaveBeenCalledOnce());
+    closing.resolve();
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
   });
 
   it('rejects portable queries and becomes permanently closed', async () => {

--- a/packages/deployment/src/runtime-supervisor.ts
+++ b/packages/deployment/src/runtime-supervisor.ts
@@ -1,0 +1,409 @@
+import type { ProtocolDeploymentReleaseTarget } from '@hypequery/protocol';
+import type {
+  DeploymentRuntimeMaterializer,
+  DeploymentRuntimeQueryBinding,
+  DeploymentRuntimeSnapshot,
+} from './runtime-materialization.js';
+
+const DEFAULT_DRAIN_TIMEOUT_MS = 30_000;
+const DEFAULT_RECONCILE_ATTEMPTS = 4;
+const MAX_DRAIN_TIMEOUT_MS = 5 * 60_000;
+const MAX_RECONCILE_ATTEMPTS = 16;
+
+export type DeploymentRuntimeSupervisorErrorCode =
+  | 'HQ_RUNTIME_SUPERVISOR_CONFIGURATION'
+  | 'HQ_RUNTIME_SUPERVISOR_CLOSED'
+  | 'HQ_RUNTIME_NOT_READY'
+  | 'HQ_RUNTIME_QUERY_NOT_FOUND'
+  | 'HQ_RUNTIME_QUERY_NOT_EXECUTABLE'
+  | 'HQ_RUNTIME_START_FAILED'
+  | 'HQ_RUNTIME_HEALTH_FAILED'
+  | 'HQ_RUNTIME_INVOCATION_FAILED'
+  | 'HQ_RUNTIME_RECONCILE_UNSTABLE'
+  | 'HQ_RUNTIME_ABORTED';
+
+export class DeploymentRuntimeSupervisorError extends Error {
+  readonly code: DeploymentRuntimeSupervisorErrorCode;
+
+  constructor(
+    code: DeploymentRuntimeSupervisorErrorCode,
+    message: string,
+    options: { readonly cause?: unknown } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'DeploymentRuntimeSupervisorError';
+    this.code = code;
+  }
+}
+
+export interface DeploymentRuntimeInstanceInvocation {
+  readonly query: string;
+  readonly binding: DeploymentRuntimeQueryBinding;
+  readonly argument: unknown;
+  readonly signal?: AbortSignal;
+}
+
+export interface DeploymentRuntimeInstance {
+  healthCheck(input: { readonly signal?: AbortSignal }): Promise<void>;
+  invoke(input: DeploymentRuntimeInstanceInvocation): Promise<unknown>;
+  close(): Promise<void>;
+}
+
+export interface DeploymentRuntimeFactory {
+  start(
+    snapshot: DeploymentRuntimeSnapshot,
+    input: { readonly signal?: AbortSignal },
+  ): Promise<DeploymentRuntimeInstance>;
+}
+
+export interface DeploymentRuntimeInvocation {
+  readonly target: ProtocolDeploymentReleaseTarget;
+  readonly query: string;
+  readonly argument: unknown;
+  readonly signal?: AbortSignal;
+}
+
+export interface DeploymentRuntimeStatus {
+  readonly target: ProtocolDeploymentReleaseTarget;
+  readonly activationRevision: string;
+  readonly releaseIdentity: string;
+  readonly bundleIdentity: string;
+}
+
+export type DeploymentRuntimeReconcileResult =
+  | { readonly status: 'activated'; readonly runtime: DeploymentRuntimeStatus }
+  | { readonly status: 'already-current'; readonly runtime: DeploymentRuntimeStatus }
+  | { readonly status: 'deactivated'; readonly previous: DeploymentRuntimeStatus }
+  | { readonly status: 'no-active-release' };
+
+export interface DeploymentRuntimeSupervisor {
+  reconcile(
+    target: ProtocolDeploymentReleaseTarget,
+    options?: { readonly signal?: AbortSignal },
+  ): Promise<DeploymentRuntimeReconcileResult>;
+  invoke(input: DeploymentRuntimeInvocation): Promise<unknown>;
+  status(target: ProtocolDeploymentReleaseTarget): DeploymentRuntimeStatus | undefined;
+  close(): Promise<void>;
+}
+
+export interface DeploymentRuntimeSupervisorOptions {
+  readonly materializer: DeploymentRuntimeMaterializer;
+  readonly factory: DeploymentRuntimeFactory;
+  /** In-flight drain deadline from 0 through 300,000 milliseconds. */
+  readonly drainTimeoutMs?: number;
+  /** Activation-stability attempts from 1 through 16. */
+  readonly maxReconcileAttempts?: number;
+  readonly onBackgroundError?: (error: unknown) => void;
+}
+
+interface Generation {
+  readonly snapshot: DeploymentRuntimeSnapshot;
+  readonly instance: DeploymentRuntimeInstance;
+  inFlight: number;
+  draining: boolean;
+  drained?: () => void;
+}
+
+function supervisorError(
+  code: DeploymentRuntimeSupervisorErrorCode,
+  message: string,
+  cause?: unknown,
+): DeploymentRuntimeSupervisorError {
+  return new DeploymentRuntimeSupervisorError(code, message, { cause });
+}
+
+function boundedInteger(
+  input: number | undefined,
+  fallback: number,
+  maximum: number,
+  name: string,
+  allowZero = false,
+): number {
+  const value = input ?? fallback;
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1) || value > maximum) {
+    throw supervisorError(
+      'HQ_RUNTIME_SUPERVISOR_CONFIGURATION',
+      `${name} must be an integer between ${allowZero ? 0 : 1} and ${maximum}.`,
+    );
+  }
+  return value;
+}
+
+function targetKey(target: ProtocolDeploymentReleaseTarget): string {
+  return JSON.stringify([target.project, target.environment]);
+}
+
+function sameTarget(
+  left: ProtocolDeploymentReleaseTarget,
+  right: ProtocolDeploymentReleaseTarget,
+): boolean {
+  return left.project === right.project && left.environment === right.environment;
+}
+
+function status(generation: Generation): DeploymentRuntimeStatus {
+  const snapshot = generation.snapshot;
+  return Object.freeze({
+    target: snapshot.target,
+    activationRevision: snapshot.activation.revision,
+    releaseIdentity: snapshot.releaseIdentity,
+    bundleIdentity: snapshot.bundleIdentity,
+  });
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw supervisorError('HQ_RUNTIME_ABORTED', 'The runtime operation was aborted.', signal.reason);
+  }
+}
+
+function binding(
+  snapshot: DeploymentRuntimeSnapshot,
+  queryName: string,
+): DeploymentRuntimeQueryBinding {
+  const query = snapshot.deployment.queries.find(candidate => candidate.name === queryName);
+  if (!query) {
+    throw supervisorError('HQ_RUNTIME_QUERY_NOT_FOUND', `Runtime query not found: ${queryName}`);
+  }
+  if (query.implementation.kind !== 'runtime-reference') {
+    throw supervisorError(
+      'HQ_RUNTIME_QUERY_NOT_EXECUTABLE',
+      `Query is portable and does not use a supervised runtime: ${queryName}`,
+    );
+  }
+  const resolved = snapshot.queries.find(candidate => candidate.query === queryName);
+  if (!resolved) {
+    throw supervisorError(
+      'HQ_RUNTIME_QUERY_NOT_EXECUTABLE',
+      `Runtime query binding is unavailable: ${queryName}`,
+    );
+  }
+  return resolved;
+}
+
+export function createDeploymentRuntimeSupervisor(
+  options: DeploymentRuntimeSupervisorOptions,
+): DeploymentRuntimeSupervisor {
+  const drainTimeoutMs = boundedInteger(
+    options.drainTimeoutMs,
+    DEFAULT_DRAIN_TIMEOUT_MS,
+    MAX_DRAIN_TIMEOUT_MS,
+    'drainTimeoutMs',
+    true,
+  );
+  const maxReconcileAttempts = boundedInteger(
+    options.maxReconcileAttempts,
+    DEFAULT_RECONCILE_ATTEMPTS,
+    MAX_RECONCILE_ATTEMPTS,
+    'maxReconcileAttempts',
+  );
+  const active = new Map<string, Generation>();
+  const updates = new Map<string, Promise<unknown>>();
+  const background = new Set<Promise<void>>();
+  const backgroundFailures: unknown[] = [];
+  let closed = false;
+
+  function ensureOpen(): void {
+    if (closed) throw supervisorError('HQ_RUNTIME_SUPERVISOR_CLOSED', 'Runtime supervisor is closed.');
+  }
+
+  async function drain(generation: Generation): Promise<void> {
+    if (generation.draining) return;
+    generation.draining = true;
+    if (generation.inFlight > 0) {
+      await new Promise<void>(resolve => {
+        let settled = false;
+        const finish = () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          generation.drained = undefined;
+          resolve();
+        };
+        generation.drained = finish;
+        const timer = setTimeout(finish, drainTimeoutMs);
+        timer.unref();
+      });
+    }
+    await generation.instance.close();
+  }
+
+  function drainInBackground(generation: Generation): void {
+    const operation = drain(generation).catch(error => {
+      backgroundFailures.push(error);
+      options.onBackgroundError?.(error);
+    });
+    background.add(operation);
+    void operation.finally(() => background.delete(operation));
+  }
+
+  async function safeClose(instance: DeploymentRuntimeInstance): Promise<void> {
+    try {
+      await instance.close();
+    } catch (error) {
+      backgroundFailures.push(error);
+      options.onBackgroundError?.(error);
+    }
+  }
+
+  async function performReconcile(
+    target: ProtocolDeploymentReleaseTarget,
+    signal: AbortSignal | undefined,
+  ): Promise<DeploymentRuntimeReconcileResult> {
+    for (let attempt = 0; attempt < maxReconcileAttempts; attempt += 1) {
+      ensureOpen();
+      throwIfAborted(signal);
+      const snapshot = await options.materializer.current(target);
+      ensureOpen();
+      throwIfAborted(signal);
+      const key = targetKey(target);
+      const existing = active.get(key);
+      if (!snapshot) {
+        if (!existing) return Object.freeze({ status: 'no-active-release' });
+        active.delete(key);
+        drainInBackground(existing);
+        return Object.freeze({ status: 'deactivated', previous: status(existing) });
+      }
+      if (!sameTarget(snapshot.target, target)) {
+        throw supervisorError(
+          'HQ_RUNTIME_START_FAILED',
+          'The materialized runtime snapshot does not match the requested target.',
+        );
+      }
+      if (existing?.snapshot.activation.revision === snapshot.activation.revision) {
+        return Object.freeze({ status: 'already-current', runtime: status(existing) });
+      }
+
+      let candidate: DeploymentRuntimeInstance;
+      try {
+        candidate = await options.factory.start(snapshot, { signal });
+      } catch (error) {
+        if (error instanceof DeploymentRuntimeSupervisorError) throw error;
+        throw supervisorError(
+          'HQ_RUNTIME_START_FAILED',
+          'The candidate deployment runtime could not be started.',
+          error,
+        );
+      }
+      try {
+        ensureOpen();
+        throwIfAborted(signal);
+        await candidate.healthCheck({ signal });
+      } catch (error) {
+        await safeClose(candidate);
+        if (error instanceof DeploymentRuntimeSupervisorError) throw error;
+        throw supervisorError(
+          'HQ_RUNTIME_HEALTH_FAILED',
+          'The candidate deployment runtime did not become ready.',
+          error,
+        );
+      }
+
+      let confirmed: DeploymentRuntimeSnapshot | undefined;
+      try {
+        ensureOpen();
+        throwIfAborted(signal);
+        confirmed = await options.materializer.current(target);
+        ensureOpen();
+        throwIfAborted(signal);
+      } catch (error) {
+        await safeClose(candidate);
+        throw error;
+      }
+      if (confirmed?.activation.revision !== snapshot.activation.revision) {
+        await safeClose(candidate);
+        continue;
+      }
+
+      const generation: Generation = {
+        snapshot,
+        instance: candidate,
+        inFlight: 0,
+        draining: false,
+      };
+      const previous = active.get(key);
+      active.set(key, generation);
+      if (previous) drainInBackground(previous);
+      return Object.freeze({ status: 'activated', runtime: status(generation) });
+    }
+    throw supervisorError(
+      'HQ_RUNTIME_RECONCILE_UNSTABLE',
+      'Deployment activation changed repeatedly while starting a runtime.',
+    );
+  }
+
+  function serialize<T>(key: string, operation: () => Promise<T>): Promise<T> {
+    const previous = updates.get(key) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(operation);
+    const tracked = current.finally(() => {
+      if (updates.get(key) === tracked) updates.delete(key);
+    });
+    updates.set(key, tracked);
+    return tracked;
+  }
+
+  return Object.freeze({
+    async reconcile(
+      target: ProtocolDeploymentReleaseTarget,
+      reconcileOptions: { readonly signal?: AbortSignal } = {},
+    ): Promise<DeploymentRuntimeReconcileResult> {
+      ensureOpen();
+      return await serialize(
+        targetKey(target),
+        () => performReconcile(target, reconcileOptions.signal),
+      );
+    },
+
+    async invoke(input: DeploymentRuntimeInvocation): Promise<unknown> {
+      ensureOpen();
+      throwIfAborted(input.signal);
+      const generation = active.get(targetKey(input.target));
+      if (!generation) {
+        throw supervisorError('HQ_RUNTIME_NOT_READY', 'No deployment runtime is ready for target.');
+      }
+      const resolved = binding(generation.snapshot, input.query);
+      generation.inFlight += 1;
+      try {
+        return await generation.instance.invoke({
+          query: input.query,
+          binding: resolved,
+          argument: input.argument,
+          signal: input.signal,
+        });
+      } catch (error) {
+        if (error instanceof DeploymentRuntimeSupervisorError) throw error;
+        throw supervisorError(
+          'HQ_RUNTIME_INVOCATION_FAILED',
+          'The deployment runtime invocation failed.',
+          error,
+        );
+      } finally {
+        generation.inFlight -= 1;
+        if (generation.draining && generation.inFlight === 0) generation.drained?.();
+      }
+    },
+
+    status(target: ProtocolDeploymentReleaseTarget): DeploymentRuntimeStatus | undefined {
+      const generation = active.get(targetKey(target));
+      return generation ? status(generation) : undefined;
+    },
+
+    async close(): Promise<void> {
+      if (closed) return;
+      closed = true;
+      await Promise.allSettled([...updates.values()]);
+      const generations = [...active.values()];
+      active.clear();
+      const results = await Promise.allSettled(generations.map(generation => drain(generation)));
+      await Promise.allSettled([...background]);
+      const failures = [
+        ...backgroundFailures,
+        ...results
+        .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+        .map(result => result.reason),
+      ];
+      if (failures.length > 0) {
+        throw new AggregateError(failures, 'One or more deployment runtimes could not be closed.');
+      }
+    },
+  });
+}

--- a/packages/deployment/src/runtime-supervisor.ts
+++ b/packages/deployment/src/runtime-supervisor.ts
@@ -201,6 +201,7 @@ export function createDeploymentRuntimeSupervisor(
   const background = new Set<Promise<void>>();
   const backgroundFailures: unknown[] = [];
   let closed = false;
+  let closePromise: Promise<void> | undefined;
 
   function ensureOpen(): void {
     if (closed) throw supervisorError('HQ_RUNTIME_SUPERVISOR_CLOSED', 'Runtime supervisor is closed.');
@@ -277,6 +278,13 @@ export function createDeploymentRuntimeSupervisor(
       try {
         candidate = await options.factory.start(snapshot, { signal });
       } catch (error) {
+        if (signal?.aborted) {
+          throw supervisorError(
+            'HQ_RUNTIME_ABORTED',
+            'The runtime operation was aborted while starting a candidate.',
+            error,
+          );
+        }
         if (error instanceof DeploymentRuntimeSupervisorError) throw error;
         throw supervisorError(
           'HQ_RUNTIME_START_FAILED',
@@ -387,23 +395,29 @@ export function createDeploymentRuntimeSupervisor(
       return generation ? status(generation) : undefined;
     },
 
-    async close(): Promise<void> {
-      if (closed) return;
+    close(): Promise<void> {
+      if (closePromise) return closePromise;
       closed = true;
-      await Promise.allSettled([...updates.values()]);
-      const generations = [...active.values()];
-      active.clear();
-      const results = await Promise.allSettled(generations.map(generation => drain(generation)));
-      await Promise.allSettled([...background]);
-      const failures = [
-        ...backgroundFailures,
-        ...results
-        .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
-        .map(result => result.reason),
-      ];
-      if (failures.length > 0) {
-        throw new AggregateError(failures, 'One or more deployment runtimes could not be closed.');
-      }
+      closePromise = (async () => {
+        await Promise.allSettled([...updates.values()]);
+        const generations = [...active.values()];
+        active.clear();
+        const results = await Promise.allSettled(generations.map(generation => drain(generation)));
+        await Promise.allSettled([...background]);
+        const failures = [
+          ...backgroundFailures,
+          ...results
+            .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+            .map(result => result.reason),
+        ];
+        if (failures.length > 0) {
+          throw new AggregateError(
+            failures,
+            'One or more deployment runtimes could not be closed.',
+          );
+        }
+      })();
+      return closePromise;
     },
   });
 }

--- a/specs/deployment/0005-runtime-supervision.md
+++ b/specs/deployment/0005-runtime-supervision.md
@@ -1,0 +1,106 @@
+# Deployment runtime 0005: Supervision and traffic switching
+
+- Status: Proposed
+- Version: deployment runtime supervision 1
+
+## Summary
+
+This specification defines how materialized snapshots become ready runtime
+generations and how named-query invocations switch between generations without
+sending new work to a draining runtime.
+
+The supervisor is runtime-neutral. A reference Node factory imports materialized
+Node artifacts in worker threads; providers may supply other factories,
+including Python processes or remote sandboxes, while retaining the same
+lifecycle contract.
+
+## Runtime factory
+
+A runtime factory receives one immutable snapshot from specification 0004 and
+starts an isolated runtime instance. An instance implements:
+
+- `healthCheck`, which resolves only when the candidate can accept work;
+- `invoke`, which executes one materialized named-query binding with an opaque
+  structured-clone-compatible argument;
+- `close`, which rejects new work and releases runtime resources.
+
+Factory startup failure MUST clean up resources it created. A failed candidate
+is never installed as active.
+
+## Reconciliation and readiness
+
+Reconciliation for one target is serialized. It performs these steps:
+
+1. materialize the confirmed current activation;
+2. return `already-current` when that revision is already serving;
+3. start a candidate while the previous generation remains active;
+4. require the candidate readiness check to succeed;
+5. materialize current state again and require the same revision;
+6. atomically replace the active generation;
+7. begin draining the previous generation.
+
+If activation changes during candidate startup, the candidate is closed and
+reconciliation retries with the new activation. Retries are bounded. Startup,
+readiness, or stability failure leaves the previous active generation
+unchanged.
+
+A target with no activation removes its active generation and starts draining
+it. No-active state is not a runtime startup error.
+
+## Invocation and cutover
+
+Invocation selects the active generation synchronously before incrementing its
+in-flight count. The named query MUST exist in the snapshot and use a
+`runtime-reference` implementation. Portable semantic plans and compiled SQL
+remain the responsibility of their native execution adapters.
+
+The active-generation replacement is one synchronous state transition. Calls
+selected before the transition complete on the old generation; calls selected
+after it use the new generation. No new invocation may enter a generation once
+draining starts.
+
+## Draining and shutdown
+
+A draining generation closes when its in-flight count reaches zero or when the
+configured drain deadline expires. Deadline expiry permits forced isolation
+shutdown so an unresponsive invocation cannot retain the generation forever.
+
+Supervisor shutdown prevents new reconciliation and invocation, waits for
+in-progress reconciliation to stop safely, drains all active generations, and
+reports explicit close failures after attempting every close. Shutdown is
+idempotent.
+
+## Reference Node worker factory
+
+The Node factory:
+
+- recomputes every materialized artifact digest before writing executable
+  temporary files;
+- accepts only Node artifacts and rejects mixed or Python snapshots;
+- imports modules in a dedicated worker thread;
+- resolves every qualified entrypoint before reporting startup success;
+- exchanges invocation values through structured clone;
+- supports abortable startup and pre-dispatch calls;
+- terminates the worker and removes temporary files on close.
+
+Worker readiness proves import and entrypoint resolution plus message-loop
+responsiveness. It does not define application-specific dependency health.
+Providers may wrap or replace the factory with stronger health checks.
+
+Worker threads provide lifecycle and failure isolation, not a security sandbox.
+Deployment code can use the Node APIs bundled or available to it and must be
+treated as trusted code. Hostile-code isolation requires a provider factory
+backed by an appropriately restricted process, container, or remote sandbox.
+
+Once a Node worker invocation is dispatched, it remains in-flight until the
+handler settles or the worker is terminated. An abort signal cannot safely
+cancel one arbitrary JavaScript handler without affecting concurrent work; this
+preserves accurate draining rather than reporting work complete while it still
+runs.
+
+## Out of scope
+
+This version does not define HTTP request mapping, protocol-schema input/output
+validation, authentication, tenant injection, portable SQL execution,
+distributed coordination, automatic activation rollback, autoscaling, or
+cross-host traffic routing.

--- a/specs/deployment/README.md
+++ b/specs/deployment/README.md
@@ -18,3 +18,5 @@ Current specifications:
   HTTP routes and adapters.
 - `0004-runtime-materialization.md` converts a confirmed current activation into
   an immutable, fully revalidated runtime snapshot.
+- `0005-runtime-supervision.md` defines readiness-gated runtime startup, atomic
+  generation switching, invocation, draining, and the reference Node worker.


### PR DESCRIPTION
## Summary

- add runtime-neutral reconciliation, readiness, atomic traffic cutover, draining, and shutdown
- add a reference Node worker factory that verifies materialized bytes before execution
- support invocation of named-query bindings through the active runtime
- document deployment runtime contract 0005 and export the supervisor APIs

## Why

Materialized snapshots need a lifecycle boundary that starts verified runtimes, switches traffic without exposing partial state, and drains retired instances safely.

## Stack

Depends on #320, which depends on #319.

## Validation

- `pnpm types`
- `pnpm lint`
- `pnpm test`
- `pnpm build`