### PR TITLE
fix(cli): clean up gateway lifecycle failures (ST-C01)

### DIFF
--- a/.changeset/quiet-dogs-clean.md
+++ b/.changeset/quiet-dogs-clean.md
@@ -1,0 +1,5 @@
+---
+'@hypequery/cli': patch
+---
+
+Clean up the experimental local gateway when dev-server startup fails.

--- a/packages/cli/src/commands/dev.test.ts
+++ b/packages/cli/src/commands/dev.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { watch } from 'node:fs';
 import * as findFiles from '../utils/find-files.js';
 import * as loadApi from '../utils/load-api.js';
 import * as detectDb from '../utils/detect-database.js';
@@ -64,6 +65,20 @@ vi.mock('node:fs', () => ({
 // Import after mocks
 let devCommand: any;
 
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function flushMicrotasks() {
+  for (let i = 0; i < 10; i += 1) {
+    await Promise.resolve();
+  }
+}
+
 describe('dev command', () => {
   let exitHandler: ReturnType<typeof mockProcessExit>;
 
@@ -97,6 +112,8 @@ describe('dev command', () => {
 
   afterEach(() => {
     exitHandler.restore();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   describe('experimental query UI', () => {
@@ -140,6 +157,67 @@ describe('dev command', () => {
         expect.any(Object),
         expect.objectContaining({ telemetryDisabled: true })
       );
+    });
+  });
+
+  describe('runtime lifecycle', () => {
+    it('serializes a second restart behind an in-progress teardown', async () => {
+      vi.useFakeTimers();
+      const gatewayStop = deferred();
+      mockGatewayShutdown.mockImplementationOnce(() => gatewayStop.promise);
+
+      await devCommand(undefined, { watch: true, uiExperimental: true });
+      const watchCallback = vi.mocked(watch).mock.calls[0]?.[2] as (
+        eventType: string,
+        filename: string
+      ) => void;
+
+      watchCallback('change', 'api.ts');
+      vi.advanceTimersByTime(100);
+      await flushMicrotasks();
+      expect(mockGatewayShutdown).toHaveBeenCalledOnce();
+
+      watchCallback('change', 'api.ts');
+      vi.advanceTimersByTime(100);
+      await flushMicrotasks();
+
+      expect(mockServeDev).toHaveBeenCalledOnce();
+
+      gatewayStop.resolve();
+      await vi.waitFor(() => expect(mockServeDev).toHaveBeenCalledTimes(3));
+    });
+
+    it('waits for an in-progress restart teardown before signal exit', async () => {
+      vi.useFakeTimers();
+      const gatewayStop = deferred();
+      const signalHandlers = new Map<string, () => void>();
+      vi.spyOn(process, 'once').mockImplementation(((event: string, listener: () => void) => {
+        signalHandlers.set(event, listener);
+        return process;
+      }) as typeof process.once);
+      exitHandler.exitMock.mockImplementation(() => undefined);
+      mockGatewayShutdown.mockImplementationOnce(() => gatewayStop.promise);
+
+      await devCommand(undefined, { watch: true, uiExperimental: true });
+      const watchCallback = vi.mocked(watch).mock.calls[0]?.[2] as (
+        eventType: string,
+        filename: string
+      ) => void;
+
+      watchCallback('change', 'api.ts');
+      vi.advanceTimersByTime(100);
+      await flushMicrotasks();
+
+      signalHandlers.get('SIGINT')?.();
+      await flushMicrotasks();
+      expect(exitHandler.exitMock).not.toHaveBeenCalled();
+
+      gatewayStop.resolve();
+      await flushMicrotasks();
+
+      expect(mockServerStop).toHaveBeenCalledOnce();
+      expect(mockServeDev).toHaveBeenCalledOnce();
+      expect(exitHandler.exitMock).toHaveBeenCalledWith(0);
     });
   });
 

--- a/packages/cli/src/commands/dev.test.ts
+++ b/packages/cli/src/commands/dev.test.ts
@@ -311,6 +311,35 @@ describe('dev command', () => {
       expect(logger.info).toHaveBeenCalledWith('Port 4000 already in use');
     });
 
+    it('shuts down a created gateway when server startup fails', async () => {
+      mockServeDev.mockRejectedValue(new Error('Port 4000 already in use'));
+
+      try {
+        await devCommand(undefined, { watch: false, uiExperimental: true });
+      } catch (error) {
+        expect(error).toBeInstanceOf(ProcessExitError);
+      }
+
+      expect(mockGatewayShutdown).toHaveBeenCalledOnce();
+      expect(exitHandler.exitMock).toHaveBeenCalledWith(1);
+    });
+
+    it('still reports the startup error when gateway cleanup fails', async () => {
+      mockServeDev.mockRejectedValue(new Error('Port 4000 already in use'));
+      mockGatewayShutdown.mockRejectedValueOnce(new Error('Gateway shutdown failed'));
+
+      try {
+        await devCommand(undefined, { watch: false, uiExperimental: true });
+      } catch (error) {
+        expect(error).toBeInstanceOf(ProcessExitError);
+      }
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Failed to clean up dev server resources: Gateway shutdown failed'
+      );
+      expect(logger.info).toHaveBeenCalledWith('Port 4000 already in use');
+    });
+
     it('should handle browser open failure silently', async () => {
       mockOpen.mockRejectedValue(new Error('open package not found'));
 

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -96,7 +96,15 @@ export async function devCommand(file?: string, options: DevOptions = {}) {
 
   let currentServer: any = null;
   let currentGateway: { mount: unknown; shutdown: () => Promise<void>; uiAvailable: boolean } | null = null;
+  let lifecycleOperation: Promise<void> = Promise.resolve();
+  let shutdownRequested = false;
   const shouldWatch = options.watch !== false; // Default to true
+
+  const queueLifecycleOperation = (operation: () => Promise<void>) => {
+    const queued = lifecycleOperation.then(operation, operation);
+    lifecycleOperation = queued.catch(() => undefined);
+    return queued;
+  };
 
   const stopCurrentRuntime = async () => {
     const gateway = currentGateway;
@@ -261,21 +269,33 @@ export async function devCommand(file?: string, options: DevOptions = {}) {
     }
   };
 
-  const restartServer = async () => {
-    if (currentServer || currentGateway) {
-      logger.newline();
-      logger.reload('File changed, restarting...');
-      logger.newline();
-      await stopCurrentRuntime();
-    }
-    await startServer();
-  };
+  const restartServer = () =>
+    queueLifecycleOperation(async () => {
+      if (shutdownRequested) return;
 
-  const shutdown = async () => {
+      if (currentServer || currentGateway) {
+        logger.newline();
+        logger.reload('File changed, restarting...');
+        logger.newline();
+        await stopCurrentRuntime();
+      }
+
+      if (!shutdownRequested) {
+        await startServer();
+      }
+    });
+
+  const shutdown = () => {
+    if (shutdownRequested) return lifecycleOperation;
+    shutdownRequested = true;
+
     logger.newline();
     logger.info('Shutting down dev server...');
-    await stopCurrentRuntime();
-    process.exit(0);
+
+    return queueLifecycleOperation(async () => {
+      await stopCurrentRuntime();
+      process.exit(0);
+    });
   };
 
   // Start initial server

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -98,6 +98,38 @@ export async function devCommand(file?: string, options: DevOptions = {}) {
   let currentGateway: { mount: unknown; shutdown: () => Promise<void>; uiAvailable: boolean } | null = null;
   const shouldWatch = options.watch !== false; // Default to true
 
+  const stopCurrentRuntime = async () => {
+    const gateway = currentGateway;
+    const server = currentServer;
+
+    // Clear references before awaiting teardown so a second signal or restart
+    // cannot stop the same resources twice.
+    currentGateway = null;
+    currentServer = null;
+
+    let teardownError: unknown;
+
+    if (gateway) {
+      try {
+        await gateway.shutdown();
+      } catch (error) {
+        teardownError = error;
+      }
+    }
+
+    if (server) {
+      try {
+        await server.stop();
+      } catch (error) {
+        teardownError ??= error;
+      }
+    }
+
+    if (teardownError) {
+      throw teardownError;
+    }
+  };
+
   const startServer = async () => {
     // Loading spinners for slow operations
     const compileSpinner = ora('Compiling queries...').start();
@@ -191,6 +223,16 @@ export async function devCommand(file?: string, options: DevOptions = {}) {
         }
       }
     } catch (error) {
+      // Gateway creation happens before serveDev so its mount can be passed to
+      // the server. If server startup (or any later setup) fails, tear down all
+      // resources acquired by this attempt before retrying or exiting.
+      try {
+        await stopCurrentRuntime();
+      } catch (teardownError) {
+        const message = teardownError instanceof Error ? teardownError.message : String(teardownError);
+        logger.warn(`Failed to clean up dev server resources: ${message}`);
+      }
+
       // Stop spinners if they're still running
       if (compileSpinner.isSpinning) {
         compileSpinner.fail('Failed to compile queries');
@@ -220,12 +262,11 @@ export async function devCommand(file?: string, options: DevOptions = {}) {
   };
 
   const restartServer = async () => {
-    if (currentServer) {
+    if (currentServer || currentGateway) {
       logger.newline();
       logger.reload('File changed, restarting...');
       logger.newline();
-      if (currentGateway) await currentGateway.shutdown();
-      await currentServer.stop();
+      await stopCurrentRuntime();
     }
     await startServer();
   };
@@ -233,10 +274,7 @@ export async function devCommand(file?: string, options: DevOptions = {}) {
   const shutdown = async () => {
     logger.newline();
     logger.info('Shutting down dev server...');
-    if (currentGateway) await currentGateway.shutdown();
-    if (currentServer) {
-      await currentServer.stop();
-    }
+    await stopCurrentRuntime();
     process.exit(0);
   };
 


### PR DESCRIPTION
## Summary

- centralize local gateway and dev-server teardown
- clean up the gateway when server startup fails
- prevent duplicate shutdown during restarts and signals
- preserve the original startup error when cleanup also fails

## Validation

- 355 CLI tests passed, 1 skipped
- CLI TypeScript build passed
- CLI ESLint passed

Roadmap: ST-C01