### PR TITLE
fix(clickhouse): escape quotes/backslashes inside stringified array/object params

### DIFF
--- a/.changeset/escape-nonscalar-params.md
+++ b/.changeset/escape-nonscalar-params.md
@@ -1,0 +1,5 @@
+---
+'@hypequery/clickhouse': patch
+---
+
+Escape single quotes and backslashes inside stringified array/object parameter values. Previously `escapeValue` embedded `JSON.stringify(value)` into a SQL string literal without escaping it, so a quote inside an array/object value could terminate the literal and change how the surrounding WHERE parsed. Scalar strings were already escaped correctly; this brings non-scalar values in line.

--- a/.changeset/escape-nonscalar-params.md
+++ b/.changeset/escape-nonscalar-params.md
@@ -2,4 +2,6 @@
 '@hypequery/clickhouse': patch
 ---
 
-Escape single quotes and backslashes inside stringified array/object parameter values. Previously `escapeValue` embedded `JSON.stringify(value)` into a SQL string literal without escaping it, so a quote inside an array/object value could terminate the literal and change how the surrounding WHERE parsed. Scalar strings were already escaped correctly; this brings non-scalar values in line.
+Support bigint SQL parameters and add regression coverage ensuring injection-
+shaped strings nested inside arrays and objects remain contained within their
+ClickHouse string literals.

--- a/packages/clickhouse/src/core/tests/utils.test.ts
+++ b/packages/clickhouse/src/core/tests/utils.test.ts
@@ -48,6 +48,20 @@ describe('escapeValue', () => {
     expect(escapeValue(null)).toBe('NULL');
     expect(() => escapeValue(undefined)).toThrow(/Cannot render undefined/);
   });
+
+  it('should escape single quotes inside stringified objects', () => {
+    expect(escapeValue({ k: "'} OR 1=1 --" })).toBe("'{\"k\":\"''} OR 1=1 --\"}'");
+  });
+
+  it('should escape single quotes inside stringified arrays', () => {
+    expect(escapeValue(["x') OR 1=1 --"])).toBe("'[\"x'') OR 1=1 --\"]'");
+  });
+
+  it('should escape backslashes inside stringified values', () => {
+    // JSON.stringify emits \" for an embedded quote; the backslash must be
+    // doubled so ClickHouse does not consume the following character.
+    expect(escapeValue({ k: 'a"b' })).toBe("'{\"k\":\"a\\\\\"b\"}'");
+  });
 });
 
 describe('substituteParameters', () => {
@@ -123,5 +137,14 @@ describe('substituteParameters', () => {
   it('should fail closed when a SQL placeholder has no parameter', () => {
     expect(() => substituteParameters('SELECT * FROM events WHERE id = ?', []))
       .toThrow('Found 1 placeholders but 0 parameters');
+  });
+
+  it('should contain an injection attempt passed as an array value', () => {
+    const sql = 'SELECT * FROM events WHERE tenant_id = ? AND meta = ?';
+    const result = substituteParameters(sql, [5, ["x') OR 1=1 --"]]);
+
+    // The quote inside the array must be doubled so the value stays a single
+    // string literal and cannot detach the preceding tenant_id filter.
+    expect(result).toBe("SELECT * FROM events WHERE tenant_id = 5 AND meta = '[\"x'') OR 1=1 --\"]'");
   });
 });

--- a/packages/clickhouse/src/core/tests/utils.test.ts
+++ b/packages/clickhouse/src/core/tests/utils.test.ts
@@ -15,6 +15,7 @@ describe('escapeValue', () => {
   it('should handle numbers', () => {
     expect(escapeValue(42)).toBe('42');
     expect(escapeValue(3.14)).toBe('3.14');
+    expect(escapeValue(42n)).toBe('42');
   });
 
   it('should reject non-finite numbers', () => {
@@ -36,17 +37,22 @@ describe('escapeValue', () => {
     expect(() => escapeValue(new Date(Number.NaN))).toThrow(/invalid Date/);
   });
 
+  it('should render null as SQL NULL', () => {
+    expect(escapeValue(null)).toBe('NULL');
+  });
+
+  it('should reject values without a JSON representation', () => {
+    expect(() => escapeValue(undefined)).toThrow(/Cannot render undefined/);
+    expect(() => escapeValue(Symbol('unsupported'))).toThrow(/Cannot render symbol/);
+    expect(() => escapeValue(() => undefined)).toThrow(/Cannot render function/);
+  });
+
   it('should handle objects by JSON stringifying', () => {
     expect(escapeValue({ key: 'value' })).toBe("'{\"key\":\"value\"}'");
   });
 
   it('should escape quotes inside JSON-stringified values', () => {
     expect(escapeValue({ key: "O'Reilly" })).toBe("'{\"key\":\"O''Reilly\"}'");
-  });
-
-  it('should render null and reject unsupported values', () => {
-    expect(escapeValue(null)).toBe('NULL');
-    expect(() => escapeValue(undefined)).toThrow(/Cannot render undefined/);
   });
 
   it('should escape single quotes inside stringified objects', () => {

--- a/packages/clickhouse/src/core/utils.ts
+++ b/packages/clickhouse/src/core/utils.ts
@@ -10,6 +10,8 @@ export function escapeValue(value: unknown): string {
       throw new Error('Cannot render a non-finite number as a SQL parameter');
     }
     return value.toString();
+  } else if (typeof value === 'bigint') {
+    return value.toString();
   } else if (typeof value === 'string') {
     const escaped = value.replace(/\\/g, '\\\\').replace(/'/g, "''");
     return `'${escaped}'`;


### PR DESCRIPTION
## Summary

After rebasing onto `main`, the substantive SQL parameter hardening originally proposed here is already provided by #349. In particular, `main` now:

- routes JSON-serialized arrays and objects through ClickHouse string-literal escaping;
- recognizes positional `?` markers only in SQL code, not inside quotes, heredocs, or comments;
- fails closed on placeholder mismatches and values without a JSON representation; and
- rejects non-finite numbers and invalid dates.

This PR now has a deliberately small post-rebase scope: it adds safe top-level `bigint` parameter rendering and additional regression coverage for structured values containing quotes, backslashes, and injection-shaped strings.

## Change

- Render a top-level JavaScript `bigint` as its decimal SQL integer literal via `value.toString()`.
  - Because the input is already a `bigint`, the resulting text can contain only an optional minus sign and decimal digits; it cannot introduce SQL syntax.
- Add explicit regression tests showing that:
  - unsupported `undefined`, `symbol`, and function values fail closed;
  - quotes and backslashes inside JSON-stringified objects and arrays remain escaped; and
  - an injection-shaped array value remains contained inside one ClickHouse string literal.

## Why the diff is minimal

#349 now owns the shared SQL scanner and the core structured-value escaping behavior. Keeping that implementation in one place avoids introducing a second placeholder parser or duplicating the escaping logic in this branch. The remaining production diff here is therefore the `bigint` branch; the rest is defense-in-depth test coverage around the behavior inherited from `main`.

The raw SQL APIs remain intentional developer-controlled escape hatches. This PR only hardens the positional parameter-rendering path.

## Testing

- ClickHouse type tests
- Full ClickHouse unit suite: 622 tests passed
- ESLint
- TypeScript package build