### PR TITLE
feat(website): add consent banner, remove reb2b

### DIFF
--- a/website-next/package-lock.json
+++ b/website-next/package-lock.json
@@ -26,7 +26,8 @@
         "remark-rehype": "^11.1.2",
         "shiki": "^3.22.0",
         "tailwind-merge": "^2.6.0",
-        "unified": "^11.0.5"
+        "unified": "^11.0.5",
+        "vanilla-cookieconsent": "^3.1.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -14210,6 +14211,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vanilla-cookieconsent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vanilla-cookieconsent/-/vanilla-cookieconsent-3.1.0.tgz",
+      "integrity": "sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA==",
       "license": "MIT"
     },
     "node_modules/vercel": {

--- a/website-next/package.json
+++ b/website-next/package.json
@@ -27,7 +27,8 @@
     "remark-rehype": "^11.1.2",
     "shiki": "^3.22.0",
     "tailwind-merge": "^2.6.0",
-    "unified": "^11.0.5"
+    "unified": "^11.0.5",
+    "vanilla-cookieconsent": "^3.1.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/website-next/src/app/layout.tsx
+++ b/website-next/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Plus_Jakarta_Sans, JetBrains_Mono, Space_Grotesk } from "next/font/goog
 import "./globals.css";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import DefaultSearchDialog from "@/components/search";
+import CookieConsentBanner from "@/components/CookieConsent";
 import { absoluteUrl, siteUrl } from "@/lib/site";
 import { THEME_STORAGE_KEY } from "@/lib/theme";
 
@@ -121,66 +122,18 @@ export default function RootLayout({
 })();`,
           }}
         />
+        {/*
+          Umami is cookieless and collects no personal data, so it is
+          consent-exempt and loads unconditionally. GA, Leadfeeder and reb2b
+          set cookies or identify visitors — they are gated behind the consent
+          banner (see CookieConsentBanner) and injected only after opt-in.
+        */}
         <Script
           defer
           src="https://cloud.umami.is/script.js"
           data-website-id="a1b133a2-bf0a-4260-9c2c-f76a2a20359f"
           strategy="afterInteractive"
         />
-        <Script
-          id="leadfeeder"
-          strategy="afterInteractive"
-          dangerouslySetInnerHTML={{
-            __html: `(function (ss, ex) {
-  window.ldfdr =
-    window.ldfdr ||
-    function () {
-      (ldfdr._q = ldfdr._q || []).push([].slice.call(arguments));
-    };
-  (function (d, s) {
-    fs = d.getElementsByTagName(s)[0];
-    function ce(src) {
-      var cs = d.createElement(s);
-      cs.src = src;
-      cs.async = 1;
-      fs.parentNode.insertBefore(cs, fs);
-    }
-    ce(
-      "https://sc.lfeeder.com/lftracker_v1_" +
-        ss +
-        (ex ? "_" + ex : "") +
-        ".js"
-    );
-  })(document, "script");
-})("DzLR5a5lx1Z4BoQ2");`,
-          }}
-        />
-        <Script
-          id="reb2b"
-          strategy="afterInteractive"
-          dangerouslySetInnerHTML={{
-            __html: `!function(key){if(window.reb2b)return;window.reb2b={loaded:true};var s=document.createElement("script");s.async=true;s.src="https://ddwl4m2hdecbv.cloudfront.net/b/"+key+"/"+key+".js.gz";document.getElementsByTagName("script")[0].parentNode.insertBefore(s,document.getElementsByTagName("script")[0]);}("QOQRJHK1W462");`,
-          }}
-        />
-        {gaMeasurementId ? (
-          <>
-            <Script
-              async
-              src={`https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`}
-              strategy="afterInteractive"
-            />
-            <Script
-              id="ga"
-              strategy="afterInteractive"
-              dangerouslySetInnerHTML={{
-                __html: `window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-gtag('config', '${gaMeasurementId}');`,
-              }}
-            />
-          </>
-        ) : null}
       </head>
       <body
         className={`${sans.variable} ${mono.variable} ${displayFont.variable} antialiased`}
@@ -199,6 +152,7 @@ gtag('config', '${gaMeasurementId}');`,
         >
           {children}
         </RootProvider>
+        <CookieConsentBanner gaMeasurementId={gaMeasurementId} />
       </body>
     </html>
   );

--- a/website-next/src/app/layout.tsx
+++ b/website-next/src/app/layout.tsx
@@ -122,12 +122,8 @@ export default function RootLayout({
 })();`,
           }}
         />
-        {/*
-          Umami is cookieless and collects no personal data, so it is
-          consent-exempt and loads unconditionally. GA and Leadfeeder set
-          cookies or identify visitors — they are gated behind the consent
-          banner (see CookieConsentBanner) and injected only after opt-in.
-        */}
+        {/* Optional analytics and marketing trackers are injected only after
+            opt-in by CookieConsentBanner. */}
         <Script
           defer
           src="https://cloud.umami.is/script.js"

--- a/website-next/src/app/layout.tsx
+++ b/website-next/src/app/layout.tsx
@@ -124,8 +124,8 @@ export default function RootLayout({
         />
         {/*
           Umami is cookieless and collects no personal data, so it is
-          consent-exempt and loads unconditionally. GA, Leadfeeder and reb2b
-          set cookies or identify visitors — they are gated behind the consent
+          consent-exempt and loads unconditionally. GA and Leadfeeder set
+          cookies or identify visitors — they are gated behind the consent
           banner (see CookieConsentBanner) and injected only after opt-in.
         */}
         <Script

--- a/website-next/src/components/CookieConsent.css
+++ b/website-next/src/components/CookieConsent.css
@@ -1,0 +1,73 @@
+/*
+ * Brand theme for vanilla-cookieconsent, mapped onto the site design tokens
+ * (globals.css). Because it references --bg-card / --text / --accent etc., the
+ * banner automatically follows the site's light and dark themes.
+ */
+#cc-main {
+  --cc-font-family: var(--font-sans, system-ui, sans-serif);
+
+  --cc-bg: var(--bg-card);
+  --cc-primary-color: var(--text);
+  --cc-secondary-color: var(--text-muted);
+  --cc-link-color: var(--accent);
+
+  --cc-btn-border-radius: var(--radius, 4px);
+  --cc-modal-border-radius: var(--radius-lg, 8px);
+  --cc-pm-toggle-border-radius: var(--radius-pill, 100px);
+
+  /* Primary (Accept) button — brand accent */
+  --cc-btn-primary-bg: var(--accent);
+  --cc-btn-primary-color: #ffffff;
+  --cc-btn-primary-border-color: var(--accent);
+  --cc-btn-primary-hover-bg: color-mix(in srgb, var(--accent) 82%, #000);
+  --cc-btn-primary-hover-color: #ffffff;
+  --cc-btn-primary-hover-border-color: color-mix(in srgb, var(--accent) 82%, #000);
+
+  /* Secondary (Reject / Manage) buttons — subtle surface */
+  --cc-btn-secondary-bg: var(--bg-alt);
+  --cc-btn-secondary-color: var(--text);
+  --cc-btn-secondary-border-color: var(--border-strong);
+  --cc-btn-secondary-hover-bg: var(--border);
+  --cc-btn-secondary-hover-color: var(--text);
+  --cc-btn-secondary-hover-border-color: var(--border-strong);
+
+  --cc-separator-border-color: var(--border);
+  --cc-section-category-border: var(--border);
+
+  /* Category toggles */
+  --cc-toggle-on-bg: var(--accent);
+  --cc-toggle-off-bg: var(--text-dim);
+  --cc-toggle-on-knob-bg: #ffffff;
+  --cc-toggle-off-knob-bg: #ffffff;
+  --cc-toggle-readonly-bg: var(--border-strong);
+  --cc-toggle-readonly-knob-bg: var(--bg-card);
+
+  /* Preferences modal category blocks */
+  --cc-cookie-category-block-bg: var(--bg-alt);
+  --cc-cookie-category-block-border: var(--border);
+  --cc-cookie-category-block-hover-bg: var(--bg-alt);
+  --cc-cookie-category-block-hover-border: var(--border-strong);
+  --cc-cookie-category-expanded-block-bg: transparent;
+  --cc-cookie-category-expanded-block-hover-bg: var(--bg-alt);
+
+  --cc-overlay-bg: rgba(0, 0, 0, 0.5);
+  --cc-footer-bg: var(--bg-card);
+  --cc-footer-color: var(--text-muted);
+  --cc-footer-border-color: var(--border);
+
+  --cc-webkit-scrollbar-bg: var(--border);
+  --cc-webkit-scrollbar-hover-bg: var(--border-strong);
+
+  border: 1px solid var(--border);
+}
+
+/*
+ * In dark mode the accent is a light lavender, so the primary button needs
+ * dark text for contrast (and a lighter hover instead of darker).
+ */
+[data-theme='dark'] #cc-main {
+  --cc-btn-primary-color: #0c0e14;
+  --cc-btn-primary-hover-color: #0c0e14;
+  --cc-btn-primary-hover-bg: color-mix(in srgb, var(--accent) 82%, #fff);
+  --cc-btn-primary-hover-border-color: color-mix(in srgb, var(--accent) 82%, #fff);
+}

--- a/website-next/src/components/CookieConsent.tsx
+++ b/website-next/src/components/CookieConsent.tsx
@@ -6,7 +6,6 @@ import 'vanilla-cookieconsent/dist/cookieconsent.css';
 
 declare global {
   interface Window {
-    reb2b?: unknown;
     ldfdr?: unknown;
     dataLayer?: unknown[];
   }
@@ -68,22 +67,10 @@ function loadLeadfeeder() {
 }
 
 /**
- * Loads reb2b (person-level visitor de-anonymization). Marketing category.
- */
-function loadReb2b() {
-  if (window.reb2b || document.getElementById('reb2b')) return;
-
-  const s = document.createElement('script');
-  s.id = 'reb2b';
-  s.textContent = `!function(key){if(window.reb2b)return;window.reb2b={loaded:true};var s=document.createElement("script");s.async=true;s.src="https://ddwl4m2hdecbv.cloudfront.net/b/"+key+"/"+key+".js.gz";document.getElementsByTagName("script")[0].parentNode.insertBefore(s,document.getElementsByTagName("script")[0]);}("QOQRJHK1W462");`;
-  document.head.appendChild(s);
-}
-
-/**
  * Consent banner (vanilla-cookieconsent). Gates the trackers that set cookies
- * or identify individuals — GA (analytics) and Leadfeeder + reb2b (marketing) —
- * so they only load after the visitor opts in. Umami is cookieless and
- * consent-exempt, so it stays in the root layout and is not managed here.
+ * or identify visitors — GA (analytics) and Leadfeeder (marketing) — so they
+ * only load after the visitor opts in. Umami is cookieless and consent-exempt,
+ * so it stays in the root layout and is not managed here.
  */
 export default function CookieConsentBanner({
   gaMeasurementId,
@@ -148,7 +135,7 @@ export default function CookieConsentBanner({
                 {
                   title: 'Marketing',
                   description:
-                    'Leadfeeder and reb2b identify visiting organizations and individuals so we can follow up. Loads only with your consent.',
+                    'Leadfeeder identifies visiting organizations so we can follow up. Loads only with your consent.',
                   linkedCategory: 'marketing',
                 },
               ],
@@ -164,7 +151,6 @@ export default function CookieConsentBanner({
       }
       if (CookieConsent.acceptedCategory('marketing')) {
         loadLeadfeeder();
-        loadReb2b();
       }
     }
   }, [gaMeasurementId]);

--- a/website-next/src/components/CookieConsent.tsx
+++ b/website-next/src/components/CookieConsent.tsx
@@ -68,10 +68,8 @@ function loadLeadfeeder() {
 }
 
 /**
- * Consent banner (vanilla-cookieconsent). Gates the trackers that set cookies
- * or identify visitors — GA (analytics) and Leadfeeder (marketing) — so they
- * only load after the visitor opts in. Umami is cookieless and consent-exempt,
- * so it stays in the root layout and is not managed here.
+ * Consent banner (vanilla-cookieconsent). Gates optional analytics and
+ * marketing trackers so they load only after the visitor opts in.
  */
 export default function CookieConsentBanner({
   gaMeasurementId,
@@ -130,13 +128,13 @@ export default function CookieConsentBanner({
                 {
                   title: 'Analytics',
                   description:
-                    'Google Analytics — helps us understand how the site is used. Umami, our cookieless analytics, runs without consent and is not covered here.',
+                    'Helps us understand how visitors use the site so we can improve it.',
                   linkedCategory: 'analytics',
                 },
                 {
                   title: 'Marketing',
                   description:
-                    'Leadfeeder identifies visiting organizations so we can follow up. Loads only with your consent.',
+                    'Helps us understand which organizations visit the site and measure interest in our products.',
                   linkedCategory: 'marketing',
                 },
               ],

--- a/website-next/src/components/CookieConsent.tsx
+++ b/website-next/src/components/CookieConsent.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import * as CookieConsent from 'vanilla-cookieconsent';
 import 'vanilla-cookieconsent/dist/cookieconsent.css';
+import './CookieConsent.css';
 
 declare global {
   interface Window {

--- a/website-next/src/components/CookieConsent.tsx
+++ b/website-next/src/components/CookieConsent.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useEffect } from 'react';
+import * as CookieConsent from 'vanilla-cookieconsent';
+import 'vanilla-cookieconsent/dist/cookieconsent.css';
+
+declare global {
+  interface Window {
+    reb2b?: unknown;
+    ldfdr?: unknown;
+    dataLayer?: unknown[];
+  }
+}
+
+/**
+ * Loads Google Analytics (gtag). Analytics category.
+ * Idempotent: no-op if the tag is already on the page.
+ */
+function loadGoogleAnalytics(measurementId?: string) {
+  if (!measurementId || document.getElementById('ga-src')) return;
+
+  const src = document.createElement('script');
+  src.id = 'ga-src';
+  src.async = true;
+  src.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`;
+  document.head.appendChild(src);
+
+  const inline = document.createElement('script');
+  inline.id = 'ga-inline';
+  inline.textContent = `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${measurementId}');`;
+  document.head.appendChild(inline);
+}
+
+/**
+ * Loads Leadfeeder (company-level visitor identification). Marketing category.
+ */
+function loadLeadfeeder() {
+  if (document.getElementById('leadfeeder')) return;
+
+  const s = document.createElement('script');
+  s.id = 'leadfeeder';
+  s.textContent = `(function (ss, ex) {
+  window.ldfdr =
+    window.ldfdr ||
+    function () {
+      (ldfdr._q = ldfdr._q || []).push([].slice.call(arguments));
+    };
+  (function (d, s) {
+    fs = d.getElementsByTagName(s)[0];
+    function ce(src) {
+      var cs = d.createElement(s);
+      cs.src = src;
+      cs.async = 1;
+      fs.parentNode.insertBefore(cs, fs);
+    }
+    ce(
+      "https://sc.lfeeder.com/lftracker_v1_" +
+        ss +
+        (ex ? "_" + ex : "") +
+        ".js"
+    );
+  })(document, "script");
+})("DzLR5a5lx1Z4BoQ2");`;
+  document.head.appendChild(s);
+}
+
+/**
+ * Loads reb2b (person-level visitor de-anonymization). Marketing category.
+ */
+function loadReb2b() {
+  if (window.reb2b || document.getElementById('reb2b')) return;
+
+  const s = document.createElement('script');
+  s.id = 'reb2b';
+  s.textContent = `!function(key){if(window.reb2b)return;window.reb2b={loaded:true};var s=document.createElement("script");s.async=true;s.src="https://ddwl4m2hdecbv.cloudfront.net/b/"+key+"/"+key+".js.gz";document.getElementsByTagName("script")[0].parentNode.insertBefore(s,document.getElementsByTagName("script")[0]);}("QOQRJHK1W462");`;
+  document.head.appendChild(s);
+}
+
+/**
+ * Consent banner (vanilla-cookieconsent). Gates the trackers that set cookies
+ * or identify individuals — GA (analytics) and Leadfeeder + reb2b (marketing) —
+ * so they only load after the visitor opts in. Umami is cookieless and
+ * consent-exempt, so it stays in the root layout and is not managed here.
+ */
+export default function CookieConsentBanner({
+  gaMeasurementId,
+}: {
+  gaMeasurementId?: string;
+}) {
+  useEffect(() => {
+    void CookieConsent.run({
+      guiOptions: {
+        consentModal: { layout: 'box wide', position: 'bottom left' },
+        preferencesModal: { layout: 'box' },
+      },
+      categories: {
+        necessary: { enabled: true, readOnly: true },
+        analytics: {},
+        marketing: {},
+      },
+      // Applying withdrawn consent to an already-running script isn't possible
+      // in-session, so reload to unload trackers when a category is turned off.
+      onChange: ({ changedCategories }) => {
+        const removed = changedCategories.some(
+          (c) => (c === 'analytics' || c === 'marketing') && !CookieConsent.acceptedCategory(c),
+        );
+        if (removed) {
+          window.location.reload();
+          return;
+        }
+        applyConsent();
+      },
+      onConsent: () => applyConsent(),
+      language: {
+        default: 'en',
+        translations: {
+          en: {
+            consentModal: {
+              title: 'We value your privacy',
+              description:
+                'We use cookies and similar tools to understand traffic and improve the site. Analytics and marketing trackers only run with your consent.',
+              acceptAllBtn: 'Accept all',
+              acceptNecessaryBtn: 'Reject all',
+              showPreferencesBtn: 'Manage preferences',
+            },
+            preferencesModal: {
+              title: 'Manage cookie preferences',
+              acceptAllBtn: 'Accept all',
+              acceptNecessaryBtn: 'Reject all',
+              savePreferencesBtn: 'Save preferences',
+              closeIconLabel: 'Close',
+              sections: [
+                {
+                  title: 'Strictly necessary',
+                  description:
+                    'Required for the site to function (e.g. remembering your theme). Always on.',
+                  linkedCategory: 'necessary',
+                },
+                {
+                  title: 'Analytics',
+                  description:
+                    'Google Analytics — helps us understand how the site is used. Umami, our cookieless analytics, runs without consent and is not covered here.',
+                  linkedCategory: 'analytics',
+                },
+                {
+                  title: 'Marketing',
+                  description:
+                    'Leadfeeder and reb2b identify visiting organizations and individuals so we can follow up. Loads only with your consent.',
+                  linkedCategory: 'marketing',
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    function applyConsent() {
+      if (CookieConsent.acceptedCategory('analytics')) {
+        loadGoogleAnalytics(gaMeasurementId);
+      }
+      if (CookieConsent.acceptedCategory('marketing')) {
+        loadLeadfeeder();
+        loadReb2b();
+      }
+    }
+  }, [gaMeasurementId]);
+
+  return null;
+}


### PR DESCRIPTION
## What

Adds a consent banner and **removes the reb2b tracker entirely**.

- **Removes reb2b.** The ungated snippet landed on `main` via #333; this PR deletes it. With opt-in gating its identification yield would be marginal, so it's not worth keeping.
- New `CookieConsentBanner` client component ([website-next/src/components/CookieConsent.tsx](website-next/src/components/CookieConsent.tsx)) built on [vanilla-cookieconsent](https://github.com/orestbida/cookieconsent) (open-source, self-hosted — no vendor).
- Gates **GA** (`analytics`) and **Leadfeeder** (`marketing`) — they inject only after opt-in; turning a category off reloads to unload them.
- **Umami stays unconditional** — cookieless, no personal data, treated as consent-exempt.

## Net effect on merge

- reb2b removed from the live site.
- GA + Leadfeeder no longer fire without consent (closes the GDPR/ePrivacy exposure they had running ungated on `main`).

## Still needed for full compliance (not in this PR)

- **Privacy-policy disclosure** naming Leadfeeder/GA, data collected, and third-party sharing.
- **US "Do Not Sell/Share" + GPC** handling (banner covers opt-in; US opt-out still needs wiring).
- Optional: geo-targeting so the banner only blocks where required.
- Not legal advice — review with counsel before relying on it.

## Validation

`next build` compiles + passes TypeScript. (Local build stops later at `/blog/[slug]`, which needs `BLOB_READ_WRITE_TOKEN` — pre-existing, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
