### PR TITLE
docs: sequence Cloud before production Python

### DIFF
--- a/plans/cloud-python-sequencing.md
+++ b/plans/cloud-python-sequencing.md
@@ -1,0 +1,91 @@
+# Cloud and Python sequencing
+
+**Status:** Accepted working plan
+**Updated:** 2026-07-22
+
+## Decision
+
+Ship the first Cloud product before committing to a production Python SDK or
+Python deployment runtime.
+
+Before Cloud, Python work is limited to one time-boxed, experimental
+cross-language conformance probe. Its purpose is to test that the protocol's
+canonical rules are genuinely language-neutral, not to establish a supported
+Python product surface.
+
+This sequencing does not weaken the language-neutral protocol boundary. Cloud
+continues to consume and revalidate public protocol artifacts, and the runtime
+supervisor continues to allow future Python, process, container, or remote
+provider factories. The first Cloud runtime may remain Node-only.
+
+## Why
+
+A production Python implementation would create a second permanent product
+surface: validators and canonical codecs, query and semantic APIs, ClickHouse
+execution, framework integration, documentation, packaging, compatibility,
+release automation, and security maintenance. Building that surface before
+Cloud demand is known would delay the product while increasing the cost of
+every protocol change.
+
+A small independent implementation is still valuable. It can expose hidden
+JavaScript assumptions around numbers, Unicode, object ordering, canonical
+JSON, limits, and failure classification before Cloud persists or accepts
+these artifacts.
+
+## Pre-Cloud Python probe
+
+The probe is deliberately bounded:
+
+- **Time box:** 3–5 engineering days. Stop and record blockers rather than
+  broadening the scope.
+- **Contracts:** RFC 0001 tagged values and RFC 0002 portable identifiers only.
+- **Interface:** an NDJSON adapter compatible with
+  `@hypequery/protocol-conformance`.
+- **Acceptance:** all `tagged-values-v1` and `identifiers-v1` cases pass,
+  including applicable fuzz seeds, with the same outputs and stable failure
+  codes as the TypeScript reference implementation.
+- **Dependencies:** prefer the Python standard library; add no runtime
+  dependency without a demonstrated correctness requirement.
+- **Lifecycle:** experimental and unpublished. CI may run the adapter as a
+  language-neutrality canary, but it is not a supported SDK.
+
+If the probe finds disagreement, fix the normative specification, fixtures, or
+reference implementation. Do not introduce a Python-specific interpretation.
+
+### Explicitly out of scope before Cloud
+
+- publishing to PyPI or promising Python version support;
+- a Python query builder, semantic layer, Serve equivalent, or framework SDK;
+- ClickHouse transport or compiled-query execution;
+- a Python deployment runtime factory or Python workload hosting;
+- porting the remaining protocol families merely for completeness.
+
+## Cloud sequence
+
+1. Keep the existing protocol specifications, fixtures, and TypeScript
+   reference implementation authoritative.
+2. Run the bounded RFC 0001/0002 Python conformance probe.
+3. Build and validate the Cloud MVP using the existing Node runtime and
+   runtime-neutral deployment interfaces.
+4. Reassess Python after real Cloud usage and workload demand are known.
+
+CH-02 and RX work that changes existing execution semantics remains governed
+by the separate major-release hold. This plan does not pull those changes
+forward.
+
+## Conditions for a production Python investment
+
+Start a supported Python SDK or runtime only when all of the following are
+true:
+
+- users need Python authoring or Cloud-hosted Python workloads, rather than a
+  hypothetical second-language option;
+- the relevant protocol and artifact versions are stable enough to support
+  independently;
+- there is explicit ownership for Python testing, packaging, releases,
+  compatibility, documentation, and security response;
+- the first product slice and its compatibility boundary are separately
+  defined and can ship without cloning the entire TypeScript stack.
+
+Until those conditions hold, Python remains a conformance probe and future
+provider boundary, not a precondition for Cloud.

--- a/plans/dev-playground-design.md
+++ b/plans/dev-playground-design.md
@@ -320,6 +320,11 @@ Local dev server ships first; a hosted playground is the natural SaaS wedge afte
 deployed serve instance). The architecture keeps that door open cheaply, and these
 boundaries must be preserved as such:
 
+Cloud also precedes a supported Python SDK or Python deployment runtime. Before Cloud,
+Python is limited to the bounded cross-language probe in the
+[Cloud and Python sequencing plan](./cloud-python-sequencing.md); it is not a second
+product implementation or a Cloud prerequisite.
+
 - The UI speaks only the gateway contract (REST+SSE) — never Node internals — and ships
   as the embeddable `@hypequery/studio` core, so the Cloud app imports the same frontend
   and mounts it against a hosted gateway implementation.

--- a/specs/security-protocol/README.md
+++ b/specs/security-protocol/README.md
@@ -19,6 +19,14 @@ establish a stable artifact version.
 Do not treat a draft document or the npm package version as an executable
 artifact version.
 
+## Implementation sequencing
+
+The protocol remains language-neutral, but a production Python SDK is not a
+precondition for the first Cloud product. The accepted sequencing is Cloud
+before a supported Python product surface, with only a time-boxed RFC 0001/0002
+Python conformance probe allowed before Cloud. See the
+[Cloud and Python sequencing plan](../../plans/cloud-python-sequencing.md).
+
 ## Authority
 
 The sources have the following roles:


### PR DESCRIPTION
## Summary

- establish Cloud-before-Python as the accepted implementation sequence
- allow only a 3–5 day, unpublished RFC 0001/0002 Python conformance probe before Cloud
- defer a supported Python SDK and Python deployment runtime until demand, protocol stability, and long-term ownership are established
- keep CH-02 and RX execution changes under the existing major-release hold

## Why

A full Python product surface before Cloud would duplicate protocol, execution, packaging, documentation, compatibility, and security maintenance. A bounded second-language probe still tests the language-neutral protocol for hidden JavaScript assumptions without turning Python into a Cloud prerequisite.

## Validation

- `git diff --check`
- cross-document links resolve locally
- documentation-only change; no package changeset required