### PR TITLE
feat(gateway): anonymous opt-out usage telemetry

### DIFF
--- a/.changeset/gateway-telemetry.md
+++ b/.changeset/gateway-telemetry.md
@@ -1,0 +1,7 @@
+---
+'@hypequery/gateway': minor
+'@hypequery/studio': minor
+'@hypequery/cli': minor
+---
+
+Add anonymous, opt-out usage telemetry to the experimental playground gateway. Telemetry is a no-op until an ingest endpoint is configured, prints a one-time disclosure on first enabled run, and never captures SQL, query names, inputs, results, or paths (machine UUID + hashed project id only; endpoint names hashed, durations bucketed). Opt out with `hypequery dev --no-telemetry`, `HYPEQUERY_TELEMETRY_DISABLED=1`, or `DO_NOT_TRACK=1`; it is also auto-disabled in CI.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -98,6 +98,7 @@ program
   .option('--redis-url <url>', 'Redis connection URL')
   .option('--open', 'Open browser automatically')
   .option('--ui-experimental', 'Serve the experimental query UI at /__dev (unstable, not for production use)')
+  .option('--no-telemetry', 'Disable anonymous playground usage telemetry')
   .option('--cors', 'Enable CORS')
   .option('--path <path>', 'Analytics directory (loads <path>/api.ts or <path>/queries.ts)')
   .option('-q, --quiet', 'Suppress startup messages')

--- a/packages/cli/src/commands/dev.test.ts
+++ b/packages/cli/src/commands/dev.test.ts
@@ -121,6 +121,26 @@ describe('dev command', () => {
         expect.objectContaining({ mount: expect.any(Function) })
       );
     });
+
+    it('leaves telemetry enabled by default', async () => {
+      const { createGateway } = await import('@hypequery/gateway');
+      await devCommand(undefined, { watch: false, uiExperimental: true });
+
+      expect(createGateway).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ telemetryDisabled: false })
+      );
+    });
+
+    it('disables telemetry with --no-telemetry (commander sets telemetry: false)', async () => {
+      const { createGateway } = await import('@hypequery/gateway');
+      await devCommand(undefined, { watch: false, uiExperimental: true, telemetry: false });
+
+      expect(createGateway).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ telemetryDisabled: true })
+      );
+    });
   });
 
   describe('Happy path (watch disabled for testing)', () => {

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -43,6 +43,12 @@ export interface DevOptions {
    * the UI is not release-ready; behaviour and flag may change or go away.
    */
   uiExperimental?: boolean;
+  /**
+   * Anonymous playground usage telemetry. Commander sets this to `false` when
+   * `--no-telemetry` is passed; otherwise it is undefined (telemetry follows
+   * its usual endpoint/env gating).
+   */
+  telemetry?: boolean;
 }
 
 /**
@@ -51,13 +57,15 @@ export interface DevOptions {
  * hint) and `hypequery dev` still runs as a plain server.
  */
 async function createGatewayIfAvailable(
-  api: unknown
+  api: unknown,
+  telemetryDisabled: boolean
 ): Promise<{ mount: unknown; shutdown: () => Promise<void>; uiAvailable: boolean } | null> {
   try {
     const { createGateway } = await import('@hypequery/gateway');
     return (await createGateway(api as any, {
       projectName: path.basename(process.cwd()),
       devToken: process.env.HYPEQUERY_DEV_TOKEN,
+      telemetryDisabled,
     })) as any;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -124,7 +132,9 @@ export async function devCommand(file?: string, options: DevOptions = {}) {
 
       // The query UI is experimental and strictly opt-in; the default dev
       // server is unchanged.
-      const gateway = options.uiExperimental ? await createGatewayIfAvailable(api) : null;
+      const gateway = options.uiExperimental
+        ? await createGatewayIfAvailable(api, options.telemetry === false)
+        : null;
       currentGateway = gateway;
 
       // Start the server

--- a/packages/gateway/src/api/router.ts
+++ b/packages/gateway/src/api/router.ts
@@ -11,6 +11,8 @@ import { getQueries, getQuery } from './query-endpoints.js';
 import { clearHistory, exportHistory, importHistory } from './history-endpoints.js';
 import { getLoggerStats } from './logger-endpoints.js';
 import { getCacheStats, clearCache } from './cache-endpoints.js';
+import { postTelemetry, getTelemetryStatus } from './telemetry-endpoints.js';
+import type { Telemetry } from '../telemetry.js';
 
 /**
  * Options for the dev API router.
@@ -28,6 +30,8 @@ export interface RouterOptions {
   capabilities: GatewayCapability[];
   /** Project name surfaced in /meta. */
   projectName?: string;
+  /** Anonymous usage telemetry (no-op unless enabled). */
+  telemetry?: Telemetry;
   /**
    * Cross-origin allowlist. Empty by default — the studio is served
    * same-origin, so no CORS headers are emitted and the wildcard `*` is
@@ -86,6 +90,7 @@ export class DevAPIRouter {
       api: this.options.api,
       capabilities: this.options.capabilities,
       projectName: this.options.projectName,
+      telemetry: this.options.telemetry,
       sseHandler: this.sseHandler,
       req,
       res
@@ -114,18 +119,21 @@ export class DevAPIRouter {
 
     // Registry
     if (path === '/__dev/registry' && method === 'GET') {
+      this.options.telemetry?.track('registry_viewed');
       await getRegistry(ctx);
       return true;
     }
 
     // Execute
     if (path === '/__dev/execute' && method === 'POST') {
+      this.options.telemetry?.track('playground_execute_requested');
       await execute(ctx);
       return true;
     }
 
     // SSE — no Last-Event-ID replay in v0 (clients refetch history on reconnect)
     if (path === '/__dev/events' && method === 'GET') {
+      this.options.telemetry?.track('sse_connected', { clients: this.sseHandler.clientCount + 1 });
       this.sseHandler.addClient(res);
       return true;
     }
@@ -151,7 +159,18 @@ export class DevAPIRouter {
       return true;
     }
     if (path === '/__dev/history' && method === 'DELETE') {
+      this.options.telemetry?.track('history_cleared');
       await clearHistory(ctx);
+      return true;
+    }
+
+    // Telemetry beacon (UI events) + transparency
+    if (path === '/__dev/telemetry' && method === 'POST') {
+      await postTelemetry(ctx);
+      return true;
+    }
+    if (path === '/__dev/telemetry' && method === 'GET') {
+      await getTelemetryStatus(ctx);
       return true;
     }
 

--- a/packages/gateway/src/api/telemetry-endpoints.ts
+++ b/packages/gateway/src/api/telemetry-endpoints.ts
@@ -4,6 +4,7 @@ import { UI_EVENT_ALLOWLIST } from '../telemetry.js';
 
 const MAX_EVENTS_PER_BATCH = 20;
 const MAX_PROP_ENTRIES = 10;
+const MAX_PROP_KEY_LENGTH = 64;
 
 interface BeaconBody {
   events?: Array<{ name?: unknown; props?: unknown }>;
@@ -16,11 +17,12 @@ function sanitizeProps(props: unknown): Record<string, string | number | boolean
   let count = 0;
   for (const [key, value] of Object.entries(props)) {
     if (count >= MAX_PROP_ENTRIES) break;
+    const safeKey = key.slice(0, MAX_PROP_KEY_LENGTH);
     if (typeof value === 'string') {
-      out[key] = value.slice(0, 100);
+      out[safeKey] = value.slice(0, 100);
       count++;
     } else if (typeof value === 'number' || typeof value === 'boolean') {
-      out[key] = value;
+      out[safeKey] = value;
       count++;
     }
   }

--- a/packages/gateway/src/api/telemetry-endpoints.ts
+++ b/packages/gateway/src/api/telemetry-endpoints.ts
@@ -1,0 +1,69 @@
+import type { EndpointContext } from './types.js';
+import { parseBody, sendJSON, sendError } from './helpers.js';
+import { UI_EVENT_ALLOWLIST } from '../telemetry.js';
+
+const MAX_EVENTS_PER_BATCH = 20;
+const MAX_PROP_ENTRIES = 10;
+
+interface BeaconBody {
+  events?: Array<{ name?: unknown; props?: unknown }>;
+}
+
+/** Keep only shallow primitive props, capped, so the UI can never smuggle payloads. */
+function sanitizeProps(props: unknown): Record<string, string | number | boolean> | undefined {
+  if (!props || typeof props !== 'object' || Array.isArray(props)) return undefined;
+  const out: Record<string, string | number | boolean> = {};
+  let count = 0;
+  for (const [key, value] of Object.entries(props)) {
+    if (count >= MAX_PROP_ENTRIES) break;
+    if (typeof value === 'string') {
+      out[key] = value.slice(0, 100);
+      count++;
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      out[key] = value;
+      count++;
+    }
+  }
+  return count > 0 ? out : undefined;
+}
+
+/**
+ * POST /__dev/telemetry
+ * Beacon for UI usage events. The browser only ever talks to the gateway
+ * (same-origin); the gateway forwards allowlisted events through the same
+ * anonymous pipeline as server events. 204 always — including when telemetry
+ * is disabled — so the UI needs no telemetry-awareness.
+ */
+export async function postTelemetry(ctx: EndpointContext): Promise<void> {
+  try {
+    const body = (await parseBody(ctx.req)) as BeaconBody;
+    const events = Array.isArray(body?.events) ? body.events.slice(0, MAX_EVENTS_PER_BATCH) : [];
+
+    if (ctx.telemetry) {
+      for (const event of events) {
+        if (typeof event?.name === 'string' && UI_EVENT_ALLOWLIST.has(event.name)) {
+          ctx.telemetry.track(`ui_${event.name}`, sanitizeProps(event.props));
+        }
+      }
+    }
+
+    ctx.res.writeHead(204);
+    ctx.res.end();
+  } catch (error) {
+    // Malformed beacon bodies are the client's problem, not the server log's.
+    sendError(ctx.res, (error as Error).message, 400);
+  }
+}
+
+/**
+ * GET /__dev/telemetry
+ * Transparency endpoint: report whether telemetry is enabled so the UI (and
+ * curious users) can see the state.
+ */
+export async function getTelemetryStatus(ctx: EndpointContext): Promise<void> {
+  sendJSON(ctx.res, {
+    enabled: ctx.telemetry?.enabled ?? false,
+    optOut: ['hypequery dev --no-telemetry', 'HYPEQUERY_TELEMETRY_DISABLED=1', 'DO_NOT_TRACK=1'],
+    docs: 'https://hypequery.com/telemetry'
+  });
+}

--- a/packages/gateway/src/api/types.ts
+++ b/packages/gateway/src/api/types.ts
@@ -3,6 +3,7 @@ import type { QueryHistoryStore } from '../storage/types.js';
 import type { DevQueryLogger } from '../query-logger.js';
 import type { SSEHandler } from './sse-handler.js';
 import type { CacheObservability, DevIntegrationApi, GatewayCapability } from '../types.js';
+import type { Telemetry } from '../telemetry.js';
 
 /**
  * Context passed to endpoint handlers.
@@ -21,6 +22,8 @@ export interface EndpointContext {
   capabilities: GatewayCapability[];
   /** Project name surfaced in /meta. */
   projectName?: string;
+  /** Anonymous usage telemetry (no-op unless enabled). */
+  telemetry?: Telemetry;
 }
 
 /**

--- a/packages/gateway/src/dev-handler.ts
+++ b/packages/gateway/src/dev-handler.ts
@@ -52,10 +52,12 @@ export class DevHandler {
   private router: DevAPIRouter;
   private apiBasePath: string;
   private distDir: string | null;
+  private telemetry?: DevHandlerOptions['telemetry'];
 
   constructor(options: DevHandlerOptions) {
     this.apiBasePath = options.apiBasePath ?? '/__dev';
     this.distDir = resolveStudioDist();
+    this.telemetry = options.telemetry;
     this.router = new DevAPIRouter(options);
   }
 
@@ -93,12 +95,15 @@ export class DevHandler {
 
   private async serveHTML(res: ServerResponse): Promise<boolean> {
     if (!this.distDir) {
+      this.telemetry?.track('ui_missing');
       res.writeHead(503, { 'Content-Type': 'text/plain; charset=utf-8' });
       res.end('hypequery studio UI is not installed. Install @hypequery/studio to enable Studio.');
       return true;
     }
     try {
       const html = await readFile(path.join(this.distDir, 'index.html'), 'utf-8');
+      // Funnel step 2: someone actually opened the playground in a browser.
+      this.telemetry?.track('ui_served');
       res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' });
       res.end(html);
     } catch {

--- a/packages/gateway/src/gateway.test.ts
+++ b/packages/gateway/src/gateway.test.ts
@@ -130,3 +130,43 @@ describe('createGateway authentication', () => {
     expect(response.headers['Access-Control-Allow-Origin']).toBe('https://studio.example');
   });
 });
+
+/** DevIntegrationApi stub whose cache layer optionally supports clearing. */
+function makeCapabilityApi(clearSupported: boolean): DevIntegrationApi {
+  return {
+    queryLogger: { on: () => () => {} } as DevIntegrationApi['queryLogger'],
+    describe: () => ({ queries: [] }),
+    execute: async () => null,
+    cacheObservability: {
+      getStats: async () =>
+        clearSupported
+          ? [{ layer: 'semantic' as const, stats: {}, clearSupported: true }]
+          : [],
+      clear: async () => ({ cleared: [] })
+    }
+  } as DevIntegrationApi;
+}
+
+describe('createGateway capabilities', () => {
+  it('always advertises telemetry — the endpoints are always mounted', async () => {
+    const gateway = await createGateway(makeCapabilityApi(false), {
+      storage: { forceMemory: true, silent: true }
+    });
+
+    expect(gateway.capabilities).toContain('telemetry');
+    expect(gateway.capabilities).toEqual(
+      expect.arrayContaining(['registry', 'execute', 'history', 'events', 'cache'])
+    );
+    expect(gateway.capabilities).not.toContain('cache:clear');
+    await gateway.shutdown();
+  });
+
+  it('advertises cache:clear only when a layer supports clearing', async () => {
+    const gateway = await createGateway(makeCapabilityApi(true), {
+      storage: { forceMemory: true, silent: true }
+    });
+
+    expect(gateway.capabilities).toContain('cache:clear');
+    await gateway.shutdown();
+  });
+});

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -4,6 +4,7 @@ import type { DevIntegrationApi, GatewayCapability } from './types.js';
 import { createStore, type StorageOptions } from './storage/index.js';
 import { DevQueryLogger } from './query-logger.js';
 import { DevHandler } from './dev-handler.js';
+import { Telemetry, anonymize, durationBucket } from './telemetry.js';
 
 export interface CreateGatewayOptions {
   /** Storage configuration for query history. */
@@ -20,6 +21,11 @@ export interface CreateGatewayOptions {
    * an HttpOnly dev session by opening `/__dev?token=<devToken>`.
    */
   devToken?: string;
+  /**
+   * Hard-disable anonymous usage telemetry regardless of endpoint/env signals.
+   * Wired to `hypequery dev --no-telemetry`.
+   */
+  telemetryDisabled?: boolean;
 }
 
 export interface Gateway {
@@ -91,9 +97,27 @@ export async function createGateway(
   // sub-capability the UI checks before rendering clear affordances —
   // advertised only when a wired layer reports clearSupported. By gateway
   // creation time the serve API is fully built, so this snapshot is accurate.
-  const capabilities: GatewayCapability[] = ['registry', 'execute', 'history', 'events', 'cache'];
+  // `telemetry` is advertised unconditionally because this gateway always
+  // mounts the endpoints: GET /telemetry reports the effective enabled state
+  // for transparency, and POST accepts-and-discards when disabled. Per the
+  // contract, the capability signals endpoint support (not enabled state),
+  // and the UI must not beacon without it.
+  const capabilities: GatewayCapability[] = [
+    'registry',
+    'execute',
+    'history',
+    'events',
+    'cache',
+    'telemetry'
+  ];
   const cacheLayers = await api.cacheObservability.getStats();
   if (cacheLayers.some((layer) => layer.clearSupported)) capabilities.push('cache:clear');
+
+  const telemetry = new Telemetry({
+    projectDir: process.cwd(),
+    disabled: options.telemetryDisabled
+  });
+  await telemetry.initialize();
 
   const handler = new DevHandler({
     store,
@@ -102,11 +126,33 @@ export async function createGateway(
     api,
     capabilities,
     projectName: options.projectName,
-    allowedOrigins: options.allowedOrigins
+    allowedOrigins: options.allowedOrigins,
+    telemetry
   });
 
   // Stream persisted query events to connected SSE clients.
   logger.onEvent((event) => handler.getSSEHandler().broadcastQueryEvent(event));
+
+  // Funnel step 1: the dev server + gateway came up.
+  telemetry.track('gateway_started', {
+    capabilities: capabilities.join(','),
+    uiAvailable: handler.uiAvailable,
+    endpointCount: description.queries.length
+  });
+
+  // Aggregate query activity from the serve layer (names hashed, no SQL).
+  logger.onEvent((event) => {
+    if (event.type === 'query:completed' || event.type === 'query:error') {
+      // endpointKey is set by DevQueryLogger at runtime but not surfaced in
+      // the QueryLog type; read it defensively.
+      const endpointKey = (event.data as { endpointKey?: string }).endpointKey;
+      telemetry.track('endpoint_executed', {
+        ok: event.type === 'query:completed',
+        endpointHash: endpointKey ? anonymize(endpointKey) : 'unknown',
+        durationBucket: durationBucket(event.data.duration ?? 0)
+      });
+    }
+  });
 
   const devToken = options.devToken;
   const browserSession = devToken ? randomBytes(32).toString('base64url') : undefined;
@@ -163,6 +209,7 @@ export async function createGateway(
     async shutdown() {
       await logger.shutdown();
       handler.shutdown();
+      await telemetry.shutdown();
       await store.close();
     }
   };

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -13,6 +13,10 @@ export type { Gateway, CreateGatewayOptions } from './gateway.js';
 export { CONTRACT_VERSION } from './api/meta-endpoints.js';
 export type { GatewayCapability, CacheObservability, CacheStatsSnapshot, DevIntegrationApi } from './types.js';
 
+// Telemetry (anonymous, opt-out; see design doc privacy rules)
+export { Telemetry, anonymize, durationBucket, UI_EVENT_ALLOWLIST } from './telemetry.js';
+export type { TelemetryEvent, TelemetryOptions } from './telemetry.js';
+
 // Storage
 export * from './storage/index.js';
 

--- a/packages/gateway/src/telemetry.test.ts
+++ b/packages/gateway/src/telemetry.test.ts
@@ -123,6 +123,17 @@ describe('Telemetry', () => {
     await expect(t.flush()).resolves.toBeUndefined();
   });
 
+  it('shutdown does not block on a slow or unreachable ingest endpoint', async () => {
+    const fetchFn = vi.fn(() => new Promise<Response>(() => {})); // never resolves
+    const t = makeTelemetry({ endpoint: ENDPOINT, fetchFn: fetchFn as unknown as typeof fetch });
+    t.track('gateway_started');
+
+    const start = Date.now();
+    await t.shutdown();
+    // Bounded by the shutdown deadline (1s), well under the network timeout (3s).
+    expect(Date.now() - start).toBeLessThan(1500);
+  });
+
   it('anonymize produces a stable 12-char hash', () => {
     expect(anonymize('myQuery')).toBe(anonymize('myQuery'));
     expect(anonymize('myQuery')).toMatch(/^[0-9a-f]{12}$/);

--- a/packages/gateway/src/telemetry.test.ts
+++ b/packages/gateway/src/telemetry.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Telemetry, anonymize, durationBucket, UI_EVENT_ALLOWLIST, type TelemetryOptions } from './telemetry.js';
+
+const ENDPOINT = 'http://127.0.0.1:9/ingest';
+
+function makeFetch() {
+  return vi.fn(async () => new Response(null, { status: 204 }));
+}
+
+describe('Telemetry', () => {
+  const envKeys = ['HYPEQUERY_TELEMETRY_DISABLED', 'DO_NOT_TRACK', 'CI', 'HYPEQUERY_TELEMETRY_ENDPOINT'] as const;
+  const saved: Record<string, string | undefined> = {};
+  let stateDir: string;
+
+  // Keep tests hermetic: never touch the real ~/.hypequery state file and never
+  // print the one-time disclosure to the test output.
+  function makeTelemetry(options: TelemetryOptions = {}): Telemetry {
+    return new Telemetry({
+      logger: () => {},
+      stateFile: join(stateDir, 'telemetry.json'),
+      ...options,
+    });
+  }
+
+  beforeEach(() => {
+    for (const k of envKeys) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    stateDir = mkdtempSync(join(tmpdir(), 'hq-telemetry-'));
+  });
+
+  afterEach(() => {
+    for (const k of envKeys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it('is disabled when no endpoint is configured', () => {
+    const t = makeTelemetry({ fetchFn: makeFetch() });
+    expect(t.enabled).toBe(false);
+  });
+
+  it('is enabled with an endpoint and no opt-out signals', () => {
+    const t = makeTelemetry({ endpoint: ENDPOINT, fetchFn: makeFetch() });
+    expect(t.enabled).toBe(true);
+  });
+
+  it.each([
+    ['HYPEQUERY_TELEMETRY_DISABLED'],
+    ['DO_NOT_TRACK'],
+    ['CI'],
+  ])('kill switch: %s=1 disables telemetry', (key) => {
+    process.env[key] = '1';
+    const t = makeTelemetry({ endpoint: ENDPOINT, fetchFn: makeFetch() });
+    expect(t.enabled).toBe(false);
+  });
+
+  it('disabled option hard-overrides a configured endpoint (--no-telemetry)', async () => {
+    const fetchFn = makeFetch();
+    const t = makeTelemetry({ endpoint: ENDPOINT, disabled: true, fetchFn });
+    expect(t.enabled).toBe(false);
+    t.track('gateway_started');
+    await t.flush();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('track + flush posts a batch with anonymous ids only', async () => {
+    const fetchFn = makeFetch();
+    const t = makeTelemetry({ endpoint: ENDPOINT, fetchFn, projectDir: '/Users/someone/secret-project' });
+    t.track('gateway_started', { capabilities: 'registry,execute' });
+    await t.flush();
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((fetchFn.mock.calls[0] as any)[1].body as string);
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].name).toBe('gateway_started');
+    // Project path must never appear anywhere in the payload
+    expect(JSON.stringify(body)).not.toContain('secret-project');
+    expect(body.projectId).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  it('lazily initializes so tracked events carry a real anonymous id', async () => {
+    const fetchFn = makeFetch();
+    // No explicit initialize() — track() must kick it off itself.
+    const t = makeTelemetry({ endpoint: ENDPOINT, fetchFn });
+    t.track('gateway_started');
+    // Let the lazy initialize() settle before flushing.
+    await t.initialize();
+    await t.flush();
+
+    const body = JSON.parse((fetchFn.mock.calls[0] as any)[1].body as string);
+    expect(body.anonymousId).not.toBe('uninitialized');
+    expect(body.anonymousId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('initialize is idempotent under concurrent calls', async () => {
+    const t = makeTelemetry({ endpoint: ENDPOINT, fetchFn: makeFetch() });
+    await Promise.all([t.initialize(), t.initialize(), t.initialize()]);
+    // A repeat after resolution is still a no-op (state already loaded).
+    await expect(t.initialize()).resolves.toBeUndefined();
+  });
+
+  it('tracks nothing when disabled', async () => {
+    const fetchFn = makeFetch();
+    const t = makeTelemetry({ fetchFn }); // no endpoint
+    t.track('gateway_started');
+    await t.flush();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('swallows network failures', async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    const t = makeTelemetry({ endpoint: ENDPOINT, fetchFn: fetchFn as unknown as typeof fetch });
+    t.track('gateway_started');
+    await expect(t.flush()).resolves.toBeUndefined();
+  });
+
+  it('anonymize produces a stable 12-char hash', () => {
+    expect(anonymize('myQuery')).toBe(anonymize('myQuery'));
+    expect(anonymize('myQuery')).toMatch(/^[0-9a-f]{12}$/);
+    expect(anonymize('myQuery')).not.toContain('myQuery');
+  });
+
+  it('durationBucket never leaks exact timings', () => {
+    expect(durationBucket(3)).toBe('<50ms');
+    expect(durationBucket(999)).toBe('<1s');
+    expect(durationBucket(120_000)).toBe('>=30s');
+  });
+
+  it('UI allowlist stays free of anything payload-shaped', () => {
+    for (const name of UI_EVENT_ALLOWLIST) {
+      expect(name).toMatch(/^[a-z_]+$/);
+    }
+  });
+});

--- a/packages/gateway/src/telemetry.ts
+++ b/packages/gateway/src/telemetry.ts
@@ -28,6 +28,7 @@ const STATE_FILE = path.join(homedir(), '.hypequery', 'telemetry.json');
 const FLUSH_INTERVAL_MS = 5_000;
 const FLUSH_BATCH_SIZE = 20;
 const REQUEST_TIMEOUT_MS = 3_000;
+const SHUTDOWN_TIMEOUT_MS = 1_000;
 
 /**
  * UI events accepted through the /__dev/telemetry beacon (allowlist).
@@ -220,9 +221,21 @@ export class Telemetry {
     await send;
   }
 
-  /** Flush remaining events and stop timers. */
+  /**
+   * Flush remaining events and stop timers. Races the flush against a short
+   * deadline so a slow or unreachable ingest endpoint never delays process
+   * exit — telemetry is fire-and-forget, including on shutdown. Any send
+   * still in flight when the deadline hits keeps running in the background;
+   * its errors are already swallowed by `flush`.
+   */
   async shutdown(): Promise<void> {
-    await this.flush();
-    await Promise.allSettled([...this.pendingSends]);
+    const flushed = this.flush().then(() => Promise.allSettled([...this.pendingSends]));
+    await Promise.race([
+      flushed,
+      new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, SHUTDOWN_TIMEOUT_MS);
+        timer.unref?.();
+      }),
+    ]);
   }
 }

--- a/packages/gateway/src/telemetry.ts
+++ b/packages/gateway/src/telemetry.ts
@@ -1,0 +1,228 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Anonymous usage telemetry for the hypequery playground.
+ *
+ * Privacy rules (enforced here, documented in plans/dev-playground-design.md):
+ * - NEVER captures SQL, query/endpoint names (hashed only), inputs, results,
+ *   hostnames, file paths, or credentials.
+ * - Anonymous machine id (random UUID) + hashed project id; no PII.
+ * - Loud one-time disclosure on first enabled run.
+ * - Opt-out: `hypequery dev --no-telemetry`, HYPEQUERY_TELEMETRY_DISABLED=1, or
+ *   DO_NOT_TRACK=1; auto-disabled in CI; entirely inert until an ingest
+ *   endpoint is configured.
+ * - Fire-and-forget: batched, 3s timeout, all failures swallowed. Telemetry
+ *   must never slow down or break the dev server.
+ */
+
+/**
+ * Ingest endpoint for telemetry events. Empty string = telemetry is a no-op.
+ * Overridable via HYPEQUERY_TELEMETRY_ENDPOINT (useful for self-hosting).
+ */
+const DEFAULT_ENDPOINT = '';
+
+const STATE_FILE = path.join(homedir(), '.hypequery', 'telemetry.json');
+const FLUSH_INTERVAL_MS = 5_000;
+const FLUSH_BATCH_SIZE = 20;
+const REQUEST_TIMEOUT_MS = 3_000;
+
+/**
+ * UI events accepted through the /__dev/telemetry beacon (allowlist).
+ * Keep this in lockstep with the events the studio actually fires — anything
+ * absent is silently dropped by the gateway. Add a name only when a matching
+ * `track(...)` call ships in the UI, not speculatively.
+ */
+export const UI_EVENT_ALLOWLIST = new Set([
+  'screen_viewed',
+  'sql_viewed',
+  'search_used',
+  'execute_clicked',
+  'history_cleared_clicked',
+]);
+
+export interface TelemetryEvent {
+  name: string;
+  props?: Record<string, string | number | boolean>;
+}
+
+interface TelemetryState {
+  anonymousId: string;
+  notifiedAt?: string;
+}
+
+export interface TelemetryOptions {
+  /** Project directory used to derive the hashed project id. */
+  projectDir?: string;
+  /** Logger used for the one-time disclosure notice. */
+  logger?: (message: string) => void;
+  /** Override the ingest endpoint (tests). */
+  endpoint?: string;
+  /** Override fetch (tests). */
+  fetchFn?: typeof fetch;
+  /** Override the anonymous-id state file location (tests / self-hosting). */
+  stateFile?: string;
+  /**
+   * Hard opt-out that overrides every enabling signal, including a configured
+   * endpoint. Wired to `hypequery dev --no-telemetry`.
+   */
+  disabled?: boolean;
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  return value === '1' || value === 'true' || value === 'yes';
+}
+
+/** Stable short hash for values we want to count but never read. */
+export function anonymize(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+/** Bucket a duration so we never ship exact timings. */
+export function durationBucket(ms: number): string {
+  if (ms < 50) return '<50ms';
+  if (ms < 250) return '<250ms';
+  if (ms < 1_000) return '<1s';
+  if (ms < 5_000) return '<5s';
+  if (ms < 30_000) return '<30s';
+  return '>=30s';
+}
+
+export class Telemetry {
+  private queue: Array<TelemetryEvent & { timestamp: number }> = [];
+  private flushTimer: NodeJS.Timeout | null = null;
+  private state: TelemetryState | null = null;
+  private projectId: string;
+  private readonly endpoint: string;
+  private readonly fetchFn: typeof fetch;
+  private readonly logger: (message: string) => void;
+  private readonly forceDisabled: boolean;
+  private readonly stateFile: string;
+  private pendingSends: Set<Promise<void>> = new Set();
+  private initPromise: Promise<void> | null = null;
+
+  constructor(options: TelemetryOptions = {}) {
+    this.endpoint =
+      options.endpoint ??
+      process.env.HYPEQUERY_TELEMETRY_ENDPOINT ??
+      DEFAULT_ENDPOINT;
+    this.fetchFn = options.fetchFn ?? fetch;
+    this.logger = options.logger ?? ((message) => console.log(message));
+    this.projectId = anonymize(options.projectDir ?? process.cwd());
+    this.forceDisabled = options.disabled ?? false;
+    this.stateFile = options.stateFile ?? STATE_FILE;
+  }
+
+  /** Telemetry is enabled only with an endpoint and no opt-out signals. */
+  get enabled(): boolean {
+    if (this.forceDisabled) return false;
+    if (!this.endpoint) return false;
+    if (isTruthyEnv(process.env.HYPEQUERY_TELEMETRY_DISABLED)) return false;
+    if (isTruthyEnv(process.env.DO_NOT_TRACK)) return false;
+    if (isTruthyEnv(process.env.CI)) return false;
+    return true;
+  }
+
+  /**
+   * Load (or create) the anonymous id and print the one-time disclosure.
+   * Safe to call when disabled — it is then a no-op — and idempotent: repeated
+   * or concurrent calls resolve the same one-time load.
+   */
+  async initialize(): Promise<void> {
+    if (!this.enabled || this.state) return;
+    this.initPromise ??= this.loadState();
+    return this.initPromise;
+  }
+
+  private async loadState(): Promise<void> {
+    try {
+      const raw = await readFile(this.stateFile, 'utf-8');
+      this.state = JSON.parse(raw) as TelemetryState;
+    } catch {
+      this.state = { anonymousId: randomUUID() };
+    }
+
+    if (!this.state.notifiedAt) {
+      this.logger(
+        '[hypequery] Anonymous usage telemetry helps improve the playground. ' +
+          'No queries, schemas, or data are ever collected. ' +
+          'Opt out any time: HYPEQUERY_TELEMETRY_DISABLED=1 ' +
+          '(details: https://hypequery.com/telemetry)'
+      );
+      this.state.notifiedAt = new Date().toISOString();
+    }
+
+    try {
+      await mkdir(path.dirname(this.stateFile), { recursive: true });
+      await writeFile(this.stateFile, JSON.stringify(this.state, null, 2));
+    } catch {
+      // Non-fatal: id will be regenerated next run.
+    }
+  }
+
+  /** Record an event. No-op when disabled. */
+  track(name: string, props?: TelemetryEvent['props']): void {
+    if (!this.enabled) return;
+    // Safety net: if a caller tracks before initialize(), kick it off now so
+    // the anonymous id is loaded and the disclosure prints before the flush.
+    if (!this.state) void this.initialize();
+    this.queue.push({ name, props, timestamp: Date.now() });
+    if (this.queue.length >= FLUSH_BATCH_SIZE) {
+      void this.flush();
+    } else {
+      this.scheduleFlush();
+    }
+  }
+
+  private scheduleFlush(): void {
+    if (this.flushTimer) return;
+    this.flushTimer = setTimeout(() => {
+      void this.flush();
+    }, FLUSH_INTERVAL_MS);
+    this.flushTimer.unref?.();
+  }
+
+  /** Send queued events. All failures are swallowed. */
+  async flush(): Promise<void> {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    if (!this.enabled || this.queue.length === 0) return;
+
+    const events = this.queue.splice(0, this.queue.length);
+    const body = JSON.stringify({
+      anonymousId: this.state?.anonymousId ?? 'uninitialized',
+      projectId: this.projectId,
+      context: {
+        nodeMajor: Number(process.versions.node.split('.')[0]),
+        platform: process.platform,
+      },
+      events,
+    });
+
+    const send = (async () => {
+      try {
+        await this.fetchFn(this.endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body,
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        });
+      } catch {
+        // Telemetry must never surface errors.
+      }
+    })();
+    this.pendingSends.add(send);
+    void send.finally(() => this.pendingSends.delete(send));
+    await send;
+  }
+
+  /** Flush remaining events and stop timers. */
+  async shutdown(): Promise<void> {
+    await this.flush();
+    await Promise.allSettled([...this.pendingSends]);
+  }
+}

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -14,7 +14,8 @@ export type GatewayCapability =
   | 'cache'
   | 'cache:clear'
   | 'schema'
-  | 'ai';
+  | 'ai'
+  | 'telemetry';
 
 /**
  * Per-layer cache stats/clear, provided by serve's `DevIntegrationApi`

--- a/packages/studio/src/components/QueryHistory.tsx
+++ b/packages/studio/src/components/QueryHistory.tsx
@@ -34,13 +34,16 @@ export function QueryHistory({ className }: QueryHistoryProps) {
     track('screen_viewed', { screen: 'runs' }, { once: true });
   }, []);
 
+  useEffect(() => {
+    if (debouncedSearch) {
+      track('search_used', undefined, { once: true });
+    }
+  }, [debouncedSearch]);
+
   // Build API filters from filter state
   const apiFilters: QueryFilters = useMemo(() => {
     const f: QueryFilters = { limit: 100 };
-    if (debouncedSearch) {
-      f.search = debouncedSearch;
-      track('search_used', undefined, { once: true });
-    }
+    if (debouncedSearch) f.search = debouncedSearch;
     return f;
   }, [debouncedSearch]);
 

--- a/packages/studio/src/components/QueryHistory.tsx
+++ b/packages/studio/src/components/QueryHistory.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Search, Trash2, RefreshCw } from 'lucide-react';
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import { cn } from '@/lib/utils';
@@ -11,6 +11,7 @@ import type { QueryFilters } from '@/lib/types';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { Tooltip } from './ui/tooltip';
+import { track } from '@/lib/telemetry';
 
 interface QueryHistoryProps {
   className?: string;
@@ -29,10 +30,17 @@ export function QueryHistory({ className }: QueryHistoryProps) {
   // stays bound to `search` for immediate feedback.
   const debouncedSearch = useDebouncedValue(search, 300);
 
+  useEffect(() => {
+    track('screen_viewed', { screen: 'runs' }, { once: true });
+  }, []);
+
   // Build API filters from filter state
   const apiFilters: QueryFilters = useMemo(() => {
     const f: QueryFilters = { limit: 100 };
-    if (debouncedSearch) f.search = debouncedSearch;
+    if (debouncedSearch) {
+      f.search = debouncedSearch;
+      track('search_used', undefined, { once: true });
+    }
     return f;
   }, [debouncedSearch]);
 
@@ -90,6 +98,7 @@ export function QueryHistory({ className }: QueryHistoryProps) {
             size="sm"
             aria-label="Clear history"
             onClick={() => {
+              track('history_cleared_clicked');
               if (confirm('Clear all query history?')) {
                 clearHistory();
               }

--- a/packages/studio/src/components/SQLViewer.tsx
+++ b/packages/studio/src/components/SQLViewer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useMemo } from 'react';
+import { track } from '@/lib/telemetry';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-sql';
 import { format as formatSQL } from 'sql-formatter';
@@ -45,6 +46,10 @@ export function SQLViewer({
       Prism.highlightElement(codeRef.current);
     }
   }, [formattedSQL]);
+
+  useEffect(() => {
+    track('sql_viewed', undefined, { once: true });
+  }, []);
 
   // Split into lines for line numbers
   const lines = formattedSQL.split('\n');

--- a/packages/studio/src/lib/api-client.ts
+++ b/packages/studio/src/lib/api-client.ts
@@ -25,6 +25,11 @@ export function gatewayEventsUrl(): string {
   return `${BASE_URL}/events`;
 }
 
+/** The telemetry beacon endpoint for the configured gateway. */
+export function gatewayTelemetryUrl(): string {
+  return `${BASE_URL}/telemetry`;
+}
+
 /**
  * API client error.
  */

--- a/packages/studio/src/lib/telemetry.ts
+++ b/packages/studio/src/lib/telemetry.ts
@@ -1,0 +1,54 @@
+import { apiClient, gatewayTelemetryUrl } from './api-client';
+
+/**
+ * UI-side usage beacon. Events go same-origin to the gateway
+ * (POST {gateway}/telemetry), which validates them against an allowlist and
+ * forwards through its anonymous pipeline — the browser never talks to any
+ * third party, and everything is a no-op when the gateway has telemetry
+ * disabled. Fire-and-forget: failures are swallowed.
+ *
+ * The contract requires the UI not to beacon unless the gateway advertises
+ * the `telemetry` capability (Cloud gateways omit it). The capability is
+ * resolved from GET /meta once and cached; events fired before it resolves
+ * are held briefly and dropped if the gateway turns out not to support it.
+ */
+
+const onceSent = new Set<string>();
+
+let telemetrySupported: Promise<boolean> | null = null;
+
+function isTelemetrySupported(): Promise<boolean> {
+  telemetrySupported ??= apiClient
+    .getMeta()
+    .then((meta) => meta.capabilities.includes('telemetry'))
+    .catch(() => false);
+  return telemetrySupported;
+}
+
+export function track(
+  name: string,
+  props?: Record<string, string | number | boolean>,
+  options?: { once?: boolean }
+): void {
+  if (options?.once) {
+    const key = `${name}:${JSON.stringify(props ?? {})}`;
+    if (onceSent.has(key)) return;
+    onceSent.add(key);
+  }
+
+  try {
+    void isTelemetrySupported()
+      .then((supported) => {
+        if (!supported) return;
+        return fetch(gatewayTelemetryUrl(), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ events: [{ name, props }] }),
+          keepalive: true,
+        });
+      })
+      .catch(() => {});
+  } catch {
+    // Telemetry must never break the UI.
+  }
+}

--- a/packages/studio/src/lib/types.ts
+++ b/packages/studio/src/lib/types.ts
@@ -123,7 +123,11 @@ export interface SSEEvent<T = unknown> {
   id?: string;
 }
 
-/** Capability strings advertised by the gateway via /meta. */
+/**
+ * Capability strings advertised by the gateway via /meta. The UI must
+ * tolerate unknown strings (contract is additive within 0.x), so treat this
+ * union as the known set, not an exhaustive one.
+ */
 export type GatewayCapability =
   | 'registry'
   | 'execute'
@@ -132,7 +136,8 @@ export type GatewayCapability =
   | 'cache'
   | 'cache:clear'
   | 'schema'
-  | 'ai';
+  | 'ai'
+  | 'telemetry';
 
 /** Response of GET /meta. */
 export interface GatewayMeta {


### PR DESCRIPTION
## What

Adds anonymous, **opt-out** usage telemetry to the experimental playground gateway (`@hypequery/gateway`), its studio UI, and the `hypequery dev` CLI.

This is a **re-home** of the telemetry work that previously lived on the stale `playground/telemetry` branch (written against the abandoned `@hypequery/playground` package name). Main already landed the gateway/studio/CLI under `@hypequery/gateway`, so only the telemetry delta is applied here — surgically, on top of main's newer gateway (which includes the HttpOnly dev-session security the old branch predated).

## Privacy model

- Anonymous machine UUID + sha256-hashed project id; endpoint names hashed; durations bucketed.
- **Never** captures SQL, query/endpoint names, inputs, results, hostnames, paths, or credentials.
- Entirely inert until an ingest endpoint is configured (`HYPEQUERY_TELEMETRY_ENDPOINT` / `DEFAULT_ENDPOINT`) — currently empty, so this ships dormant.
- Loud one-time disclosure on first enabled run; `GET /__dev/telemetry` reports state for transparency.
- Fire-and-forget: batched, 3s timeout, all failures swallowed.

## Opt-out

- `hypequery dev --no-telemetry` (hard override, beats endpoint/env)
- `HYPEQUERY_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=1`
- Auto-disabled in CI
- Cloud gateways omit the `telemetry` capability, so the UI never beacons there

## Events

- **Server:** `gateway_started`, `ui_served`, `ui_missing`, `registry_viewed`, `playground_execute_requested`, `endpoint_executed` (hashed key + duration bucket), `sse_connected`, `history_cleared`
- **UI:** allowlist-validated, prop-sanitized same-origin beacons to `POST /__dev/telemetry` (`screen_viewed`, `sql_viewed`, `search_used`, `execute_clicked`, `history_cleared_clicked`). The browser never talks to third parties.

## Tests

- `@hypequery/gateway`: 148 passing (incl. telemetry kill-switches, no-op-without-endpoint, payload-never-contains-path, capability advertisement)
- `@hypequery/cli` dev: 31 passing (incl. `--no-telemetry` threading)
- `@hypequery/studio`: typecheck + build clean

## Follow-up (not in this PR)

- `hypequery.com/telemetry` docs page must exist before any ingest endpoint is configured (referenced by the disclosure + status endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)