### PR TITLE
feat(studio): interactive query playground — run queries against datasets

### DIFF
--- a/.changeset/studio-query-playground.md
+++ b/.changeset/studio-query-playground.md
@@ -1,0 +1,8 @@
+---
+'@hypequery/studio': minor
+'@hypequery/gateway': patch
+---
+
+Add an interactive query playground to the studio (the default **Playground** tab; Runs moves beside it). Pick a dataset from the registry, toggle dimension/measure chips, build filter rows (field/operator/value; `in`/`notIn` accept comma-separated lists; numbers and booleans are coerced), set a limit, and run — the query goes through the real serve `/execute` pipeline (auth/tenant/validation included) and renders as a result table with duration and row-count badges. Pickers are driven entirely by the JSON Schemas serve already publishes per dataset, so no new gateway surface is required.
+
+Also fixes a gateway contract bug: registry keys for dataset endpoints were not executable (serve's `describe()` reports the internal name while execution registers `dataset:<name>`). The gateway now normalizes dataset registry keys to their executable form.

--- a/packages/gateway/src/api/registry-endpoints.ts
+++ b/packages/gateway/src/api/registry-endpoints.ts
@@ -2,6 +2,23 @@ import type { EndpointContext, RegistryEntry } from './types.js';
 import { sendJSON, sendError } from './helpers.js';
 
 /**
+ * The contract requires every registry `key` to be executable via
+ * POST /execute, but serve registers dataset endpoints under
+ * `dataset:<name>` while `describe()` reports the endpoint's internal
+ * key (`<name>`). Normalize here until serve's describe() reports the
+ * canonical execute key itself. Internal `__`-prefixed entries (the
+ * semantic contract endpoint) also carry the `datasets` tag and are
+ * excluded from rewriting.
+ */
+function executeKey(q: { key: string; tags?: string[] }): string {
+  const isDataset =
+    (q.tags ?? []).includes('datasets') &&
+    !q.key.startsWith('__') &&
+    !q.key.startsWith('dataset:');
+  return isDataset ? `dataset:${q.key}` : q.key;
+}
+
+/**
  * GET /__dev/registry
  * List all serve endpoints (queries + semantic dataset/metric routes) mapped
  * from serve's `describe()` (ToolkitDescription). Written fresh against the
@@ -15,7 +32,7 @@ export async function getRegistry(ctx: EndpointContext): Promise<void> {
 
     const description = ctx.api.describe();
     const endpoints: RegistryEntry[] = description.queries.map((q) => ({
-      key: q.key,
+      key: executeKey(q),
       name: q.name,
       path: q.path,
       method: q.method,

--- a/packages/gateway/src/api/router.test.ts
+++ b/packages/gateway/src/api/router.test.ts
@@ -121,6 +121,33 @@ describe('DevAPIRouter (gateway contract v0)', () => {
     expect(body.project.name).toBe('demo');
   });
 
+  it('GET /__dev/registry rewrites dataset keys to their executable form', async () => {
+    const withDatasets = createDevRouter({
+      store,
+      api: makeApi({
+        describe: () => ({
+          basePath: '/api',
+          queries: [
+            { key: 'orders', path: '/api/datasets/orders/query', method: 'POST', tags: ['datasets'], visibility: 'public', requiresAuth: false, inputSchema: { type: 'object' } },
+            { key: '__hypequery_semantic_contract__', path: '/api/contract', method: 'GET', tags: ['datasets'], visibility: 'public', requiresAuth: false },
+            { key: 'listUsers', path: '/api/users', method: 'GET', tags: ['users'], visibility: 'public', requiresAuth: false }
+          ]
+        })
+      }),
+      capabilities: ['registry'],
+      projectName: 'demo'
+    });
+    const r = res();
+    await withDatasets.handleRequest(req('/__dev/registry'), r);
+    const body = (r as unknown as MockResponse).getBody<{ endpoints: Array<{ key: string }> }>();
+    expect(body.endpoints.map((e) => e.key)).toEqual([
+      'dataset:orders',
+      '__hypequery_semantic_contract__',
+      'listUsers'
+    ]);
+    await withDatasets.shutdown();
+  });
+
   it('GET /__dev/registry maps describe() output', async () => {
     const r = res();
     await router.handleRequest(req('/__dev/registry'), r);

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -1,21 +1,51 @@
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
 import { ConnectionStatus } from '@/components/ConnectionStatus';
 import { Logo } from '@/components/Logo';
+import { Playground } from '@/components/Playground';
 import { QueryHistory } from '@/components/QueryHistory';
 
+type Screen = 'playground' | 'runs';
+
+const SCREENS: Array<{ id: Screen; label: string }> = [
+  { id: 'playground', label: 'Playground' },
+  { id: 'runs', label: 'Runs' },
+];
+
 function App() {
+  const [screen, setScreen] = useState<Screen>('playground');
+
   return (
     <div className="h-screen overflow-hidden bg-background">
       <header className="flex h-16 items-center justify-between border-b border-border bg-card/80 px-4 backdrop-blur-md md:px-6">
         <div className="flex items-center gap-4">
           <Logo />
-          <span className="border-l border-border pl-4 font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-            Studio / Runs
-          </span>
+          <nav className="flex items-center gap-1 border-l border-border pl-4">
+            {SCREENS.map(({ id, label }) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setScreen(id)}
+                className={cn(
+                  'rounded-md px-3 py-1.5 font-mono text-[11px] font-medium uppercase tracking-[0.18em] transition-colors',
+                  screen === id
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </nav>
         </div>
         <ConnectionStatus />
       </header>
       <main className="h-[calc(100vh-64px)]">
-        <QueryHistory className="h-full" />
+        {screen === 'playground' ? (
+          <Playground className="h-full" />
+        ) : (
+          <QueryHistory className="h-full" />
+        )}
       </main>
     </div>
   );

--- a/packages/studio/src/components/Playground.tsx
+++ b/packages/studio/src/components/Playground.tsx
@@ -1,0 +1,455 @@
+import { useMemo, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { Play, Plus, X, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { apiClient } from '@/lib/api-client';
+import { track } from '@/lib/telemetry';
+import {
+  datasetLabel,
+  isDatasetEntry,
+  parseDatasetQueryShape,
+} from '@/lib/semantic-schema';
+import { useRegistry } from '@/hooks/useRegistry';
+import { EmptyState } from './EmptyState';
+import { SQLViewer } from './SQLViewer';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Select } from './ui/select';
+import { Badge } from './ui/badge';
+
+interface FilterRow {
+  id: number;
+  field: string;
+  operator: string;
+  value: string;
+}
+
+interface PlaygroundProps {
+  className?: string;
+}
+
+let nextFilterId = 1;
+
+/**
+ * Interactive query playground: pick a dataset, choose dimensions and
+ * measures, add filters, and run the query through the real serve pipeline
+ * via POST /execute. Completed runs also stream into the Runs screen over
+ * SSE — this screen shows the immediate result.
+ */
+export function Playground({ className }: PlaygroundProps) {
+  const { endpoints, loading: registryLoading, error: registryError } = useRegistry();
+  const datasets = useMemo(() => endpoints.filter(isDatasetEntry), [endpoints]);
+
+  const [datasetKey, setDatasetKey] = useState<string>('');
+  const [dimensions, setDimensions] = useState<string[]>([]);
+  const [measures, setMeasures] = useState<string[]>([]);
+  const [filters, setFilters] = useState<FilterRow[]>([]);
+  const [limit, setLimit] = useState<string>('100');
+
+  const selected = datasets.find((d) => d.key === datasetKey) ?? datasets[0];
+  const shape = useMemo(
+    () => (selected ? parseDatasetQueryShape(selected) : null),
+    [selected]
+  );
+
+  const runMutation = useMutation({
+    mutationFn: async () => {
+      if (!selected) throw new Error('No dataset selected');
+      const input: Record<string, unknown> = {};
+      if (dimensions.length) input.dimensions = dimensions;
+      if (measures.length) input.measures = measures;
+      const activeFilters = filters.filter((f) => f.field && f.operator);
+      if (activeFilters.length) {
+        input.filters = activeFilters.map((f) => ({
+          field: f.field,
+          operator: f.operator,
+          value: parseFilterValue(f.value, f.operator),
+        }));
+      }
+      const parsedLimit = Number(limit);
+      if (Number.isFinite(parsedLimit) && parsedLimit > 0) input.limit = parsedLimit;
+
+      track('execute_clicked', undefined, { once: true });
+      return apiClient.execute(selected.key, input);
+    },
+  });
+
+  const selectDataset = (key: string) => {
+    setDatasetKey(key);
+    // Field lists differ per dataset; stale selections would fail validation.
+    setDimensions([]);
+    setMeasures([]);
+    setFilters([]);
+    runMutation.reset();
+  };
+
+  const toggle = (list: string[], set: (v: string[]) => void, value: string) => {
+    set(list.includes(value) ? list.filter((v) => v !== value) : [...list, value]);
+  };
+
+  if (registryError) {
+    return (
+      <div className={cn('p-4 text-center text-destructive', className)}>
+        Failed to load registry: {registryError.message}
+      </div>
+    );
+  }
+
+  if (!registryLoading && datasets.length === 0) {
+    return (
+      <EmptyState
+        type="no-results"
+        title="No datasets registered"
+        description="Register datasets on your serve API to query them here. Plain queries and metrics appear in Runs when executed."
+        className={cn('h-full', className)}
+      />
+    );
+  }
+
+  return (
+    <div className={cn('flex h-full min-w-0', className)}>
+      {/* Query builder rail */}
+      <div className="flex w-[320px] flex-shrink-0 flex-col gap-5 overflow-auto border-r border-border bg-card/45 p-4">
+        <section>
+          <label className="mb-1.5 block font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+            Dataset
+          </label>
+          <Select
+            value={selected?.key ?? ''}
+            onChange={(e) => selectDataset(e.target.value)}
+          >
+            {datasets.map((d) => (
+              <option key={d.key} value={d.key}>
+                {datasetLabel(d)}
+              </option>
+            ))}
+          </Select>
+          {selected?.description && (
+            <p className="mt-1.5 text-xs text-muted-foreground">{selected.description}</p>
+          )}
+        </section>
+
+        <CheckboxGroup
+          label="Dimensions"
+          options={shape?.dimensions ?? []}
+          selected={dimensions}
+          onToggle={(v) => toggle(dimensions, setDimensions, v)}
+        />
+
+        <CheckboxGroup
+          label="Measures"
+          options={shape?.measures ?? []}
+          selected={measures}
+          onToggle={(v) => toggle(measures, setMeasures, v)}
+        />
+
+        <section>
+          <div className="mb-1.5 flex items-center justify-between">
+            <label className="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+              Filters
+            </label>
+            <Button
+              variant="outline"
+              size="sm"
+              aria-label="Add filter"
+              onClick={() =>
+                setFilters([
+                  ...filters,
+                  {
+                    id: nextFilterId++,
+                    field: shape?.filterFields[0] ?? '',
+                    operator: shape?.operators[0] ?? 'eq',
+                    value: '',
+                  },
+                ])
+              }
+            >
+              <Plus className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+          <div className="flex flex-col gap-2">
+            {filters.map((filter) => (
+              <div key={filter.id} className="flex items-center gap-1.5">
+                <Select
+                  className="min-w-0 flex-1"
+                  value={filter.field}
+                  onChange={(e) => updateFilter(setFilters, filter.id, { field: e.target.value })}
+                >
+                  {(shape?.filterFields ?? []).map((f) => (
+                    <option key={f} value={f}>
+                      {f}
+                    </option>
+                  ))}
+                </Select>
+                <Select
+                  className="w-[86px] flex-shrink-0"
+                  value={filter.operator}
+                  onChange={(e) =>
+                    updateFilter(setFilters, filter.id, { operator: e.target.value })
+                  }
+                >
+                  {(shape?.operators ?? []).map((op) => (
+                    <option key={op} value={op}>
+                      {op}
+                    </option>
+                  ))}
+                </Select>
+                <Input
+                  className="min-w-0 flex-1"
+                  placeholder={filter.operator === 'in' || filter.operator === 'notIn' ? 'a, b, c' : 'value'}
+                  value={filter.value}
+                  onChange={(e) => updateFilter(setFilters, filter.id, { value: e.target.value })}
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  aria-label="Remove filter"
+                  onClick={() => setFilters(filters.filter((f) => f.id !== filter.id))}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            ))}
+            {filters.length === 0 && (
+              <p className="text-xs text-muted-foreground">No filters.</p>
+            )}
+          </div>
+        </section>
+
+        <section>
+          <label className="mb-1.5 block font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+            Limit
+          </label>
+          <Input
+            type="number"
+            min={1}
+            {...(shape?.maxLimit != null ? { max: shape.maxLimit } : {})}
+            value={limit}
+            onChange={(e) => setLimit(e.target.value)}
+          />
+        </section>
+
+        <Button
+          onClick={() => runMutation.mutate()}
+          disabled={runMutation.isPending || !selected || (dimensions.length === 0 && measures.length === 0)}
+        >
+          {runMutation.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Play className="h-4 w-4" />
+          )}
+          Run query
+        </Button>
+      </div>
+
+      {/* Results */}
+      <div className="min-w-0 flex-1 overflow-auto p-4">
+        <PlaygroundResult
+          pending={runMutation.isPending}
+          error={runMutation.error}
+          result={runMutation.data}
+        />
+      </div>
+    </div>
+  );
+}
+
+function updateFilter(
+  setFilters: React.Dispatch<React.SetStateAction<FilterRow[]>>,
+  id: number,
+  patch: Partial<FilterRow>
+) {
+  setFilters((rows) => rows.map((row) => (row.id === id ? { ...row, ...patch } : row)));
+}
+
+/** `in`/`notIn` take comma-separated lists; numbers pass through typed. */
+function parseFilterValue(raw: string, operator: string): unknown {
+  const coerce = (v: string): unknown => {
+    const trimmed = v.trim();
+    if (trimmed !== '' && !Number.isNaN(Number(trimmed))) return Number(trimmed);
+    if (trimmed === 'true') return true;
+    if (trimmed === 'false') return false;
+    return trimmed;
+  };
+  if (operator === 'in' || operator === 'notIn') {
+    return raw.split(',').map(coerce);
+  }
+  return coerce(raw);
+}
+
+function CheckboxGroup({
+  label,
+  options,
+  selected,
+  onToggle,
+}: {
+  label: string;
+  options: string[];
+  selected: string[];
+  onToggle: (value: string) => void;
+}) {
+  return (
+    <section>
+      <label className="mb-1.5 block font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+      </label>
+      {options.length === 0 ? (
+        <p className="text-xs text-muted-foreground">None declared.</p>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {options.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => onToggle(option)}
+              className={cn(
+                'rounded-md border px-2 py-1 font-mono text-xs transition-colors',
+                selected.includes(option)
+                  ? 'border-primary bg-primary text-primary-foreground'
+                  : 'border-border bg-card text-muted-foreground hover:text-foreground'
+              )}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** Rows live under `data`/`rows`, or the result itself is an array. */
+function extractRows(result: unknown): Array<Record<string, unknown>> | null {
+  if (Array.isArray(result)) return result as Array<Record<string, unknown>>;
+  if (result && typeof result === 'object') {
+    const container = result as { data?: unknown; rows?: unknown };
+    if (Array.isArray(container.data)) return container.data as Array<Record<string, unknown>>;
+    if (Array.isArray(container.rows)) return container.rows as Array<Record<string, unknown>>;
+  }
+  return null;
+}
+
+function extractSql(result: unknown): string | null {
+  if (result && typeof result === 'object') {
+    const container = result as { sql?: unknown; meta?: { sql?: unknown } };
+    if (typeof container.sql === 'string') return container.sql;
+    if (typeof container.meta?.sql === 'string') return container.meta.sql;
+  }
+  return null;
+}
+
+function unionColumns(rows: Array<Record<string, unknown>>): string[] {
+  const columns = new Set<string>();
+  for (const row of rows) {
+    if (row && typeof row === 'object') {
+      for (const key of Object.keys(row)) columns.add(key);
+    }
+  }
+  return Array.from(columns);
+}
+
+function formatCell(value: unknown): string {
+  if (value == null) return '-';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+function PlaygroundResult({
+  pending,
+  error,
+  result,
+}: {
+  pending: boolean;
+  error: Error | null;
+  result?: Awaited<ReturnType<typeof apiClient.execute>>;
+}) {
+  if (pending) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Running…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-destructive/30 bg-destructive/10 p-4">
+        <p className="font-mono text-sm text-destructive">{error.message}</p>
+      </div>
+    );
+  }
+
+  if (!result) {
+    return (
+      <EmptyState
+        type="no-results"
+        title="Run a query"
+        description="Pick dimensions and measures on the left, then run the query through your API's real pipeline."
+        className="h-full"
+      />
+    );
+  }
+
+  if (!result.success) {
+    return (
+      <div className="rounded-md border border-destructive/30 bg-destructive/10 p-4">
+        <p className="font-mono text-sm text-destructive">
+          {result.error?.message ?? 'Query failed'}
+        </p>
+      </div>
+    );
+  }
+
+  const rows = extractRows(result.result);
+  const sql = extractSql(result.result);
+  const columns = rows ? unionColumns(rows) : [];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Badge variant="secondary">{result.durationMs}ms</Badge>
+        {rows && <Badge variant="secondary">{rows.length} rows</Badge>}
+      </div>
+
+      {rows && rows.length > 0 ? (
+        <div className="overflow-auto rounded-md border border-border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/45">
+              <tr>
+                {columns.map((column) => (
+                  <th
+                    key={column}
+                    className="px-3 py-2 text-left font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground"
+                  >
+                    {column}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, i) => (
+                <tr key={i} className="border-t border-border">
+                  {columns.map((column) => (
+                    <td key={column} className="px-3 py-2 font-mono text-xs">
+                      {formatCell(row[column])}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : rows ? (
+        <p className="text-sm text-muted-foreground">Query returned no rows.</p>
+      ) : (
+        <pre className="overflow-auto rounded-md border border-border bg-muted/45 p-3 font-mono text-xs">
+          {JSON.stringify(result.result, null, 2)}
+        </pre>
+      )}
+
+      {sql && <SQLViewer sql={sql} />}
+    </div>
+  );
+}
+
+export default Playground;

--- a/packages/studio/src/hooks/useRegistry.ts
+++ b/packages/studio/src/hooks/useRegistry.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+
+/**
+ * Endpoint registry from GET /registry. The registry only changes when the
+ * dev server restarts (endpoints are registered at build time), so a long
+ * stale time is safe; Refresh-by-reload covers the restart case.
+ */
+export function useRegistry() {
+  const registryQuery = useQuery({
+    queryKey: ['registry'],
+    queryFn: () => apiClient.getRegistry(),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return {
+    endpoints: registryQuery.data?.endpoints ?? [],
+    loading: registryQuery.isPending,
+    error: registryQuery.error as Error | null,
+  };
+}

--- a/packages/studio/src/lib/semantic-schema.ts
+++ b/packages/studio/src/lib/semantic-schema.ts
@@ -1,0 +1,58 @@
+import type { RegistryEntry } from './types';
+
+/**
+ * Parses the JSON Schema (`inputSchema`) of a semantic dataset endpoint from
+ * GET /registry into picker-ready field lists. Serve enumerates dimension /
+ * measure / filter-field names in the schema (see serve's
+ * semantic-input-schema); where a list would have been empty serve falls back
+ * to a plain string, which we surface as an empty list so the UI can render a
+ * free-text input instead of an empty picker.
+ */
+export interface DatasetQueryShape {
+  dimensions: string[];
+  measures: string[];
+  filterFields: string[];
+  operators: string[];
+  grains: string[];
+  maxLimit?: number;
+}
+
+interface JsonSchemaNode {
+  type?: string;
+  enum?: unknown[];
+  items?: JsonSchemaNode;
+  properties?: Record<string, JsonSchemaNode>;
+  maxItems?: number;
+  maximum?: number;
+}
+
+function enumOf(node: JsonSchemaNode | undefined): string[] {
+  const values = node?.enum;
+  return Array.isArray(values) ? values.filter((v): v is string => typeof v === 'string') : [];
+}
+
+/** A dataset endpoint as registered by serve (key `dataset:<name>`). */
+export function isDatasetEntry(entry: RegistryEntry): boolean {
+  return entry.tags.includes('datasets') && entry.key.startsWith('dataset:');
+}
+
+/** Human name of a dataset entry ("dataset:orders" → "orders"). */
+export function datasetLabel(entry: RegistryEntry): string {
+  return entry.name ?? entry.key.replace(/^dataset:/, '');
+}
+
+export function parseDatasetQueryShape(entry: RegistryEntry): DatasetQueryShape {
+  const schema = (entry.inputSchema ?? {}) as JsonSchemaNode;
+  const props = schema.properties ?? {};
+
+  const filterProps = props.filters?.items?.properties ?? {};
+
+  return {
+    dimensions: enumOf(props.dimensions?.items),
+    measures: enumOf(props.measures?.items),
+    filterFields: enumOf(filterProps.field),
+    operators: enumOf(filterProps.operator),
+    grains: enumOf(props.by),
+    maxLimit: props.limit?.maximum,
+  };
+}


### PR DESCRIPTION
## What

Gives users the actual **playground** the package is named for: a screen to run queries against their datasets and metrics and see results — until now the studio only showed run history.

This **re-homes the closed [#307](https://github.com/hypequery/hypequery/pull/307)** (`playground/query-ui`), which was based on the stale `@hypequery/playground` stack retired during the telemetry re-home ([#335](https://github.com/hypequery/hypequery/pull/335)). The work is applied onto main's `@hypequery/studio` + `@hypequery/gateway` — all file bases were identical, so it's a faithful port, not a rewrite.

## New **Playground** tab (default; Runs moves beside it)

- **Dataset picker** from `GET /registry` (dataset endpoints only; the internal semantic-contract entry is excluded)
- **Dimension / measure chips** and a **filter builder** (field / operator / value rows; `in`/`notIn` take comma-separated lists; numeric and boolean values coerced), plus a limit bound to the dataset's declared max
- **Run** posts to `/execute` — through the real serve pipeline, so auth/tenant/validation all apply — and renders a union-keyed result table with duration/row-count badges (raw-JSON fallback for non-tabular results; SQL panel when the result carries it)
- Runs stream into the **Runs** screen over SSE as before
- Pickers are driven entirely by the enumerated JSON Schemas serve already publishes per dataset (`lib/semantic-schema.ts`) — **no new gateway surface**
- Wired to the existing `execute_clicked` telemetry event, so the funnel's execute step is now reachable from the UI

## Gateway contract fix (surfaced by building this)

Registry keys for dataset endpoints were **not executable**: serve's `describe()` reports the endpoint's internal name (`orders`) while execution registers `dataset:orders`, violating the contract rule that every registry `key` works with `/execute`. The gateway now normalizes dataset entries to their executable key. Test added. (Upstream serve unification tracked separately.)

## Where it lives

Behind the opt-in `hypequery dev --ui-experimental` flag — the default dev server is unchanged.

## Validation

- `@hypequery/gateway`: 150 tests pass (incl. the new dataset-key normalization test)
- `@hypequery/studio`: typecheck + production build clean
- **Not yet done:** live end-to-end run against a real ClickHouse dataset project — see PR discussion. Recommend a manual smoke test (pick dataset → add filter → Run → rows render → run appears in Runs via SSE) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)