### PR TITLE
fix(release): include gateway and studio workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
     "packages/clickhouse",
     "packages/datasets",
     "packages/deployment",
+    "packages/gateway",
     "packages/mcp-server",
     "packages/protocol",
     "packages/protocol-conformance",
     "packages/react",
     "packages/serve",
+    "packages/studio",
     "packages/tsconfig"
   ],
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- align the root `package.json` workspace list with `pnpm-workspace.yaml`
- make Changesets recognize `@hypequery/gateway` and `@hypequery/studio`
- unblock the release and canary jobs failing after #338

## Verification

- `pnpm exec changeset status` recognizes gateway, studio, and CLI
- `pnpm release:version` completes successfully in an isolated repository copy
- `git diff --check` passes