### PR TITLE
Add deployment data-plane hosting

### DIFF
--- a/.changeset/deployment-data-plane-host.md
+++ b/.changeset/deployment-data-plane-host.md
@@ -1,0 +1,6 @@
+---
+'@hypequery/deployment': minor
+'@hypequery/protocol': minor
+---
+
+Add generation-pinned deployment host assembly, bounded Fetch and Node data-plane adapters, duplicate-aware JSON schema parsing, activation-triggered reconciliation, and a reference filesystem host lifecycle.

--- a/packages/deployment/README.md
+++ b/packages/deployment/README.md
@@ -1,13 +1,12 @@
 # @hypequery/deployment
 
-Provider-neutral verification, intake, activation, and HTTP control-plane
+Provider-neutral verification, intake, activation, runtime, and HTTP hosting
 building blocks for Hypequery deployment bundles.
 
 The package accepts the authenticated multipart transport emitted by
 `hypequery deploy`, reconstructs only manifest-declared files in temporary
 storage, and revalidates the release, bundle manifest, file hashes, deployment
-identity, and runtime references before handing the submission to a store. It
-does not activate or execute a release.
+identity, and runtime references before handing the submission to a store.
 
 ## Intake adapters
 
@@ -291,5 +290,59 @@ host can preserve the handler contract of its chosen runtime.
 Semantic-plan and compiled-SQL adapters own database execution. The core passes
 only validated values, the fixed implementation artifact, and closed typed SQL
 parameter bindings; it does not select credentials or interpolate SQL.
+
+## Data-plane hosting
+
+`createDeploymentHost` keeps route/schema execution and supervised runtime
+dispatch pinned to the same activation revision. Reconciliation builds a new
+data plane from the supervisor's immutable generation view and publishes it
+only after confirming that the active generation did not change during
+configuration.
+
+`createDeploymentDataPlaneFetchHandler` and
+`createDeploymentDataPlaneNodeHandler` expose a hosted data plane over HTTP.
+They accept either query parameters or one bounded UTF-8 JSON body, reject
+duplicate JSON property names, forward cancellation, and return bounded JSON
+errors. Public cache metadata is emitted only when execution confirms the
+request was public, tenant-independent, and unauthenticated.
+
+For a single-node service, `createFileSystemDeploymentHost` composes the
+filesystem submission store, activation registry, intake, control plane,
+runtime materializer, supervisor, and generation-pinned data plane. It
+reconciles configured targets at startup and schedules reconciliation after a
+durable activation without changing an already-successful activation response
+if runtime startup later fails.
+
+```ts
+import {
+  createDeploymentDataPlaneNodeHandler,
+  createFileSystemDeploymentHost,
+} from '@hypequery/deployment';
+
+const service = createFileSystemDeploymentHost({
+  directory: '/var/lib/hypequery/deployments',
+  targets: [{ project: 'analytics', environment: 'production' }],
+  intake: { authenticator: deploymentAuthenticator, authorizer: deploymentAuthorizer },
+  controlPlane: { authenticator: operatorAuthenticator, authorizer: operatorAuthorizer },
+  configureDataPlane: () => ({
+    authenticate: queryAuthenticator,
+    resolveTenant,
+    executeSemanticPlan,
+    executeCompiledSql,
+    runtimeArgument: ({ input, principal, tenant }) => ({ input, principal, tenant }),
+  }),
+});
+
+await service.start();
+const queryHandler = createDeploymentDataPlaneNodeHandler(
+  service.host.dataPlane({ project: 'analytics', environment: 'production' }),
+);
+```
+
+Cloud and other distributed systems can use the same host, supervisor, and HTTP
+adapter interfaces while supplying provider-owned persistence, runtime, SQL,
+authentication, tenant, routing, and observability implementations. The
+filesystem assembly is a reference single-host composition, not a distributed
+control plane.
 
 The package is ESM-only and requires Node.js 20 or newer.

--- a/packages/deployment/src/control-plane.test.ts
+++ b/packages/deployment/src/control-plane.test.ts
@@ -68,6 +68,8 @@ function fixture(overrides: {
   readonly registry?: Partial<DeploymentActivationRegistry>;
   readonly intake?: DeploymentIntake;
   readonly limits?: { readonly maxActivationRequestBytes?: number; readonly maxHistoryPageSize?: number };
+  readonly onActivation?: (activation: DeploymentActivationRecord) => void | Promise<void>;
+  readonly onBackgroundError?: (error: unknown) => void;
 } = {}) {
   const defaultActivation = activation(REVISION_ONE);
   const registry: DeploymentActivationRegistry = {
@@ -98,6 +100,8 @@ function fixture(overrides: {
     authenticator: { authenticate },
     authorizer: { authorize },
     limits: overrides.limits,
+    onActivation: overrides.onActivation,
+    onBackgroundError: overrides.onBackgroundError,
   });
   return { controlPlane, registry, intake, authenticate, authorize };
 }
@@ -181,6 +185,30 @@ describe('deployment control plane', () => {
       releaseIdentity: RELEASE,
       expectedRevision: REVISION_ONE,
     });
+  });
+
+  it('notifies the host after durable activation without changing a successful response', async () => {
+    const record = activation(REVISION_TWO, REVISION_ONE);
+    const failure = new Error('host reconciliation failed');
+    const onBackgroundError = vi.fn();
+    const { controlPlane } = fixture({
+      registry: {
+        activate: async () => ({ status: 'activated', activation: record }),
+      },
+      onActivation: async () => { throw failure; },
+      onBackgroundError,
+    });
+
+    const response = await controlPlane.handle(request({
+      method: 'PUT',
+      headers: { authorization: 'Bearer secret', 'content-type': 'application/json' },
+      body: body(activationRequest(REVISION_ONE)),
+      hasBody: true,
+    }));
+
+    expect(response.status).toBe(201);
+    expect(parsed(response).activation).toEqual(record);
+    await vi.waitFor(() => expect(onBackgroundError).toHaveBeenCalledWith(failure));
   });
 
   it('returns conflicts and already-active results without losing current state', async () => {

--- a/packages/deployment/src/control-plane.ts
+++ b/packages/deployment/src/control-plane.ts
@@ -58,6 +58,11 @@ export interface DeploymentControlPlaneOptions<Principal> {
   readonly authenticator: DeploymentAuthenticator<Principal>;
   readonly authorizer: DeploymentControlPlaneAuthorizer<Principal>;
   readonly limits?: Partial<DeploymentControlPlaneLimits>;
+  /** Called after a successful activation has been durably committed. */
+  readonly onActivation?: (
+    activation: DeploymentActivationRecord,
+  ) => void | Promise<void>;
+  readonly onBackgroundError?: (error: unknown) => void;
 }
 
 export type DeploymentControlPlaneErrorCode =
@@ -457,6 +462,23 @@ export function createDeploymentControlPlane<Principal>(
 ): DeploymentControlPlane {
   const limits = resolveDeploymentControlPlaneLimits(options.limits);
 
+  function reportBackgroundError(error: unknown): void {
+    try {
+      options.onBackgroundError?.(error);
+    } catch {
+      // Diagnostics cannot change the result of an already-durable activation.
+    }
+  }
+
+  function notifyActivation(activation: DeploymentActivationRecord): void {
+    try {
+      const operation = options.onActivation?.(activation);
+      if (operation) void Promise.resolve(operation).catch(reportBackgroundError);
+    } catch (error) {
+      reportBackgroundError(error);
+    }
+  }
+
   async function authenticateAndAuthorize(
     request: DeploymentControlPlaneRequest,
     action: DeploymentControlPlaneAction,
@@ -541,6 +563,7 @@ export function createDeploymentControlPlane<Principal>(
           current: result.current,
         });
       }
+      notifyActivation(result.activation);
       return activationResponse(result.status, result.activation);
     }
     requireMethod(method, 'GET');

--- a/packages/deployment/src/data-plane-adapters.test.ts
+++ b/packages/deployment/src/data-plane-adapters.test.ts
@@ -1,0 +1,125 @@
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+  validateProtocolDeploymentContract,
+  type ProtocolDeploymentContract,
+} from '@hypequery/protocol';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createDeploymentDataPlaneFetchHandler,
+  createDeploymentDataPlaneNodeHandler,
+} from './data-plane-adapters.js';
+import { createDeploymentDataPlane } from './data-plane.js';
+
+const ARTIFACT = 'a'.repeat(64);
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(server => new Promise<void>((resolve, reject) => {
+    server.close(error => { if (error) reject(error); else resolve(); });
+  })));
+});
+
+function deployment(): ProtocolDeploymentContract {
+  return validateProtocolDeploymentContract({
+    kind: 'hypequery-deployment',
+    version: 1,
+    datasets: [],
+    queries: [{
+      name: 'echo',
+      input: { kind: 'any' },
+      output: { kind: 'any' },
+      implementation: {
+        kind: 'runtime-reference',
+        runtime: 'node',
+        artifactSha256: ARTIFACT,
+        entrypoint: 'queries.echo',
+      },
+      endpoint: {
+        access: { kind: 'public' },
+        tenant: { kind: 'not-required' },
+        method: 'POST',
+        path: '/echo',
+        cacheTtlMs: 10_000,
+      },
+      tags: [],
+    }],
+    artifacts: [{ runtime: 'node', artifactSha256: ARTIFACT }],
+  });
+}
+
+function dataPlane() {
+  return createDeploymentDataPlane({
+    deployment: deployment(),
+    executeRuntimeReference: async ({ input }) => input,
+  });
+}
+
+describe('deployment data-plane HTTP adapters', () => {
+  it('maps Fetch query parameters and public cache metadata', async () => {
+    const handler = createDeploymentDataPlaneFetchHandler(dataPlane());
+
+    const response = await handler(new Request(
+      'https://query.example/echo?state=paid&tag=a&tag=b&__proto__=safe',
+      { method: 'POST' },
+    ));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('public, max-age=10');
+    expect(await response.json()).toEqual(JSON.parse(
+      '{"state":"paid","tag":["a","b"],"__proto__":"safe"}',
+    ));
+  });
+
+  it('rejects duplicate JSON names, mixed query/body input, and oversized bodies', async () => {
+    const handler = createDeploymentDataPlaneFetchHandler(dataPlane(), { maxRequestBytes: 32 });
+    const duplicate = await handler(new Request('https://query.example/echo', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{"state":"paid","state":"open"}',
+    }));
+    expect(duplicate.status).toBe(400);
+    await expect(duplicate.json()).resolves.toMatchObject({
+      error: { code: 'HQ_DATA_PLANE_INPUT_INVALID' },
+    });
+
+    const mixed = await handler(new Request('https://query.example/echo?state=paid', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    }));
+    expect(mixed.status).toBe(400);
+
+    const oversized = await handler(new Request('https://query.example/echo', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ value: 'x'.repeat(40) }),
+    }));
+    expect(oversized.status).toBe(413);
+  });
+
+  it('adapts Node requests and contains route errors', async () => {
+    const handler = createDeploymentDataPlaneNodeHandler(dataPlane());
+    const server = createServer(handler);
+    servers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const { port } = server.address() as AddressInfo;
+
+    const response = await fetch(`http://127.0.0.1:${port}/echo`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ source: 'node' }),
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ source: 'node' });
+
+    const missing = await fetch(`http://127.0.0.1:${port}/missing`, { method: 'POST' });
+    expect(missing.status).toBe(404);
+    await expect(missing.json()).resolves.toMatchObject({
+      error: { code: 'HQ_DATA_PLANE_ROUTE_NOT_FOUND' },
+    });
+  });
+});

--- a/packages/deployment/src/data-plane-adapters.ts
+++ b/packages/deployment/src/data-plane-adapters.ts
@@ -252,6 +252,9 @@ async function fetchBytes(
       }
       chunks.push(result.value);
     }
+  } catch (error) {
+    await reader.cancel(error).catch(() => undefined);
+    throw error;
   } finally {
     reader.releaseLock();
   }

--- a/packages/deployment/src/data-plane-adapters.ts
+++ b/packages/deployment/src/data-plane-adapters.ts
@@ -1,0 +1,392 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import {
+  DEFAULT_PROTOCOL_SCHEMA_VALUE_LIMITS,
+} from '@hypequery/protocol';
+import {
+  DeploymentDataPlaneError,
+  type DeploymentDataPlane,
+  type DeploymentDataPlaneResult,
+} from './data-plane.js';
+import { DeploymentHostError } from './host.js';
+
+export type DeploymentDataPlaneFetchHandler = (request: Request) => Promise<Response>;
+export type DeploymentDataPlaneNodeHandler = (
+  request: IncomingMessage,
+  response: ServerResponse,
+) => Promise<void>;
+
+export interface DeploymentDataPlaneAdapterRequest {
+  readonly method: string;
+  readonly path: string;
+  readonly query: Readonly<Record<string, string | readonly string[]>>;
+  readonly headers: Readonly<Record<string, string>>;
+}
+
+export interface DeploymentDataPlaneAdapterOptions {
+  /** Request body limit from 1 through 1,048,576 bytes. */
+  readonly maxRequestBytes?: number;
+  readonly credentials?: (request: DeploymentDataPlaneAdapterRequest) => unknown;
+}
+
+interface AdapterResponse {
+  readonly status: number;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body?: string;
+}
+
+class AdapterError extends Error {
+  constructor(
+    readonly code: 'HQ_DATA_PLANE_INPUT_INVALID' | 'HQ_DATA_PLANE_REQUEST_TOO_LARGE',
+    readonly status: 400 | 413,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+const JSON_CONTENT_TYPE = /^application\/json(?:;\s*charset=utf-8)?$/i;
+
+function maximumBytes(input: number | undefined): number {
+  const maximum = DEFAULT_PROTOCOL_SCHEMA_VALUE_LIMITS.maxInputBytes;
+  const value = input ?? maximum;
+  if (!Number.isSafeInteger(value) || value < 1 || value > maximum) {
+    throw new RangeError(`maxRequestBytes must be an integer between 1 and ${maximum}`);
+  }
+  return value;
+}
+
+function queryParameters(search: URLSearchParams): Readonly<Record<string, string | readonly string[]>> {
+  const query = Object.create(null) as Record<string, string | readonly string[]>;
+  for (const [name, value] of search) {
+    const current = query[name];
+    if (current === undefined) query[name] = value;
+    else if (typeof current === 'string') query[name] = Object.freeze([current, value]);
+    else query[name] = Object.freeze([...current, value]);
+  }
+  return Object.freeze(query);
+}
+
+function contentLength(headers: Readonly<Record<string, string>>, maximum: number): number | undefined {
+  const value = headers['content-length'];
+  if (value === undefined) return undefined;
+  if (!/^(?:0|[1-9][0-9]*)$/.test(value)) {
+    throw new AdapterError('HQ_DATA_PLANE_INPUT_INVALID', 400, 'Content-Length is invalid.');
+  }
+  const length = Number(value);
+  if (!Number.isSafeInteger(length)) {
+    throw new AdapterError('HQ_DATA_PLANE_INPUT_INVALID', 400, 'Content-Length is invalid.');
+  }
+  if (length > maximum) {
+    throw new AdapterError(
+      'HQ_DATA_PLANE_REQUEST_TOO_LARGE',
+      413,
+      'The data-plane request exceeds its byte limit.',
+    );
+  }
+  return length;
+}
+
+function requestInput(
+  query: Readonly<Record<string, string | readonly string[]>>,
+  body: Uint8Array | undefined,
+  contentType: string | undefined,
+): string | Uint8Array | undefined {
+  const hasQuery = Object.keys(query).length > 0;
+  if (body !== undefined && hasQuery) {
+    throw new AdapterError(
+      'HQ_DATA_PLANE_INPUT_INVALID',
+      400,
+      'A data-plane request cannot contain both query parameters and a JSON body.',
+    );
+  }
+  if (body !== undefined) {
+    if (!contentType || !JSON_CONTENT_TYPE.test(contentType)) {
+      throw new AdapterError(
+        'HQ_DATA_PLANE_INPUT_INVALID',
+        400,
+        'Data-plane request bodies require application/json with UTF-8 encoding.',
+      );
+    }
+    return body;
+  }
+  return hasQuery ? JSON.stringify(query) : undefined;
+}
+
+function credentials(
+  options: DeploymentDataPlaneAdapterOptions,
+  request: DeploymentDataPlaneAdapterRequest,
+): unknown {
+  return options.credentials ? options.credentials(request) : request.headers.authorization;
+}
+
+function cacheControl(result: DeploymentDataPlaneResult): string {
+  if (result.cacheTtlMs === undefined || result.cacheTtlMs <= 0) return 'no-store';
+  return `public, max-age=${Math.floor(result.cacheTtlMs / 1_000)}`;
+}
+
+function successResponse(result: DeploymentDataPlaneResult): AdapterResponse {
+  if (result.output === undefined) {
+    return Object.freeze({
+      status: 204,
+      headers: Object.freeze({ 'cache-control': cacheControl(result) }),
+    });
+  }
+  const body = `${JSON.stringify(result.output)}\n`;
+  return Object.freeze({
+    status: 200,
+    headers: Object.freeze({
+      'content-type': 'application/json; charset=utf-8',
+      'content-length': String(Buffer.byteLength(body)),
+      'cache-control': cacheControl(result),
+    }),
+    body,
+  });
+}
+
+function errorStatus(error: DeploymentDataPlaneError): number {
+  switch (error.code) {
+    case 'HQ_DATA_PLANE_INPUT_INVALID': return 400;
+    case 'HQ_DATA_PLANE_UNAUTHENTICATED': return 401;
+    case 'HQ_DATA_PLANE_FORBIDDEN':
+    case 'HQ_DATA_PLANE_TENANT_REQUIRED': return 403;
+    case 'HQ_DATA_PLANE_ROUTE_NOT_FOUND': return 404;
+    case 'HQ_DATA_PLANE_METHOD_NOT_ALLOWED': return 405;
+    case 'HQ_DATA_PLANE_ABORTED': return 499;
+    case 'HQ_DATA_PLANE_EXECUTOR_UNAVAILABLE': return 503;
+    default: return 500;
+  }
+}
+
+function errorResponse(error: unknown): AdapterResponse {
+  let status = 500;
+  let code = 'HQ_DATA_PLANE_INTERNAL';
+  let message = 'The deployment data-plane request could not be processed.';
+  let path: string | undefined;
+  if (error instanceof AdapterError) {
+    status = error.status;
+    code = error.code;
+    message = error.message;
+  } else if (error instanceof DeploymentDataPlaneError) {
+    status = errorStatus(error);
+    code = error.code;
+    if (status < 500) {
+      message = error.message;
+      path = error.path;
+    }
+  } else if (error instanceof DeploymentHostError) {
+    code = error.code;
+    if (error.code === 'HQ_DEPLOYMENT_HOST_NOT_READY'
+      || error.code === 'HQ_DEPLOYMENT_HOST_CLOSED') {
+      status = 503;
+      message = error.message;
+    }
+  }
+  const body = `${JSON.stringify({
+    error: { code, message, ...(path === undefined ? {} : { path }) },
+  })}\n`;
+  return Object.freeze({
+    status,
+    headers: Object.freeze({
+      'content-type': 'application/json; charset=utf-8',
+      'content-length': String(Buffer.byteLength(body)),
+      'cache-control': 'no-store',
+      ...(status === 401 ? { 'www-authenticate': 'Bearer' } : {}),
+    }),
+    body,
+  });
+}
+
+async function execute(
+  dataPlane: DeploymentDataPlane,
+  options: DeploymentDataPlaneAdapterOptions,
+  request: DeploymentDataPlaneAdapterRequest,
+  input: string | Uint8Array | undefined,
+  signal: AbortSignal | undefined,
+): Promise<AdapterResponse> {
+  try {
+    const result = await dataPlane.executeJson({
+      ...request,
+      input,
+      credentials: credentials(options, request),
+      signal,
+    });
+    return successResponse(result);
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+function fetchHeaders(input: Headers): Readonly<Record<string, string>> {
+  const headers = Object.create(null) as Record<string, string>;
+  for (const [name, value] of input) headers[name.toLowerCase()] = value;
+  if (headers.authorization?.includes(',')) {
+    throw new AdapterError('HQ_DATA_PLANE_INPUT_INVALID', 400, 'Authorization header is ambiguous.');
+  }
+  return Object.freeze(headers);
+}
+
+async function fetchBytes(
+  stream: ReadableStream<Uint8Array> | null,
+  declared: number | undefined,
+  maximum: number,
+): Promise<Uint8Array | undefined> {
+  if (stream === null) {
+    if (declared !== undefined && declared !== 0) {
+      throw new AdapterError('HQ_DATA_PLANE_INPUT_INVALID', 400, 'Request body length is invalid.');
+    }
+    return undefined;
+  }
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) break;
+      total += result.value.byteLength;
+      if (total > maximum) throw new AdapterError(
+        'HQ_DATA_PLANE_REQUEST_TOO_LARGE', 413, 'The data-plane request exceeds its byte limit.',
+      );
+      if (declared !== undefined && total > declared) {
+        throw new AdapterError('HQ_DATA_PLANE_INPUT_INVALID', 400, 'Request body length is invalid.');
+      }
+      chunks.push(result.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  if (declared !== undefined && total !== declared) {
+    throw new AdapterError('HQ_DATA_PLANE_INPUT_INVALID', 400, 'Request body length is invalid.');
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes.byteLength === 0 ? undefined : bytes;
+}
+
+export function createDeploymentDataPlaneFetchHandler(
+  dataPlane: DeploymentDataPlane,
+  options: DeploymentDataPlaneAdapterOptions = {},
+): DeploymentDataPlaneFetchHandler {
+  const maximum = maximumBytes(options.maxRequestBytes);
+  return async request => {
+    let response: AdapterResponse;
+    try {
+      const url = new URL(request.url);
+      const headers = fetchHeaders(request.headers);
+      const query = queryParameters(url.searchParams);
+      const body = await fetchBytes(request.body, contentLength(headers, maximum), maximum);
+      const adapted = Object.freeze({
+        method: request.method.toUpperCase(), path: url.pathname, query, headers,
+      });
+      response = await execute(
+        dataPlane,
+        options,
+        adapted,
+        requestInput(query, body, headers['content-type']),
+        request.signal,
+      );
+    } catch (error) {
+      response = errorResponse(error);
+    }
+    return new Response(response.body ?? null, { status: response.status, headers: response.headers });
+  };
+}
+
+function nodeHeaders(request: IncomingMessage): Readonly<Record<string, string>> {
+  const headers = Object.create(null) as Record<string, string>;
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    const name = request.rawHeaders[index]!.toLowerCase();
+    const value = request.rawHeaders[index + 1]!;
+    if (name === 'authorization' && headers[name] !== undefined) {
+      throw new AdapterError('HQ_DATA_PLANE_INPUT_INVALID', 400, 'Authorization header is ambiguous.');
+    }
+    headers[name] = headers[name] === undefined ? value : `${headers[name]}, ${value}`;
+  }
+  return Object.freeze(headers);
+}
+
+function nodeHasBody(headers: Readonly<Record<string, string>>): boolean {
+  return headers['transfer-encoding'] !== undefined
+    || headers['content-length'] !== undefined && headers['content-length'] !== '0';
+}
+
+async function nodeBytes(
+  request: IncomingMessage,
+  hasBody: boolean,
+  declared: number | undefined,
+  maximum: number,
+): Promise<Uint8Array | undefined> {
+  if (!hasBody) return undefined;
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of request) {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string);
+    total += bytes.byteLength;
+    if (total > maximum) throw new AdapterError(
+      'HQ_DATA_PLANE_REQUEST_TOO_LARGE', 413, 'The data-plane request exceeds its byte limit.',
+    );
+    if (declared !== undefined && total > declared) {
+      throw new AdapterError('HQ_DATA_PLANE_INPUT_INVALID', 400, 'Request body length is invalid.');
+    }
+    chunks.push(bytes);
+  }
+  if (declared !== undefined && total !== declared) {
+    throw new AdapterError('HQ_DATA_PLANE_INPUT_INVALID', 400, 'Request body length is invalid.');
+  }
+  return total === 0 ? undefined : Buffer.concat(chunks, total);
+}
+
+function sendNodeResponse(response: ServerResponse, result: AdapterResponse): void {
+  if (response.writableEnded || response.headersSent) return;
+  response.statusCode = result.status;
+  for (const [name, value] of Object.entries(result.headers)) response.setHeader(name, value);
+  response.end(result.body);
+}
+
+export function createDeploymentDataPlaneNodeHandler(
+  dataPlane: DeploymentDataPlane,
+  options: DeploymentDataPlaneAdapterOptions = {},
+): DeploymentDataPlaneNodeHandler {
+  const maximum = maximumBytes(options.maxRequestBytes);
+  return async (request, response) => {
+    const abort = new AbortController();
+    const onRequestClose = () => {
+      if (!request.complete) abort.abort(new Error('The data-plane request was interrupted.'));
+    };
+    const onResponseClose = () => {
+      if (!response.writableEnded) abort.abort(new Error('The data-plane response was interrupted.'));
+    };
+    request.once('close', onRequestClose);
+    response.once('close', onResponseClose);
+    try {
+      const url = new URL(request.url ?? '/', 'http://deployment-data-plane.invalid');
+      const headers = nodeHeaders(request);
+      const query = queryParameters(url.searchParams);
+      const body = await nodeBytes(
+        request,
+        nodeHasBody(headers),
+        contentLength(headers, maximum),
+        maximum,
+      );
+      const adapted = Object.freeze({
+        method: (request.method ?? 'GET').toUpperCase(), path: url.pathname, query, headers,
+      });
+      sendNodeResponse(response, await execute(
+        dataPlane,
+        options,
+        adapted,
+        requestInput(query, body, headers['content-type']),
+        abort.signal,
+      ));
+    } catch (error) {
+      sendNodeResponse(response, errorResponse(error));
+    } finally {
+      request.off('close', onRequestClose);
+      response.off('close', onResponseClose);
+    }
+  };
+}

--- a/packages/deployment/src/data-plane.ts
+++ b/packages/deployment/src/data-plane.ts
@@ -7,6 +7,7 @@ import type {
 import {
   createProtocolSchemaValueParser,
   ProtocolSchemaValueError,
+  ProtocolValueError,
   validateProtocolDeploymentContract,
 } from '@hypequery/protocol';
 import {
@@ -56,9 +57,15 @@ export interface DeploymentDataPlaneRequest {
   readonly method: string;
   readonly path: string;
   readonly input?: unknown;
+  readonly query?: Readonly<Record<string, string | readonly string[]>>;
+  readonly headers?: Readonly<Record<string, string>>;
   readonly credentials?: unknown;
   readonly signal?: AbortSignal;
 }
+
+export type DeploymentDataPlaneJsonRequest = Omit<DeploymentDataPlaneRequest, 'input'> & {
+  readonly input?: string | Uint8Array;
+};
 
 export interface DeploymentDataPlaneAuthenticationInput {
   readonly credentials: unknown;
@@ -103,6 +110,7 @@ export interface DeploymentDataPlaneResult {
 
 export interface DeploymentDataPlane {
   execute(request: DeploymentDataPlaneRequest): Promise<DeploymentDataPlaneResult>;
+  executeJson(request: DeploymentDataPlaneJsonRequest): Promise<DeploymentDataPlaneResult>;
 }
 
 export interface DeploymentDataPlaneOptions {
@@ -213,152 +221,160 @@ export function createDeploymentDataPlane(options: DeploymentDataPlaneOptions): 
   const routes = routeTable(deployment, limits);
   const paths = new Set(deployment.queries.map(query => query.endpoint.path));
 
-  return Object.freeze({
-    async execute(request: DeploymentDataPlaneRequest): Promise<DeploymentDataPlaneResult> {
-      throwIfAborted(request.signal);
-      const route = routes.get(`${request.method}\0${request.path}`);
-      if (!route) {
-        if (paths.has(request.path)) {
-          throw dataPlaneError(
-            'HQ_DATA_PLANE_METHOD_NOT_ALLOWED',
-            'The deployment route does not support this method.',
-          );
-        }
-        throw dataPlaneError('HQ_DATA_PLANE_ROUTE_NOT_FOUND', 'The deployment route was not found.');
-      }
-      const { query } = route;
-
-      let principal: DeploymentDataPlanePrincipal | null = null;
-      if (query.endpoint.access.kind === 'authenticated' && !options.authenticate) {
+  async function execute(
+    request: DeploymentDataPlaneRequest,
+    json: boolean,
+  ): Promise<DeploymentDataPlaneResult> {
+    throwIfAborted(request.signal);
+    const route = routes.get(`${request.method}\0${request.path}`);
+    if (!route) {
+      if (paths.has(request.path)) {
         throw dataPlaneError(
-          'HQ_DATA_PLANE_CONFIGURATION',
-          'An authenticator is required for this deployment route.',
+          'HQ_DATA_PLANE_METHOD_NOT_ALLOWED',
+          'The deployment route does not support this method.',
         );
       }
-      if (options.authenticate
-        && (query.endpoint.access.kind === 'authenticated' || request.credentials !== undefined)) {
+      throw dataPlaneError('HQ_DATA_PLANE_ROUTE_NOT_FOUND', 'The deployment route was not found.');
+    }
+    const { query } = route;
+
+    let principal: DeploymentDataPlanePrincipal | null = null;
+    if (query.endpoint.access.kind === 'authenticated' && !options.authenticate) {
+      throw dataPlaneError(
+        'HQ_DATA_PLANE_CONFIGURATION',
+        'An authenticator is required for this deployment route.',
+      );
+    }
+    if (options.authenticate
+      && (query.endpoint.access.kind === 'authenticated' || request.credentials !== undefined)) {
+      try {
+        principal = await options.authenticate({ credentials: request.credentials, request, query });
+      } catch (error) {
+        throw dataPlaneError('HQ_DATA_PLANE_UNAUTHENTICATED', 'Authentication failed.', error);
+      }
+    }
+    throwIfAborted(request.signal);
+    if (query.endpoint.access.kind === 'authenticated') {
+      if (!principal) {
+        throw dataPlaneError('HQ_DATA_PLANE_UNAUTHENTICATED', 'Authentication is required.');
+      }
+      if (missing(query.endpoint.access.roles, principal.roles).length > 0
+        || missing(query.endpoint.access.scopes, principal.scopes).length > 0) {
+        throw dataPlaneError('HQ_DATA_PLANE_FORBIDDEN', 'The principal lacks required access.');
+      }
+    }
+
+    let tenant: unknown;
+    if (query.endpoint.tenant.kind !== 'not-required') {
+      if (!options.resolveTenant) {
+        if (query.endpoint.tenant.kind === 'required') {
+          throw dataPlaneError(
+            'HQ_DATA_PLANE_CONFIGURATION',
+            'A tenant resolver is required for this deployment route.',
+          );
+        }
+      } else {
         try {
-          principal = await options.authenticate({ credentials: request.credentials, request, query });
+          tenant = await options.resolveTenant({ principal, request, query });
         } catch (error) {
-          throw dataPlaneError('HQ_DATA_PLANE_UNAUTHENTICATED', 'Authentication failed.', error);
+          throw dataPlaneError('HQ_DATA_PLANE_FORBIDDEN', 'Tenant resolution failed.', error);
         }
       }
-      throwIfAborted(request.signal);
-      if (query.endpoint.access.kind === 'authenticated') {
-        if (!principal) {
-          throw dataPlaneError('HQ_DATA_PLANE_UNAUTHENTICATED', 'Authentication is required.');
-        }
-        if (missing(query.endpoint.access.roles, principal.roles).length > 0
-          || missing(query.endpoint.access.scopes, principal.scopes).length > 0) {
-          throw dataPlaneError('HQ_DATA_PLANE_FORBIDDEN', 'The principal lacks required access.');
-        }
+      if (query.endpoint.tenant.kind === 'required' && (tenant === undefined || tenant === null)) {
+        throw dataPlaneError('HQ_DATA_PLANE_TENANT_REQUIRED', 'Tenant context is required.');
       }
+    }
+    throwIfAborted(request.signal);
 
-      let tenant: unknown;
-      if (query.endpoint.tenant.kind !== 'not-required') {
-        if (!options.resolveTenant) {
-          if (query.endpoint.tenant.kind === 'required') {
-            throw dataPlaneError(
-              'HQ_DATA_PLANE_CONFIGURATION',
-              'A tenant resolver is required for this deployment route.',
-            );
-          }
-        } else {
-          try {
-            tenant = await options.resolveTenant({ principal, request, query });
-          } catch (error) {
-            throw dataPlaneError('HQ_DATA_PLANE_FORBIDDEN', 'Tenant resolution failed.', error);
-          }
-        }
-        if (query.endpoint.tenant.kind === 'required' && (tenant === undefined || tenant === null)) {
-          throw dataPlaneError('HQ_DATA_PLANE_TENANT_REQUIRED', 'Tenant context is required.');
-        }
+    let input: unknown;
+    try {
+      input = json && request.input !== undefined
+        ? route.input.parseJson(request.input as string | Uint8Array)
+        : route.input.parse(request.input);
+    } catch (error) {
+      if (error instanceof ProtocolSchemaValueError || error instanceof ProtocolValueError) {
+        throw dataPlaneError(
+          'HQ_DATA_PLANE_INPUT_INVALID',
+          'The request input does not match the deployment schema.',
+          error,
+          error.path,
+        );
       }
-      throwIfAborted(request.signal);
+      throw error;
+    }
 
-      let input: unknown;
-      try {
-        input = route.input.parse(request.input);
-      } catch (error) {
-        if (error instanceof ProtocolSchemaValueError) {
-          throw dataPlaneError(
-            'HQ_DATA_PLANE_INPUT_INVALID',
-            'The request input does not match the deployment schema.',
-            error,
-            error.path,
+    const common = { query, input, principal, tenant, request, signal: request.signal } as const;
+    let output: unknown;
+    try {
+      switch (query.implementation.kind) {
+        case 'semantic-plan':
+          if (!options.executeSemanticPlan) throw dataPlaneError(
+            'HQ_DATA_PLANE_EXECUTOR_UNAVAILABLE',
+            'No semantic-plan executor is configured.',
           );
-        }
-        throw error;
-      }
-
-      const common = { query, input, principal, tenant, request, signal: request.signal } as const;
-      let output: unknown;
-      try {
-        switch (query.implementation.kind) {
-          case 'semantic-plan':
-            if (!options.executeSemanticPlan) throw dataPlaneError(
-              'HQ_DATA_PLANE_EXECUTOR_UNAVAILABLE',
-              'No semantic-plan executor is configured.',
-            );
-            output = await options.executeSemanticPlan({
-              ...common,
-              implementation: query.implementation,
-              deployment,
-            });
-            break;
-          case 'compiled-sql':
-            if (!options.executeCompiledSql) throw dataPlaneError(
-              'HQ_DATA_PLANE_EXECUTOR_UNAVAILABLE',
-              'No compiled SQL executor is configured.',
-            );
-            output = await options.executeCompiledSql({
-              ...common,
-              implementation: query.implementation,
-              parameters: sqlParameters(query, input, tenant),
-            });
-            break;
-          case 'runtime-reference':
-            if (!options.executeRuntimeReference) throw dataPlaneError(
-              'HQ_DATA_PLANE_EXECUTOR_UNAVAILABLE',
-              'No runtime-reference executor is configured.',
-            );
-            output = await options.executeRuntimeReference({
-              ...common,
-              implementation: query.implementation,
-            });
-            break;
-        }
-      } catch (error) {
-        if (error instanceof DeploymentDataPlaneError) throw error;
-        if (request.signal?.aborted) {
-          throw dataPlaneError('HQ_DATA_PLANE_ABORTED', 'The data-plane request was aborted.', error);
-        }
-        throw dataPlaneError('HQ_DATA_PLANE_EXECUTION_FAILED', 'Deployment query execution failed.', error);
-      }
-
-      try {
-        output = route.output.parse(output);
-      } catch (error) {
-        if (error instanceof ProtocolSchemaValueError) {
-          throw dataPlaneError(
-            'HQ_DATA_PLANE_OUTPUT_INVALID',
-            'The query output does not match the deployment schema.',
-            error,
-            error.path,
+          output = await options.executeSemanticPlan({
+            ...common,
+            implementation: query.implementation,
+            deployment,
+          });
+          break;
+        case 'compiled-sql':
+          if (!options.executeCompiledSql) throw dataPlaneError(
+            'HQ_DATA_PLANE_EXECUTOR_UNAVAILABLE',
+            'No compiled SQL executor is configured.',
           );
-        }
-        throw error;
+          output = await options.executeCompiledSql({
+            ...common,
+            implementation: query.implementation,
+            parameters: sqlParameters(query, input, tenant),
+          });
+          break;
+        case 'runtime-reference':
+          if (!options.executeRuntimeReference) throw dataPlaneError(
+            'HQ_DATA_PLANE_EXECUTOR_UNAVAILABLE',
+            'No runtime-reference executor is configured.',
+          );
+          output = await options.executeRuntimeReference({
+            ...common,
+            implementation: query.implementation,
+          });
+          break;
       }
-      const publicCacheTtlMs = query.endpoint.access.kind === 'public'
-        && query.endpoint.tenant.kind === 'not-required'
-        && principal === null
-        ? query.endpoint.cacheTtlMs
-        : undefined;
-      return Object.freeze({
-        query: query.name,
-        output,
-        ...(publicCacheTtlMs === undefined ? {} : { cacheTtlMs: publicCacheTtlMs }),
-      });
-    },
+    } catch (error) {
+      if (error instanceof DeploymentDataPlaneError) throw error;
+      if (request.signal?.aborted) {
+        throw dataPlaneError('HQ_DATA_PLANE_ABORTED', 'The data-plane request was aborted.', error);
+      }
+      throw dataPlaneError('HQ_DATA_PLANE_EXECUTION_FAILED', 'Deployment query execution failed.', error);
+    }
+
+    try {
+      output = route.output.parse(output);
+    } catch (error) {
+      if (error instanceof ProtocolSchemaValueError) {
+        throw dataPlaneError(
+          'HQ_DATA_PLANE_OUTPUT_INVALID',
+          'The query output does not match the deployment schema.',
+          error,
+          error.path,
+        );
+      }
+      throw error;
+    }
+    const publicCacheTtlMs = query.endpoint.access.kind === 'public'
+      && query.endpoint.tenant.kind === 'not-required'
+      && principal === null
+      ? query.endpoint.cacheTtlMs
+      : undefined;
+    return Object.freeze({
+      query: query.name,
+      output,
+      ...(publicCacheTtlMs === undefined ? {} : { cacheTtlMs: publicCacheTtlMs }),
+    });
+  }
+
+  return Object.freeze({
+    execute: (request: DeploymentDataPlaneRequest) => execute(request, false),
+    executeJson: (request: DeploymentDataPlaneJsonRequest) => execute(request, true),
   });
 }

--- a/packages/deployment/src/data-plane.ts
+++ b/packages/deployment/src/data-plane.ts
@@ -288,9 +288,15 @@ export function createDeploymentDataPlane(options: DeploymentDataPlaneOptions): 
 
     let input: unknown;
     try {
-      input = json && request.input !== undefined
-        ? route.input.parseJson(request.input as string | Uint8Array)
-        : route.input.parse(request.input);
+      if (json && request.input !== undefined) {
+        if (typeof route.input.parseJson !== 'function') throw dataPlaneError(
+          'HQ_DATA_PLANE_CONFIGURATION',
+          'The route input parser does not support JSON request bodies.',
+        );
+        input = route.input.parseJson(request.input as string | Uint8Array);
+      } else {
+        input = route.input.parse(request.input);
+      }
     } catch (error) {
       if (error instanceof ProtocolSchemaValueError || error instanceof ProtocolValueError) {
         throw dataPlaneError(

--- a/packages/deployment/src/filesystem-host.test.ts
+++ b/packages/deployment/src/filesystem-host.test.ts
@@ -1,0 +1,69 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createFileSystemDeploymentHost } from './filesystem-host.js';
+import type { DeploymentRuntimeFactory } from './runtime-supervisor.js';
+
+const TARGET = Object.freeze({ project: 'analytics', environment: 'production' });
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map(directory => (
+    rm(directory, { force: true, recursive: true })
+  )));
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), 'hypequery-filesystem-host-test-'));
+  directories.push(directory);
+  return directory;
+}
+
+describe('filesystem deployment host', () => {
+  it('assembles durable control, activation, runtime, and data-plane components', async () => {
+    const runtimeFactory: DeploymentRuntimeFactory = {
+      start: vi.fn(async () => { throw new Error('No inactive runtime should start.'); }),
+    };
+    const service = createFileSystemDeploymentHost({
+      directory: await temporaryDirectory(),
+      targets: [TARGET],
+      intake: {
+        authenticator: { authenticate: async () => 'deployer' },
+        authorizer: { authorize: async () => true },
+      },
+      controlPlane: {
+        authenticator: { authenticate: async () => 'operator' },
+        authorizer: { authorize: async () => true },
+      },
+      runtimeFactory,
+      configureDataPlane: () => ({ runtimeArgument: ({ input }) => input }),
+    });
+
+    await expect(service.start()).resolves.toBeUndefined();
+    expect(runtimeFactory.start).not.toHaveBeenCalled();
+    expect(service.supervisor.status(TARGET)).toBeUndefined();
+    await expect(service.host.execute(TARGET, { method: 'POST', path: '/missing' }))
+      .rejects.toMatchObject({ code: 'HQ_DEPLOYMENT_HOST_NOT_READY' });
+    await expect(service.close()).resolves.toBeUndefined();
+  });
+
+  it('rejects ambiguous default and custom runtime-factory configuration', async () => {
+    const directory = await temporaryDirectory();
+    expect(() => createFileSystemDeploymentHost({
+      directory,
+      targets: [],
+      intake: {
+        authenticator: { authenticate: async () => 'deployer' },
+        authorizer: { authorize: async () => true },
+      },
+      controlPlane: {
+        authenticator: { authenticate: async () => 'operator' },
+        authorizer: { authorize: async () => true },
+      },
+      runtimeFactory: { start: async () => { throw new Error('unused'); } },
+      nodeRuntime: {},
+      configureDataPlane: () => ({ runtimeArgument: ({ input }) => input }),
+    })).toThrow('runtimeFactory and nodeRuntime cannot both be configured');
+  });
+});

--- a/packages/deployment/src/filesystem-host.ts
+++ b/packages/deployment/src/filesystem-host.ts
@@ -1,0 +1,149 @@
+import type { ProtocolDeploymentReleaseTarget } from '@hypequery/protocol';
+import {
+  createFileSystemDeploymentActivationRegistry,
+  type DeploymentActivationRegistry,
+} from './activation.js';
+import {
+  createDeploymentControlPlane,
+  type DeploymentControlPlane,
+  type DeploymentControlPlaneAuthorizer,
+} from './control-plane.js';
+import type { DeploymentControlPlaneLimits } from './control-plane-limits.js';
+import {
+  createFileSystemDeploymentSubmissionStore,
+  type FileSystemDeploymentSubmissionStore,
+} from './filesystem-store.js';
+import {
+  createDeploymentHost,
+  type DeploymentHost,
+  type DeploymentHostDataPlaneConfiguration,
+  type DeploymentHostDataPlaneInput,
+} from './host.js';
+import { createDeploymentIntake } from './intake.js';
+import type { DeploymentIntakeLimits } from './limits.js';
+import {
+  createNodeWorkerDeploymentRuntimeFactory,
+  type NodeDeploymentRuntimeFactoryOptions,
+} from './node-runtime-factory.js';
+import {
+  createDeploymentRuntimeMaterializer,
+  type DeploymentRuntimeMaterializer,
+} from './runtime-materialization.js';
+import {
+  createDeploymentRuntimeSupervisor,
+  type DeploymentRuntimeFactory,
+  type DeploymentRuntimeSupervisor,
+} from './runtime-supervisor.js';
+import type {
+  DeploymentAuthenticator,
+  DeploymentAuthorizer,
+  DeploymentIntake,
+} from './types.js';
+
+export interface FileSystemDeploymentHostOptions<SubmissionPrincipal, ControlPrincipal> {
+  readonly directory: string;
+  readonly targets: readonly ProtocolDeploymentReleaseTarget[];
+  readonly intake: {
+    readonly authenticator: DeploymentAuthenticator<SubmissionPrincipal>;
+    readonly authorizer: DeploymentAuthorizer<SubmissionPrincipal>;
+    readonly limits?: Partial<DeploymentIntakeLimits>;
+    readonly temporaryDirectory?: string;
+  };
+  readonly controlPlane: {
+    readonly authenticator: DeploymentAuthenticator<ControlPrincipal>;
+    readonly authorizer: DeploymentControlPlaneAuthorizer<ControlPrincipal>;
+    readonly limits?: Partial<DeploymentControlPlaneLimits>;
+  };
+  readonly configureDataPlane: (
+    input: DeploymentHostDataPlaneInput,
+  ) => DeploymentHostDataPlaneConfiguration | Promise<DeploymentHostDataPlaneConfiguration>;
+  /** Defaults to the reference Node worker runtime factory. */
+  readonly runtimeFactory?: DeploymentRuntimeFactory;
+  readonly nodeRuntime?: NodeDeploymentRuntimeFactoryOptions;
+  readonly activationClock?: () => Date;
+  readonly maxMaterializationAttempts?: number;
+  readonly drainTimeoutMs?: number;
+  readonly maxReconcileAttempts?: number;
+  readonly maxHostStabilityAttempts?: number;
+  readonly onBackgroundError?: (error: unknown) => void;
+}
+
+export interface FileSystemDeploymentHost<SubmissionPrincipal> {
+  readonly store: FileSystemDeploymentSubmissionStore<SubmissionPrincipal>;
+  readonly activations: DeploymentActivationRegistry;
+  readonly intake: DeploymentIntake;
+  readonly controlPlane: DeploymentControlPlane;
+  readonly materializer: DeploymentRuntimeMaterializer;
+  readonly supervisor: DeploymentRuntimeSupervisor;
+  readonly host: DeploymentHost;
+  start(options?: { readonly signal?: AbortSignal }): Promise<void>;
+  close(): Promise<void>;
+}
+
+export function createFileSystemDeploymentHost<SubmissionPrincipal, ControlPrincipal>(
+  options: FileSystemDeploymentHostOptions<SubmissionPrincipal, ControlPrincipal>,
+): FileSystemDeploymentHost<SubmissionPrincipal> {
+  if (options.runtimeFactory !== undefined && options.nodeRuntime !== undefined) {
+    throw new TypeError('runtimeFactory and nodeRuntime cannot both be configured.');
+  }
+  const targets = Object.freeze([...options.targets]);
+  const store = createFileSystemDeploymentSubmissionStore<SubmissionPrincipal>({
+    directory: options.directory,
+  });
+  const activations = createFileSystemDeploymentActivationRegistry({
+    directory: options.directory,
+    releases: store,
+    clock: options.activationClock,
+  });
+  const intake = createDeploymentIntake({
+    ...options.intake,
+    store,
+  });
+  const materializer = createDeploymentRuntimeMaterializer({
+    activations,
+    releases: store,
+    maxStabilityAttempts: options.maxMaterializationAttempts,
+  });
+  const runtimeFactory = options.runtimeFactory
+    ?? createNodeWorkerDeploymentRuntimeFactory(options.nodeRuntime);
+  const supervisor = createDeploymentRuntimeSupervisor({
+    materializer,
+    factory: runtimeFactory,
+    drainTimeoutMs: options.drainTimeoutMs,
+    maxReconcileAttempts: options.maxReconcileAttempts,
+    onBackgroundError: options.onBackgroundError,
+  });
+  const host = createDeploymentHost({
+    supervisor,
+    configureDataPlane: options.configureDataPlane,
+    maxStabilityAttempts: options.maxHostStabilityAttempts,
+    onBackgroundError: options.onBackgroundError,
+  });
+  const controlPlane = createDeploymentControlPlane({
+    intake,
+    activations,
+    ...options.controlPlane,
+    onActivation: activation => host.scheduleReconcile(activation.target),
+    onBackgroundError: options.onBackgroundError,
+  });
+  let startPromise: Promise<void> | undefined;
+
+  const result: FileSystemDeploymentHost<SubmissionPrincipal> = {
+    store,
+    activations,
+    intake,
+    controlPlane,
+    materializer,
+    supervisor,
+    host,
+    start(startOptions = {}): Promise<void> {
+      const pending = startPromise ??= host.start(targets, startOptions).then(() => undefined);
+      void pending.catch(() => {
+        if (startPromise === pending) startPromise = undefined;
+      });
+      return pending;
+    },
+    close: () => host.close(),
+  };
+  return Object.freeze(result);
+}

--- a/packages/deployment/src/host.test.ts
+++ b/packages/deployment/src/host.test.ts
@@ -1,0 +1,141 @@
+import {
+  validateProtocolDeploymentContract,
+  type ProtocolDeploymentContract,
+} from '@hypequery/protocol';
+import { describe, expect, it, vi } from 'vitest';
+import { createDeploymentHost } from './host.js';
+import type {
+  DeploymentRuntimeGeneration,
+  DeploymentRuntimeStatus,
+  DeploymentRuntimeSupervisor,
+} from './runtime-supervisor.js';
+
+const TARGET = Object.freeze({ project: 'analytics', environment: 'production' });
+const ARTIFACT = 'a'.repeat(64);
+const RELEASE = 'b'.repeat(64);
+const BUNDLE = 'c'.repeat(64);
+const REVISION = 'd'.repeat(64);
+
+function deployment(): ProtocolDeploymentContract {
+  return validateProtocolDeploymentContract({
+    kind: 'hypequery-deployment',
+    version: 1,
+    datasets: [],
+    queries: [{
+      name: 'orders',
+      input: { kind: 'any' },
+      output: { kind: 'any' },
+      implementation: {
+        kind: 'runtime-reference',
+        runtime: 'node',
+        artifactSha256: ARTIFACT,
+        entrypoint: 'queries.orders',
+      },
+      endpoint: {
+        access: { kind: 'public' },
+        tenant: { kind: 'not-required' },
+        method: 'POST',
+        path: '/orders',
+      },
+      tags: [],
+    }],
+    artifacts: [{ runtime: 'node', artifactSha256: ARTIFACT }],
+  });
+}
+
+function generation(revision = REVISION): DeploymentRuntimeGeneration {
+  const status: DeploymentRuntimeStatus = Object.freeze({
+    target: TARGET,
+    activationRevision: revision,
+    releaseIdentity: RELEASE,
+    bundleIdentity: BUNDLE,
+  });
+  return Object.freeze({ status, deployment: deployment() });
+}
+
+function supervisor(active: { value?: DeploymentRuntimeGeneration }): DeploymentRuntimeSupervisor {
+  return {
+    reconcile: vi.fn(async () => active.value
+      ? { status: 'already-current' as const, runtime: active.value.status }
+      : { status: 'no-active-release' as const }),
+    invoke: vi.fn(async invocation => ({ query: invocation.query, argument: invocation.argument })),
+    status: vi.fn(() => active.value?.status),
+    generation: vi.fn(() => active.value),
+    close: vi.fn(async () => undefined),
+  };
+}
+
+describe('deployment host', () => {
+  it('installs and invokes one activation-pinned data-plane generation', async () => {
+    const active = { value: generation() };
+    const runtime = supervisor(active);
+    const host = createDeploymentHost({
+      supervisor: runtime,
+      configureDataPlane: async () => ({
+        runtimeArgument: ({ input }) => ({ input }),
+      }),
+    });
+
+    await expect(host.start([TARGET])).resolves.toEqual([{
+      status: 'already-current',
+      runtime: active.value.status,
+    }]);
+    await expect(host.execute(TARGET, {
+      method: 'POST',
+      path: '/orders',
+      input: { state: 'paid' },
+    })).resolves.toEqual({
+      query: 'orders',
+      output: { query: 'orders', argument: { input: { state: 'paid' } } },
+    });
+    expect(runtime.invoke).toHaveBeenCalledWith(expect.objectContaining({
+      target: TARGET,
+      activationRevision: REVISION,
+      query: 'orders',
+    }));
+    expect(host.status(TARGET)).toEqual(active.value.status);
+  });
+
+  it('retries when activation changes while a data plane is being configured', async () => {
+    const first = generation('1'.repeat(64));
+    const second = generation('2'.repeat(64));
+    const active = { value: first };
+    const runtime = supervisor(active);
+    const configureDataPlane = vi.fn(async ({ status }) => {
+      if (status.activationRevision === first.status.activationRevision) active.value = second;
+      return { runtimeArgument: ({ input }: { input: unknown }) => input };
+    });
+    const host = createDeploymentHost({ supervisor: runtime, configureDataPlane });
+
+    await host.reconcile(TARGET);
+
+    expect(configureDataPlane).toHaveBeenCalledTimes(2);
+    expect(host.status(TARGET)?.activationRevision).toBe(second.status.activationRevision);
+  });
+
+  it('removes inactive targets and makes concurrent close callers await one shutdown', async () => {
+    const active: { value?: DeploymentRuntimeGeneration } = { value: generation() };
+    const runtime = supervisor(active);
+    let releaseClose!: () => void;
+    runtime.close = vi.fn(() => new Promise<void>(resolve => { releaseClose = resolve; }));
+    const host = createDeploymentHost({
+      supervisor: runtime,
+      configureDataPlane: () => ({ runtimeArgument: ({ input }) => input }),
+    });
+    await host.reconcile(TARGET);
+    active.value = undefined;
+    await host.reconcile(TARGET);
+    expect(() => host.dataPlane(TARGET)).not.toThrow();
+    await expect(host.dataPlane(TARGET).execute({ method: 'POST', path: '/orders' }))
+      .rejects.toMatchObject({ code: 'HQ_DEPLOYMENT_HOST_NOT_READY' });
+
+    const first = host.close();
+    const second = host.close();
+    let secondSettled = false;
+    void second.then(() => { secondSettled = true; });
+    await vi.waitFor(() => expect(runtime.close).toHaveBeenCalledOnce());
+    expect(secondSettled).toBe(false);
+    releaseClose();
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+  });
+});

--- a/packages/deployment/src/host.ts
+++ b/packages/deployment/src/host.ts
@@ -1,0 +1,315 @@
+import {
+  validateProtocolDeploymentReleaseTarget,
+  type ProtocolDeploymentContract,
+  type ProtocolDeploymentReleaseTarget,
+} from '@hypequery/protocol';
+import {
+  createDeploymentDataPlane,
+  type DeploymentDataPlane,
+  type DeploymentDataPlaneJsonRequest,
+  type DeploymentDataPlaneOptions,
+  type DeploymentDataPlaneRequest,
+  type DeploymentDataPlaneResult,
+  type DeploymentRuntimeReferenceExecutionInput,
+} from './data-plane.js';
+import { createDeploymentRuntimeSupervisorExecutor } from './data-plane-runtime.js';
+import type {
+  DeploymentRuntimeGeneration,
+  DeploymentRuntimeReconcileResult,
+  DeploymentRuntimeStatus,
+  DeploymentRuntimeSupervisor,
+} from './runtime-supervisor.js';
+
+const DEFAULT_STABILITY_ATTEMPTS = 4;
+const MAX_STABILITY_ATTEMPTS = 16;
+
+export type DeploymentHostErrorCode =
+  | 'HQ_DEPLOYMENT_HOST_CONFIGURATION'
+  | 'HQ_DEPLOYMENT_HOST_CLOSED'
+  | 'HQ_DEPLOYMENT_HOST_NOT_READY'
+  | 'HQ_DEPLOYMENT_HOST_RECONCILE_FAILED'
+  | 'HQ_DEPLOYMENT_HOST_RECONCILE_UNSTABLE';
+
+export class DeploymentHostError extends Error {
+  readonly code: DeploymentHostErrorCode;
+
+  constructor(
+    code: DeploymentHostErrorCode,
+    message: string,
+    options: { readonly cause?: unknown } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'DeploymentHostError';
+    this.code = code;
+  }
+}
+
+export interface DeploymentHostDataPlaneInput {
+  readonly target: ProtocolDeploymentReleaseTarget;
+  readonly status: DeploymentRuntimeStatus;
+  readonly deployment: ProtocolDeploymentContract;
+}
+
+export type DeploymentHostDataPlaneConfiguration = Omit<
+  DeploymentDataPlaneOptions,
+  'deployment' | 'executeRuntimeReference'
+> & {
+  readonly runtimeArgument: (input: DeploymentRuntimeReferenceExecutionInput) => unknown;
+};
+
+export interface DeploymentHostOptions {
+  readonly supervisor: DeploymentRuntimeSupervisor;
+  readonly configureDataPlane: (
+    input: DeploymentHostDataPlaneInput,
+  ) => DeploymentHostDataPlaneConfiguration | Promise<DeploymentHostDataPlaneConfiguration>;
+  /** Generation-stability attempts from 1 through 16. */
+  readonly maxStabilityAttempts?: number;
+  readonly onBackgroundError?: (error: unknown) => void;
+}
+
+export interface DeploymentHost {
+  start(
+    targets: readonly ProtocolDeploymentReleaseTarget[],
+    options?: { readonly signal?: AbortSignal },
+  ): Promise<readonly DeploymentRuntimeReconcileResult[]>;
+  reconcile(
+    target: ProtocolDeploymentReleaseTarget,
+    options?: { readonly signal?: AbortSignal },
+  ): Promise<DeploymentRuntimeReconcileResult>;
+  scheduleReconcile(target: ProtocolDeploymentReleaseTarget): void;
+  execute(
+    target: ProtocolDeploymentReleaseTarget,
+    request: DeploymentDataPlaneRequest,
+  ): Promise<DeploymentDataPlaneResult>;
+  dataPlane(target: ProtocolDeploymentReleaseTarget): DeploymentDataPlane;
+  status(target: ProtocolDeploymentReleaseTarget): DeploymentRuntimeStatus | undefined;
+  close(): Promise<void>;
+}
+
+interface HostedGeneration {
+  readonly generation: DeploymentRuntimeGeneration;
+  readonly dataPlane: DeploymentDataPlane;
+}
+
+function hostError(
+  code: DeploymentHostErrorCode,
+  message: string,
+  cause?: unknown,
+): DeploymentHostError {
+  return new DeploymentHostError(code, message, { cause });
+}
+
+function targetKey(target: ProtocolDeploymentReleaseTarget): string {
+  return JSON.stringify([target.project, target.environment]);
+}
+
+function target(input: ProtocolDeploymentReleaseTarget): ProtocolDeploymentReleaseTarget {
+  try {
+    return validateProtocolDeploymentReleaseTarget(input);
+  } catch (error) {
+    throw hostError(
+      'HQ_DEPLOYMENT_HOST_CONFIGURATION',
+      'The deployment host target is invalid.',
+      error,
+    );
+  }
+}
+
+function stabilityAttempts(input: number | undefined): number {
+  const value = input ?? DEFAULT_STABILITY_ATTEMPTS;
+  if (!Number.isSafeInteger(value) || value < 1 || value > MAX_STABILITY_ATTEMPTS) {
+    throw hostError(
+      'HQ_DEPLOYMENT_HOST_CONFIGURATION',
+      `maxStabilityAttempts must be between 1 and ${MAX_STABILITY_ATTEMPTS}.`,
+    );
+  }
+  return value;
+}
+
+function sameGeneration(
+  left: DeploymentRuntimeGeneration | undefined,
+  right: DeploymentRuntimeGeneration | undefined,
+): boolean {
+  return left?.status.activationRevision === right?.status.activationRevision;
+}
+
+export function createDeploymentHost(options: DeploymentHostOptions): DeploymentHost {
+  if (!options.supervisor || typeof options.configureDataPlane !== 'function') {
+    throw hostError(
+      'HQ_DEPLOYMENT_HOST_CONFIGURATION',
+      'A runtime supervisor and data-plane configurator are required.',
+    );
+  }
+  const maximumAttempts = stabilityAttempts(options.maxStabilityAttempts);
+  const active = new Map<string, HostedGeneration>();
+  const updates = new Map<string, Promise<unknown>>();
+  const background = new Set<Promise<void>>();
+  let closed = false;
+  let closePromise: Promise<void> | undefined;
+
+  function ensureOpen(): void {
+    if (closed) throw hostError('HQ_DEPLOYMENT_HOST_CLOSED', 'The deployment host is closed.');
+  }
+
+  function serialize<T>(key: string, operation: () => Promise<T>): Promise<T> {
+    const previous = updates.get(key) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(operation);
+    const tracked = current.finally(() => {
+      if (updates.get(key) === tracked) updates.delete(key);
+    });
+    updates.set(key, tracked);
+    return tracked;
+  }
+
+  async function install(
+    desiredTarget: ProtocolDeploymentReleaseTarget,
+    signal: AbortSignal | undefined,
+  ): Promise<DeploymentRuntimeReconcileResult> {
+    for (let attempt = 0; attempt < maximumAttempts; attempt += 1) {
+      ensureOpen();
+      const result = await options.supervisor.reconcile(desiredTarget, { signal });
+      ensureOpen();
+      if (result.status === 'deactivated' || result.status === 'no-active-release') {
+        active.delete(targetKey(desiredTarget));
+        return result;
+      }
+      const generation = options.supervisor.generation(desiredTarget);
+      if (!generation
+        || generation.status.activationRevision !== result.runtime.activationRevision) {
+        continue;
+      }
+      let configuration: DeploymentHostDataPlaneConfiguration;
+      try {
+        configuration = await options.configureDataPlane(Object.freeze({
+          target: desiredTarget,
+          status: generation.status,
+          deployment: generation.deployment,
+        }));
+      } catch (error) {
+        throw hostError(
+          'HQ_DEPLOYMENT_HOST_RECONCILE_FAILED',
+          'The active deployment data plane could not be configured.',
+          error,
+        );
+      }
+      ensureOpen();
+      let dataPlane: DeploymentDataPlane;
+      try {
+        dataPlane = createDeploymentDataPlane({
+          ...configuration,
+          deployment: generation.deployment,
+          executeRuntimeReference: createDeploymentRuntimeSupervisorExecutor({
+            supervisor: options.supervisor,
+            target: desiredTarget,
+            activationRevision: generation.status.activationRevision,
+            argument: configuration.runtimeArgument,
+          }),
+        });
+      } catch (error) {
+        throw hostError(
+          'HQ_DEPLOYMENT_HOST_RECONCILE_FAILED',
+          'The active deployment data plane could not be constructed.',
+          error,
+        );
+      }
+      const confirmed = options.supervisor.generation(desiredTarget);
+      if (!sameGeneration(generation, confirmed)) continue;
+      active.set(targetKey(desiredTarget), Object.freeze({ generation, dataPlane }));
+      return result;
+    }
+    throw hostError(
+      'HQ_DEPLOYMENT_HOST_RECONCILE_UNSTABLE',
+      'The active deployment generation changed repeatedly during host reconciliation.',
+    );
+  }
+
+  const host: DeploymentHost = {
+    async start(targets, startOptions = {}) {
+      ensureOpen();
+      const validated = targets.map(target);
+      const keys = validated.map(targetKey);
+      if (new Set(keys).size !== keys.length) {
+        throw hostError(
+          'HQ_DEPLOYMENT_HOST_CONFIGURATION',
+          'Deployment host startup targets must be unique.',
+        );
+      }
+      return Object.freeze(await Promise.all(validated.map(candidate => (
+        host.reconcile(candidate, startOptions)
+      ))));
+    },
+
+    reconcile(input, reconcileOptions = {}) {
+      ensureOpen();
+      const desiredTarget = target(input);
+      return serialize(
+        targetKey(desiredTarget),
+        () => install(desiredTarget, reconcileOptions.signal),
+      );
+    },
+
+    scheduleReconcile(input): void {
+      ensureOpen();
+      const operation = host.reconcile(input).then(() => undefined).catch(error => {
+        try {
+          options.onBackgroundError?.(error);
+        } catch {
+          // A diagnostic callback cannot make reconciliation an unhandled rejection.
+        }
+      });
+      background.add(operation);
+      void operation.finally(() => background.delete(operation));
+    },
+
+    async execute(input, request): Promise<DeploymentDataPlaneResult> {
+      ensureOpen();
+      const desiredTarget = target(input);
+      const hosted = active.get(targetKey(desiredTarget));
+      if (!hosted) {
+        throw hostError(
+          'HQ_DEPLOYMENT_HOST_NOT_READY',
+          'No deployment data plane is ready for target.',
+        );
+      }
+      return await hosted.dataPlane.execute(request);
+    },
+
+    dataPlane(input): DeploymentDataPlane {
+      ensureOpen();
+      const desiredTarget = target(input);
+      return Object.freeze({
+        execute: (request: DeploymentDataPlaneRequest) => host.execute(desiredTarget, request),
+        executeJson: (request: DeploymentDataPlaneJsonRequest) => {
+          ensureOpen();
+          const hosted = active.get(targetKey(desiredTarget));
+          if (!hosted) {
+            throw hostError(
+              'HQ_DEPLOYMENT_HOST_NOT_READY',
+              'No deployment data plane is ready for target.',
+            );
+          }
+          return hosted.dataPlane.executeJson(request);
+        },
+      });
+    },
+
+    status(input): DeploymentRuntimeStatus | undefined {
+      ensureOpen();
+      const desiredTarget = target(input);
+      return active.get(targetKey(desiredTarget))?.generation.status;
+    },
+
+    close(): Promise<void> {
+      if (closePromise) return closePromise;
+      closed = true;
+      closePromise = (async () => {
+        await Promise.allSettled([...updates.values()]);
+        await Promise.allSettled([...background]);
+        active.clear();
+        await options.supervisor.close();
+      })();
+      return closePromise;
+    },
+  };
+  return Object.freeze(host);
+}

--- a/packages/deployment/src/host.ts
+++ b/packages/deployment/src/host.ts
@@ -258,7 +258,7 @@ export function createDeploymentHost(options: DeploymentHostOptions): Deployment
         }
       });
       background.add(operation);
-      void operation.finally(() => background.delete(operation));
+      void operation.finally(() => background.delete(operation)).catch(() => undefined);
     },
 
     async execute(input, request): Promise<DeploymentDataPlaneResult> {

--- a/packages/deployment/src/index.ts
+++ b/packages/deployment/src/index.ts
@@ -97,6 +97,7 @@ export {
 } from './runtime-supervisor.js';
 export type {
   DeploymentRuntimeFactory,
+  DeploymentRuntimeGeneration,
   DeploymentRuntimeInstance,
   DeploymentRuntimeInstanceInvocation,
   DeploymentRuntimeInvocation,
@@ -129,6 +130,7 @@ export type {
   DeploymentDataPlaneAuthenticationInput,
   DeploymentDataPlaneErrorCode,
   DeploymentDataPlaneExecutionInput,
+  DeploymentDataPlaneJsonRequest,
   DeploymentDataPlaneOptions,
   DeploymentDataPlanePrincipal,
   DeploymentDataPlaneRequest,
@@ -144,3 +146,29 @@ export {
 export type { DeploymentDataPlaneLimits } from './data-plane-limits.js';
 export { createDeploymentRuntimeSupervisorExecutor } from './data-plane-runtime.js';
 export type { DeploymentRuntimeSupervisorExecutorOptions } from './data-plane-runtime.js';
+export {
+  createDeploymentDataPlaneFetchHandler,
+  createDeploymentDataPlaneNodeHandler,
+} from './data-plane-adapters.js';
+export type {
+  DeploymentDataPlaneAdapterOptions,
+  DeploymentDataPlaneAdapterRequest,
+  DeploymentDataPlaneFetchHandler,
+  DeploymentDataPlaneNodeHandler,
+} from './data-plane-adapters.js';
+export {
+  createDeploymentHost,
+  DeploymentHostError,
+} from './host.js';
+export { createFileSystemDeploymentHost } from './filesystem-host.js';
+export type {
+  FileSystemDeploymentHost,
+  FileSystemDeploymentHostOptions,
+} from './filesystem-host.js';
+export type {
+  DeploymentHost,
+  DeploymentHostDataPlaneConfiguration,
+  DeploymentHostDataPlaneInput,
+  DeploymentHostErrorCode,
+  DeploymentHostOptions,
+} from './host.js';

--- a/packages/deployment/src/runtime-supervisor.test.ts
+++ b/packages/deployment/src/runtime-supervisor.test.ts
@@ -151,6 +151,11 @@ describe('deployment runtime supervisor', () => {
     });
     expect(response).toEqual({ label: 'v1', argument: 42 });
     expect(supervisor.status(TARGET)?.releaseIdentity).toBe(active.releaseIdentity);
+    expect(supervisor.generation(TARGET)).toEqual({
+      status: supervisor.status(TARGET),
+      deployment: active.deployment,
+    });
+    expect(Object.isFrozen(supervisor.generation(TARGET))).toBe(true);
     await supervisor.close();
   });
 

--- a/packages/deployment/src/runtime-supervisor.ts
+++ b/packages/deployment/src/runtime-supervisor.ts
@@ -1,4 +1,7 @@
-import type { ProtocolDeploymentReleaseTarget } from '@hypequery/protocol';
+import type {
+  ProtocolDeploymentContract,
+  ProtocolDeploymentReleaseTarget,
+} from '@hypequery/protocol';
 import type {
   DeploymentRuntimeMaterializer,
   DeploymentRuntimeQueryBinding,
@@ -72,6 +75,11 @@ export interface DeploymentRuntimeStatus {
   readonly bundleIdentity: string;
 }
 
+export interface DeploymentRuntimeGeneration {
+  readonly status: DeploymentRuntimeStatus;
+  readonly deployment: ProtocolDeploymentContract;
+}
+
 export type DeploymentRuntimeReconcileResult =
   | { readonly status: 'activated'; readonly runtime: DeploymentRuntimeStatus }
   | { readonly status: 'already-current'; readonly runtime: DeploymentRuntimeStatus }
@@ -85,6 +93,7 @@ export interface DeploymentRuntimeSupervisor {
   ): Promise<DeploymentRuntimeReconcileResult>;
   invoke(input: DeploymentRuntimeInvocation): Promise<unknown>;
   status(target: ProtocolDeploymentReleaseTarget): DeploymentRuntimeStatus | undefined;
+  generation(target: ProtocolDeploymentReleaseTarget): DeploymentRuntimeGeneration | undefined;
   close(): Promise<void>;
 }
 
@@ -402,6 +411,14 @@ export function createDeploymentRuntimeSupervisor(
     status(target: ProtocolDeploymentReleaseTarget): DeploymentRuntimeStatus | undefined {
       const generation = active.get(targetKey(target));
       return generation ? status(generation) : undefined;
+    },
+
+    generation(target: ProtocolDeploymentReleaseTarget): DeploymentRuntimeGeneration | undefined {
+      const generation = active.get(targetKey(target));
+      return generation ? Object.freeze({
+        status: status(generation),
+        deployment: generation.snapshot.deployment,
+      }) : undefined;
     },
 
     close(): Promise<void> {

--- a/packages/protocol/src/schemas/apply.ts
+++ b/packages/protocol/src/schemas/apply.ts
@@ -1,4 +1,6 @@
 import type { CanonicalValue } from '../values/index.js';
+import { DEFAULT_CANONICAL_VALUE_LIMITS } from '../values/limits.js';
+import { parseDuplicateAwareJson } from '../values/parser.js';
 import { resolveProtocolSchemaValueLimits } from './value-limits.js';
 import type {
   ProtocolSchema,
@@ -20,6 +22,7 @@ export class ProtocolSchemaValueError extends Error {
 
 export interface ProtocolSchemaValueParser {
   parse(input: unknown): unknown;
+  parseJson(input: string | Uint8Array): unknown;
 }
 
 interface State {
@@ -275,9 +278,21 @@ export function createProtocolSchemaValueParser(
 ): ProtocolSchemaValueParser {
   const schema = validateProtocolSchema(input);
   const limits = resolveProtocolSchemaValueLimits(options);
+  const jsonLimits = Object.freeze({
+    ...DEFAULT_CANONICAL_VALUE_LIMITS,
+    maxInputBytes: limits.maxInputBytes,
+    maxDepth: limits.maxDepth,
+    maxNodes: limits.maxNodes,
+    maxCollectionItems: limits.maxCollectionItems,
+    maxStringBytes: limits.maxStringBytes,
+  });
+  const parse = (value: unknown) => (
+    apply(schema, value, '$', 1, { active: new WeakSet(), limits, nodes: 0 })
+  );
   return Object.freeze({
-    parse(value: unknown): unknown {
-      return apply(schema, value, '$', 1, { active: new WeakSet(), limits, nodes: 0 });
+    parse,
+    parseJson(value: string | Uint8Array): unknown {
+      return parse(parseDuplicateAwareJson(value, jsonLimits));
     },
   });
 }

--- a/packages/protocol/src/schemas/apply.ts
+++ b/packages/protocol/src/schemas/apply.ts
@@ -22,7 +22,7 @@ export class ProtocolSchemaValueError extends Error {
 
 export interface ProtocolSchemaValueParser {
   parse(input: unknown): unknown;
-  parseJson(input: string | Uint8Array): unknown;
+  parseJson?(input: string | Uint8Array): unknown;
 }
 
 interface State {

--- a/packages/protocol/src/schemas/schema-values.test.ts
+++ b/packages/protocol/src/schemas/schema-values.test.ts
@@ -159,8 +159,8 @@ describe('protocol schema values', () => {
       unknownProperties: 'reject',
     }));
 
-    expect(parser.parseJson('{"id":"one"}')).toEqual({ id: 'one' });
-    expect(() => parser.parseJson('{"id":"one","id":"two"}')).toThrow(expect.objectContaining({
+    expect(parser.parseJson?.('{"id":"one"}')).toEqual({ id: 'one' });
+    expect(() => parser.parseJson?.('{"id":"one","id":"two"}')).toThrow(expect.objectContaining({
       code: 'HQ_VALUE_DUPLICATE_KEY',
     }));
   });

--- a/packages/protocol/src/schemas/schema-values.test.ts
+++ b/packages/protocol/src/schemas/schema-values.test.ts
@@ -150,4 +150,18 @@ describe('protocol schema values', () => {
     expect(resolveProtocolSchemaValueLimits({ limits: { maxDepth: undefined } }))
       .toMatchObject({ maxDepth: 32 });
   });
+
+  it('parses duplicate-aware JSON before applying the schema', () => {
+    const parser = createProtocolSchemaValueParser(validateProtocolSchema({
+      kind: 'object',
+      properties: { id: { kind: 'string' } },
+      required: ['id'],
+      unknownProperties: 'reject',
+    }));
+
+    expect(parser.parseJson('{"id":"one"}')).toEqual({ id: 'one' });
+    expect(() => parser.parseJson('{"id":"one","id":"two"}')).toThrow(expect.objectContaining({
+      code: 'HQ_VALUE_DUPLICATE_KEY',
+    }));
+  });
 });

--- a/packages/protocol/src/schemas/types.ts
+++ b/packages/protocol/src/schemas/types.ts
@@ -64,6 +64,7 @@ export interface ProtocolSchemaOptions {
 }
 
 export interface ProtocolSchemaValueLimits {
+  readonly maxInputBytes: number;
   readonly maxDepth: number;
   readonly maxNodes: number;
   readonly maxCollectionItems: number;

--- a/packages/protocol/src/schemas/value-limits.ts
+++ b/packages/protocol/src/schemas/value-limits.ts
@@ -2,6 +2,7 @@ import type { ProtocolSchemaValueLimits, ProtocolSchemaValueOptions } from './ty
 
 export const DEFAULT_PROTOCOL_SCHEMA_VALUE_LIMITS: Readonly<ProtocolSchemaValueLimits> =
   Object.freeze({
+    maxInputBytes: 1_048_576,
     maxDepth: 32,
     maxNodes: 10_000,
     maxCollectionItems: 1_000,

--- a/specs/deployment/0007-data-plane-hosting.md
+++ b/specs/deployment/0007-data-plane-hosting.md
@@ -1,0 +1,85 @@
+# Deployment runtime 0007: Data-plane hosting
+
+- Status: Proposed
+- Version: deployment host 1
+
+## Summary
+
+This specification defines provider-neutral hosting for deployment data planes.
+It binds one immutable deployment contract, one supervised runtime generation,
+and one set of query routes to the same activation revision. It also defines
+bounded Fetch and Node HTTP adaptation and a reference single-host filesystem
+composition.
+
+## Generation-pinned installation
+
+A host reconciles a deployment target through its runtime supervisor. When a
+runtime is active, the supervisor returns an atomic generation view containing
+both runtime status and the immutable deployment contract materialized for that
+activation revision.
+
+The host constructs query policy, schemas, and routes from that exact contract.
+Runtime-reference dispatch includes the exact activation revision. Before
+publishing the data plane, the host confirms that the supervisor still exposes
+the same revision. If activation changes during asynchronous configuration, the
+host discards the candidate and retries within a fixed bound.
+
+New requests use only the published generation. Existing requests may drain on
+the previous runtime according to runtime-supervision rules. A stale data plane
+cannot invoke a newer runtime generation because revision-pinned invocation
+fails closed.
+
+## Reconciliation lifecycle
+
+Configured targets are reconciled during startup. A target with no active
+release has no published data plane. Durable activation schedules serialized
+reconciliation for that target.
+
+Activation persistence and runtime readiness are distinct outcomes. A runtime
+startup or host-configuration failure after durable activation is reported to
+provider diagnostics, but cannot change the successful activation response.
+Operators can retry reconciliation or activate a previous release through the
+normal compare-and-swap operation.
+
+Shutdown rejects new host work, waits for target reconciliation and background
+work to settle, removes published data planes, and closes the runtime
+supervisor. Concurrent shutdown callers await the same operation.
+
+## HTTP adaptation
+
+Fetch and Node adapters pass an exact uppercase method, URL pathname, duplicate-
+preserving query record, normalized header record, credentials, and cancellation
+signal to the data plane.
+
+A request supplies input through either query parameters or one JSON body, not
+both. Bodies require `application/json` with optional UTF-8 charset, are read
+within a configurable protocol maximum, and are parsed with duplicate-property
+awareness. Declared and observed body lengths must agree. Query names with
+multiple values become arrays.
+
+Successful non-void output is encoded as UTF-8 JSON. Void output uses status
+204. Public cache headers are emitted only from data-plane results that confirm
+public, tenant-independent, unauthenticated execution; every other response is
+`no-store`. Internal exception details are never placed in public responses.
+
+## Reference filesystem composition
+
+The reference single-host assembly composes:
+
+- the durable filesystem submission store and activation registry;
+- authenticated intake and control-plane handling;
+- runtime materialization and supervision;
+- generation-pinned data-plane hosting; and
+- activation-triggered reconciliation and graceful shutdown.
+
+The assembly defaults to the trusted Node worker runtime factory. Providers may
+inject another runtime factory and all data-plane authentication, tenant,
+semantic-plan, compiled-SQL, and runtime argument adapters.
+
+## Out of scope
+
+Version 1 does not define listeners, TLS, distributed activation propagation,
+leader election, shared storage, database clients, credential stores, rate
+limiting, tracing export, autoscaling, release retention, or hostile-code
+sandboxing. Cloud systems own those concerns while consuming these interfaces
+and immutable artifacts.

--- a/specs/deployment/README.md
+++ b/specs/deployment/README.md
@@ -22,3 +22,5 @@ Current specifications:
   generation switching, invocation, draining, and the reference Node worker.
 - `0006-data-plane-execution.md` defines named-query route matching, policy,
   schema application, implementation dispatch, and output validation.
+- `0007-data-plane-hosting.md` defines generation-pinned host assembly,
+  activation reconciliation, HTTP adaptation, and graceful shutdown.


### PR DESCRIPTION
## Summary

- add generation-pinned deployment host assembly
- add bounded Fetch and Node data-plane HTTP adapters
- reconcile hosted data planes after durable activation
- expose an atomic supervisor generation view for route/runtime consistency
- add a reference filesystem host composing intake, activation, materialization, supervision, control, and execution
- add duplicate-aware raw JSON schema parsing and deployment-hosting specification 0007

## Why

An active runtime and its routes, schemas, and policy must come from the same activation generation. Hosts also need a reusable lifecycle that can start configured targets, react to activation, and shut down without coupling successful persistence to later runtime startup.

## Impact

Cloud and self-hosted services can mount Fetch or Node handlers over the same provider-neutral host. Stale route metadata cannot invoke a newer runtime generation, and post-activation reconciliation failures are reported diagnostically without turning a durable activation into an HTTP 500.

## Stack

This PR is stacked on `codex/deployment-data-plane-execution` and should land after that PR.

## Validation

- full monorepo tests, types, lint, and build passed before publication
- after rebasing the stack: protocol build and 299 tests passed
- deployment types, lint, and 101 tests passed (1 skipped)
