### PR TITLE
feat(clickhouse): CompiledQuery v1 execution contract (CH-01)

### DIFF
--- a/.changeset/compiled-query-v1.md
+++ b/.changeset/compiled-query-v1.md
@@ -1,0 +1,17 @@
+---
+'@hypequery/clickhouse': minor
+---
+
+Add CompiledQuery v1 (RFC 0010) beside the legacy positional query path (CH-01).
+
+Introduces `@hypequery/clickhouse` exports for a versioned execution-request contract:
+named typed parameters bound to native server placeholders (values never render into SQL
+text), a closed operation set (`query`/`command`/`insert`), a bounded settings allow-list,
+an authoritative query id plus optional correlation id, caller-vs-policy deadline
+precedence, a redacted non-executable debug form, and the stable public error envelope with
+a closed category set. Parameter values reuse the RFC 0001 tagged-value contract from
+`@hypequery/protocol`.
+
+Additive and non-breaking: the legacy `adapter.query(sql, params[])` path and
+`substituteParameters`/`escapeValue` are unchanged. Wiring the built-in `@clickhouse/client`
+`{name:Type}` + `query_params` transport is a follow-up (CH-02).

--- a/packages/clickhouse/package.json
+++ b/packages/clickhouse/package.json
@@ -54,6 +54,7 @@
   ],
   "dependencies": {
     "@clickhouse/client": "^1.18.3",
+    "@hypequery/protocol": "workspace:*",
     "dotenv": "^16.0.0"
   },
   "peerDependencies": {

--- a/packages/clickhouse/src/core/compiled/compile.ts
+++ b/packages/clickhouse/src/core/compiled/compile.ts
@@ -1,0 +1,104 @@
+import { buildDebugForm } from './debug.js';
+import { CompiledQueryError } from './errors.js';
+import {
+  assertNoValuesInSql,
+  buildParameterBindings,
+  validateParameterReferences,
+} from './parameters.js';
+import { resolveCompiledDeadline, resolveCompiledSettings } from './settings.js';
+import {
+  COMPILED_QUERY_VERSION,
+  type CompiledDeadline,
+  type CompiledIdentifiers,
+  type CompiledOperation,
+  type CompiledParameterDeclaration,
+  type CompiledParameterValue,
+  type CompiledQueryV1,
+  type CompiledSensitivity,
+  type CompiledSettings,
+} from './types.js';
+
+const MAX_CORRELATION_ID_BYTES = 1024;
+// eslint-disable-next-line no-control-regex -- control chars are exactly what we reject
+const CONTROL_CHAR_PATTERN = /[\u0000-\u001F\u007F]/;
+const utf8 = new TextEncoder();
+
+export interface CompileQueryInput {
+  readonly operation: CompiledOperation;
+  /** Trusted build/server output. Callers never author this. */
+  readonly sql: string;
+  readonly parameters?: readonly CompiledParameterDeclaration[];
+  /** Values supplied for declared parameter names. */
+  readonly values?: Readonly<Record<string, CompiledParameterValue>>;
+  readonly settings?: CompiledSettings;
+  readonly sensitivity?: CompiledSensitivity;
+  /** Server-generated authoritative identifier; the caller may add a correlation id. */
+  readonly identifiers: CompiledIdentifiers;
+  readonly deadline?: {
+    readonly callerAtEpochMs?: number;
+    readonly policyMaxMs?: number;
+    readonly nowEpochMs: number;
+  };
+}
+
+/**
+ * Assemble and validate a `CompiledQueryV1` (RFC 0010). This constructs the execution
+ * request beside the legacy positional path; it performs every fail-closed check before an
+ * adapter is ever handed the query, but performs no I/O.
+ */
+export function compileQueryV1(input: CompileQueryInput): CompiledQueryV1 {
+  const parameters = input.parameters ?? [];
+  const values = input.values ?? {};
+
+  validateParameterReferences(input.sql, parameters);
+  const bindings = buildParameterBindings(parameters, values);
+  assertNoValuesInSql(input.sql, bindings);
+
+  const settings = resolveCompiledSettings(input.settings ?? {});
+  const identifiers = validateIdentifiers(input.identifiers);
+  const deadline: CompiledDeadline | undefined = input.deadline
+    ? resolveCompiledDeadline(input.deadline)
+    : undefined;
+
+  const sensitivity: CompiledSensitivity = input.sensitivity ?? {
+    tenantScoped: false,
+    labels: [],
+  };
+
+  return {
+    version: COMPILED_QUERY_VERSION,
+    operation: input.operation,
+    sql: input.sql,
+    parameters,
+    bindings,
+    settings,
+    identifiers,
+    deadline,
+    sensitivity,
+    debug: buildDebugForm(input.sql, parameters, settings),
+  };
+}
+
+function validateIdentifiers(identifiers: CompiledIdentifiers): CompiledIdentifiers {
+  if (typeof identifiers.queryId !== 'string' || identifiers.queryId.length === 0) {
+    throw new CompiledQueryError('internal', 'A server-generated query id is required.');
+  }
+  const { correlationId } = identifiers;
+  if (correlationId !== undefined) {
+    if (CONTROL_CHAR_PATTERN.test(correlationId)) {
+      throw new CompiledQueryError(
+        'input-invalid',
+        'The correlation id contains control characters.'
+      );
+    }
+    if (utf8.encode(correlationId).length > MAX_CORRELATION_ID_BYTES) {
+      throw new CompiledQueryError(
+        'too-large',
+        'The correlation id exceeds the allowed size.'
+      );
+    }
+  }
+  return correlationId === undefined
+    ? { queryId: identifiers.queryId }
+    : { queryId: identifiers.queryId, correlationId };
+}

--- a/packages/clickhouse/src/core/compiled/compile.ts
+++ b/packages/clickhouse/src/core/compiled/compile.ts
@@ -19,8 +19,20 @@ import {
 } from './types.js';
 
 const MAX_CORRELATION_ID_BYTES = 1024;
+const MAX_QUERY_ID_BYTES = 200;
+const MAX_SQL_BYTES = 1_048_576;
+const MAX_PARAMETERS = 256;
+const MAX_CLICKHOUSE_TYPE_BYTES = 256;
+const MAX_SENSITIVITY_LABELS = 32;
+const MAX_SENSITIVITY_LABEL_BYTES = 64;
 // eslint-disable-next-line no-control-regex -- control chars are exactly what we reject
-const CONTROL_CHAR_PATTERN = /[\u0000-\u001F\u007F]/;
+const CONTROL_CHAR_PATTERN = /[\u0000-\u001F\u007F-\u009F]/;
+const QUERY_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+const SENSITIVITY_LABEL_PATTERN = /^[a-z][a-z0-9._-]*$/;
+const LOGICAL_TYPES = new Set([
+  'array', 'boolean', 'bytes', 'date', 'datetime', 'decimal', 'enum', 'float',
+  'integer', 'map', 'null', 'string', 'tuple', 'uuid',
+]);
 const utf8 = new TextEncoder();
 
 export interface CompileQueryInput {
@@ -47,7 +59,9 @@ export interface CompileQueryInput {
  * adapter is ever handed the query, but performs no I/O.
  */
 export function compileQueryV1(input: CompileQueryInput): CompiledQueryV1 {
-  const parameters = input.parameters ?? [];
+  validateOperation(input.operation);
+  validateSql(input.sql);
+  const parameters = snapshotParameters(input.parameters ?? []);
   const values = input.values ?? {};
 
   validateParameterReferences(input.sql, parameters);
@@ -56,16 +70,20 @@ export function compileQueryV1(input: CompileQueryInput): CompiledQueryV1 {
 
   const settings = resolveCompiledSettings(input.settings ?? {});
   const identifiers = validateIdentifiers(input.identifiers);
-  const deadline: CompiledDeadline | undefined = input.deadline
-    ? resolveCompiledDeadline(input.deadline)
+  const deadlineInputs = input.deadline
+    ? {
+      ...input.deadline,
+      policyMaxMs: minimumDefined(input.deadline.policyMaxMs, settings.maxExecutionMs),
+    }
+    : undefined;
+  const deadline: CompiledDeadline | undefined = deadlineInputs
+    ? resolveCompiledDeadline(deadlineInputs)
     : undefined;
 
-  const sensitivity: CompiledSensitivity = input.sensitivity ?? {
-    tenantScoped: false,
-    labels: [],
-  };
+  const sensitivity = snapshotSensitivity(input.sensitivity);
+  const debug = buildDebugForm(input.sql, parameters, settings);
 
-  return {
+  return Object.freeze({
     version: COMPILED_QUERY_VERSION,
     operation: input.operation,
     sql: input.sql,
@@ -75,12 +93,80 @@ export function compileQueryV1(input: CompileQueryInput): CompiledQueryV1 {
     identifiers,
     deadline,
     sensitivity,
-    debug: buildDebugForm(input.sql, parameters, settings),
-  };
+    debug,
+  });
+}
+
+function minimumDefined(left?: number, right?: number): number | undefined {
+  if (left === undefined) return right;
+  if (right === undefined) return left;
+  return Math.min(left, right);
+}
+
+function validateOperation(operation: unknown): asserts operation is CompiledOperation {
+  if (operation !== 'query' && operation !== 'command' && operation !== 'insert') {
+    throw new CompiledQueryError('input-invalid', 'The compiled operation is invalid.');
+  }
+}
+
+function validateSql(sql: unknown): asserts sql is string {
+  if (typeof sql !== 'string' || sql.length === 0 || utf8.encode(sql).length > MAX_SQL_BYTES) {
+    throw new CompiledQueryError('input-invalid', 'The compiled SQL is empty or too large.');
+  }
+}
+
+function snapshotParameters(
+  input: readonly CompiledParameterDeclaration[],
+): readonly CompiledParameterDeclaration[] {
+  if (!Array.isArray(input) || input.length > MAX_PARAMETERS) {
+    throw new CompiledQueryError('too-large', 'The compiled query has too many parameters.');
+  }
+  return Object.freeze(input.map((declaration) => {
+    const logical = declaration?.type?.logical;
+    const clickHouseType = declaration?.type?.clickHouseType;
+    if (
+      !LOGICAL_TYPES.has(logical)
+      || typeof clickHouseType !== 'string'
+      || clickHouseType.length === 0
+      || CONTROL_CHAR_PATTERN.test(clickHouseType)
+      || utf8.encode(clickHouseType).length > MAX_CLICKHOUSE_TYPE_BYTES
+      || typeof declaration.optional !== 'boolean'
+    ) {
+      throw new CompiledQueryError('input-invalid', 'A parameter declaration is invalid.');
+    }
+    return Object.freeze({
+      name: declaration.name,
+      type: Object.freeze({ logical, clickHouseType }),
+      optional: declaration.optional,
+    });
+  }));
+}
+
+function snapshotSensitivity(input?: CompiledSensitivity): CompiledSensitivity {
+  const tenantScoped = input?.tenantScoped ?? false;
+  const labels = input?.labels ?? [];
+  if (typeof tenantScoped !== 'boolean' || !Array.isArray(labels) || labels.length > MAX_SENSITIVITY_LABELS) {
+    throw new CompiledQueryError('input-invalid', 'Sensitivity metadata is invalid.');
+  }
+  const snapshot = labels.map((label) => {
+    if (
+      typeof label !== 'string'
+      || !SENSITIVITY_LABEL_PATTERN.test(label)
+      || utf8.encode(label).length > MAX_SENSITIVITY_LABEL_BYTES
+    ) {
+      throw new CompiledQueryError('input-invalid', 'A sensitivity label is invalid.');
+    }
+    return label;
+  });
+  return Object.freeze({ tenantScoped, labels: Object.freeze(snapshot) });
 }
 
 function validateIdentifiers(identifiers: CompiledIdentifiers): CompiledIdentifiers {
-  if (typeof identifiers.queryId !== 'string' || identifiers.queryId.length === 0) {
+  if (
+    typeof identifiers.queryId !== 'string'
+    || !QUERY_ID_PATTERN.test(identifiers.queryId)
+    || utf8.encode(identifiers.queryId).length > MAX_QUERY_ID_BYTES
+  ) {
     throw new CompiledQueryError('internal', 'A server-generated query id is required.');
   }
   const { correlationId } = identifiers;
@@ -98,7 +184,7 @@ function validateIdentifiers(identifiers: CompiledIdentifiers): CompiledIdentifi
       );
     }
   }
-  return correlationId === undefined
+  return Object.freeze(correlationId === undefined
     ? { queryId: identifiers.queryId }
-    : { queryId: identifiers.queryId, correlationId };
+    : { queryId: identifiers.queryId, correlationId });
 }

--- a/packages/clickhouse/src/core/compiled/compiled-query.test.ts
+++ b/packages/clickhouse/src/core/compiled/compiled-query.test.ts
@@ -77,6 +77,27 @@ describe('CompiledQuery v1 — construction', () => {
     });
     expect(Object.keys(compiled.bindings).sort()).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
   });
+
+  it('snapshots declarations, tagged values, sensitivity, and debug metadata', () => {
+    const parameter = decl('id', 'UInt64', 'integer');
+    const value = uint64('7');
+    const labels = ['pii'];
+    const compiled = compileQueryV1({
+      operation: 'query',
+      sql: 'SELECT {id:UInt64}',
+      parameters: [parameter],
+      values: { id: value },
+      identifiers: { queryId: 'q-snapshot' },
+      sensitivity: { tenantScoped: true, labels },
+    });
+
+    expect(Object.isFrozen(compiled)).toBe(true);
+    expect(Object.isFrozen(compiled.parameters)).toBe(true);
+    expect(Object.isFrozen(compiled.bindings.id)).toBe(true);
+    expect(Object.isFrozen(compiled.sensitivity.labels)).toBe(true);
+    labels[0] = 'public';
+    expect(compiled.sensitivity.labels).toEqual(['pii']);
+  });
 });
 
 describe('CompiledQuery v1 — no value enters SQL text', () => {
@@ -97,6 +118,12 @@ describe('CompiledQuery v1 — no value enters SQL text', () => {
       'SELECT {a:String} WHERE b = {b:UInt64} AND note = 42'
     );
     expect([...names].sort()).toEqual(['a', 'b']);
+  });
+
+  it('ignores question marks and placeholder-looking text in literals and comments', () => {
+    const sql = "SELECT '?', '{ghost:String}', {id:UInt64} -- {comment:String} ?\n";
+    expect([...extractReferencedParameters(sql)]).toEqual(['id']);
+    expect(() => assertNoValuesInSql(sql, { id: uint64('1') })).not.toThrow();
   });
 });
 
@@ -121,6 +148,33 @@ describe('CompiledQuery v1 — parameter binding fail-closed', () => {
     expect(() =>
       validateParameterReferences('SELECT {ghost:UInt64}', params)
     ).toThrow(/undeclared parameter ghost/);
+  });
+
+  it('rejects a placeholder whose ClickHouse type differs from its declaration', () => {
+    expect(() =>
+      validateParameterReferences('SELECT {id:String}', [decl('id', 'UInt64', 'integer')])
+    ).toThrow(/does not match its declared ClickHouse type/);
+  });
+
+  it('rejects native values that do not match the logical or ClickHouse type', () => {
+    expect(() =>
+      buildParameterBindings([decl('id', 'UInt64', 'integer')], { id: 1.5 })
+    ).toThrow(CompiledQueryError);
+    expect(() =>
+      buildParameterBindings([decl('id', 'UUID', 'uuid')], { id: true })
+    ).toThrow(CompiledQueryError);
+    expect(() =>
+      buildParameterBindings([decl('value', 'Float64', 'float')], { value: Number.NaN })
+    ).toThrow(CompiledQueryError);
+  });
+
+  it('rejects an optional parameter that remains referenced without a binding', () => {
+    expect(() => compileQueryV1({
+      operation: 'query',
+      sql: 'SELECT {optional:String}',
+      parameters: [decl('optional', 'String', 'string', true)],
+      identifiers: { queryId: 'q-optional' },
+    })).toThrow(/does not have a bound value/);
   });
 
   it('rejects a structurally invalid tagged value', () => {
@@ -177,6 +231,26 @@ describe('CompiledQuery v1 — deadline precedence', () => {
 
   it('returns undefined when neither deadline is present', () => {
     expect(resolveCompiledDeadline({ nowEpochMs: now })).toBeUndefined();
+  });
+
+  it('rejects non-finite, negative, and overflowing deadline inputs', () => {
+    expect(() => resolveCompiledDeadline({ nowEpochMs: Number.NaN })).toThrow();
+    expect(() => resolveCompiledDeadline({ nowEpochMs: now, policyMaxMs: -1 })).toThrow();
+    expect(() => resolveCompiledDeadline({
+      nowEpochMs: Number.MAX_SAFE_INTEGER,
+      policyMaxMs: 1,
+    })).toThrow();
+  });
+
+  it('tightens the policy deadline to maxExecutionMs', () => {
+    const compiled = compileQueryV1({
+      operation: 'query',
+      sql: 'SELECT 1',
+      settings: { maxExecutionMs: 100 },
+      deadline: { nowEpochMs: now, policyMaxMs: 500 },
+      identifiers: { queryId: 'q-deadline' },
+    });
+    expect(compiled.deadline).toEqual({ atEpochMs: now + 100, source: 'policy' });
   });
 });
 
@@ -251,6 +325,17 @@ describe('CompiledQuery v1 — identifiers', () => {
     expect(() =>
       compileQueryV1({ ...base, identifiers: { queryId: 'q', correlationId: 'a\u0001b' } })
     ).toThrow(/control characters/);
+  });
+
+  it('rejects unsafe authoritative ids and C1 correlation controls', () => {
+    expect(() => compileQueryV1({
+      ...base,
+      identifiers: { queryId: 'q\nspoofed' },
+    })).toThrow(CompiledQueryError);
+    expect(() => compileQueryV1({
+      ...base,
+      identifiers: { queryId: 'q', correlationId: 'a\u0085b' },
+    })).toThrow(/control characters/);
   });
 
   it('rejects an oversized correlation id', () => {

--- a/packages/clickhouse/src/core/compiled/compiled-query.test.ts
+++ b/packages/clickhouse/src/core/compiled/compiled-query.test.ts
@@ -1,0 +1,264 @@
+import type { ProtocolIdentifier, TaggedValue } from '@hypequery/protocol';
+import {
+  COMPILED_QUERY_VERSION,
+  COMPILED_SETTING_BOUNDS,
+  CompiledQueryError,
+  assertNoValuesInSql,
+  buildParameterBindings,
+  compileQueryV1,
+  extractReferencedParameters,
+  resolveCompiledDeadline,
+  resolveCompiledSettings,
+  validateParameterReferences,
+  type CompiledParameterDeclaration,
+} from './index.js';
+
+const id = (name: string): ProtocolIdentifier => name as ProtocolIdentifier;
+
+const decl = (
+  name: string,
+  clickHouseType: string,
+  logical: CompiledParameterDeclaration['type']['logical'],
+  optional = false
+): CompiledParameterDeclaration => ({
+  name: id(name),
+  type: { logical, clickHouseType },
+  optional,
+});
+
+const uint64 = (value: string): TaggedValue => ({
+  $hypequery: { type: 'integer', version: 1, bits: 64, signed: false, value },
+});
+
+const uuid = (value: string): TaggedValue => ({
+  $hypequery: { type: 'uuid', version: 1, value },
+});
+
+describe('CompiledQuery v1 — construction', () => {
+  it('builds a versioned query with resolved bindings and never mutates the SQL text', () => {
+    const sql = 'SELECT * FROM events WHERE tenant_id = {tenant:String} AND id = {id:UInt64}';
+    const compiled = compileQueryV1({
+      operation: 'query',
+      sql,
+      parameters: [decl('tenant', 'String', 'string'), decl('id', 'UInt64', 'integer')],
+      values: { tenant: 'acme', id: uint64('42') },
+      identifiers: { queryId: 'q-1' },
+      sensitivity: { tenantScoped: true, labels: ['pii'] },
+    });
+
+    expect(compiled.version).toBe(COMPILED_QUERY_VERSION);
+    expect(compiled.operation).toBe('query');
+    expect(compiled.sql).toBe(sql); // byte-identical: no substitution happened
+    expect(compiled.bindings).toEqual({ tenant: 'acme', id: uint64('42') });
+    expect(compiled.sensitivity).toEqual({ tenantScoped: true, labels: ['pii'] });
+  });
+
+  it('accepts every RFC 0001 native + tagged parameter shape', () => {
+    const compiled = compileQueryV1({
+      operation: 'query',
+      sql: 'SELECT {a:String}, {b:UInt64}, {c:UUID}, {d:Float64}, {e:Bool}, {f:Nullable(String)}',
+      parameters: [
+        decl('a', 'String', 'string'),
+        decl('b', 'UInt64', 'integer'),
+        decl('c', 'UUID', 'uuid'),
+        decl('d', 'Float64', 'float'),
+        decl('e', 'Bool', 'boolean'),
+        decl('f', 'Nullable(String)', 'null'),
+      ],
+      values: {
+        a: 'x',
+        b: uint64('7'),
+        c: uuid('00000000-0000-0000-0000-000000000000'),
+        d: 3.5,
+        e: true,
+        f: null,
+      },
+      identifiers: { queryId: 'q-2' },
+    });
+    expect(Object.keys(compiled.bindings).sort()).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
+  });
+});
+
+describe('CompiledQuery v1 — no value enters SQL text', () => {
+  it('rejects legacy positional placeholders', () => {
+    expect(() => assertNoValuesInSql('SELECT * WHERE id = ?', { id: 1 })).toThrow(
+      CompiledQueryError
+    );
+  });
+
+  it('rejects a bound parameter the SQL does not reference', () => {
+    expect(() =>
+      assertNoValuesInSql('SELECT * FROM t WHERE a = {a:UInt64}', { a: 1, b: 2 })
+    ).toThrow(/not referenced/);
+  });
+
+  it('extracts only declared placeholder names', () => {
+    const names = extractReferencedParameters(
+      'SELECT {a:String} WHERE b = {b:UInt64} AND note = 42'
+    );
+    expect([...names].sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('CompiledQuery v1 — parameter binding fail-closed', () => {
+  const params = [decl('tenant', 'String', 'string'), decl('id', 'UInt64', 'integer', true)];
+
+  it('rejects a value for an undeclared parameter', () => {
+    expect(() =>
+      buildParameterBindings(params, { tenant: 'a', ghost: 'x' })
+    ).toThrow(/undeclared parameter ghost/);
+  });
+
+  it('rejects a missing required parameter', () => {
+    expect(() => buildParameterBindings(params, {})).toThrow(/Required parameter tenant/);
+  });
+
+  it('omits an absent optional parameter', () => {
+    expect(buildParameterBindings(params, { tenant: 'a' })).toEqual({ tenant: 'a' });
+  });
+
+  it('rejects an undeclared placeholder referenced by SQL', () => {
+    expect(() =>
+      validateParameterReferences('SELECT {ghost:UInt64}', params)
+    ).toThrow(/undeclared parameter ghost/);
+  });
+
+  it('rejects a structurally invalid tagged value', () => {
+    const bad = { $hypequery: { type: 'integer', version: 1, bits: 64, signed: false } } as unknown as TaggedValue;
+    expect(() => buildParameterBindings(params, { tenant: bad })).toThrow(CompiledQueryError);
+  });
+});
+
+describe('CompiledQuery v1 — settings allow-list', () => {
+  it('passes settings within their inclusive range through unchanged', () => {
+    expect(resolveCompiledSettings({ maxExecutionMs: 5000, maxResultRows: 100 })).toEqual({
+      maxExecutionMs: 5000,
+      maxResultRows: 100,
+    });
+  });
+
+  it('rejects a setting above its ceiling', () => {
+    expect(() =>
+      resolveCompiledSettings({ maxExecutionMs: COMPILED_SETTING_BOUNDS.maxExecutionMs.max + 1 })
+    ).toThrow(/outside its allowed range/);
+  });
+
+  it('rejects a non-integer setting', () => {
+    expect(() => resolveCompiledSettings({ maxResultRows: 1.5 })).toThrow(CompiledQueryError);
+  });
+});
+
+describe('CompiledQuery v1 — deadline precedence', () => {
+  const now = 1_000_000;
+
+  it('takes the earlier of caller and policy', () => {
+    expect(
+      resolveCompiledDeadline({ callerAtEpochMs: now + 100, policyMaxMs: 500, nowEpochMs: now })
+    ).toEqual({ atEpochMs: now + 100, source: 'caller' });
+    expect(
+      resolveCompiledDeadline({ callerAtEpochMs: now + 900, policyMaxMs: 500, nowEpochMs: now })
+    ).toEqual({ atEpochMs: now + 500, source: 'policy' });
+  });
+
+  it('never extends beyond the policy ceiling when the caller asks for more', () => {
+    const resolved = resolveCompiledDeadline({
+      callerAtEpochMs: now + 10_000,
+      policyMaxMs: 500,
+      nowEpochMs: now,
+    });
+    expect(resolved).toEqual({ atEpochMs: now + 500, source: 'policy' });
+  });
+
+  it('fails immediately when the caller deadline is at or before now', () => {
+    expect(() =>
+      resolveCompiledDeadline({ callerAtEpochMs: now, nowEpochMs: now })
+    ).toThrow(/at or before the current time/);
+  });
+
+  it('returns undefined when neither deadline is present', () => {
+    expect(resolveCompiledDeadline({ nowEpochMs: now })).toBeUndefined();
+  });
+});
+
+describe('CompiledQuery v1 — debug form redaction', () => {
+  it('shows placeholders + types, hides values, and is non-executable', () => {
+    const compiled = compileQueryV1({
+      operation: 'query',
+      sql: 'SELECT * FROM t WHERE tenant = {tenant:String} AND id = {id:UInt64}',
+      parameters: [decl('tenant', 'String', 'string'), decl('id', 'UInt64', 'integer')],
+      values: { tenant: 'secret-tenant', id: uint64('42') },
+      settings: { maxExecutionMs: 5000 },
+      identifiers: { queryId: 'q-3' },
+    });
+
+    expect(compiled.debug.sql).not.toContain('secret-tenant');
+    expect(compiled.debug.sql).not.toContain('42');
+    expect(compiled.debug.sql).toContain('«param tenant: String»');
+    // Non-executable: no native placeholder braces survive in the debug SQL.
+    expect(compiled.debug.sql).not.toMatch(/\{[^}]*:[^}]*\}/);
+    // Setting names only, never values.
+    expect(compiled.debug.settings).toEqual(['maxExecutionMs']);
+    expect(JSON.stringify(compiled.debug)).not.toContain('5000');
+  });
+});
+
+describe('CompiledQuery v1 — error envelope', () => {
+  it('keeps a safe caller message for client-fault categories', () => {
+    const err = new CompiledQueryError('input-invalid', 'name is not declared', {
+      queryId: 'q-4',
+    });
+    expect(err.toEnvelope()).toEqual({
+      category: 'input-invalid',
+      message: 'name is not declared',
+      queryId: 'q-4',
+    });
+  });
+
+  it('redacts server-fault messages regardless of the supplied text', () => {
+    const err = new CompiledQueryError('internal', 'DB::Exception: table events on shard 3', {
+      queryId: 'q-5',
+      cause: new Error('raw adapter text'),
+    });
+    expect(err.message).not.toContain('events');
+    expect(err.message).not.toContain('shard');
+    expect(err.toEnvelope()).toEqual({
+      category: 'internal',
+      message: 'The request could not be completed.',
+      queryId: 'q-5',
+    });
+  });
+
+  it('drops multi-line client messages to a safe default', () => {
+    const err = new CompiledQueryError('forbidden', 'line1\nline2');
+    expect(err.message).toBe('Access is denied.');
+  });
+});
+
+describe('CompiledQuery v1 — identifiers', () => {
+  const base = {
+    operation: 'query' as const,
+    sql: 'SELECT 1',
+    identifiers: { queryId: 'q-6' },
+  };
+
+  it('rejects a missing authoritative query id', () => {
+    expect(() => compileQueryV1({ ...base, identifiers: { queryId: '' } })).toThrow(
+      CompiledQueryError
+    );
+  });
+
+  it('rejects a correlation id with control characters', () => {
+    expect(() =>
+      compileQueryV1({ ...base, identifiers: { queryId: 'q', correlationId: 'a\u0001b' } })
+    ).toThrow(/control characters/);
+  });
+
+  it('rejects an oversized correlation id', () => {
+    expect(() =>
+      compileQueryV1({
+        ...base,
+        identifiers: { queryId: 'q', correlationId: 'x'.repeat(1025) },
+      })
+    ).toThrow(/exceeds the allowed size/);
+  });
+});

--- a/packages/clickhouse/src/core/compiled/debug.ts
+++ b/packages/clickhouse/src/core/compiled/debug.ts
@@ -3,6 +3,7 @@ import type {
   CompiledParameterDeclaration,
   CompiledSettings,
 } from './types.js';
+import { replaceParameterPlaceholders } from './parameters.js';
 
 /**
  * Marker wrapping placeholders in the debug form. The guillemets make the rendered SQL
@@ -11,8 +12,6 @@ import type {
  */
 const DEBUG_OPEN = '«param ';
 const DEBUG_CLOSE = '»';
-
-const PLACEHOLDER_PATTERN = /\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^{}]+)\}/g;
 
 /**
  * Build the redacted, non-executable debug form. It carries no parameter values, tenant
@@ -23,22 +22,21 @@ export function buildDebugForm(
   parameters: readonly CompiledParameterDeclaration[],
   settings: CompiledSettings
 ): CompiledDebugForm {
-  const redactedSql = sql.replace(
-    PLACEHOLDER_PATTERN,
-    (_match, name: string, type: string) =>
-      `${DEBUG_OPEN}${name}: ${type.trim()}${DEBUG_CLOSE}`
+  const redactedSql = replaceParameterPlaceholders(
+    sql,
+    (name, type) => `${DEBUG_OPEN}${name}: ${type}${DEBUG_CLOSE}`,
   );
 
-  return {
+  return Object.freeze({
     sql: redactedSql,
-    parameters: parameters.map((p) => ({
+    parameters: Object.freeze(parameters.map((p) => Object.freeze({
       name: p.name as string,
       type: p.type.clickHouseType,
       optional: p.optional,
-    })),
+    }))),
     // Setting names only; values are policy and never appear in diagnostics.
-    settings: Object.keys(settings).filter(
+    settings: Object.freeze(Object.keys(settings).filter(
       (key) => settings[key as keyof CompiledSettings] !== undefined
-    ),
-  };
+    )),
+  });
 }

--- a/packages/clickhouse/src/core/compiled/debug.ts
+++ b/packages/clickhouse/src/core/compiled/debug.ts
@@ -1,0 +1,44 @@
+import type {
+  CompiledDebugForm,
+  CompiledParameterDeclaration,
+  CompiledSettings,
+} from './types.js';
+
+/**
+ * Marker wrapping placeholders in the debug form. The guillemets make the rendered SQL
+ * deliberately invalid as database SQL — it cannot be pasted into a client and run — while
+ * still showing structure and declared types (RFC 0010 §Debug form).
+ */
+const DEBUG_OPEN = '«param ';
+const DEBUG_CLOSE = '»';
+
+const PLACEHOLDER_PATTERN = /\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^{}]+)\}/g;
+
+/**
+ * Build the redacted, non-executable debug form. It carries no parameter values, tenant
+ * values, credentials, or setting values — only names, declared types, and structure.
+ */
+export function buildDebugForm(
+  sql: string,
+  parameters: readonly CompiledParameterDeclaration[],
+  settings: CompiledSettings
+): CompiledDebugForm {
+  const redactedSql = sql.replace(
+    PLACEHOLDER_PATTERN,
+    (_match, name: string, type: string) =>
+      `${DEBUG_OPEN}${name}: ${type.trim()}${DEBUG_CLOSE}`
+  );
+
+  return {
+    sql: redactedSql,
+    parameters: parameters.map((p) => ({
+      name: p.name as string,
+      type: p.type.clickHouseType,
+      optional: p.optional,
+    })),
+    // Setting names only; values are policy and never appear in diagnostics.
+    settings: Object.keys(settings).filter(
+      (key) => settings[key as keyof CompiledSettings] !== undefined
+    ),
+  };
+}

--- a/packages/clickhouse/src/core/compiled/errors.ts
+++ b/packages/clickhouse/src/core/compiled/errors.ts
@@ -1,0 +1,123 @@
+/**
+ * Public execution-failure envelope from RFC 0010 §Error envelope.
+ *
+ * The category set is closed and stable within version 1. It matches the frozen set in
+ * `@hypequery/protocol` (`events` module) so runtime failures and emitted diagnostics
+ * speak the same vocabulary. New categories require a new contract version.
+ */
+export const COMPILED_ERROR_CATEGORIES = [
+  'input-invalid',
+  'unauthenticated',
+  'forbidden',
+  'tenant-required',
+  'not-found',
+  'too-large',
+  'aborted',
+  'deadline-exceeded',
+  'unavailable',
+  'internal',
+] as const;
+
+export type CompiledErrorCategory = (typeof COMPILED_ERROR_CATEGORIES)[number];
+
+/**
+ * Categories that describe a client-supplied fault. Their messages MAY carry a safe,
+ * caller-facing explanation. Every other category is a server/dependency fault whose
+ * message MUST NOT expose adapter error text, SQL, values, or tenant identifiers.
+ */
+const CLIENT_FAULT_CATEGORIES: ReadonlySet<CompiledErrorCategory> = new Set([
+  'input-invalid',
+  'unauthenticated',
+  'forbidden',
+  'tenant-required',
+  'not-found',
+  'too-large',
+  'aborted',
+  'deadline-exceeded',
+]);
+
+const SAFE_MESSAGE_PATTERN = /[\r\n\t]/;
+
+export function isCompiledErrorCategory(value: unknown): value is CompiledErrorCategory {
+  return (
+    typeof value === 'string' &&
+    (COMPILED_ERROR_CATEGORIES as readonly string[]).includes(value)
+  );
+}
+
+export function isClientFaultCategory(category: CompiledErrorCategory): boolean {
+  return CLIENT_FAULT_CATEGORIES.has(category);
+}
+
+/** The stable, serializable error object surfaced to callers. */
+export interface CompiledErrorEnvelope {
+  readonly category: CompiledErrorCategory;
+  readonly message: string;
+  /** Authoritative query identifier; safe for logs. Absent only before one is assigned. */
+  readonly queryId?: string;
+}
+
+export interface CompiledQueryErrorOptions {
+  readonly queryId?: string;
+  /** Non-public cause retained for local logging; never serialized into the envelope. */
+  readonly cause?: unknown;
+}
+
+/**
+ * The only execution-failure shape a runtime may surface for a compiled query. For
+ * server-fault categories the caller-facing message is fixed to a generic string so no
+ * adapter text, SQL, value, or tenant identifier can leak.
+ */
+export class CompiledQueryError extends Error {
+  readonly category: CompiledErrorCategory;
+  readonly queryId?: string;
+  override readonly cause?: unknown;
+
+  constructor(
+    category: CompiledErrorCategory,
+    message: string,
+    options: CompiledQueryErrorOptions = {}
+  ) {
+    const safeMessage = CompiledQueryError.resolveMessage(category, message);
+    super(safeMessage);
+    this.name = 'CompiledQueryError';
+    this.category = category;
+    this.queryId = options.queryId;
+    this.cause = options.cause;
+  }
+
+  private static resolveMessage(category: CompiledErrorCategory, message: string): string {
+    if (!isClientFaultCategory(category)) {
+      // Server-fault categories never carry a caller-authored message.
+      return DEFAULT_SERVER_FAULT_MESSAGE[category] ?? 'The request could not be completed.';
+    }
+    const trimmed = typeof message === 'string' ? message.trim() : '';
+    if (trimmed.length === 0 || SAFE_MESSAGE_PATTERN.test(trimmed)) {
+      return DEFAULT_CLIENT_FAULT_MESSAGE[category] ?? 'The request was rejected.';
+    }
+    return trimmed;
+  }
+
+  /** The redacted, serializable envelope. Only closed fields; no `cause`, no stack. */
+  toEnvelope(): CompiledErrorEnvelope {
+    return this.queryId === undefined
+      ? { category: this.category, message: this.message }
+      : { category: this.category, message: this.message, queryId: this.queryId };
+  }
+}
+
+const DEFAULT_CLIENT_FAULT_MESSAGE: Partial<Record<CompiledErrorCategory, string>> = {
+  'input-invalid': 'The request parameters were invalid.',
+  unauthenticated: 'Authentication is required.',
+  forbidden: 'Access is denied.',
+  'tenant-required': 'A tenant context is required.',
+  'not-found': 'The requested resource was not found.',
+  'too-large': 'The request or result exceeded an allowed bound.',
+  aborted: 'The request was cancelled.',
+  'deadline-exceeded': 'The request deadline was exceeded.',
+};
+
+const DEFAULT_SERVER_FAULT_MESSAGE: Partial<Record<CompiledErrorCategory, string>> = {
+  unavailable: 'The executor is temporarily unavailable.',
+  internal: 'The request could not be completed.',
+};

--- a/packages/clickhouse/src/core/compiled/index.ts
+++ b/packages/clickhouse/src/core/compiled/index.ts
@@ -1,0 +1,52 @@
+/**
+ * CompiledQuery v1 (RFC 0010) — the versioned execution-request contract for the
+ * ClickHouse runtime, introduced beside the legacy positional path. See `./types.ts`.
+ *
+ * CH-01 provides the shape, validation, and redacted debug/error surfaces. Wiring the real
+ * `@clickhouse/client` `{name:Type}` + `query_params` transport, capability negotiation,
+ * and end-to-end cancellation is CH-02+ and does not touch the legacy adapter signature.
+ */
+export {
+  COMPILED_QUERY_VERSION,
+  type CompiledDeadline,
+  type CompiledDebugForm,
+  type CompiledIdentifiers,
+  type CompiledOperation,
+  type CompiledParameterBindings,
+  type CompiledParameterDeclaration,
+  type CompiledParameterType,
+  type CompiledParameterValue,
+  type CompiledQueryV1,
+  type CompiledSensitivity,
+  type CompiledSettings,
+} from './types.js';
+
+export { compileQueryV1, type CompileQueryInput } from './compile.js';
+
+export {
+  assertNoValuesInSql,
+  buildParameterBindings,
+  extractReferencedParameters,
+  validateParameterReferences,
+} from './parameters.js';
+
+export {
+  COMPILED_SETTING_BOUNDS,
+  type CompiledSettingName,
+  type DeadlineInputs,
+  type SettingBound,
+  resolveCompiledDeadline,
+  resolveCompiledSettings,
+} from './settings.js';
+
+export {
+  COMPILED_ERROR_CATEGORIES,
+  CompiledQueryError,
+  type CompiledErrorCategory,
+  type CompiledErrorEnvelope,
+  type CompiledQueryErrorOptions,
+  isClientFaultCategory,
+  isCompiledErrorCategory,
+} from './errors.js';
+
+export { buildDebugForm } from './debug.js';

--- a/packages/clickhouse/src/core/compiled/parameters.ts
+++ b/packages/clickhouse/src/core/compiled/parameters.ts
@@ -15,25 +15,151 @@ import type {
  * ONLY way a value reaches a query — the name references a declared parameter and the
  * value is bound out-of-band, never rendered into the SQL text.
  */
-const PLACEHOLDER_PATTERN = /\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*[^{}]+\}/g;
+interface SqlParameterReference {
+  readonly name: string;
+  readonly type: string;
+  readonly start: number;
+  readonly end: number;
+}
 
-/** Native JSON scalars that are valid parameter values without an RFC 0001 tag. */
-function isNativeScalar(value: unknown): value is string | number | boolean | null {
-  return (
-    value === null ||
-    typeof value === 'string' ||
-    typeof value === 'number' ||
-    typeof value === 'boolean'
-  );
+interface SqlParameterScan {
+  readonly references: readonly SqlParameterReference[];
+  readonly hasPositionalPlaceholder: boolean;
+}
+
+const LOGICAL_TYPES = new Set([
+  'array', 'boolean', 'bytes', 'date', 'datetime', 'decimal', 'enum', 'float',
+  'integer', 'map', 'null', 'string', 'tuple', 'uuid',
+]);
+
+function skipQuoted(sql: string, start: number, quote: string): number {
+  let index = start + 1;
+  while (index < sql.length) {
+    if (sql[index] === '\\') {
+      index += 2;
+      continue;
+    }
+    if (sql[index] === quote) {
+      if (sql[index + 1] === quote) {
+        index += 2;
+        continue;
+      }
+      return index + 1;
+    }
+    index += 1;
+  }
+  return sql.length;
+}
+
+function parsePlaceholder(sql: string, start: number): SqlParameterReference | undefined {
+  let index = start + 1;
+  while (/\s/.test(sql[index] ?? '')) index += 1;
+  const nameStart = index;
+  if (!/[A-Za-z_]/.test(sql[index] ?? '')) return undefined;
+  index += 1;
+  while (/[A-Za-z0-9_]/.test(sql[index] ?? '')) index += 1;
+  const name = sql.slice(nameStart, index);
+  while (/\s/.test(sql[index] ?? '')) index += 1;
+  if (sql[index] !== ':') return undefined;
+  index += 1;
+  const typeStart = index;
+  let quote: string | undefined;
+  let parenthesisDepth = 0;
+  while (index < sql.length) {
+    const character = sql[index];
+    if (quote) {
+      if (character === '\\') {
+        index += 2;
+        continue;
+      }
+      if (character === quote) {
+        if (sql[index + 1] === quote) {
+          index += 2;
+          continue;
+        }
+        quote = undefined;
+      }
+      index += 1;
+      continue;
+    }
+    if (character === "'" || character === '"' || character === '`') {
+      quote = character;
+      index += 1;
+      continue;
+    }
+    if (character === '(') parenthesisDepth += 1;
+    if (character === ')') {
+      parenthesisDepth -= 1;
+      if (parenthesisDepth < 0) return undefined;
+    }
+    if (character === '{') return undefined;
+    if (character === '}' && parenthesisDepth === 0) {
+      const type = sql.slice(typeStart, index).trim();
+      if (type.length === 0) return undefined;
+      return { name, type, start, end: index + 1 };
+    }
+    index += 1;
+  }
+  return undefined;
+}
+
+function scanSqlParameters(sql: string): SqlParameterScan {
+  const references: SqlParameterReference[] = [];
+  let hasPositionalPlaceholder = false;
+  let index = 0;
+  while (index < sql.length) {
+    const character = sql[index];
+    if (character === "'" || character === '"' || character === '`') {
+      index = skipQuoted(sql, index, character);
+      continue;
+    }
+    if (character === '-' && sql[index + 1] === '-') {
+      const newline = sql.indexOf('\n', index + 2);
+      index = newline === -1 ? sql.length : newline + 1;
+      continue;
+    }
+    if (character === '#') {
+      const newline = sql.indexOf('\n', index + 1);
+      index = newline === -1 ? sql.length : newline + 1;
+      continue;
+    }
+    if (character === '/' && sql[index + 1] === '*') {
+      const close = sql.indexOf('*/', index + 2);
+      index = close === -1 ? sql.length : close + 2;
+      continue;
+    }
+    if (character === '?') hasPositionalPlaceholder = true;
+    if (character === '{') {
+      const reference = parsePlaceholder(sql, index);
+      if (reference) {
+        references.push(reference);
+        index = reference.end;
+        continue;
+      }
+    }
+    index += 1;
+  }
+  return { references, hasPositionalPlaceholder };
 }
 
 /** Extract the set of parameter names a SQL text references via `{name:Type}`. */
 export function extractReferencedParameters(sql: string): Set<string> {
-  const names = new Set<string>();
-  for (const match of sql.matchAll(PLACEHOLDER_PATTERN)) {
-    names.add(match[1]);
+  return new Set(scanSqlParameters(sql).references.map(({ name }) => name));
+}
+
+export function replaceParameterPlaceholders(
+  sql: string,
+  replace: (name: string, type: string) => string,
+): string {
+  const references = scanSqlParameters(sql).references;
+  let result = '';
+  let offset = 0;
+  for (const reference of references) {
+    result += sql.slice(offset, reference.start);
+    result += replace(reference.name, reference.type);
+    offset = reference.end;
   }
-  return names;
+  return result + sql.slice(offset);
 }
 
 /**
@@ -44,12 +170,22 @@ export function validateParameterReferences(
   sql: string,
   declarations: readonly CompiledParameterDeclaration[]
 ): void {
-  const declared = new Set(declarations.map((d) => d.name as string));
-  for (const name of extractReferencedParameters(sql)) {
-    if (!declared.has(name)) {
+  const declared = new Map(declarations.map((declaration) => [
+    declaration.name as string,
+    declaration,
+  ]));
+  for (const reference of scanSqlParameters(sql).references) {
+    const declaration = declared.get(reference.name);
+    if (!declaration) {
       throw new CompiledQueryError(
         'input-invalid',
-        `SQL references undeclared parameter ${name}.`
+        `SQL references undeclared parameter ${reference.name}.`
+      );
+    }
+    if (reference.type !== declaration.type.clickHouseType) {
+      throw new CompiledQueryError(
+        'input-invalid',
+        `SQL parameter ${reference.name} does not match its declared ClickHouse type.`,
       );
     }
   }
@@ -116,16 +252,12 @@ function validateParameterValue(
   declaration: CompiledParameterDeclaration,
   value: CompiledParameterValue
 ): CompiledParameterValue {
-  if (isNativeScalar(value)) {
-    return value;
-  }
-  // Tagged values must satisfy the RFC 0001 canonical contract, bounded by the declared
-  // ClickHouse type so schema-dependent checks apply.
   try {
-    validateCanonicalValue(value, {
+    const validated = validateCanonicalValue(value, {
       declaredClickHouseType: declaration.type.clickHouseType,
     });
-    return value;
+    validateLogicalType(name, declaration, validated);
+    return validated as CompiledParameterValue;
   } catch (error) {
     if (error instanceof ProtocolValueError) {
       throw new CompiledQueryError(
@@ -135,6 +267,64 @@ function validateParameterValue(
       );
     }
     throw error;
+  }
+}
+
+function logicalTypeOf(value: CompiledParameterValue): string {
+  if (value === null) return 'null';
+  if (typeof value === 'string') return 'string';
+  if (typeof value === 'number') return 'float';
+  if (typeof value === 'boolean') return 'boolean';
+  return value.$hypequery.type;
+}
+
+function unwrapNullable(type: string): { readonly nullable: boolean; readonly inner: string } {
+  const trimmed = type.trim();
+  if (trimmed.startsWith('Nullable(') && trimmed.endsWith(')')) {
+    return { nullable: true, inner: trimmed.slice(9, -1).trim() };
+  }
+  return { nullable: false, inner: trimmed };
+}
+
+function clickHouseTypeSupportsLogical(type: string, logical: string): boolean {
+  const { nullable, inner } = unwrapNullable(type);
+  if (logical === 'null') return nullable;
+  switch (logical) {
+    case 'string': return /^(?:String|FixedString\(\d+\)|LowCardinality\(String\))$/.test(inner);
+    case 'float': return /^Float(?:32|64)$/.test(inner);
+    case 'boolean': return /^(?:Bool|Boolean)$/.test(inner);
+    case 'integer': return /^(?:U?Int)(?:8|16|32|64|128|256)$/.test(inner);
+    case 'decimal': return /^Decimal(?:(?:32|64|128|256)\(\d+\)|\(\d+\s*,\s*\d+\))$/.test(inner);
+    case 'date': return /^(?:Date|Date32)$/.test(inner);
+    case 'datetime': return /^DateTime(?:64)?(?:\(.*\))?$/.test(inner);
+    case 'uuid': return inner === 'UUID';
+    case 'bytes': return /^(?:String|FixedString\(\d+\))$/.test(inner);
+    case 'enum': return /^Enum(?:8|16)\(.*\)$/.test(inner);
+    case 'array': return /^Array\(.+\)$/.test(inner);
+    case 'tuple': return /^Tuple\(.+\)$/.test(inner);
+    case 'map': return /^Map\(.+\)$/.test(inner);
+    default: return false;
+  }
+}
+
+function validateLogicalType(
+  name: string,
+  declaration: CompiledParameterDeclaration,
+  value: CompiledParameterValue,
+): void {
+  const actual = logicalTypeOf(value);
+  const declared = declaration.type.logical;
+  if (!LOGICAL_TYPES.has(declared) || (actual !== declared && actual !== 'null')) {
+    throw new CompiledQueryError(
+      'input-invalid',
+      `Parameter ${name} does not match its declared logical type.`,
+    );
+  }
+  if (!clickHouseTypeSupportsLogical(declaration.type.clickHouseType, actual)) {
+    throw new CompiledQueryError(
+      'input-invalid',
+      `Parameter ${name} does not match its declared ClickHouse type.`,
+    );
   }
 }
 
@@ -148,18 +338,27 @@ export function assertNoValuesInSql(
   sql: string,
   bindings: CompiledParameterBindings
 ): void {
-  if (sql.includes('?')) {
+  const scan = scanSqlParameters(sql);
+  if (scan.hasPositionalPlaceholder) {
     throw new CompiledQueryError(
       'input-invalid',
       'Compiled SQL must not use positional placeholders.'
     );
   }
-  const referenced = extractReferencedParameters(sql);
+  const referenced = new Set(scan.references.map(({ name }) => name));
   for (const name of Object.keys(bindings)) {
     if (!referenced.has(name)) {
       throw new CompiledQueryError(
         'input-invalid',
         `Bound parameter ${name} is not referenced by the SQL.`
+      );
+    }
+  }
+  for (const name of referenced) {
+    if (!Object.prototype.hasOwnProperty.call(bindings, name)) {
+      throw new CompiledQueryError(
+        'input-invalid',
+        `SQL parameter ${name} does not have a bound value.`,
       );
     }
   }

--- a/packages/clickhouse/src/core/compiled/parameters.ts
+++ b/packages/clickhouse/src/core/compiled/parameters.ts
@@ -1,0 +1,166 @@
+import {
+  ProtocolValueError,
+  isProtocolIdentifier,
+  validateCanonicalValue,
+} from '@hypequery/protocol';
+import { CompiledQueryError } from './errors.js';
+import type {
+  CompiledParameterBindings,
+  CompiledParameterDeclaration,
+  CompiledParameterValue,
+} from './types.js';
+
+/**
+ * Matches ClickHouse native server-parameter placeholders: `{name:Type}`. This is the
+ * ONLY way a value reaches a query — the name references a declared parameter and the
+ * value is bound out-of-band, never rendered into the SQL text.
+ */
+const PLACEHOLDER_PATTERN = /\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*[^{}]+\}/g;
+
+/** Native JSON scalars that are valid parameter values without an RFC 0001 tag. */
+function isNativeScalar(value: unknown): value is string | number | boolean | null {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  );
+}
+
+/** Extract the set of parameter names a SQL text references via `{name:Type}`. */
+export function extractReferencedParameters(sql: string): Set<string> {
+  const names = new Set<string>();
+  for (const match of sql.matchAll(PLACEHOLDER_PATTERN)) {
+    names.add(match[1]);
+  }
+  return names;
+}
+
+/**
+ * Validate that the SQL only references declared parameters. Fails closed when a
+ * placeholder names an undeclared parameter (RFC 0010 §Parameters).
+ */
+export function validateParameterReferences(
+  sql: string,
+  declarations: readonly CompiledParameterDeclaration[]
+): void {
+  const declared = new Set(declarations.map((d) => d.name as string));
+  for (const name of extractReferencedParameters(sql)) {
+    if (!declared.has(name)) {
+      throw new CompiledQueryError(
+        'input-invalid',
+        `SQL references undeclared parameter ${name}.`
+      );
+    }
+  }
+}
+
+/**
+ * Resolve supplied values against declarations into the native `{name: value}` bindings
+ * an adapter binds to server parameters. Fail-closed rules (RFC 0010 §Parameters):
+ *   - a supplied name that is not declared is rejected;
+ *   - a required declared name with no supplied value is rejected;
+ *   - an optional declared name may be absent;
+ *   - every supplied value is validated (RFC 0001 for tagged values).
+ *
+ * No value is ever concatenated into SQL text: values live only in the returned bindings.
+ */
+export function buildParameterBindings(
+  declarations: readonly CompiledParameterDeclaration[],
+  values: Readonly<Record<string, CompiledParameterValue>>
+): CompiledParameterBindings {
+  const declaredByName = new Map<string, CompiledParameterDeclaration>();
+  for (const declaration of declarations) {
+    if (!isProtocolIdentifier(declaration.name)) {
+      throw new CompiledQueryError(
+        'input-invalid',
+        'Parameter declaration has an invalid name.'
+      );
+    }
+    if (declaredByName.has(declaration.name)) {
+      throw new CompiledQueryError(
+        'input-invalid',
+        `Duplicate parameter declaration ${declaration.name}.`
+      );
+    }
+    declaredByName.set(declaration.name, declaration);
+  }
+
+  for (const suppliedName of Object.keys(values)) {
+    if (!declaredByName.has(suppliedName)) {
+      throw new CompiledQueryError(
+        'input-invalid',
+        `Value supplied for undeclared parameter ${suppliedName}.`
+      );
+    }
+  }
+
+  const bindings: Record<string, CompiledParameterValue> = {};
+  for (const [name, declaration] of declaredByName) {
+    const present = Object.prototype.hasOwnProperty.call(values, name);
+    if (!present) {
+      if (declaration.optional) continue;
+      throw new CompiledQueryError(
+        'input-invalid',
+        `Required parameter ${name} is missing.`
+      );
+    }
+    bindings[name] = validateParameterValue(name, declaration, values[name]);
+  }
+
+  return Object.freeze(bindings);
+}
+
+function validateParameterValue(
+  name: string,
+  declaration: CompiledParameterDeclaration,
+  value: CompiledParameterValue
+): CompiledParameterValue {
+  if (isNativeScalar(value)) {
+    return value;
+  }
+  // Tagged values must satisfy the RFC 0001 canonical contract, bounded by the declared
+  // ClickHouse type so schema-dependent checks apply.
+  try {
+    validateCanonicalValue(value, {
+      declaredClickHouseType: declaration.type.clickHouseType,
+    });
+    return value;
+  } catch (error) {
+    if (error instanceof ProtocolValueError) {
+      throw new CompiledQueryError(
+        'input-invalid',
+        `Parameter ${name} failed value validation (${error.code}).`,
+        { cause: error }
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Assert the invariant that no bound value has leaked into the SQL text. The compile path
+ * never substitutes values, so this is a defense-in-depth check: the SQL must reference
+ * every non-optional bound name through a placeholder and must not be the legacy
+ * positional form (`?`).
+ */
+export function assertNoValuesInSql(
+  sql: string,
+  bindings: CompiledParameterBindings
+): void {
+  if (sql.includes('?')) {
+    throw new CompiledQueryError(
+      'input-invalid',
+      'Compiled SQL must not use positional placeholders.'
+    );
+  }
+  const referenced = extractReferencedParameters(sql);
+  for (const name of Object.keys(bindings)) {
+    if (!referenced.has(name)) {
+      throw new CompiledQueryError(
+        'input-invalid',
+        `Bound parameter ${name} is not referenced by the SQL.`
+      );
+    }
+  }
+}

--- a/packages/clickhouse/src/core/compiled/settings.ts
+++ b/packages/clickhouse/src/core/compiled/settings.ts
@@ -1,0 +1,86 @@
+import { CompiledQueryError } from './errors.js';
+import type { CompiledDeadline, CompiledSettings } from './types.js';
+
+/**
+ * Closed, typed settings allow-list (RFC 0010 §Settings). Each entry defines an inclusive
+ * range; products may TIGHTEN a range but never loosen it. Settings originate only from
+ * trusted components — a request can never set, override, or relax them.
+ */
+export interface SettingBound {
+  readonly min: number;
+  readonly max: number;
+}
+
+export const COMPILED_SETTING_BOUNDS = Object.freeze({
+  maxExecutionMs: { min: 1, max: 3_600_000 },
+  maxResultRows: { min: 0, max: 1_000_000_000_000 },
+  maxResultBytes: { min: 0, max: 1_099_511_627_776 },
+} as const satisfies Record<keyof CompiledSettings, SettingBound>);
+
+export type CompiledSettingName = keyof typeof COMPILED_SETTING_BOUNDS;
+
+/**
+ * Clamp trusted settings into the allow-list. A value outside the closed range is
+ * rejected fail-closed rather than silently coerced, since settings are trusted input and
+ * an out-of-range value signals a policy bug, not caller data.
+ */
+export function resolveCompiledSettings(input: CompiledSettings): CompiledSettings {
+  const resolved: { -readonly [K in CompiledSettingName]?: number } = {};
+  for (const key of Object.keys(COMPILED_SETTING_BOUNDS) as CompiledSettingName[]) {
+    const value = input[key];
+    if (value === undefined) continue;
+    const bound = COMPILED_SETTING_BOUNDS[key];
+    if (!Number.isInteger(value) || value < bound.min || value > bound.max) {
+      throw new CompiledQueryError(
+        'input-invalid',
+        `Setting ${key} is outside its allowed range.`
+      );
+    }
+    resolved[key] = value;
+  }
+  return resolved;
+}
+
+export interface DeadlineInputs {
+  /** Absolute caller-supplied deadline, epoch-millis. */
+  readonly callerAtEpochMs?: number;
+  /** Policy-derived maximum window from `now`, milliseconds. */
+  readonly policyMaxMs?: number;
+  /** Current time, epoch-millis. Injected so resolution stays deterministic/testable. */
+  readonly nowEpochMs: number;
+}
+
+/**
+ * Resolve the effective deadline (RFC 0010 §Deadline and cancellation precedence).
+ *
+ * The effective deadline is the EARLIER of the caller-supplied deadline and the
+ * policy-derived maximum — a caller can shorten but never extend the window. A supplied
+ * deadline at or before `now` fails immediately with `deadline-exceeded` rather than being
+ * extended or ignored.
+ */
+export function resolveCompiledDeadline(inputs: DeadlineInputs): CompiledDeadline | undefined {
+  const { callerAtEpochMs, policyMaxMs, nowEpochMs } = inputs;
+
+  const policyAt =
+    policyMaxMs === undefined ? undefined : nowEpochMs + policyMaxMs;
+
+  if (callerAtEpochMs !== undefined && callerAtEpochMs <= nowEpochMs) {
+    throw new CompiledQueryError(
+      'deadline-exceeded',
+      'The supplied deadline is at or before the current time.'
+    );
+  }
+
+  if (callerAtEpochMs === undefined && policyAt === undefined) {
+    return undefined;
+  }
+  if (callerAtEpochMs === undefined) {
+    return { atEpochMs: policyAt as number, source: 'policy' };
+  }
+  if (policyAt === undefined) {
+    return { atEpochMs: callerAtEpochMs, source: 'caller' };
+  }
+  return callerAtEpochMs <= policyAt
+    ? { atEpochMs: callerAtEpochMs, source: 'caller' }
+    : { atEpochMs: policyAt, source: 'policy' };
+}

--- a/packages/clickhouse/src/core/compiled/settings.ts
+++ b/packages/clickhouse/src/core/compiled/settings.ts
@@ -38,7 +38,7 @@ export function resolveCompiledSettings(input: CompiledSettings): CompiledSettin
     }
     resolved[key] = value;
   }
-  return resolved;
+  return Object.freeze(resolved);
 }
 
 export interface DeadlineInputs {
@@ -61,8 +61,24 @@ export interface DeadlineInputs {
 export function resolveCompiledDeadline(inputs: DeadlineInputs): CompiledDeadline | undefined {
   const { callerAtEpochMs, policyMaxMs, nowEpochMs } = inputs;
 
+  if (!Number.isSafeInteger(nowEpochMs) || nowEpochMs < 0) {
+    throw new CompiledQueryError('input-invalid', 'The current time is invalid.');
+  }
+  if (
+    callerAtEpochMs !== undefined
+    && (!Number.isSafeInteger(callerAtEpochMs) || callerAtEpochMs < 0)
+  ) {
+    throw new CompiledQueryError('input-invalid', 'The supplied deadline is invalid.');
+  }
+  if (policyMaxMs !== undefined && (!Number.isSafeInteger(policyMaxMs) || policyMaxMs <= 0)) {
+    throw new CompiledQueryError('input-invalid', 'The policy deadline window is invalid.');
+  }
+
   const policyAt =
     policyMaxMs === undefined ? undefined : nowEpochMs + policyMaxMs;
+  if (policyAt !== undefined && !Number.isSafeInteger(policyAt)) {
+    throw new CompiledQueryError('input-invalid', 'The policy deadline is outside the safe range.');
+  }
 
   if (callerAtEpochMs !== undefined && callerAtEpochMs <= nowEpochMs) {
     throw new CompiledQueryError(
@@ -75,12 +91,12 @@ export function resolveCompiledDeadline(inputs: DeadlineInputs): CompiledDeadlin
     return undefined;
   }
   if (callerAtEpochMs === undefined) {
-    return { atEpochMs: policyAt as number, source: 'policy' };
+    return Object.freeze({ atEpochMs: policyAt as number, source: 'policy' });
   }
   if (policyAt === undefined) {
-    return { atEpochMs: callerAtEpochMs, source: 'caller' };
+    return Object.freeze({ atEpochMs: callerAtEpochMs, source: 'caller' });
   }
-  return callerAtEpochMs <= policyAt
+  return Object.freeze(callerAtEpochMs <= policyAt
     ? { atEpochMs: callerAtEpochMs, source: 'caller' }
-    : { atEpochMs: policyAt, source: 'policy' };
+    : { atEpochMs: policyAt, source: 'policy' });
 }

--- a/packages/clickhouse/src/core/compiled/types.ts
+++ b/packages/clickhouse/src/core/compiled/types.ts
@@ -1,0 +1,126 @@
+import type { ProtocolIdentifier, TaggedValue } from '@hypequery/protocol';
+
+/**
+ * Execution-request contract from RFC 0010 (compiled query, error, cancellation),
+ * realized for the ClickHouse runtime.
+ *
+ * This is the versioned shape a runtime hands to an adapter. It sits *beside* the
+ * legacy positional path (`adapter.query(sql, params: unknown[])`, which renders
+ * values into SQL text via `substituteParameters`). Nothing here lets a request
+ * author SQL, tenant proof, or settings — those are trusted build/policy output.
+ *
+ * NOTE: distinct from the internal `CompiledQuery` in `../../types/base.ts`, which
+ * is the SQL-formatter fragment `{ query, parameters }`.
+ */
+export const COMPILED_QUERY_VERSION = 1 as const;
+
+/** Closed operation set (RFC 0010 §Operations). The operation belongs to the compiled
+ * query, never to the request. */
+export type CompiledOperation = 'query' | 'command' | 'insert';
+
+/**
+ * A logical parameter type. The logical tag drives validation and the `{name:Type}`
+ * placeholder the adapter sends; `clickHouseType` is the concrete server type string
+ * (e.g. `UInt64`, `DateTime64(3, 'UTC')`, `Array(String)`).
+ */
+export interface CompiledParameterType {
+  /** RFC 0001 logical tag, or a scalar shorthand for native JSON scalars. */
+  readonly logical: TaggedValue['$hypequery']['type'] | 'boolean' | 'string' | 'float' | 'null';
+  /** Concrete ClickHouse server type used to build the native placeholder. */
+  readonly clickHouseType: string;
+}
+
+/**
+ * A named, typed parameter declaration carried beside the SQL text. A request supplies
+ * only values for declared names; it can neither add names nor change types.
+ */
+export interface CompiledParameterDeclaration {
+  readonly name: ProtocolIdentifier;
+  readonly type: CompiledParameterType;
+  /** Optional parameters may be absent from a request; required ones fail closed. */
+  readonly optional: boolean;
+}
+
+/** A supplied parameter value: an RFC 0001 tagged value or a native JSON scalar. */
+export type CompiledParameterValue = TaggedValue | string | number | boolean | null;
+
+/**
+ * The resolved `{name: value}` map the adapter binds to native server parameters.
+ * Every key is a declared parameter name; no value is ever rendered into SQL text.
+ */
+export type CompiledParameterBindings = Readonly<Record<string, CompiledParameterValue>>;
+
+/**
+ * Data sensitivity metadata. Marks whether the query touches tenant-scoped or otherwise
+ * sensitive data so diagnostics/redaction downstream can act without inspecting values.
+ */
+export interface CompiledSensitivity {
+  /** The compiled SQL already contains trusted tenant predicates (RFC 0010 §Operations). */
+  readonly tenantScoped: boolean;
+  /** Free-form trusted classification labels (e.g. 'pii'); never request-supplied. */
+  readonly labels: readonly string[];
+}
+
+/**
+ * Bounded settings the runtime applies per execution. These originate only from trusted
+ * components; a request can never set, override, or relax them. See `settings.ts` for the
+ * closed allow-list and ranges.
+ */
+export interface CompiledSettings {
+  /** Wall-clock ceiling for server-side execution, milliseconds. Always enforced. */
+  readonly maxExecutionMs?: number;
+  /** Maximum rows the result may contain. */
+  readonly maxResultRows?: number;
+  /** Maximum bytes the result may contain. */
+  readonly maxResultBytes?: number;
+}
+
+/** Effective deadline + cancellation inputs (RFC 0010 §Deadline and cancellation). */
+export interface CompiledDeadline {
+  /** Epoch-millis absolute deadline. Earlier of caller-supplied and policy-derived. */
+  readonly atEpochMs: number;
+  /** Which side set the effective deadline, for honest diagnostics. */
+  readonly source: 'caller' | 'policy';
+}
+
+/** Authoritative + optional correlation identifiers (RFC 0010 §Query identifier). */
+export interface CompiledIdentifiers {
+  /** Server-generated, unique per execution, unguessable, safe for logs/cache metadata. */
+  readonly queryId: string;
+  /** Caller-supplied, non-authoritative, ≤1024 UTF-8 bytes, no control chars; never
+   * influences routing, cache keys, or authorization. */
+  readonly correlationId?: string;
+}
+
+/**
+ * Redacted, non-executable debug form (RFC 0010 §Debug form). Shows SQL structure with
+ * placeholders and declared types; carries no values, tenant values, credentials, or
+ * settings beyond their names. `sql` here is deliberately not valid database SQL.
+ */
+export interface CompiledDebugForm {
+  readonly sql: string;
+  readonly parameters: readonly {
+    readonly name: string;
+    readonly type: string;
+    readonly optional: boolean;
+  }[];
+  readonly settings: readonly string[];
+}
+
+/**
+ * The compiled query: the only way a runtime asks a ClickHouse adapter to execute.
+ */
+export interface CompiledQueryV1 {
+  readonly version: typeof COMPILED_QUERY_VERSION;
+  readonly operation: CompiledOperation;
+  /** Trusted build/server output. Callers influence execution only via `bindings`. */
+  readonly sql: string;
+  readonly parameters: readonly CompiledParameterDeclaration[];
+  /** Resolved values for declared names, bound to native server parameters. */
+  readonly bindings: CompiledParameterBindings;
+  readonly settings: CompiledSettings;
+  readonly identifiers: CompiledIdentifiers;
+  readonly deadline?: CompiledDeadline;
+  readonly sensitivity: CompiledSensitivity;
+  readonly debug: CompiledDebugForm;
+}

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -26,6 +26,12 @@ export { isClientConfig } from './core/query-builder.js';
 // SQL rendering used by the built-in adapter; exported so third-party DatabaseAdapter
 // implementations (e.g. embedded engines) reproduce identical ?-param rendering.
 export { substituteParameters, escapeValue } from './core/utils.js';
+
+// CompiledQuery v1 (RFC 0010) — versioned execution-request contract with named typed
+// parameters, closed operations/settings, authoritative ids, deadlines, a redacted debug
+// form, and the public error envelope. Introduced beside the legacy ?-param path (CH-01);
+// the built-in adapter transport is wired in a later change.
+export * from './core/compiled/index.js';
 export type {
   CacheOptions,
   CacheConfig,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       '@clickhouse/client':
         specifier: ^1.18.3
         version: 1.18.3
+      '@hypequery/protocol':
+        specifier: workspace:*
+        version: link:../protocol
       dotenv:
         specifier: ^16.0.0
         version: 16.6.1


### PR DESCRIPTION
## Summary

Implements **CH-01** — the RFC 0010 compiled-query / error / cancellation execution contract as a concrete, versioned data structure in `@hypequery/clickhouse`, placed **beside** the legacy positional query path. This is the head of train R1B (ClickHouse execution), unblocked by R1A-10 (RFC 0010, #328) now that R1A is complete (#338).

CH-01 provides the shape, validation, and redacted debug/error surfaces. Wiring the real `@clickhouse/client` `{name:Type}` + `query_params` transport, capability negotiation, and end-to-end cancellation is CH-02+ and does **not** touch the legacy adapter signature.

## What's included

New `packages/clickhouse/src/core/compiled/` module:

- **`types.ts`** — `CompiledQueryV1`: version, closed operation set (`query`/`command`/`insert`), SQL, named typed parameter declarations, resolved bindings, bounded settings, authoritative + optional correlation identifiers, deadline, sensitivity metadata, and the redacted debug form. (Named `CompiledQueryV1` because `CompiledQuery` is already taken by the internal SQL-formatter fragment in `types/base.ts`.)
- **`parameters.ts`** — builds the `{name: value}` binding map from RFC 0001 tagged values keyed by RFC 0002 identifiers; fails closed on undeclared / missing / extra names; `assertNoValuesInSql` rejects positional `?` and any bound value not referenced by a `{name:Type}` placeholder. **No value is ever rendered into SQL text.**
- **`settings.ts`** — closed settings allow-list with inclusive ranges (tighten-not-loosen), and caller-vs-policy deadline precedence (caller can only shorten; at/before-now fails immediately).
- **`errors.ts`** — `CompiledQueryError` public envelope reusing the frozen RFC 0010/0011 category set; server-fault messages are redacted to a generic string; `toEnvelope()` serializes only `category`/`message`/`queryId`.
- **`debug.ts`** — non-executable redacted debug form (guillemet placeholders, declared types, setting names only — no values).
- **`compile.ts`** — `compileQueryV1` constructor performing every fail-closed check with no I/O.

Additive re-export from the package index; adds `@hypequery/protocol` (`workspace:*`) as a direct dependency (reuses its tagged-value and identifier primitives).

## Verification

- New suite: **24/24 pass** (every parameter type, no-value-in-SQL invariant, fail-closed binding, settings clamp, deadline precedence, debug redaction, error-envelope safety).
- Full `@hypequery/clickhouse` unit suite: **572/572** (548 existing + 24 new), no regressions.
- `tsc` build + type-tests clean; ESLint clean.
- `/security-review` over this diff: **no findings**.

## Semver

Additive and non-breaking — **minor** (`@hypequery/clickhouse` 2.4.0 → 2.5.0). The legacy `adapter.query(sql, params[])` path and `substituteParameters`/`escapeValue` are unchanged.

> Note: RFC 0010 marks this security-review-required. An automated security review found no findings; a human security sign-off is still recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)