### PR TITLE
Isolate deployment worker environments

### DIFF
--- a/.changeset/deployment-worker-environment.md
+++ b/.changeset/deployment-worker-environment.md
@@ -1,0 +1,7 @@
+---
+'@hypequery/deployment': minor
+---
+
+Add asynchronous, snapshot-specific environment resolution to the reference
+Node worker factory so providers can isolate deployment credentials without
+mutating shared process state.

--- a/packages/deployment/README.md
+++ b/packages/deployment/README.md
@@ -223,7 +223,17 @@ import {
 
 const supervisor = createDeploymentRuntimeSupervisor({
   materializer,
-  factory: createNodeWorkerDeploymentRuntimeFactory(),
+  factory: createNodeWorkerDeploymentRuntimeFactory({
+    async resolveEnvironment(snapshot, { signal }) {
+      const connection = await resolveClickHouseConnection(snapshot.target, { signal });
+      return {
+        CLICKHOUSE_URL: connection.url,
+        CLICKHOUSE_DATABASE: connection.database,
+        CLICKHOUSE_USERNAME: connection.username,
+        CLICKHOUSE_PASSWORD: connection.password,
+      };
+    },
+  }),
 });
 
 await supervisor.reconcile({ project: 'analytics', environment: 'production' });
@@ -240,6 +250,19 @@ zero or the drain deadline expires. The reference Node factory loads exact
 materialized bytes in worker threads and removes their temporary files on
 shutdown. Provider factories can implement Python, process, container, or
 remote-sandbox isolation behind the same lifecycle interface.
+
+`resolveEnvironment(snapshot, { signal })` lets a provider resolve secrets and
+configuration for one immutable deployment target before its worker imports any
+artifact. When configured, the returned string record replaces the inherited
+process environment for that worker, so concurrent targets do not need to
+mutate shared `process.env`. Returning an empty record creates a worker with an
+empty environment. Omitting the resolver preserves Node's default environment
+inheritance for existing single-host integrations.
+
+Resolvers should return the smallest environment the deployment needs and
+honour the startup abort signal during external secret-store calls. Environment
+resolution failure prevents the candidate from becoming ready and removes its
+temporary artifact bytes.
 
 The reference worker is a lifecycle boundary, not a hostile-code security
 sandbox. Only trusted deployment code should use it directly.

--- a/packages/deployment/src/index.ts
+++ b/packages/deployment/src/index.ts
@@ -74,6 +74,8 @@ export {
   NodeDeploymentRuntimeError,
 } from './node-runtime-factory.js';
 export type {
+  NodeDeploymentRuntimeEnvironment,
+  NodeDeploymentRuntimeEnvironmentResolver,
   NodeDeploymentRuntimeErrorCode,
   NodeDeploymentRuntimeFactoryOptions,
 } from './node-runtime-factory.js';

--- a/packages/deployment/src/node-runtime-factory.test.ts
+++ b/packages/deployment/src/node-runtime-factory.test.ts
@@ -34,12 +34,18 @@ function sha256(bytes: Uint8Array): string {
 
 function snapshot(
   source: string,
-  options: { readonly runtime?: 'node' | 'python'; readonly entrypoint?: string; readonly digest?: string } = {},
+  options: {
+    readonly runtime?: 'node' | 'python';
+    readonly entrypoint?: string;
+    readonly digest?: string;
+    readonly target?: { readonly project: string; readonly environment: string };
+  } = {},
 ): DeploymentRuntimeSnapshot {
   const bytes = Buffer.from(source);
   const runtime = options.runtime ?? 'node';
   const artifactSha256 = options.digest ?? sha256(bytes);
   const entrypoint = options.entrypoint ?? 'queries.handler';
+  const target = options.target ?? TARGET;
   const binding = Object.freeze({
     query: 'handler',
     runtime,
@@ -71,12 +77,12 @@ function snapshot(
     artifacts: [{ runtime, artifactSha256 }],
   }).contract;
   return Object.freeze({
-    target: TARGET,
+    target,
     activation: Object.freeze({
       kind: 'hypequery-deployment-activation',
       version: 1,
       revision: '1'.repeat(64),
-      target: TARGET,
+      target,
       releaseIdentity: '2'.repeat(64),
       previousRevision: null,
       previousReleaseIdentity: null,
@@ -86,7 +92,7 @@ function snapshot(
       kind: 'hypequery-deployment-release',
       version: 1,
       bundleIdentity: '3'.repeat(64),
-      target: TARGET,
+      target,
     }),
     releaseIdentity: '2'.repeat(64),
     bundleIdentity: '3'.repeat(64),
@@ -164,6 +170,158 @@ describe('Node worker deployment runtime factory', () => {
     expect(await readdir(directory)).toEqual([]);
   });
 
+  it('injects one explicit environment per snapshot without mutating the parent process', async () => {
+    const directory = await temporaryDirectory();
+    const parentKey = 'HQ_NODE_RUNTIME_PARENT_TEST';
+    const secretKey = 'HQ_NODE_RUNTIME_SECRET_TEST';
+    const previousParent = process.env[parentKey];
+    const previousSecret = process.env[secretKey];
+    process.env[parentKey] = 'parent-only';
+    delete process.env[secretKey];
+    try {
+      const source = [
+        'export const queries = {',
+        '  handler: async () => ({',
+        `    parent: process.env.${parentKey} ?? null,`,
+        `    secret: process.env.${secretKey} ?? null,`,
+        '    project: process.env.HQ_NODE_RUNTIME_PROJECT ?? null,',
+        '  }),',
+        '};',
+        '',
+      ].join('\n');
+      const production = snapshot(source, {
+        target: { project: 'analytics', environment: 'production' },
+      });
+      const preview = snapshot(source, {
+        target: { project: 'analytics', environment: 'preview' },
+      });
+      const resolutions: string[] = [];
+      const factory = createNodeWorkerDeploymentRuntimeFactory({
+        temporaryDirectory: directory,
+        async resolveEnvironment(deployed) {
+          resolutions.push(deployed.target.environment);
+          return {
+            [secretKey]: `${deployed.target.environment}-secret`,
+            HQ_NODE_RUNTIME_PROJECT: deployed.target.project,
+          };
+        },
+      });
+
+      const [productionInstance, previewInstance] = await Promise.all([
+        factory.start(production, {}),
+        factory.start(preview, {}),
+      ]);
+      instances.push(productionInstance, previewInstance);
+      const invoke = (instance: DeploymentRuntimeInstance, deployed: DeploymentRuntimeSnapshot) => (
+        instance.invoke({
+          query: 'handler',
+          binding: deployed.queries[0]!,
+          argument: {},
+        })
+      );
+
+      await expect(invoke(productionInstance, production)).resolves.toEqual({
+        parent: null,
+        secret: 'production-secret',
+        project: 'analytics',
+      });
+      await expect(invoke(previewInstance, preview)).resolves.toEqual({
+        parent: null,
+        secret: 'preview-secret',
+        project: 'analytics',
+      });
+      expect(resolutions.sort()).toEqual(['preview', 'production']);
+      expect(process.env[parentKey]).toBe('parent-only');
+      expect(process.env[secretKey]).toBeUndefined();
+    } finally {
+      if (previousParent === undefined) delete process.env[parentKey];
+      else process.env[parentKey] = previousParent;
+      if (previousSecret === undefined) delete process.env[secretKey];
+      else process.env[secretKey] = previousSecret;
+    }
+  });
+
+  it('inherits the parent environment when no resolver is configured', async () => {
+    const directory = await temporaryDirectory();
+    const key = 'HQ_NODE_RUNTIME_INHERIT_TEST';
+    const previous = process.env[key];
+    process.env[key] = 'inherited';
+    try {
+      const deployed = snapshot([
+        'export const queries = {',
+        `  handler: async () => process.env.${key} ?? null,`,
+        '};',
+        '',
+      ].join('\n'));
+      const factory = createNodeWorkerDeploymentRuntimeFactory({
+        temporaryDirectory: directory,
+      });
+      const instance = await factory.start(deployed, {});
+      instances.push(instance);
+
+      await expect(instance.invoke({
+        query: 'handler',
+        binding: deployed.queries[0]!,
+        argument: {},
+      })).resolves.toBe('inherited');
+    } finally {
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    }
+  });
+
+  it('rejects invalid or failed environment resolution and removes temporary bytes', async () => {
+    const directory = await temporaryDirectory();
+    const deployed = snapshot('export const queries = { handler: () => true };\n');
+    const invalid = createNodeWorkerDeploymentRuntimeFactory({
+      temporaryDirectory: directory,
+      resolveEnvironment: async () => ({ SECRET: 42 }) as unknown as Record<string, string>,
+    });
+    const failed = createNodeWorkerDeploymentRuntimeFactory({
+      temporaryDirectory: directory,
+      resolveEnvironment: async () => {
+        throw new Error('provider failure');
+      },
+    });
+
+    await expect(invalid.start(deployed, {})).rejects.toMatchObject({
+      code: 'HQ_NODE_RUNTIME_START_FAILED',
+      message: 'The Node deployment runtime environment is invalid.',
+    });
+    await expect(failed.start(deployed, {})).rejects.toMatchObject({
+      code: 'HQ_NODE_RUNTIME_START_FAILED',
+      message: 'The Node deployment runtime environment could not be resolved.',
+    });
+    expect(await readdir(directory)).toEqual([]);
+  });
+
+  it('passes the startup abort signal through environment resolution', async () => {
+    const directory = await temporaryDirectory();
+    const deployed = snapshot('export const queries = { handler: () => true };\n');
+    const controller = new AbortController();
+    let markResolverStarted!: () => void;
+    const resolverStarted = new Promise<void>(resolve => {
+      markResolverStarted = resolve;
+    });
+    const factory = createNodeWorkerDeploymentRuntimeFactory({
+      temporaryDirectory: directory,
+      resolveEnvironment: async (_snapshot, { signal }) => {
+        markResolverStarted();
+        return await new Promise<Record<string, string>>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+          if (signal?.aborted) reject(signal.reason);
+        });
+      },
+    });
+
+    const starting = factory.start(deployed, { signal: controller.signal });
+    await resolverStarted;
+    controller.abort(new Error('cancel environment lookup'));
+
+    await expect(starting).rejects.toMatchObject({ code: 'HQ_NODE_RUNTIME_ABORTED' });
+    expect(await readdir(directory)).toEqual([]);
+  });
+
   it.skipIf(process.platform === 'win32')(
     'seals generated runtime directories before writing artifacts',
     async () => {
@@ -183,7 +341,14 @@ describe('Node worker deployment runtime factory', () => {
 
   it('rejects unsupported or identity-mismatched artifacts before execution', async () => {
     const directory = await temporaryDirectory();
-    const factory = createNodeWorkerDeploymentRuntimeFactory({ temporaryDirectory: directory });
+    let environmentResolutions = 0;
+    const factory = createNodeWorkerDeploymentRuntimeFactory({
+      temporaryDirectory: directory,
+      resolveEnvironment: async () => {
+        environmentResolutions += 1;
+        return {};
+      },
+    });
     const python = snapshot('print("hello")\n', { runtime: 'python' });
     const mismatched = snapshot('export const queries = {};\n', { digest: 'f'.repeat(64) });
 
@@ -193,6 +358,7 @@ describe('Node worker deployment runtime factory', () => {
     await expect(factory.start(mismatched, {})).rejects.toMatchObject({
       code: 'HQ_NODE_RUNTIME_INVALID_ARTIFACT',
     });
+    expect(environmentResolutions).toBe(0);
     expect(await readdir(directory)).toEqual([]);
     expect(() => createNodeWorkerDeploymentRuntimeFactory({ startupTimeoutMs: 0 }))
       .toThrow(NodeDeploymentRuntimeError);

--- a/packages/deployment/src/node-runtime-factory.test.ts
+++ b/packages/deployment/src/node-runtime-factory.test.ts
@@ -322,6 +322,34 @@ describe('Node worker deployment runtime factory', () => {
     expect(await readdir(directory)).toEqual([]);
   });
 
+  it('detects aborts between environment resolution and worker startup', async () => {
+    const directory = await temporaryDirectory();
+    const deployed = snapshot('export const queries = { handler: () => true };\n');
+    const controller = new AbortController();
+    const reason = new Error('cancel before worker creation');
+    const environment = new Proxy<Record<string, string>>(
+      { SAFE: 'value' },
+      {
+        ownKeys(target) {
+          queueMicrotask(() => controller.abort(reason));
+          return Reflect.ownKeys(target);
+        },
+      },
+    );
+    const factory = createNodeWorkerDeploymentRuntimeFactory({
+      temporaryDirectory: directory,
+      resolveEnvironment: async () => environment,
+    });
+
+    await expect(
+      factory.start(deployed, { signal: controller.signal }),
+    ).rejects.toMatchObject({
+      code: 'HQ_NODE_RUNTIME_ABORTED',
+      cause: reason,
+    });
+    expect(await readdir(directory)).toEqual([]);
+  });
+
   it.skipIf(process.platform === 'win32')(
     'seals generated runtime directories before writing artifacts',
     async () => {

--- a/packages/deployment/src/node-runtime-factory.ts
+++ b/packages/deployment/src/node-runtime-factory.ts
@@ -79,10 +79,23 @@ export class NodeDeploymentRuntimeError extends Error {
   }
 }
 
+export type NodeDeploymentRuntimeEnvironment = Readonly<Record<string, string>>;
+
+export type NodeDeploymentRuntimeEnvironmentResolver = (
+  snapshot: DeploymentRuntimeSnapshot,
+  input: { readonly signal?: AbortSignal },
+) => NodeDeploymentRuntimeEnvironment | Promise<NodeDeploymentRuntimeEnvironment>;
+
 export interface NodeDeploymentRuntimeFactoryOptions {
   readonly temporaryDirectory?: string;
   /** Worker import deadline from 1 through 300,000 milliseconds. */
   readonly startupTimeoutMs?: number;
+  /**
+   * Resolve an explicit environment for one immutable runtime snapshot.
+   * When configured, this replaces inherited process environment state for
+   * the worker. Omit it to preserve Node's default environment inheritance.
+   */
+  readonly resolveEnvironment?: NodeDeploymentRuntimeEnvironmentResolver;
   readonly onCleanupError?: (error: unknown, directory: string) => void;
 }
 
@@ -125,6 +138,85 @@ function startupTimeout(input: number | undefined): number {
 
 function sha256(bytes: Uint8Array): string {
   return createHash('sha256').update(bytes).digest('hex');
+}
+
+function invalidEnvironment(): NodeDeploymentRuntimeError {
+  return nodeRuntimeError(
+    'HQ_NODE_RUNTIME_START_FAILED',
+    'The Node deployment runtime environment is invalid.',
+  );
+}
+
+function validateEnvironment(input: unknown): Record<string, string> {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw invalidEnvironment();
+  }
+  let keys: readonly PropertyKey[];
+  try {
+    keys = Reflect.ownKeys(input);
+  } catch {
+    throw invalidEnvironment();
+  }
+  const environment = Object.create(null) as Record<string, string>;
+  for (const key of keys) {
+    if (typeof key !== 'string' || key.length === 0 || key.includes('\0') || key.includes('=')) {
+      throw invalidEnvironment();
+    }
+    let descriptor: PropertyDescriptor | undefined;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(input, key);
+    } catch {
+      throw invalidEnvironment();
+    }
+    if (!descriptor?.enumerable
+      || !Object.hasOwn(descriptor, 'value')
+      || typeof descriptor.value !== 'string'
+      || descriptor.value.includes('\0')) {
+      throw invalidEnvironment();
+    }
+    environment[key] = descriptor.value;
+  }
+  return environment;
+}
+
+async function resolveWorkerEnvironment(
+  resolver: NodeDeploymentRuntimeEnvironmentResolver | undefined,
+  snapshot: DeploymentRuntimeSnapshot,
+  signal: AbortSignal | undefined,
+): Promise<Record<string, string> | undefined> {
+  if (!resolver) return undefined;
+  if (signal?.aborted) {
+    throw nodeRuntimeError(
+      'HQ_NODE_RUNTIME_ABORTED',
+      'Node runtime startup was aborted.',
+      signal.reason,
+    );
+  }
+  let resolved: unknown;
+  try {
+    resolved = await resolver(snapshot, { signal });
+  } catch (error) {
+    if (signal?.aborted) {
+      throw nodeRuntimeError(
+        'HQ_NODE_RUNTIME_ABORTED',
+        'Node runtime startup was aborted.',
+        signal.reason,
+      );
+    }
+    throw nodeRuntimeError(
+      'HQ_NODE_RUNTIME_START_FAILED',
+      'The Node deployment runtime environment could not be resolved.',
+      error,
+    );
+  }
+  if (signal?.aborted) {
+    throw nodeRuntimeError(
+      'HQ_NODE_RUNTIME_ABORTED',
+      'Node runtime startup was aborted.',
+      signal.reason,
+    );
+  }
+  return validateEnvironment(resolved);
 }
 
 async function ensureTemporaryDirectory(input: string | undefined): Promise<string> {
@@ -283,6 +375,7 @@ async function startWorker(
   directory: string,
   timeoutMs: number,
   signal: AbortSignal | undefined,
+  resolveEnvironment: NodeDeploymentRuntimeEnvironmentResolver | undefined,
 ): Promise<DeploymentRuntimeInstance> {
   if (signal?.aborted) {
     throw nodeRuntimeError('HQ_NODE_RUNTIME_ABORTED', 'Node runtime startup was aborted.', signal.reason);
@@ -313,9 +406,11 @@ async function startWorker(
     );
   }
 
+  const environment = await resolveWorkerEnvironment(resolveEnvironment, snapshot, signal);
   const worker = new Worker(WORKER_SOURCE, {
     eval: true,
     workerData: { artifacts },
+    ...(environment === undefined ? {} : { env: environment }),
   });
   let resolveReady!: () => void;
   let rejectReady!: (error: unknown) => void;
@@ -389,7 +484,13 @@ export function createNodeWorkerDeploymentRuntimeFactory(
       const directory = await mkdtemp(path.join(root, 'hypequery-node-runtime-'));
       try {
         await chmod(directory, 0o700);
-        return await startWorker(snapshot, directory, timeoutMs, input.signal);
+        return await startWorker(
+          snapshot,
+          directory,
+          timeoutMs,
+          input.signal,
+          options.resolveEnvironment,
+        );
       } catch (error) {
         try {
           await rm(directory, { force: true, recursive: true });

--- a/packages/deployment/src/node-runtime-factory.ts
+++ b/packages/deployment/src/node-runtime-factory.ts
@@ -407,6 +407,13 @@ async function startWorker(
   }
 
   const environment = await resolveWorkerEnvironment(resolveEnvironment, snapshot, signal);
+  if (signal?.aborted) {
+    throw nodeRuntimeError(
+      'HQ_NODE_RUNTIME_ABORTED',
+      'Node runtime startup was aborted.',
+      signal.reason,
+    );
+  }
   const worker = new Worker(WORKER_SOURCE, {
     eval: true,
     workerData: { artifacts },

--- a/specs/deployment/0005-runtime-supervision.md
+++ b/specs/deployment/0005-runtime-supervision.md
@@ -79,9 +79,17 @@ The Node factory:
 - accepts only Node artifacts and rejects mixed or Python snapshots;
 - imports modules in a dedicated worker thread;
 - resolves every qualified entrypoint before reporting startup success;
+- optionally resolves a snapshot-specific string environment before import;
 - exchanges invocation values through structured clone;
 - supports abortable startup and pre-dispatch calls;
 - terminates the worker and removes temporary files on close.
+
+When a provider configures snapshot-specific environment resolution, the
+returned environment replaces inherited host process state for that worker.
+The factory MUST copy and validate the resolved string record before worker
+startup, MUST NOT mutate the parent `process.env`, and MUST fail candidate
+startup if resolution or validation fails. Omitting the resolver retains
+Node's default environment inheritance for backwards compatibility.
 
 Worker readiness proves import and entrypoint resolution plus message-loop
 responsiveness. It does not define application-specific dependency health.


### PR DESCRIPTION
## Summary

- add async `resolveEnvironment(snapshot, { signal })` support to the reference Node deployment runtime factory
- replace inherited process environment state with a copied, validated string record when the resolver is configured
- keep existing environment inheritance unchanged when no resolver is provided
- export the new resolver/environment types and document the lifecycle contract
- add a minor changeset for `@hypequery/deployment`

## Why

Cloud stores ClickHouse credentials per deployment environment. Mutating the parent process's `process.env` would allow concurrent customer targets to race or observe the wrong credentials. This hook lets a provider decrypt credentials for the immutable materialized snapshot and pass them only to that worker.

## Safety and lifecycle

- artifact runtimes and hashes are validated before the environment resolver is called
- explicit worker environments do not inherit unrelated parent values
- concurrent targets receive independent environment copies
- invalid or failed resolution prevents readiness and removes temporary artifact bytes
- startup cancellation is forwarded to external secret-store lookups
- customer deployment code remains trusted; worker threads are still a lifecycle boundary, not a hostile-code sandbox

## Validation

- focused Node runtime factory suite: 8 tests passed
- full deployment package suite: 106 passed, 1 existing platform skip
- full monorepo lint: 9 packages passed
- full monorepo build: 9 packages passed
- full monorepo unit tests: 18 tasks passed

This is the Core prerequisite for enabling managed ClickHouse query execution in Hypequery Cloud without shared-process credential mutation.