### PR TITLE
Add interactive Cloud login

### DIFF
--- a/.changeset/curly-badgers-login.md
+++ b/.changeset/curly-badgers-login.md
@@ -4,3 +4,11 @@
 
 Add browser-based Cloud login with PKCE, OS credential-vault storage, logout,
 and automatic authenticated deployment.
+
+`hypequery deploy` now also accepts an `http://127.0.0.1` or `http://localhost`
+submission endpoint for local Cloud development, warning that the token is sent
+in cleartext; all other endpoints still require HTTPS. `HYPEQUERY_API_TOKEN`
+must now be paired with `--endpoint` or `HYPEQUERY_DEPLOYMENT_ENDPOINT` — the
+CLI never combines one explicit value with the other from the stored login
+profile. A `HYPEQUERY_API_TOKEN` left in a project `.env` is picked up by this
+rule and must be unset to use `hypequery login`.

--- a/.changeset/curly-badgers-login.md
+++ b/.changeset/curly-badgers-login.md
@@ -1,0 +1,6 @@
+---
+"@hypequery/cli": minor
+---
+
+Add browser-based Cloud login with PKCE, OS credential-vault storage, logout,
+and automatic authenticated deployment.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -202,6 +202,15 @@ it is the authenticated upload API, not the browser login endpoint. For
 non-interactive CI usage, set both `HYPEQUERY_API_TOKEN` and
 `HYPEQUERY_DEPLOYMENT_ENDPOINT` (or pass `--endpoint`).
 
+Because the CLI also loads a project `.env`, a `HYPEQUERY_API_TOKEN` left there
+takes precedence over the login flow and is rejected unless it is paired with an
+endpoint. Unset it to use `hypequery login`.
+
+Token storage requires an operating-system credential vault (Keychain,
+Credential Manager, or a Secret Service implementation such as
+gnome-keyring/KWallet). Headless environments without one should use
+`HYPEQUERY_API_TOKEN` instead of `hypequery login`.
+
 ### `hypequery logout`
 
 Revokes the current Cloud token and removes it from the operating-system
@@ -210,6 +219,9 @@ credential vault:
 ```bash
 npx hypequery logout
 ```
+
+If the stored profile is unreadable, `logout` still removes the local state and
+reports that the token was not revoked; it expires on its own.
 
 ### `hypequery deployment:release`
 
@@ -264,9 +276,11 @@ and token from its secure Cloud profile. For CI and manual credentials, set
 `HYPEQUERY_DEPLOYMENT_ENDPOINT`. The CLI never combines one explicit value with
 the other value from the stored profile. Tokens are never accepted as
 command-line arguments, keeping them out of shell history. The submission
-endpoint must use HTTPS and must not contain credentials or a URL fragment. The
-release identity is sent as the idempotency key, so an unchanged release can be
-submitted safely again.
+endpoint must not contain credentials or a URL fragment, and must use HTTPS
+except for `127.0.0.1`/`localhost`, which is permitted for local Cloud
+development and warns that the token is sent in cleartext. The release identity
+is sent as the idempotency key, so an unchanged release can be submitted safely
+again.
 
 This command submits immutable deployment inputs. Activation, status changes,
 promotion, and rollback remain control-plane operations.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -182,6 +182,33 @@ are still accepted for metadata-only validation.
 npx hypequery deployment:validate analytics/hypequery-deployment
 ```
 
+### `hypequery login`
+
+Authorizes the local CLI through your existing Hypequery Cloud browser
+session. The command uses an S256 PKCE loopback flow, then stores the
+target-scoped deployment token in the operating-system credential vault.
+Tokens expire after 12 hours.
+
+```bash
+npx hypequery login
+```
+
+Use `--cloud-url <origin>` or `HYPEQUERY_CLOUD_URL` for a self-hosted or local
+Cloud instance. HTTPS is required except for loopback development origins.
+
+Once logged in, `hypequery deploy` automatically uses the stored endpoint and
+token. Explicit `HYPEQUERY_API_TOKEN` and `HYPEQUERY_DEPLOYMENT_ENDPOINT`
+values take precedence, which preserves non-interactive CI usage.
+
+### `hypequery logout`
+
+Revokes the current Cloud token and removes it from the operating-system
+credential vault:
+
+```bash
+npx hypequery logout
+```
+
 ### `hypequery deployment:release`
 
 Prepares a deterministic release request from a verified deployment bundle and
@@ -211,17 +238,18 @@ release. The command verifies both inputs again, requires their bundle
 identities to match, and streams only the files declared by the bundle.
 
 ```bash
-HYPEQUERY_API_TOKEN=<token> \
 npx hypequery deploy analytics/hypequery-deployment \
-  --release analytics/hypequery-deployment.release.json \
-  --endpoint https://deploy.example.com/v1/releases
+  --release analytics/hypequery-deployment.release.json
 ```
 
-The token is accepted only through `HYPEQUERY_API_TOKEN`, keeping it out of
-shell history. The submission endpoint must use HTTPS, may also be supplied by
-`HYPEQUERY_DEPLOYMENT_ENDPOINT`, and must not contain credentials or a URL
-fragment. The release identity is sent as the idempotency key, so an unchanged
-release can be submitted safely again.
+For local development, run `hypequery login` first; the CLI reads the endpoint
+and token from its secure Cloud profile. For CI and manual credentials, set
+`HYPEQUERY_API_TOKEN` and either pass `--endpoint` or set
+`HYPEQUERY_DEPLOYMENT_ENDPOINT`. Tokens are never accepted as command-line
+arguments, keeping them out of shell history. The submission endpoint must use
+HTTPS and must not contain credentials or a URL fragment. Explicit environment
+values override the stored profile. The release identity is sent as the
+idempotency key, so an unchanged release can be submitted safely again.
 
 This command submits immutable deployment inputs. Activation, status changes,
 promotion, and rollback remain control-plane operations.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -212,8 +212,20 @@ npx hypequery logout
 ### `hypequery deployment:release`
 
 Prepares a deterministic release request from a verified deployment bundle and
-an explicit project/environment target. This command does not upload, authorize,
-or execute the release.
+a project/environment target. This command does not upload, authorize, or
+execute the release.
+
+After `hypequery login` the target is read from the stored Cloud profile, and
+the resolved target is printed alongside the release identity:
+
+```bash
+npx hypequery deployment:release analytics/hypequery-deployment
+```
+
+To target something other than the logged-in project and environment, pass both
+flags. A half-specified override is rejected rather than completed from the
+stored profile, so an unset shell variable fails loudly instead of silently
+retargeting the release:
 
 ```bash
 npx hypequery deployment:release analytics/hypequery-deployment \
@@ -227,8 +239,10 @@ invalidate bundle verification.
 
 Options:
 
-- `--project <project>`: required target project identifier
-- `--environment <environment>`: required target environment identifier
+- `--project <project>`: target project identifier; defaults to the logged-in
+  target and must be paired with `--environment`
+- `--environment <environment>`: target environment identifier; defaults to the
+  logged-in target and must be paired with `--project`
 - `--output <path>`: release JSON path, default beside the bundle
 
 ### `hypequery deploy`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -197,8 +197,10 @@ Use `--cloud-url <origin>` or `HYPEQUERY_CLOUD_URL` for a self-hosted or local
 Cloud instance. HTTPS is required except for loopback development origins.
 
 Once logged in, `hypequery deploy` automatically uses the stored endpoint and
-token. Explicit `HYPEQUERY_API_TOKEN` and `HYPEQUERY_DEPLOYMENT_ENDPOINT`
-values take precedence, which preserves non-interactive CI usage.
+token. The deployment endpoint is returned by Cloud during the token exchange;
+it is the authenticated upload API, not the browser login endpoint. For
+non-interactive CI usage, set both `HYPEQUERY_API_TOKEN` and
+`HYPEQUERY_DEPLOYMENT_ENDPOINT` (or pass `--endpoint`).
 
 ### `hypequery logout`
 
@@ -258,12 +260,13 @@ npx hypequery deploy analytics/hypequery-deployment \
 
 For local development, run `hypequery login` first; the CLI reads the endpoint
 and token from its secure Cloud profile. For CI and manual credentials, set
-`HYPEQUERY_API_TOKEN` and either pass `--endpoint` or set
-`HYPEQUERY_DEPLOYMENT_ENDPOINT`. Tokens are never accepted as command-line
-arguments, keeping them out of shell history. The submission endpoint must use
-HTTPS and must not contain credentials or a URL fragment. Explicit environment
-values override the stored profile. The release identity is sent as the
-idempotency key, so an unchanged release can be submitted safely again.
+`HYPEQUERY_API_TOKEN` together with either `--endpoint` or
+`HYPEQUERY_DEPLOYMENT_ENDPOINT`. The CLI never combines one explicit value with
+the other value from the stored profile. Tokens are never accepted as
+command-line arguments, keeping them out of shell history. The submission
+endpoint must use HTTPS and must not contain credentials or a URL fragment. The
+release identity is sent as the idempotency key, so an unchanged release can be
+submitted safely again.
 
 This command submits immutable deployment inputs. Activation, status changes,
 promotion, and rollback remain control-plane operations.
@@ -271,7 +274,7 @@ promotion, and rollback remain control-plane operations.
 Options:
 
 - `--release <path>`: required target-bound release JSON
-- `--endpoint <url>`: HTTPS submission endpoint; defaults to `HYPEQUERY_DEPLOYMENT_ENDPOINT`
+- `--endpoint <url>`: HTTPS submission endpoint; requires `HYPEQUERY_API_TOKEN`
 
 ## Non-interactive Setup
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,7 @@
     "@clickhouse/client": "^1.18.3",
     "@hypequery/deployment": "workspace:*",
     "@hypequery/protocol": "workspace:*",
+    "@napi-rs/keyring": "1.3.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "dotenv": "^16.4.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,6 @@
     "@clickhouse/client": "^1.18.3",
     "@hypequery/deployment": "workspace:*",
     "@hypequery/protocol": "workspace:*",
-    "@napi-rs/keyring": "1.3.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "dotenv": "^16.4.7",
@@ -28,6 +27,9 @@
     "open": "^10.0.0",
     "ora": "^8.0.1",
     "prompts": "^2.4.2"
+  },
+  "optionalDependencies": {
+    "@napi-rs/keyring": "1.3.0"
   },
   "peerDependencies": {
     "@hypequery/clickhouse": "*",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -17,6 +17,11 @@ import {
   deployCommand,
   type DeployOptions,
 } from './commands/deploy.js';
+import {
+  loginCommand,
+  logoutCommand,
+  type LoginOptions,
+} from './commands/login.js';
 
 const program = new Command();
 
@@ -42,6 +47,21 @@ program
   .name('hypequery')
   .description('Type-safe analytics layer for ClickHouse')
   .version(getCliVersion());
+
+program
+  .command('login')
+  .description('Authorize this machine with Hypequery Cloud')
+  .option('--cloud-url <url>', 'Cloud origin (or HYPEQUERY_CLOUD_URL)')
+  .action(runCommand(async (options: LoginOptions) => {
+    await loginCommand(options);
+  }));
+
+program
+  .command('logout')
+  .description('Revoke and remove the local Hypequery Cloud credential')
+  .action(runCommand(async () => {
+    await logoutCommand();
+  }));
 
 function runCommand<TArgs extends unknown[]>(
   action: (...args: TArgs) => Promise<void>,
@@ -197,6 +217,8 @@ program
 program.on('--help', () => {
   console.log('');
   console.log('Examples:');
+  console.log('  hypequery login');
+  console.log('  hypequery logout');
   console.log('  hypequery init');
   console.log('  hypequery dev');
   console.log('  hypequery dev --port 3000');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -179,8 +179,8 @@ program
 program
   .command('deployment:release <bundle>')
   .description('Prepare a target-bound release from a verified deployment bundle')
-  .requiredOption('--project <project>', 'Target project identifier')
-  .requiredOption('--environment <environment>', 'Target environment identifier')
+  .option('--project <project>', 'Target project identifier (advanced override)')
+  .option('--environment <environment>', 'Target environment identifier (advanced override)')
   .option('-o, --output <path>', 'Release JSON path (default: beside the bundle)')
   .action(runCommand(async (bundle: string, options: PrepareDeploymentReleaseOptions) => {
     await prepareDeploymentReleaseCommand(bundle, options);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -190,7 +190,10 @@ program
   .command('deploy <bundle>')
   .description('Submit a verified deployment bundle and release')
   .requiredOption('--release <path>', 'Target-bound release JSON path')
-  .option('--endpoint <url>', 'HTTPS submission endpoint (or HYPEQUERY_DEPLOYMENT_ENDPOINT)')
+  .option(
+    '--endpoint <url>',
+    'HTTPS submission endpoint; requires HYPEQUERY_API_TOKEN',
+  )
   .action(runCommand(async (bundle: string, options: DeployOptions) => {
     await deployCommand(bundle, options);
   }));

--- a/packages/cli/src/commands/deploy.test.ts
+++ b/packages/cli/src/commands/deploy.test.ts
@@ -129,6 +129,52 @@ describe('deploy command', () => {
     }));
   });
 
+  it('uses the credential stored by interactive login', async () => {
+    const release = await releaseFile();
+    const submit = vi.fn().mockResolvedValue({
+      kind: 'hypequery-deployment-submission',
+      version: 1,
+      status: 'accepted',
+      releaseIdentity: release.identity,
+      bundleIdentity: BUNDLE_IDENTITY,
+    });
+    const createTransport = vi.fn(() => ({ submit }));
+
+    await deployCommand('dist/bundle', { release: release.path }, {
+      env: {},
+      loadCredential: async () => ({
+        cloudUrl: 'https://cloud.example.test',
+        deploymentEndpoint:
+          'https://cloud.example.test/v1/deployments/submissions',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        scope: 'deploy:submit',
+        token: `hqdp_v1_${'f'.repeat(43)}`,
+      }),
+      createTransport,
+    });
+
+    expect(createTransport).toHaveBeenCalledWith({
+      endpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      token: `hqdp_v1_${'f'.repeat(43)}`,
+    });
+  });
+
+  it('requires a new login when the stored credential expired', async () => {
+    const release = await releaseFile();
+    await expect(deployCommand('dist/bundle', { release: release.path }, {
+      env: {},
+      loadCredential: async () => ({
+        cloudUrl: 'https://cloud.example.test',
+        deploymentEndpoint:
+          'https://cloud.example.test/v1/deployments/submissions',
+        expiresAt: '2020-01-01T00:00:00.000Z',
+        scope: 'deploy:submit',
+        token: `hqdp_v1_${'f'.repeat(43)}`,
+      }),
+    })).rejects.toThrow(/expired[\s\S]*hypequery login/);
+    expect(mockVerifyDeploymentBundle).not.toHaveBeenCalled();
+  });
+
   it('requires endpoint and token configuration before bundle verification', async () => {
     const release = await releaseFile();
     await expect(deployCommand('dist/bundle', { release: release.path }, { env: {} }))
@@ -136,7 +182,7 @@ describe('deploy command', () => {
     await expect(deployCommand('dist/bundle', {
       release: release.path,
       endpoint: 'https://deploy.example.test/v1/releases',
-    }, { env: {} })).rejects.toThrow(/Missing HYPEQUERY_API_TOKEN/);
+    }, { env: {} })).rejects.toThrow(/HYPEQUERY_API_TOKEN/);
     expect(mockVerifyDeploymentBundle).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/src/commands/deploy.test.ts
+++ b/packages/cli/src/commands/deploy.test.ts
@@ -222,8 +222,10 @@ describe('deploy command', () => {
 
   it('requires endpoint and token configuration before bundle verification', async () => {
     const release = await releaseFile();
-    await expect(deployCommand('dist/bundle', { release: release.path }, { env: {} }))
-      .rejects.toThrow(/Missing deployment endpoint/);
+    await expect(deployCommand('dist/bundle', { release: release.path }, {
+      env: {},
+      loadCredential: async () => null,
+    })).rejects.toThrow(/Missing deployment endpoint/);
     await expect(deployCommand('dist/bundle', {
       release: release.path,
       endpoint: 'https://deploy.example.test/v1/releases',

--- a/packages/cli/src/commands/deploy.test.ts
+++ b/packages/cli/src/commands/deploy.test.ts
@@ -159,61 +159,49 @@ describe('deploy command', () => {
     });
   });
 
-  it('refuses to send the stored token to a different origin', async () => {
+  it('never combines an explicit endpoint with the stored Cloud token', async () => {
     const release = await releaseFile();
-    const createTransport = vi.fn();
+    const loadCredential = vi.fn(async () => ({
+      cloudUrl: 'https://cloud.example.test',
+      deploymentEndpoint:
+        'https://cloud.example.test/v1/deployments/submissions',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      scope: 'deploy:submit',
+      token: `hqdp_v1_${'f'.repeat(43)}`,
+    }));
 
     await expect(deployCommand('dist/bundle', {
       release: release.path,
-      endpoint: 'https://evil.example.test/v1/deployments/submissions',
+      endpoint: 'https://deploy.example.test/v1/releases',
     }, {
       env: {},
-      loadCredential: async () => ({
-        cloudUrl: 'https://cloud.example.test',
-        deploymentEndpoint:
-          'https://cloud.example.test/v1/deployments/submissions',
-        expiresAt: new Date(Date.now() + 60_000).toISOString(),
-        scope: 'deploy:submit',
-        token: `hqdp_v1_${'f'.repeat(43)}`,
-      }),
-      createTransport,
-    })).rejects.toThrow(/will not be sent to https:\/\/evil\.example\.test/);
+      loadCredential,
+    })).rejects.toThrow(/explicit deployment endpoint requires HYPEQUERY_API_TOKEN/);
 
-    expect(createTransport).not.toHaveBeenCalled();
+    expect(loadCredential).not.toHaveBeenCalled();
     expect(mockVerifyDeploymentBundle).not.toHaveBeenCalled();
   });
 
-  it('still honours an explicit endpoint on the logged-in origin', async () => {
+  it('never combines an explicit token with the stored Cloud endpoint', async () => {
     const release = await releaseFile();
-    const submit = vi.fn().mockResolvedValue({
-      kind: 'hypequery-deployment-submission',
-      version: 1,
-      status: 'accepted',
-      releaseIdentity: release.identity,
-      bundleIdentity: BUNDLE_IDENTITY,
-    });
-    const createTransport = vi.fn(() => ({ submit }));
-
-    await deployCommand('dist/bundle', {
-      release: release.path,
-      endpoint: 'https://cloud.example.test/v1/deployments/submissions',
-    }, {
-      env: {},
-      loadCredential: async () => ({
-        cloudUrl: 'https://cloud.example.test',
-        deploymentEndpoint:
-          'https://cloud.example.test/v1/deployments/submissions',
-        expiresAt: new Date(Date.now() + 60_000).toISOString(),
-        scope: 'deploy:submit',
-        token: `hqdp_v1_${'f'.repeat(43)}`,
-      }),
-      createTransport,
-    });
-
-    expect(createTransport).toHaveBeenCalledWith({
-      endpoint: 'https://cloud.example.test/v1/deployments/submissions',
+    const loadCredential = vi.fn(async () => ({
+      cloudUrl: 'https://cloud.example.test',
+      deploymentEndpoint:
+        'https://cloud.example.test/v1/deployments/submissions',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      scope: 'deploy:submit',
       token: `hqdp_v1_${'f'.repeat(43)}`,
-    });
+    }));
+
+    await expect(deployCommand('dist/bundle', { release: release.path }, {
+      env: { HYPEQUERY_API_TOKEN: 'explicit-token' },
+      loadCredential,
+    })).rejects.toThrow(
+      /HYPEQUERY_API_TOKEN requires --endpoint or HYPEQUERY_DEPLOYMENT_ENDPOINT/,
+    );
+
+    expect(loadCredential).not.toHaveBeenCalled();
+    expect(mockVerifyDeploymentBundle).not.toHaveBeenCalled();
   });
 
   it('requires a new login when the stored credential expired', async () => {

--- a/packages/cli/src/commands/deploy.test.ts
+++ b/packages/cli/src/commands/deploy.test.ts
@@ -159,6 +159,63 @@ describe('deploy command', () => {
     });
   });
 
+  it('refuses to send the stored token to a different origin', async () => {
+    const release = await releaseFile();
+    const createTransport = vi.fn();
+
+    await expect(deployCommand('dist/bundle', {
+      release: release.path,
+      endpoint: 'https://evil.example.test/v1/deployments/submissions',
+    }, {
+      env: {},
+      loadCredential: async () => ({
+        cloudUrl: 'https://cloud.example.test',
+        deploymentEndpoint:
+          'https://cloud.example.test/v1/deployments/submissions',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        scope: 'deploy:submit',
+        token: `hqdp_v1_${'f'.repeat(43)}`,
+      }),
+      createTransport,
+    })).rejects.toThrow(/will not be sent to https:\/\/evil\.example\.test/);
+
+    expect(createTransport).not.toHaveBeenCalled();
+    expect(mockVerifyDeploymentBundle).not.toHaveBeenCalled();
+  });
+
+  it('still honours an explicit endpoint on the logged-in origin', async () => {
+    const release = await releaseFile();
+    const submit = vi.fn().mockResolvedValue({
+      kind: 'hypequery-deployment-submission',
+      version: 1,
+      status: 'accepted',
+      releaseIdentity: release.identity,
+      bundleIdentity: BUNDLE_IDENTITY,
+    });
+    const createTransport = vi.fn(() => ({ submit }));
+
+    await deployCommand('dist/bundle', {
+      release: release.path,
+      endpoint: 'https://cloud.example.test/v1/deployments/submissions',
+    }, {
+      env: {},
+      loadCredential: async () => ({
+        cloudUrl: 'https://cloud.example.test',
+        deploymentEndpoint:
+          'https://cloud.example.test/v1/deployments/submissions',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        scope: 'deploy:submit',
+        token: `hqdp_v1_${'f'.repeat(43)}`,
+      }),
+      createTransport,
+    });
+
+    expect(createTransport).toHaveBeenCalledWith({
+      endpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      token: `hqdp_v1_${'f'.repeat(43)}`,
+    });
+  });
+
   it('requires a new login when the stored credential expired', async () => {
     const release = await releaseFile();
     await expect(deployCommand('dist/bundle', { release: release.path }, {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -18,14 +18,6 @@ import {
 const MAX_RELEASE_FILE_BYTES = 16 * 1024;
 const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 
-function sameOrigin(left: string, right: string): boolean {
-  try {
-    return new URL(left).origin === new URL(right).origin;
-  } catch {
-    return false;
-  }
-}
-
 export interface DeployOptions {
   release?: string;
   endpoint?: string;
@@ -112,39 +104,33 @@ export async function deployCommand(
     'Missing required --release <path>.',
   );
   const env = dependencies.env ?? process.env;
-  let endpoint = options.endpoint ?? env.HYPEQUERY_DEPLOYMENT_ENDPOINT;
+  let deploymentEndpoint = options.endpoint ?? env.HYPEQUERY_DEPLOYMENT_ENDPOINT;
   let token = env.HYPEQUERY_API_TOKEN;
-  if (!endpoint || !token) {
+  const hasExplicitEndpoint = Boolean(deploymentEndpoint);
+  const hasExplicitToken = Boolean(token);
+  if (hasExplicitEndpoint !== hasExplicitToken) {
+    throw new Error(
+      hasExplicitEndpoint
+        ? 'An explicit deployment endpoint requires HYPEQUERY_API_TOKEN.'
+        : 'HYPEQUERY_API_TOKEN requires --endpoint or HYPEQUERY_DEPLOYMENT_ENDPOINT.',
+    );
+  }
+  if (!hasExplicitEndpoint) {
     const loadCredential = dependencies.loadCredential
       ?? (dependencies.env === undefined
         ? loadCloudCredential
         : async () => null);
     const credential = await loadCredential();
     if (credential) {
-      // The stored token authenticates one Cloud. An explicit --endpoint or
-      // HYPEQUERY_DEPLOYMENT_ENDPOINT aimed anywhere else must never receive
-      // it, or a mistyped or hostile endpoint silently exfiltrates the
-      // credential the user never typed.
-      const resolved = endpoint ?? credential.deploymentEndpoint;
-      if (!token) {
-        if (!sameOrigin(resolved, credential.cloudUrl)) {
-          throw new Error(
-            `The stored Cloud credential belongs to ${credential.cloudUrl} and will not be `
-            + `sent to ${resolved}.\n\n`
-            + 'Drop --endpoint/HYPEQUERY_DEPLOYMENT_ENDPOINT to use the logged-in Cloud, '
-            + 'or set HYPEQUERY_API_TOKEN for this endpoint.',
-          );
-        }
-        if (Date.parse(credential.expiresAt) <= Date.now()) {
-          throw new Error('The stored Cloud credential has expired. Run `hypequery login` again.');
-        }
-        token = credential.token;
+      if (Date.parse(credential.expiresAt) <= Date.now()) {
+        throw new Error('The stored Cloud credential has expired. Run `hypequery login` again.');
       }
-      endpoint = resolved;
+      deploymentEndpoint = credential.deploymentEndpoint;
+      token = credential.token;
     }
   }
-  endpoint = requiredConfiguration(
-    endpoint,
+  deploymentEndpoint = requiredConfiguration(
+    deploymentEndpoint,
     'Missing deployment endpoint. Run `hypequery login`, pass --endpoint, or set HYPEQUERY_DEPLOYMENT_ENDPOINT.',
   );
   token = requiredConfiguration(
@@ -178,7 +164,10 @@ export async function deployCommand(
     );
   }
   const createTransport = dependencies.createTransport ?? createHttpDeploymentUploadTransport;
-  const transportOptions: HttpDeploymentUploadTransportOptions = { endpoint, token };
+  const transportOptions: HttpDeploymentUploadTransportOptions = {
+    endpoint: deploymentEndpoint,
+    token,
+  };
   const result = await createTransport(transportOptions).submit(bundle, release);
   logger.success(
     result.status === 'accepted'

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -112,15 +112,13 @@ export async function deployCommand(
     throw new Error(
       hasExplicitEndpoint
         ? 'An explicit deployment endpoint requires HYPEQUERY_API_TOKEN.'
-        : 'HYPEQUERY_API_TOKEN requires --endpoint or HYPEQUERY_DEPLOYMENT_ENDPOINT.',
+        : 'HYPEQUERY_API_TOKEN requires --endpoint or HYPEQUERY_DEPLOYMENT_ENDPOINT.\n\n'
+          + 'If you meant to use `hypequery login`, unset HYPEQUERY_API_TOKEN — '
+          + 'the CLI also reads it from a project .env file.',
     );
   }
   if (!hasExplicitEndpoint) {
-    const loadCredential = dependencies.loadCredential
-      ?? (dependencies.env === undefined
-        ? loadCloudCredential
-        : async () => null);
-    const credential = await loadCredential();
+    const credential = await (dependencies.loadCredential ?? loadCloudCredential)();
     if (credential) {
       if (Date.parse(credential.expiresAt) <= Date.now()) {
         throw new Error('The stored Cloud credential has expired. Run `hypequery login` again.');

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -10,6 +10,10 @@ import {
   type HttpDeploymentUploadTransportOptions,
 } from '../utils/deployment-upload.js';
 import { logger } from '../utils/logger.js';
+import {
+  loadCloudCredential,
+  type StoredCloudCredential,
+} from '../utils/cloud-credential-store.js';
 
 const MAX_RELEASE_FILE_BYTES = 16 * 1024;
 const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
@@ -22,6 +26,7 @@ export interface DeployOptions {
 export interface DeployDependencies {
   readonly env?: Readonly<Record<string, string | undefined>>;
   readonly createTransport?: typeof createHttpDeploymentUploadTransport;
+  readonly loadCredential?: () => Promise<StoredCloudCredential | null>;
 }
 
 async function readReleaseFile(releasePath: string): Promise<unknown> {
@@ -99,13 +104,31 @@ export async function deployCommand(
     'Missing required --release <path>.',
   );
   const env = dependencies.env ?? process.env;
-  const endpoint = requiredConfiguration(
-    options.endpoint ?? env.HYPEQUERY_DEPLOYMENT_ENDPOINT,
-    'Missing deployment endpoint. Pass --endpoint or set HYPEQUERY_DEPLOYMENT_ENDPOINT.',
+  let endpoint = options.endpoint ?? env.HYPEQUERY_DEPLOYMENT_ENDPOINT;
+  let token = env.HYPEQUERY_API_TOKEN;
+  if (!endpoint || !token) {
+    const loadCredential = dependencies.loadCredential
+      ?? (dependencies.env === undefined
+        ? loadCloudCredential
+        : async () => null);
+    const credential = await loadCredential();
+    if (credential) {
+      endpoint ??= credential.deploymentEndpoint;
+      if (!token) {
+        if (Date.parse(credential.expiresAt) <= Date.now()) {
+          throw new Error('The stored Cloud credential has expired. Run `hypequery login` again.');
+        }
+        token = credential.token;
+      }
+    }
+  }
+  endpoint = requiredConfiguration(
+    endpoint,
+    'Missing deployment endpoint. Run `hypequery login`, pass --endpoint, or set HYPEQUERY_DEPLOYMENT_ENDPOINT.',
   );
-  const token = requiredConfiguration(
-    env.HYPEQUERY_API_TOKEN,
-    'Missing HYPEQUERY_API_TOKEN.',
+  token = requiredConfiguration(
+    token,
+    'Missing deployment credential. Run `hypequery login` or set HYPEQUERY_API_TOKEN.',
   );
 
   let bundle: Awaited<ReturnType<typeof verifyDeploymentBundle>>;

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -18,6 +18,14 @@ import {
 const MAX_RELEASE_FILE_BYTES = 16 * 1024;
 const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 
+function sameOrigin(left: string, right: string): boolean {
+  try {
+    return new URL(left).origin === new URL(right).origin;
+  } catch {
+    return false;
+  }
+}
+
 export interface DeployOptions {
   release?: string;
   endpoint?: string;
@@ -113,13 +121,26 @@ export async function deployCommand(
         : async () => null);
     const credential = await loadCredential();
     if (credential) {
-      endpoint ??= credential.deploymentEndpoint;
+      // The stored token authenticates one Cloud. An explicit --endpoint or
+      // HYPEQUERY_DEPLOYMENT_ENDPOINT aimed anywhere else must never receive
+      // it, or a mistyped or hostile endpoint silently exfiltrates the
+      // credential the user never typed.
+      const resolved = endpoint ?? credential.deploymentEndpoint;
       if (!token) {
+        if (!sameOrigin(resolved, credential.cloudUrl)) {
+          throw new Error(
+            `The stored Cloud credential belongs to ${credential.cloudUrl} and will not be `
+            + `sent to ${resolved}.\n\n`
+            + 'Drop --endpoint/HYPEQUERY_DEPLOYMENT_ENDPOINT to use the logged-in Cloud, '
+            + 'or set HYPEQUERY_API_TOKEN for this endpoint.',
+          );
+        }
         if (Date.parse(credential.expiresAt) <= Date.now()) {
           throw new Error('The stored Cloud credential has expired. Run `hypequery login` again.');
         }
         token = credential.token;
       }
+      endpoint = resolved;
     }
   }
   endpoint = requiredConfiguration(

--- a/packages/cli/src/commands/deployment.test.ts
+++ b/packages/cli/src/commands/deployment.test.ts
@@ -400,6 +400,49 @@ describe('deployment commands', () => {
     expect(Object.isFrozen(result)).toBe(true);
   });
 
+  it('uses the target stored by interactive login when flags are omitted', async () => {
+    mockVerifyDeploymentBundle.mockResolvedValue({
+      directory: '/project/dist/bundle',
+      manifest: {
+        kind: 'hypequery-deployment-bundle',
+        version: 1,
+        deployment: {
+          path: 'deployment.json',
+          identity: '1'.repeat(64),
+          sha256: '2'.repeat(64),
+          byteLength: 1,
+        },
+        artifacts: [],
+      },
+      identity: BUNDLE_IDENTITY,
+      contract,
+    });
+
+    const result = await prepareDeploymentReleaseCommand(
+      'dist/bundle',
+      {},
+      {
+        loadCredential: async () => ({
+          cloudUrl: 'https://cloud.example.test',
+          deploymentEndpoint:
+            'https://cloud.example.test/v1/deployments/submissions',
+          expiresAt: '2030-01-01T00:00:00.000Z',
+          scope: 'deploy:submit',
+          target: {
+            project: 'acme:analytics',
+            environment: 'production',
+          },
+          token: `hqdp_v1_${'a'.repeat(43)}`,
+        }),
+      },
+    );
+
+    expect(result.target).toEqual({
+      project: 'acme:analytics',
+      environment: 'production',
+    });
+  });
+
   it('requires release target options before reading the bundle', async () => {
     await expect(prepareDeploymentReleaseCommand('dist/bundle', {
       environment: 'production',

--- a/packages/cli/src/commands/deployment.test.ts
+++ b/packages/cli/src/commands/deployment.test.ts
@@ -453,6 +453,31 @@ describe('deployment commands', () => {
     expect(mockVerifyDeploymentBundle).not.toHaveBeenCalled();
   });
 
+  it('never completes a half-specified target from the stored login', async () => {
+    const loadCredential = vi.fn(async () => ({
+      cloudUrl: 'https://cloud.example.test',
+      deploymentEndpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+      scope: 'deploy:submit',
+      target: { project: 'acme:analytics', environment: 'production' },
+      token: `hqdp_v1_${'a'.repeat(43)}`,
+    }));
+
+    // An unset shell variable reaches commander as an empty string. Falling
+    // back here would silently retarget the release at the logged-in target.
+    await expect(prepareDeploymentReleaseCommand('dist/bundle', {
+      project: 'project_1',
+      environment: '',
+    }, { loadCredential })).rejects.toThrow(/--environment/);
+    await expect(prepareDeploymentReleaseCommand('dist/bundle', {
+      project: '',
+      environment: '',
+    }, { loadCredential })).rejects.toThrow(/--project/);
+
+    expect(loadCredential).not.toHaveBeenCalled();
+    expect(mockVerifyDeploymentBundle).not.toHaveBeenCalled();
+  });
+
   it('does not permit release output inside the closed bundle', async () => {
     await expect(prepareDeploymentReleaseCommand('dist/bundle', {
       project: 'project_1',

--- a/packages/cli/src/commands/deployment.ts
+++ b/packages/cli/src/commands/deployment.ts
@@ -385,28 +385,29 @@ export async function prepareDeploymentReleaseCommand(
       + 'Usage: hypequery deployment:release analytics/hypequery-deployment',
     );
   }
-  const hasProject = options.project !== undefined;
-  const hasEnvironment = options.environment !== undefined;
-  if (hasProject !== hasEnvironment && !hasProject) {
-    throw new Error('Missing required --project <project>.');
-  }
-  if (hasProject !== hasEnvironment) {
-    throw new Error('Missing required --environment <environment>.');
-  }
-  let project = options.project;
-  let environment = options.environment;
-  if (!project || !environment) {
+  // Passing either flag opts out of the logged-in target entirely. Completing
+  // a half-specified override from the stored profile would silently retarget
+  // the release — `--project "$P" --environment "$E"` with an unset variable
+  // must fail loudly, not bind to whatever the last login used.
+  let project: string | undefined;
+  let environment: string | undefined;
+  if (options.project !== undefined || options.environment !== undefined) {
+    if (!options.project) throw new Error('Missing required --project <project>.');
+    if (!options.environment) throw new Error('Missing required --environment <environment>.');
+    project = options.project;
+    environment = options.environment;
+  } else {
     const credential = await (
       dependencies.loadCredential ?? loadCloudCredential
     )();
     project = credential?.target?.project;
     environment = credential?.target?.environment;
-  }
-  if (!project || !environment) {
-    throw new Error(
-      'Missing deployment target. Run `hypequery login` or pass both '
-      + '--project <project> and --environment <environment>.',
-    );
+    if (!project || !environment) {
+      throw new Error(
+        'Missing deployment target. Run `hypequery login` or pass both '
+        + '--project <project> and --environment <environment>.',
+      );
+    }
   }
   const outputPath = options.output ?? `${bundlePath.replace(/[\\/]+$/, '')}.release.json`;
   assertOutputOutsideBundle(bundlePath, outputPath);
@@ -437,6 +438,7 @@ export async function prepareDeploymentReleaseCommand(
   await assertOutputIsNotSymbolicLink(outputPath);
   await writeFile(outputPath, `${prepared.canonical}\n`, 'utf8');
   logger.success(`Deployment release written to ${outputPath}`);
+  logger.info(`Target: ${project}/${environment}`);
   logger.info(`Release identity: ${prepared.identity}`);
   logger.info(`Bundle identity: ${bundle.identity}`);
   return prepared.release;

--- a/packages/cli/src/commands/deployment.ts
+++ b/packages/cli/src/commands/deployment.ts
@@ -20,6 +20,10 @@ import {
 } from '../utils/deployment-runtime-artifact.js';
 import { loadApiModule } from '../utils/load-api.js';
 import { logger } from '../utils/logger.js';
+import {
+  loadCloudCredential,
+  type StoredCloudCredential,
+} from '../utils/cloud-credential-store.js';
 
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
 
@@ -38,6 +42,10 @@ export interface PrepareDeploymentReleaseOptions {
   project?: string;
   environment?: string;
   output?: string;
+}
+
+export interface PrepareDeploymentReleaseDependencies {
+  loadCredential?: () => Promise<StoredCloudCredential | null>;
 }
 
 const DEFAULT_BUNDLE_OUTPUT = 'analytics/hypequery-deployment';
@@ -369,19 +377,36 @@ async function assertOutputIsNotSymbolicLink(outputPath: string): Promise<void> 
 export async function prepareDeploymentReleaseCommand(
   bundlePath: string | undefined,
   options: PrepareDeploymentReleaseOptions = {},
+  dependencies: PrepareDeploymentReleaseDependencies = {},
 ): Promise<ProtocolDeploymentReleaseEnvelope> {
   if (!bundlePath) {
     throw new Error(
       'Missing deployment bundle path.\n\n'
-      + 'Usage: hypequery deployment:release analytics/hypequery-deployment '
-      + '--project <project> --environment <environment>',
+      + 'Usage: hypequery deployment:release analytics/hypequery-deployment',
     );
   }
-  if (options.project === undefined) {
+  const hasProject = options.project !== undefined;
+  const hasEnvironment = options.environment !== undefined;
+  if (hasProject !== hasEnvironment && !hasProject) {
     throw new Error('Missing required --project <project>.');
   }
-  if (options.environment === undefined) {
+  if (hasProject !== hasEnvironment) {
     throw new Error('Missing required --environment <environment>.');
+  }
+  let project = options.project;
+  let environment = options.environment;
+  if (!project || !environment) {
+    const credential = await (
+      dependencies.loadCredential ?? loadCloudCredential
+    )();
+    project = credential?.target?.project;
+    environment = credential?.target?.environment;
+  }
+  if (!project || !environment) {
+    throw new Error(
+      'Missing deployment target. Run `hypequery login` or pass both '
+      + '--project <project> and --environment <environment>.',
+    );
   }
   const outputPath = options.output ?? `${bundlePath.replace(/[\\/]+$/, '')}.release.json`;
   assertOutputOutsideBundle(bundlePath, outputPath);
@@ -404,8 +429,8 @@ export async function prepareDeploymentReleaseCommand(
     version: 1,
     bundleIdentity: bundle.identity,
     target: {
-      project: options.project,
-      environment: options.environment,
+      project,
+      environment,
     },
   });
   await mkdir(path.dirname(outputPath), { recursive: true });

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -31,6 +31,10 @@ describe('Cloud CLI authentication', () => {
         scope: 'deploy:submit',
         deployment_endpoint:
           'https://cloud.example.test/v1/deployments/submissions',
+        deployment_target: {
+          project: 'acme:analytics',
+          environment: 'production',
+        },
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -63,6 +67,10 @@ describe('Cloud CLI authentication', () => {
         'https://cloud.example.test/v1/deployments/submissions',
       expiresAt: '2030-01-01T00:00:00.000Z',
       scope: 'deploy:submit',
+      target: {
+        project: 'acme:analytics',
+        environment: 'production',
+      },
       token: `hqdp_v1_${'c'.repeat(43)}`,
     });
   });

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -75,6 +75,49 @@ describe('Cloud CLI authentication', () => {
     });
   });
 
+  it('ignores a mismatched callback and still completes the login', async () => {
+    let authorizeUrl: URL | undefined;
+    const saveCredential = vi.fn();
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      access_token: `hqdp_v1_${'c'.repeat(43)}`,
+      token_type: 'Bearer',
+      expires_at: '2030-01-01T00:00:00.000Z',
+      scope: 'deploy:submit',
+      deployment_endpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      deployment_target: { project: 'acme:analytics', environment: 'production' },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+
+    const openBrowser = vi.fn(async (input: string) => {
+      authorizeUrl = new URL(input);
+      const callbackUrl = authorizeUrl.searchParams.get('redirect_uri') as string;
+
+      // Any page the user has open can reach this port with a no-CORS
+      // request. A wrong state must not abort the pending login.
+      const stray = new URL(callbackUrl);
+      stray.searchParams.set('code', `hqac_v1_${'9'.repeat(43)}`);
+      stray.searchParams.set('state', 'not-the-real-state');
+      const strayResponse = await fetch(stray);
+      expect(strayResponse.status).toBe(400);
+
+      const callback = new URL(callbackUrl);
+      callback.searchParams.set('code', `hqac_v1_${'d'.repeat(43)}`);
+      callback.searchParams.set(
+        'state',
+        authorizeUrl.searchParams.get('state') as string,
+      );
+      await fetch(callback);
+    });
+
+    await loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
+      fetch: fetchMock as typeof fetch,
+      openBrowser,
+      saveCredential,
+      timeoutMs: 2_000,
+    });
+
+    expect(saveCredential).toHaveBeenCalledOnce();
+  });
+
   it('revokes the remote token before deleting it locally', async () => {
     const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
     const deleteCredential = vi.fn();

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -209,4 +209,101 @@ describe('Cloud CLI authentication', () => {
     );
     expect(deleteCredential).toHaveBeenCalledOnce();
   });
+
+  it('still clears local state when the stored credential cannot be read', async () => {
+    const fetchMock = vi.fn();
+    const deleteCredential = vi.fn();
+
+    await logoutCommand({
+      fetch: fetchMock as unknown as typeof fetch,
+      loadCredential: async () => {
+        throw new Error('The stored Hypequery Cloud profile is invalid.');
+      },
+      deleteCredential,
+    });
+
+    // Nothing to revoke without a readable token, but logout is what users run
+    // when local state is broken, so it must not leave the profile behind.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(deleteCredential).toHaveBeenCalledOnce();
+  });
+
+  it('does not clear anything when no credential is stored', async () => {
+    const deleteCredential = vi.fn();
+
+    await logoutCommand({
+      loadCredential: async () => null,
+      deleteCredential,
+    });
+
+    expect(deleteCredential).not.toHaveBeenCalled();
+  });
+
+  it('accepts a token whose format Cloud has rotated', async () => {
+    const saveCredential = vi.fn();
+    await loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
+      fetch: vi.fn(async () => new Response(JSON.stringify({
+        access_token: `hqdp_v2_${'c'.repeat(64)}`,
+        token_type: 'Bearer',
+        expires_at: '2030-01-01T00:00:00.000Z',
+        scope: 'deploy:submit',
+        deployment_endpoint: 'https://cloud.example.test/v2/deploy/submissions',
+        deployment_target: {
+          project: 'acme:analytics',
+          environment: 'production',
+        },
+      }), { status: 200 })) as typeof fetch,
+      now: () => TOKEN_RESPONSE_NOW,
+      openBrowser: authorizeInBrowser,
+      saveCredential,
+      timeoutMs: 2_000,
+    });
+
+    expect(saveCredential).toHaveBeenCalledWith(expect.objectContaining({
+      deploymentEndpoint: 'https://cloud.example.test/v2/deploy/submissions',
+      token: `hqdp_v2_${'c'.repeat(64)}`,
+    }));
+  });
+
+  it('rejects a token that is not a header-safe opaque credential', async () => {
+    await expect(loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
+      fetch: vi.fn(async () => new Response(JSON.stringify({
+        access_token: 'hqdp_short',
+        token_type: 'Bearer',
+        expires_at: '2030-01-01T00:00:00.000Z',
+        scope: 'deploy:submit',
+        deployment_endpoint:
+          'https://cloud.example.test/v1/deployments/submissions',
+        deployment_target: {
+          project: 'acme:analytics',
+          environment: 'production',
+        },
+      }), { status: 200 })) as typeof fetch,
+      now: () => TOKEN_RESPONSE_NOW,
+      openBrowser: authorizeInBrowser,
+      saveCredential: vi.fn(),
+      timeoutMs: 2_000,
+    })).rejects.toThrow('Cloud returned an invalid CLI token response.');
+  });
+
+  it('rejects a deployment endpoint on another origin', async () => {
+    await expect(loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
+      fetch: vi.fn(async () => new Response(JSON.stringify({
+        access_token: `hqdp_v1_${'c'.repeat(43)}`,
+        token_type: 'Bearer',
+        expires_at: '2030-01-01T00:00:00.000Z',
+        scope: 'deploy:submit',
+        deployment_endpoint:
+          'https://attacker.example.test/v1/deployments/submissions',
+        deployment_target: {
+          project: 'acme:analytics',
+          environment: 'production',
+        },
+      }), { status: 200 })) as typeof fetch,
+      now: () => TOKEN_RESPONSE_NOW,
+      openBrowser: authorizeInBrowser,
+      saveCredential: vi.fn(),
+      timeoutMs: 2_000,
+    })).rejects.toThrow('Cloud returned an invalid deployment endpoint.');
+  });
 });

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -11,6 +11,21 @@ vi.mock('../utils/logger.js', () => ({
 
 import { loginCommand, logoutCommand } from './login.js';
 
+const TOKEN_RESPONSE_NOW = Date.parse('2029-12-31T12:00:00.000Z');
+
+function authorizeInBrowser(input: string) {
+  const authorizeUrl = new URL(input);
+  const callback = new URL(
+    authorizeUrl.searchParams.get('redirect_uri') as string,
+  );
+  callback.searchParams.set('code', `hqac_v1_${'d'.repeat(43)}`);
+  callback.searchParams.set(
+    'state',
+    authorizeUrl.searchParams.get('state') as string,
+  );
+  return fetch(callback);
+}
+
 describe('Cloud CLI authentication', () => {
   it('completes a browser loopback PKCE flow and stores the returned token', async () => {
     let authorizeUrl: URL | undefined;
@@ -24,6 +39,7 @@ describe('Cloud CLI authentication', () => {
         createHash('sha256').update(body.code_verifier).digest('base64url'),
       ).toBe(authorizeUrl?.searchParams.get('code_challenge'));
       expect(body.redirect_uri).toBe(authorizeUrl?.searchParams.get('redirect_uri'));
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
       return new Response(JSON.stringify({
         access_token: `hqdp_v1_${'c'.repeat(43)}`,
         token_type: 'Bearer',
@@ -45,6 +61,9 @@ describe('Cloud CLI authentication', () => {
       const callback = new URL(
         authorizeUrl.searchParams.get('redirect_uri') as string,
       );
+      const invalidCallback = new URL(callback);
+      invalidCallback.searchParams.set('code', `hqac_v1_${'d'.repeat(43)}`);
+      await expect(fetch(invalidCallback)).resolves.toMatchObject({ status: 400 });
       callback.searchParams.set('code', `hqac_v1_${'d'.repeat(43)}`);
       callback.searchParams.set(
         'state',
@@ -55,6 +74,7 @@ describe('Cloud CLI authentication', () => {
 
     await loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
       fetch: fetchMock as typeof fetch,
+      now: () => TOKEN_RESPONSE_NOW,
       openBrowser,
       saveCredential,
       timeoutMs: 2_000,
@@ -75,47 +95,92 @@ describe('Cloud CLI authentication', () => {
     });
   });
 
-  it('ignores a mismatched callback and still completes the login', async () => {
-    let authorizeUrl: URL | undefined;
-    const saveCredential = vi.fn();
-    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
-      access_token: `hqdp_v1_${'c'.repeat(43)}`,
-      token_type: 'Bearer',
-      expires_at: '2030-01-01T00:00:00.000Z',
-      scope: 'deploy:submit',
-      deployment_endpoint: 'https://cloud.example.test/v1/deployments/submissions',
-      deployment_target: { project: 'acme:analytics', environment: 'production' },
-    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
-
-    const openBrowser = vi.fn(async (input: string) => {
-      authorizeUrl = new URL(input);
-      const callbackUrl = authorizeUrl.searchParams.get('redirect_uri') as string;
-
-      // Any page the user has open can reach this port with a no-CORS
-      // request. A wrong state must not abort the pending login.
-      const stray = new URL(callbackUrl);
-      stray.searchParams.set('code', `hqac_v1_${'9'.repeat(43)}`);
-      stray.searchParams.set('state', 'not-the-real-state');
-      const strayResponse = await fetch(stray);
-      expect(strayResponse.status).toBe(400);
-
-      const callback = new URL(callbackUrl);
-      callback.searchParams.set('code', `hqac_v1_${'d'.repeat(43)}`);
-      callback.searchParams.set(
-        'state',
-        authorizeUrl.searchParams.get('state') as string,
-      );
-      await fetch(callback);
-    });
-
-    await loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
-      fetch: fetchMock as typeof fetch,
-      openBrowser,
-      saveCredential,
+  it('reports a non-object token response as an invalid Cloud response', async () => {
+    await expect(loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
+      fetch: vi.fn(async () => new Response('null', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as typeof fetch,
+      openBrowser: authorizeInBrowser,
+      saveCredential: vi.fn(),
       timeoutMs: 2_000,
-    });
+    })).rejects.toThrow('Cloud returned an invalid CLI token response.');
+  });
 
-    expect(saveCredential).toHaveBeenCalledOnce();
+  it('reports a malformed deployment endpoint as an invalid Cloud response', async () => {
+    await expect(loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
+      fetch: vi.fn(async () => new Response(JSON.stringify({
+        access_token: `hqdp_v1_${'c'.repeat(43)}`,
+        token_type: 'Bearer',
+        expires_at: '2030-01-01T00:00:00.000Z',
+        scope: 'deploy:submit',
+        deployment_endpoint: 'not a URL',
+        deployment_target: {
+          project: 'acme:analytics',
+          environment: 'production',
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as typeof fetch,
+      now: () => TOKEN_RESPONSE_NOW,
+      openBrowser: authorizeInBrowser,
+      saveCredential: vi.fn(),
+      timeoutMs: 2_000,
+    })).rejects.toThrow('Cloud returned an invalid deployment endpoint.');
+  });
+
+  it('rejects a token response with an unexpected scope', async () => {
+    await expect(loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
+      fetch: vi.fn(async () => new Response(JSON.stringify({
+        access_token: `hqdp_v1_${'c'.repeat(43)}`,
+        token_type: 'Bearer',
+        expires_at: '2030-01-01T00:00:00.000Z',
+        scope: 'admin',
+        deployment_endpoint:
+          'https://cloud.example.test/v1/deployments/submissions',
+        deployment_target: {
+          project: 'acme:analytics',
+          environment: 'production',
+        },
+      }), { status: 200 })) as typeof fetch,
+      now: () => TOKEN_RESPONSE_NOW,
+      openBrowser: authorizeInBrowser,
+      saveCredential: vi.fn(),
+      timeoutMs: 2_000,
+    })).rejects.toThrow('Cloud returned an invalid CLI token response.');
+  });
+
+  it('rejects an unexpectedly long-lived token response', async () => {
+    await expect(loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
+      fetch: vi.fn(async () => new Response(JSON.stringify({
+        access_token: `hqdp_v1_${'c'.repeat(43)}`,
+        token_type: 'Bearer',
+        expires_at: '2030-01-02T00:00:00.000Z',
+        scope: 'deploy:submit',
+        deployment_endpoint:
+          'https://cloud.example.test/v1/deployments/submissions',
+        deployment_target: {
+          project: 'acme:analytics',
+          environment: 'production',
+        },
+      }), { status: 200 })) as typeof fetch,
+      now: () => TOKEN_RESPONSE_NOW,
+      openBrowser: authorizeInBrowser,
+      saveCredential: vi.fn(),
+      timeoutMs: 2_000,
+    })).rejects.toThrow('Cloud returned an invalid CLI token expiration.');
+  });
+
+  it('bounds the token response body', async () => {
+    await expect(loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
+      fetch: vi.fn(async () => new Response('x'.repeat(65_537), {
+        status: 200,
+      })) as typeof fetch,
+      openBrowser: authorizeInBrowser,
+      saveCredential: vi.fn(),
+      timeoutMs: 2_000,
+    })).rejects.toThrow('Cloud returned an oversized CLI token response.');
   });
 
   it('revokes the remote token before deleting it locally', async () => {
@@ -139,6 +204,7 @@ describe('Cloud CLI authentication', () => {
       expect.objectContaining({
         method: 'DELETE',
         headers: { Authorization: `Bearer hqdp_v1_${'e'.repeat(43)}` },
+        signal: expect.any(AbortSignal),
       }),
     );
     expect(deleteCredential).toHaveBeenCalledOnce();

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -1,0 +1,95 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { loginCommand, logoutCommand } from './login.js';
+
+describe('Cloud CLI authentication', () => {
+  it('completes a browser loopback PKCE flow and stores the returned token', async () => {
+    let authorizeUrl: URL | undefined;
+    const saveCredential = vi.fn();
+    const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        code_verifier: string;
+        redirect_uri: string;
+      };
+      expect(
+        createHash('sha256').update(body.code_verifier).digest('base64url'),
+      ).toBe(authorizeUrl?.searchParams.get('code_challenge'));
+      expect(body.redirect_uri).toBe(authorizeUrl?.searchParams.get('redirect_uri'));
+      return new Response(JSON.stringify({
+        access_token: `hqdp_v1_${'c'.repeat(43)}`,
+        token_type: 'Bearer',
+        expires_at: '2030-01-01T00:00:00.000Z',
+        scope: 'deploy:submit',
+        deployment_endpoint:
+          'https://cloud.example.test/v1/deployments/submissions',
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const openBrowser = vi.fn(async (input: string) => {
+      authorizeUrl = new URL(input);
+      const callback = new URL(
+        authorizeUrl.searchParams.get('redirect_uri') as string,
+      );
+      callback.searchParams.set('code', `hqac_v1_${'d'.repeat(43)}`);
+      callback.searchParams.set(
+        'state',
+        authorizeUrl.searchParams.get('state') as string,
+      );
+      await fetch(callback);
+    });
+
+    await loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
+      fetch: fetchMock as typeof fetch,
+      openBrowser,
+      saveCredential,
+      timeoutMs: 2_000,
+    });
+
+    expect(openBrowser).toHaveBeenCalledOnce();
+    expect(saveCredential).toHaveBeenCalledWith({
+      cloudUrl: 'https://cloud.example.test',
+      deploymentEndpoint:
+        'https://cloud.example.test/v1/deployments/submissions',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+      scope: 'deploy:submit',
+      token: `hqdp_v1_${'c'.repeat(43)}`,
+    });
+  });
+
+  it('revokes the remote token before deleting it locally', async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    const deleteCredential = vi.fn();
+    await logoutCommand({
+      fetch: fetchMock as typeof fetch,
+      loadCredential: async () => ({
+        cloudUrl: 'https://cloud.example.test',
+        deploymentEndpoint:
+          'https://cloud.example.test/v1/deployments/submissions',
+        expiresAt: '2030-01-01T00:00:00.000Z',
+        scope: 'deploy:submit',
+        token: `hqdp_v1_${'e'.repeat(43)}`,
+      }),
+      deleteCredential,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL('https://cloud.example.test/api/cli/token'),
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: { Authorization: `Bearer hqdp_v1_${'e'.repeat(43)}` },
+      }),
+    );
+    expect(deleteCredential).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -5,8 +5,11 @@ import open from 'open';
 import { validateProtocolDeploymentReleaseTarget } from '@hypequery/protocol';
 
 import {
+  CLOUD_DEPLOYMENT_SCOPE,
   deleteCloudCredential,
   loadCloudCredential,
+  normalizeCloudDeploymentEndpoint,
+  normalizeCloudOrigin,
   saveCloudCredential,
   type StoredCloudCredential,
 } from '../utils/cloud-credential-store.js';
@@ -14,7 +17,12 @@ import { logger } from '../utils/logger.js';
 
 const DEFAULT_CLOUD_URL = 'https://cloud.hypequery.com';
 const LOGIN_TIMEOUT_MS = 5 * 60_000;
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_TOKEN_RESPONSE_BYTES = 64 * 1024;
+// Cloud issues 12-hour credentials; allow limited client/server clock skew.
+const MAX_TOKEN_LIFETIME_MS = 13 * 60 * 60_000;
 const TOKEN_PATTERN = /^hqdp_v1_[A-Za-z0-9_-]{43}$/;
+const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 
 export interface LoginOptions {
   readonly cloudUrl?: string;
@@ -23,6 +31,8 @@ export interface LoginOptions {
 export interface LoginDependencies {
   readonly fetch?: typeof fetch;
   readonly openBrowser?: (url: string) => Promise<unknown>;
+  readonly now?: () => number;
+  readonly requestTimeoutMs?: number;
   readonly saveCredential?: typeof saveCloudCredential;
   readonly timeoutMs?: number;
 }
@@ -31,22 +41,7 @@ export interface LogoutDependencies {
   readonly fetch?: typeof fetch;
   readonly loadCredential?: typeof loadCloudCredential;
   readonly deleteCredential?: typeof deleteCloudCredential;
-}
-
-function cloudOrigin(input: string) {
-  let url: URL;
-  try {
-    url = new URL(input);
-  } catch {
-    throw new Error('Cloud URL must be an absolute HTTPS URL.');
-  }
-  const loopback = url.protocol === 'http:'
-    && (url.hostname === '127.0.0.1' || url.hostname === 'localhost');
-  if ((url.protocol !== 'https:' && !loopback) || url.username || url.password
-    || url.pathname !== '/' || url.search || url.hash) {
-    throw new Error('Cloud URL must be an HTTPS origin without a path, query, or credentials.');
-  }
-  return url.origin;
+  readonly requestTimeoutMs?: number;
 }
 
 function callbackHtml(success: boolean) {
@@ -77,7 +72,12 @@ async function callbackServer(state: string, timeoutMs: number) {
     }
     const returnedState = url.searchParams.get('state');
     const authorizationCode = url.searchParams.get('code');
-    const valid = returnedState === state && Boolean(authorizationCode);
+    const authorizationError = url.searchParams.get('error');
+    const stateMatches = returnedState === state;
+    const valid = stateMatches
+      && typeof authorizationCode === 'string'
+      && authorizationCode.length >= 1
+      && authorizationCode.length <= 4096;
     response.writeHead(valid ? 200 : 400, {
       'Cache-Control': 'no-store',
       'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'",
@@ -89,8 +89,11 @@ async function callbackServer(state: string, timeoutMs: number) {
     // Only a matching callback completes the login. Any web page the user has
     // open can issue a no-CORS request to this port, so a mismatch is ignored
     // rather than settled: aborting here would let a background tab cancel a
-    // legitimate login. The timeout remains the only failure path.
+    // legitimate login. A matching Cloud error still ends the transaction.
     if (valid) settle?.(authorizationCode as string);
+    else if (stateMatches && authorizationError) {
+      reject?.(new Error('Cloud authorization was not completed.'));
+    }
   });
   server.listen(0, '127.0.0.1');
   await new Promise<void>((resolve, rejectListen) => {
@@ -112,7 +115,46 @@ async function callbackServer(state: string, timeoutMs: number) {
   };
 }
 
-function tokenResponse(input: unknown, origin: string): StoredCloudCredential {
+async function boundedJsonResponse(response: Response): Promise<unknown> {
+  if (!response.body) return null;
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_TOKEN_RESPONSE_BYTES) {
+        await reader.cancel().catch(() => undefined);
+        throw new Error('Cloud returned an oversized CLI token response.');
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return JSON.parse(utf8Decoder.decode(bytes)) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function tokenResponse(
+  input: unknown,
+  origin: string,
+  now: number,
+): StoredCloudCredential {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new Error('Cloud returned an invalid CLI token response.');
+  }
   const value = input as Record<string, unknown>;
   if (
     typeof value.access_token !== 'string'
@@ -120,17 +162,20 @@ function tokenResponse(input: unknown, origin: string): StoredCloudCredential {
     || value.token_type !== 'Bearer'
     || typeof value.expires_at !== 'string'
     || !Number.isFinite(Date.parse(value.expires_at))
-    || typeof value.scope !== 'string'
+    || value.scope !== CLOUD_DEPLOYMENT_SCOPE
     || typeof value.deployment_endpoint !== 'string'
     || value.deployment_target === undefined
   ) {
     throw new Error('Cloud returned an invalid CLI token response.');
   }
-  const endpoint = new URL(value.deployment_endpoint);
-  if (endpoint.origin !== origin || endpoint.pathname !== '/v1/deployments/submissions'
-    || endpoint.search || endpoint.hash) {
-    throw new Error('Cloud returned an invalid deployment endpoint.');
+  const expiresAt = Date.parse(value.expires_at);
+  if (expiresAt <= now || expiresAt > now + MAX_TOKEN_LIFETIME_MS) {
+    throw new Error('Cloud returned an invalid CLI token expiration.');
   }
+  const deploymentEndpoint = normalizeCloudDeploymentEndpoint(
+    value.deployment_endpoint,
+    origin,
+  );
   let target;
   try {
     target = validateProtocolDeploymentReleaseTarget(value.deployment_target);
@@ -139,7 +184,7 @@ function tokenResponse(input: unknown, origin: string): StoredCloudCredential {
   }
   return {
     cloudUrl: origin,
-    deploymentEndpoint: endpoint.toString(),
+    deploymentEndpoint,
     expiresAt: value.expires_at,
     scope: value.scope,
     target,
@@ -151,7 +196,7 @@ export async function loginCommand(
   options: LoginOptions = {},
   dependencies: LoginDependencies = {},
 ) {
-  const origin = cloudOrigin(
+  const origin = normalizeCloudOrigin(
     options.cloudUrl ?? process.env.HYPEQUERY_CLOUD_URL ?? DEFAULT_CLOUD_URL,
   );
   const state = randomBytes(24).toString('base64url');
@@ -181,12 +226,20 @@ export async function loginCommand(
         redirect_uri: callback.redirectUri,
       }),
       redirect: 'error',
+      signal: AbortSignal.timeout(
+        dependencies.requestTimeoutMs ?? REQUEST_TIMEOUT_MS,
+      ),
     });
-    const body = await response.json().catch(() => null);
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
       throw new Error('Cloud rejected the CLI authorization code. Run `hypequery login` again.');
     }
-    const credential = tokenResponse(body, origin);
+    const body = await boundedJsonResponse(response);
+    const credential = tokenResponse(
+      body,
+      origin,
+      (dependencies.now ?? Date.now)(),
+    );
     await (dependencies.saveCredential ?? saveCloudCredential)(credential);
     logger.success('Logged in to Hypequery Cloud');
     logger.info(`Credential expires ${new Date(credential.expiresAt).toLocaleString()}`);
@@ -209,7 +262,11 @@ export async function logoutCommand(dependencies: LogoutDependencies = {}) {
       method: 'DELETE',
       headers: { Authorization: `Bearer ${credential.token}` },
       redirect: 'error',
+      signal: AbortSignal.timeout(
+        dependencies.requestTimeoutMs ?? REQUEST_TIMEOUT_MS,
+      ),
     });
+    await response.body?.cancel().catch(() => undefined);
     if (!response.ok) throw new Error(`Cloud returned HTTP ${response.status}.`);
   } catch {
     logger.warn('Cloud could not be reached; the local credential was removed and the token will expire automatically.');

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes } from 'node:crypto';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import open from 'open';
+import { validateProtocolDeploymentReleaseTarget } from '@hypequery/protocol';
 
 import {
   deleteCloudCredential,
@@ -114,6 +115,7 @@ function tokenResponse(input: unknown, origin: string): StoredCloudCredential {
     || !Number.isFinite(Date.parse(value.expires_at))
     || typeof value.scope !== 'string'
     || typeof value.deployment_endpoint !== 'string'
+    || value.deployment_target === undefined
   ) {
     throw new Error('Cloud returned an invalid CLI token response.');
   }
@@ -122,11 +124,18 @@ function tokenResponse(input: unknown, origin: string): StoredCloudCredential {
     || endpoint.search || endpoint.hash) {
     throw new Error('Cloud returned an invalid deployment endpoint.');
   }
+  let target;
+  try {
+    target = validateProtocolDeploymentReleaseTarget(value.deployment_target);
+  } catch {
+    throw new Error('Cloud returned an invalid CLI deployment target.');
+  }
   return {
     cloudUrl: origin,
     deploymentEndpoint: endpoint.toString(),
     expiresAt: value.expires_at,
     scope: value.scope,
+    target,
     token: value.access_token,
   };
 }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -21,7 +21,11 @@ const REQUEST_TIMEOUT_MS = 30_000;
 const MAX_TOKEN_RESPONSE_BYTES = 64 * 1024;
 // Cloud issues 12-hour credentials; allow limited client/server clock skew.
 const MAX_TOKEN_LIFETIME_MS = 13 * 60 * 60_000;
-const TOKEN_PATTERN = /^hqdp_v1_[A-Za-z0-9_-]{43}$/;
+// Cloud owns the token format. Validate only what protects this client — an
+// opaque, header-safe bearer credential of a sane length — rather than pinning
+// a version prefix or exact length that would break every already-published
+// CLI the day Cloud rotates its token format.
+const TOKEN_PATTERN = /^hqdp_[A-Za-z0-9_-]{16,512}$/;
 const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 
 export interface LoginOptions {
@@ -251,25 +255,36 @@ export async function loginCommand(
 export async function logoutCommand(dependencies: LogoutDependencies = {}) {
   const load = dependencies.loadCredential ?? loadCloudCredential;
   const remove = dependencies.deleteCredential ?? deleteCloudCredential;
-  const credential = await load();
-  if (!credential) {
+  let credential: StoredCloudCredential | null = null;
+  let unreadable = false;
+  try {
+    credential = await load();
+  } catch {
+    // Logout is the command users reach for when local state is broken, so a
+    // corrupt profile or an unreachable vault must not block the cleanup below.
+    unreadable = true;
+    logger.warn('The stored Cloud credential could not be read; removing local state without revoking. The token will expire automatically.');
+  }
+  if (!credential && !unreadable) {
     logger.info('You are not logged in to Hypequery Cloud.');
     return;
   }
-  try {
-    const request = dependencies.fetch ?? fetch;
-    const response = await request(new URL('/api/cli/token', credential.cloudUrl), {
-      method: 'DELETE',
-      headers: { Authorization: `Bearer ${credential.token}` },
-      redirect: 'error',
-      signal: AbortSignal.timeout(
-        dependencies.requestTimeoutMs ?? REQUEST_TIMEOUT_MS,
-      ),
-    });
-    await response.body?.cancel().catch(() => undefined);
-    if (!response.ok) throw new Error(`Cloud returned HTTP ${response.status}.`);
-  } catch {
-    logger.warn('Cloud could not be reached; the local credential was removed and the token will expire automatically.');
+  if (credential) {
+    try {
+      const request = dependencies.fetch ?? fetch;
+      const response = await request(new URL('/api/cli/token', credential.cloudUrl), {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${credential.token}` },
+        redirect: 'error',
+        signal: AbortSignal.timeout(
+          dependencies.requestTimeoutMs ?? REQUEST_TIMEOUT_MS,
+        ),
+      });
+      await response.body?.cancel().catch(() => undefined);
+      if (!response.ok) throw new Error(`Cloud returned HTTP ${response.status}.`);
+    } catch {
+      logger.warn('Cloud could not be reached; the local credential was removed and the token will expire automatically.');
+    }
   }
   await remove();
   logger.success('Logged out of Hypequery Cloud');

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -64,6 +64,10 @@ async function callbackServer(state: string, timeoutMs: number) {
     settle = resolve;
     reject = rejectPromise;
   });
+  // The caller only awaits `code` after the browser has been opened, which
+  // takes long enough for a rejection to be seen as unhandled and terminate
+  // the process. This keeps a handler attached from the very first tick.
+  code.catch(() => undefined);
   const server = createServer((request, response) => {
     const url = new URL(request.url ?? '/', 'http://127.0.0.1');
     if (request.method !== 'GET' || url.pathname !== '/callback') {
@@ -82,8 +86,11 @@ async function callbackServer(state: string, timeoutMs: number) {
       'X-Content-Type-Options': 'nosniff',
     });
     response.end(callbackHtml(valid));
+    // Only a matching callback completes the login. Any web page the user has
+    // open can issue a no-CORS request to this port, so a mismatch is ignored
+    // rather than settled: aborting here would let a background tab cancel a
+    // legitimate login. The timeout remains the only failure path.
     if (valid) settle?.(authorizationCode as string);
-    else reject?.(new Error('The CLI authorization callback was invalid.'));
   });
   server.listen(0, '127.0.0.1');
   await new Promise<void>((resolve, rejectListen) => {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,0 +1,203 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import open from 'open';
+
+import {
+  deleteCloudCredential,
+  loadCloudCredential,
+  saveCloudCredential,
+  type StoredCloudCredential,
+} from '../utils/cloud-credential-store.js';
+import { logger } from '../utils/logger.js';
+
+const DEFAULT_CLOUD_URL = 'https://cloud.hypequery.com';
+const LOGIN_TIMEOUT_MS = 5 * 60_000;
+const TOKEN_PATTERN = /^hqdp_v1_[A-Za-z0-9_-]{43}$/;
+
+export interface LoginOptions {
+  readonly cloudUrl?: string;
+}
+
+export interface LoginDependencies {
+  readonly fetch?: typeof fetch;
+  readonly openBrowser?: (url: string) => Promise<unknown>;
+  readonly saveCredential?: typeof saveCloudCredential;
+  readonly timeoutMs?: number;
+}
+
+export interface LogoutDependencies {
+  readonly fetch?: typeof fetch;
+  readonly loadCredential?: typeof loadCloudCredential;
+  readonly deleteCredential?: typeof deleteCloudCredential;
+}
+
+function cloudOrigin(input: string) {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    throw new Error('Cloud URL must be an absolute HTTPS URL.');
+  }
+  const loopback = url.protocol === 'http:'
+    && (url.hostname === '127.0.0.1' || url.hostname === 'localhost');
+  if ((url.protocol !== 'https:' && !loopback) || url.username || url.password
+    || url.pathname !== '/' || url.search || url.hash) {
+    throw new Error('Cloud URL must be an HTTPS origin without a path, query, or credentials.');
+  }
+  return url.origin;
+}
+
+function callbackHtml(success: boolean) {
+  const title = success ? 'CLI authorized' : 'Authorization failed';
+  const message = success
+    ? 'You can close this window and return to your terminal.'
+    : 'Return to your terminal and run the login command again.';
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>${title}</title></head><body><main><h1>${title}</h1><p>${message}</p></main></body></html>`;
+}
+
+async function callbackServer(state: string, timeoutMs: number) {
+  let settle: ((code: string) => void) | undefined;
+  let reject: ((error: Error) => void) | undefined;
+  const code = new Promise<string>((resolve, rejectPromise) => {
+    settle = resolve;
+    reject = rejectPromise;
+  });
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+    if (request.method !== 'GET' || url.pathname !== '/callback') {
+      response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      response.end('Not found');
+      return;
+    }
+    const returnedState = url.searchParams.get('state');
+    const authorizationCode = url.searchParams.get('code');
+    const valid = returnedState === state && Boolean(authorizationCode);
+    response.writeHead(valid ? 200 : 400, {
+      'Cache-Control': 'no-store',
+      'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'",
+      'Content-Type': 'text/html; charset=utf-8',
+      'Referrer-Policy': 'no-referrer',
+      'X-Content-Type-Options': 'nosniff',
+    });
+    response.end(callbackHtml(valid));
+    if (valid) settle?.(authorizationCode as string);
+    else reject?.(new Error('The CLI authorization callback was invalid.'));
+  });
+  server.listen(0, '127.0.0.1');
+  await new Promise<void>((resolve, rejectListen) => {
+    server.once('listening', resolve);
+    server.once('error', rejectListen);
+  });
+  const address = server.address() as AddressInfo;
+  const timer = setTimeout(() => {
+    reject?.(new Error('CLI authorization timed out. Run `hypequery login` again.'));
+  }, timeoutMs);
+  timer.unref();
+  return {
+    code,
+    redirectUri: `http://127.0.0.1:${address.port}/callback`,
+    close: () => {
+      clearTimeout(timer);
+      server.close();
+    },
+  };
+}
+
+function tokenResponse(input: unknown, origin: string): StoredCloudCredential {
+  const value = input as Record<string, unknown>;
+  if (
+    typeof value.access_token !== 'string'
+    || !TOKEN_PATTERN.test(value.access_token)
+    || value.token_type !== 'Bearer'
+    || typeof value.expires_at !== 'string'
+    || !Number.isFinite(Date.parse(value.expires_at))
+    || typeof value.scope !== 'string'
+    || typeof value.deployment_endpoint !== 'string'
+  ) {
+    throw new Error('Cloud returned an invalid CLI token response.');
+  }
+  const endpoint = new URL(value.deployment_endpoint);
+  if (endpoint.origin !== origin || endpoint.pathname !== '/v1/deployments/submissions'
+    || endpoint.search || endpoint.hash) {
+    throw new Error('Cloud returned an invalid deployment endpoint.');
+  }
+  return {
+    cloudUrl: origin,
+    deploymentEndpoint: endpoint.toString(),
+    expiresAt: value.expires_at,
+    scope: value.scope,
+    token: value.access_token,
+  };
+}
+
+export async function loginCommand(
+  options: LoginOptions = {},
+  dependencies: LoginDependencies = {},
+) {
+  const origin = cloudOrigin(
+    options.cloudUrl ?? process.env.HYPEQUERY_CLOUD_URL ?? DEFAULT_CLOUD_URL,
+  );
+  const state = randomBytes(24).toString('base64url');
+  const verifier = randomBytes(32).toString('base64url');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  const callback = await callbackServer(state, dependencies.timeoutMs ?? LOGIN_TIMEOUT_MS);
+  const authorizeUrl = new URL('/cli/authorize', origin);
+  authorizeUrl.searchParams.set('redirect_uri', callback.redirectUri);
+  authorizeUrl.searchParams.set('code_challenge', challenge);
+  authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+  authorizeUrl.searchParams.set('state', state);
+
+  try {
+    logger.info('Opening your browser to authorize Hypequery CLI…');
+    await (dependencies.openBrowser ?? open)(authorizeUrl.toString());
+    logger.info(`If the browser did not open, visit:\n${authorizeUrl}`);
+    const code = await callback.code;
+    callback.close();
+    const request = dependencies.fetch ?? fetch;
+    const response = await request(new URL('/api/cli/token', origin), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code,
+        code_verifier: verifier,
+        redirect_uri: callback.redirectUri,
+      }),
+      redirect: 'error',
+    });
+    const body = await response.json().catch(() => null);
+    if (!response.ok) {
+      throw new Error('Cloud rejected the CLI authorization code. Run `hypequery login` again.');
+    }
+    const credential = tokenResponse(body, origin);
+    await (dependencies.saveCredential ?? saveCloudCredential)(credential);
+    logger.success('Logged in to Hypequery Cloud');
+    logger.info(`Credential expires ${new Date(credential.expiresAt).toLocaleString()}`);
+  } finally {
+    callback.close();
+  }
+}
+
+export async function logoutCommand(dependencies: LogoutDependencies = {}) {
+  const load = dependencies.loadCredential ?? loadCloudCredential;
+  const remove = dependencies.deleteCredential ?? deleteCloudCredential;
+  const credential = await load();
+  if (!credential) {
+    logger.info('You are not logged in to Hypequery Cloud.');
+    return;
+  }
+  try {
+    const request = dependencies.fetch ?? fetch;
+    const response = await request(new URL('/api/cli/token', credential.cloudUrl), {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${credential.token}` },
+      redirect: 'error',
+    });
+    if (!response.ok) throw new Error(`Cloud returned HTTP ${response.status}.`);
+  } catch {
+    logger.warn('Cloud could not be reached; the local credential was removed and the token will expire automatically.');
+  }
+  await remove();
+  logger.success('Logged out of Hypequery Cloud');
+}

--- a/packages/cli/src/utils/cloud-credential-store.test.ts
+++ b/packages/cli/src/utils/cloud-credential-store.test.ts
@@ -109,6 +109,71 @@ describe('Cloud credential store', () => {
     );
   });
 
+  it('accepts a deployment endpoint whose path Cloud has moved or versioned', async () => {
+    const dependencies = await store();
+    const credential = {
+      cloudUrl: 'https://cloud.example.test',
+      deploymentEndpoint: 'https://cloud.example.test/v2/deploy/submissions',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+      scope: 'deploy:submit',
+      token: `hqdp_v9_${'a'.repeat(60)}`,
+    };
+    await saveCloudCredential(credential, dependencies);
+    await expect(loadCloudCredential(dependencies)).resolves.toEqual(credential);
+  });
+
+  it('removes a corrupt profile and its vault token instead of failing logout', async () => {
+    const dependencies = await store();
+    await saveCloudCredential({
+      cloudUrl: 'https://cloud.example.test',
+      deploymentEndpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+      scope: 'deploy:submit',
+      token: `hqdp_v1_${'a'.repeat(43)}`,
+    }, dependencies);
+    const profilePath = path.join(dependencies.configDirectory, 'cloud-profile.json');
+    await writeFile(profilePath, JSON.stringify({
+      version: 1,
+      keychainAccount: 'https://cloud.example.test',
+      truncated: true,
+    }), { encoding: 'utf8', mode: 0o600 });
+
+    await expect(deleteCloudCredential(dependencies)).resolves.toBeUndefined();
+    await expect(loadCloudCredential(dependencies)).resolves.toBeNull();
+    expect(dependencies.passwords.size).toBe(0);
+  });
+
+  it('removes an unsalvageable profile even when the vault account is gone', async () => {
+    const dependencies = await store();
+    const profilePath = path.join(dependencies.configDirectory, 'cloud-profile.json');
+    await writeFile(profilePath, '{ not json', { encoding: 'utf8', mode: 0o600 });
+
+    await expect(deleteCloudCredential(dependencies)).resolves.toBeUndefined();
+    await expect(loadCloudCredential(dependencies)).resolves.toBeNull();
+  });
+
+  it('reports an unusable credential vault with an actionable error', async () => {
+    const dependencies = await store();
+    await saveCloudCredential({
+      cloudUrl: 'https://cloud.example.test',
+      deploymentEndpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+      scope: 'deploy:submit',
+      token: `hqdp_v1_${'a'.repeat(43)}`,
+    }, dependencies);
+
+    // The vault is only contacted on get/set, so a locked keyring surfaces
+    // there rather than when the entry is constructed.
+    await expect(loadCloudCredential({
+      ...dependencies,
+      createKeyringEntry: () => ({
+        setPassword: () => { throw new Error('SecretService: not available'); },
+        getPassword: (): string | null => { throw new Error('SecretService: not available'); },
+        deletePassword: () => { throw new Error('SecretService: not available'); },
+      }),
+    })).rejects.toThrow(/credential vault is unavailable[\s\S]*HYPEQUERY_API_TOKEN/);
+  });
+
   it('deletes both the local profile and keychain token', async () => {
     const dependencies = await store();
     await saveCloudCredential({

--- a/packages/cli/src/utils/cloud-credential-store.test.ts
+++ b/packages/cli/src/utils/cloud-credential-store.test.ts
@@ -45,6 +45,10 @@ describe('Cloud credential store', () => {
       deploymentEndpoint: 'https://cloud.example.test/v1/deployments/submissions',
       expiresAt: '2030-01-01T00:00:00.000Z',
       scope: 'deploy:submit',
+      target: {
+        project: 'acme:analytics',
+        environment: 'production',
+      },
       token: `hqdp_v1_${'a'.repeat(43)}`,
     };
     await saveCloudCredential(credential, dependencies);

--- a/packages/cli/src/utils/cloud-credential-store.test.ts
+++ b/packages/cli/src/utils/cloud-credential-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -60,6 +60,55 @@ describe('Cloud credential store', () => {
     await expect(loadCloudCredential(dependencies)).resolves.toEqual(credential);
   });
 
+  it('rejects profile metadata that redirects a vault token to another origin', async () => {
+    const dependencies = await store();
+    await saveCloudCredential({
+      cloudUrl: 'https://cloud.example.test',
+      deploymentEndpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+      scope: 'deploy:submit',
+      token: `hqdp_v1_${'a'.repeat(43)}`,
+    }, dependencies);
+    const profilePath = path.join(dependencies.configDirectory, 'cloud-profile.json');
+    const profile = JSON.parse(await readFile(profilePath, 'utf8')) as {
+      deploymentEndpoint: string;
+    };
+    profile.deploymentEndpoint =
+      'https://attacker.example.test/v1/deployments/submissions';
+    await writeFile(profilePath, `${JSON.stringify(profile)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+
+    await expect(loadCloudCredential(dependencies)).rejects.toThrow(
+      /stored Hypequery Cloud profile is invalid/,
+    );
+  });
+
+  it('rejects a profile whose vault account is not bound to its Cloud origin', async () => {
+    const dependencies = await store();
+    await saveCloudCredential({
+      cloudUrl: 'https://cloud.example.test',
+      deploymentEndpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+      scope: 'deploy:submit',
+      token: `hqdp_v1_${'a'.repeat(43)}`,
+    }, dependencies);
+    const profilePath = path.join(dependencies.configDirectory, 'cloud-profile.json');
+    const profile = JSON.parse(await readFile(profilePath, 'utf8')) as {
+      keychainAccount: string;
+    };
+    profile.keychainAccount = 'https://another-cloud.example.test';
+    await writeFile(profilePath, `${JSON.stringify(profile)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+
+    await expect(loadCloudCredential(dependencies)).rejects.toThrow(
+      /stored Hypequery Cloud profile is invalid/,
+    );
+  });
+
   it('deletes both the local profile and keychain token', async () => {
     const dependencies = await store();
     await saveCloudCredential({
@@ -73,5 +122,61 @@ describe('Cloud credential store', () => {
     await deleteCloudCredential(dependencies);
     await expect(loadCloudCredential(dependencies)).resolves.toBeNull();
     expect(dependencies.passwords.size).toBe(0);
+  });
+
+  it('restores an existing keychain token when the profile cannot be committed', async () => {
+    const parent = await mkdtemp(path.join(tmpdir(), 'hypequery-credential-test-'));
+    directories.push(parent);
+    const configDirectory = path.join(parent, 'not-a-directory');
+    await writeFile(configDirectory, 'blocked', 'utf8');
+    const account = 'https://cloud.example.test';
+    const passwords = new Map([[account, 'previous-token']]);
+    const dependencies = {
+      configDirectory,
+      createKeyringEntry: (_service: string, keychainAccount: string) => ({
+        setPassword: (password: string) => {
+          passwords.set(keychainAccount, password);
+        },
+        getPassword: () => passwords.get(keychainAccount) ?? null,
+        deletePassword: () => passwords.delete(keychainAccount),
+      }),
+    };
+
+    await expect(saveCloudCredential({
+      cloudUrl: account,
+      deploymentEndpoint: `${account}/v1/deployments/submissions`,
+      expiresAt: '2030-01-01T00:00:00.000Z',
+      scope: 'deploy:submit',
+      token: 'replacement-token',
+    }, dependencies)).rejects.toThrow();
+
+    expect(passwords.get(account)).toBe('previous-token');
+  });
+
+  it('removes the previous keychain entry when the Cloud origin changes', async () => {
+    const dependencies = await store();
+    await saveCloudCredential({
+      cloudUrl: 'https://first-cloud.example.test',
+      deploymentEndpoint:
+        'https://first-cloud.example.test/v1/deployments/submissions',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+      scope: 'deploy:submit',
+      token: 'first-token',
+    }, dependencies);
+
+    const replacement = {
+      cloudUrl: 'https://second-cloud.example.test',
+      deploymentEndpoint:
+        'https://second-cloud.example.test/v1/deployments/submissions',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+      scope: 'deploy:submit',
+      token: 'second-token',
+    };
+    await saveCloudCredential(replacement, dependencies);
+
+    expect(dependencies.passwords).toEqual(new Map([
+      ['https://second-cloud.example.test', 'second-token'],
+    ]));
+    await expect(loadCloudCredential(dependencies)).resolves.toEqual(replacement);
   });
 });

--- a/packages/cli/src/utils/cloud-credential-store.test.ts
+++ b/packages/cli/src/utils/cloud-credential-store.test.ts
@@ -1,0 +1,73 @@
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  deleteCloudCredential,
+  loadCloudCredential,
+  saveCloudCredential,
+} from './cloud-credential-store.js';
+
+const directories: string[] = [];
+
+async function store() {
+  const configDirectory = await mkdtemp(path.join(tmpdir(), 'hypequery-credential-test-'));
+  directories.push(configDirectory);
+  const passwords = new Map<string, string>();
+  return {
+    configDirectory,
+    passwords,
+    createKeyringEntry: (_service: string, account: string) => ({
+      setPassword: (password: string) => {
+        passwords.set(account, password);
+      },
+      getPassword: () => passwords.get(account) ?? null,
+      deletePassword: () => passwords.delete(account),
+    }),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    directories.splice(0).map(directory => rm(directory, {
+      force: true,
+      recursive: true,
+    })),
+  );
+});
+
+describe('Cloud credential store', () => {
+  it('stores only profile metadata on disk and keeps the token in the keychain', async () => {
+    const dependencies = await store();
+    const credential = {
+      cloudUrl: 'https://cloud.example.test',
+      deploymentEndpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+      scope: 'deploy:submit',
+      token: `hqdp_v1_${'a'.repeat(43)}`,
+    };
+    await saveCloudCredential(credential, dependencies);
+
+    const profilePath = path.join(dependencies.configDirectory, 'cloud-profile.json');
+    const profile = await readFile(profilePath, 'utf8');
+    expect(profile).not.toContain(credential.token);
+    expect((await stat(profilePath)).mode & 0o777).toBe(0o600);
+    await expect(loadCloudCredential(dependencies)).resolves.toEqual(credential);
+  });
+
+  it('deletes both the local profile and keychain token', async () => {
+    const dependencies = await store();
+    await saveCloudCredential({
+      cloudUrl: 'https://cloud.example.test',
+      deploymentEndpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+      scope: 'deploy:submit',
+      token: `hqdp_v1_${'b'.repeat(43)}`,
+    }, dependencies);
+
+    await deleteCloudCredential(dependencies);
+    await expect(loadCloudCredential(dependencies)).resolves.toBeNull();
+    expect(dependencies.passwords.size).toBe(0);
+  });
+});

--- a/packages/cli/src/utils/cloud-credential-store.ts
+++ b/packages/cli/src/utils/cloud-credential-store.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+const KEYCHAIN_SERVICE = 'dev.hypequery.cli';
+const PROFILE_FILE = 'cloud-profile.json';
+
+export interface StoredCloudCredential {
+  readonly cloudUrl: string;
+  readonly deploymentEndpoint: string;
+  readonly expiresAt: string;
+  readonly scope: string;
+  readonly token: string;
+}
+
+interface StoredCloudProfile {
+  readonly version: 1;
+  readonly cloudUrl: string;
+  readonly deploymentEndpoint: string;
+  readonly expiresAt: string;
+  readonly scope: string;
+  readonly keychainAccount: string;
+}
+
+interface KeyringEntry {
+  setPassword(password: string): void;
+  getPassword(): string | null;
+  deletePassword(): unknown;
+}
+
+export interface CloudCredentialStoreDependencies {
+  readonly configDirectory?: string;
+  readonly createKeyringEntry?: (
+    service: string,
+    account: string,
+  ) => Promise<KeyringEntry> | KeyringEntry;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly platform?: NodeJS.Platform;
+}
+
+function defaultConfigDirectory(
+  env: Readonly<Record<string, string | undefined>>,
+  platform: NodeJS.Platform,
+) {
+  if (env.HYPEQUERY_CONFIG_DIR) return env.HYPEQUERY_CONFIG_DIR;
+  if (platform === 'win32') {
+    return path.join(env.APPDATA ?? env.LOCALAPPDATA ?? homedir(), 'hypequery');
+  }
+  if (platform === 'darwin') {
+    return path.join(homedir(), 'Library', 'Application Support', 'hypequery');
+  }
+  return path.join(env.XDG_CONFIG_HOME ?? path.join(homedir(), '.config'), 'hypequery');
+}
+
+async function defaultKeyringEntry(service: string, account: string) {
+  try {
+    const { Entry } = await import('@napi-rs/keyring');
+    return new Entry(service, account);
+  } catch (error) {
+    throw new Error(
+      'The operating-system credential vault is unavailable. '
+      + 'Install its keyring service or use HYPEQUERY_API_TOKEN for manual authentication.',
+      { cause: error },
+    );
+  }
+}
+
+function paths(dependencies: CloudCredentialStoreDependencies) {
+  const env = dependencies.env ?? process.env;
+  const platform = dependencies.platform ?? process.platform;
+  const directory = dependencies.configDirectory
+    ?? defaultConfigDirectory(env, platform);
+  return { directory, profile: path.join(directory, PROFILE_FILE) };
+}
+
+function parseProfile(input: string): StoredCloudProfile {
+  const value = JSON.parse(input) as Partial<StoredCloudProfile>;
+  if (
+    value.version !== 1
+    || typeof value.cloudUrl !== 'string'
+    || typeof value.deploymentEndpoint !== 'string'
+    || typeof value.expiresAt !== 'string'
+    || typeof value.scope !== 'string'
+    || typeof value.keychainAccount !== 'string'
+  ) {
+    throw new Error('The stored Hypequery Cloud profile is invalid. Run `hypequery login` again.');
+  }
+  return value as StoredCloudProfile;
+}
+
+async function entry(
+  account: string,
+  dependencies: CloudCredentialStoreDependencies,
+) {
+  const create = dependencies.createKeyringEntry ?? defaultKeyringEntry;
+  return create(KEYCHAIN_SERVICE, account);
+}
+
+export async function saveCloudCredential(
+  credential: StoredCloudCredential,
+  dependencies: CloudCredentialStoreDependencies = {},
+) {
+  const location = paths(dependencies);
+  const keychainAccount = new URL(credential.cloudUrl).origin;
+  const keyring = await entry(keychainAccount, dependencies);
+  await Promise.resolve(keyring.setPassword(credential.token));
+
+  const profile: StoredCloudProfile = {
+    version: 1,
+    cloudUrl: credential.cloudUrl,
+    deploymentEndpoint: credential.deploymentEndpoint,
+    expiresAt: credential.expiresAt,
+    scope: credential.scope,
+    keychainAccount,
+  };
+  await mkdir(location.directory, { recursive: true, mode: 0o700 });
+  await chmod(location.directory, 0o700);
+  const temporary = `${location.profile}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporary, `${JSON.stringify(profile, null, 2)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: 0o600,
+    });
+    await rename(temporary, location.profile);
+    await chmod(location.profile, 0o600);
+  } catch (error) {
+    await unlink(temporary).catch(() => undefined);
+    await Promise.resolve(keyring.deletePassword()).catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function loadCloudCredential(
+  dependencies: CloudCredentialStoreDependencies = {},
+): Promise<StoredCloudCredential | null> {
+  const location = paths(dependencies);
+  let profile: StoredCloudProfile;
+  try {
+    profile = parseProfile(await readFile(location.profile, 'utf8'));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+  const keyring = await entry(profile.keychainAccount, dependencies);
+  const token = await Promise.resolve(keyring.getPassword());
+  if (!token) {
+    throw new Error('The Hypequery Cloud token is missing from your credential vault. Run `hypequery login` again.');
+  }
+  return {
+    cloudUrl: profile.cloudUrl,
+    deploymentEndpoint: profile.deploymentEndpoint,
+    expiresAt: profile.expiresAt,
+    scope: profile.scope,
+    token,
+  };
+}
+
+export async function deleteCloudCredential(
+  dependencies: CloudCredentialStoreDependencies = {},
+) {
+  const location = paths(dependencies);
+  let profile: StoredCloudProfile | null = null;
+  try {
+    profile = parseProfile(await readFile(location.profile, 'utf8'));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  if (profile) {
+    const keyring = await entry(profile.keychainAccount, dependencies);
+    await Promise.resolve(keyring.deletePassword()).catch(() => undefined);
+  }
+  await unlink(location.profile).catch(error => {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  });
+}

--- a/packages/cli/src/utils/cloud-credential-store.ts
+++ b/packages/cli/src/utils/cloud-credential-store.ts
@@ -9,6 +9,8 @@ import {
 
 const KEYCHAIN_SERVICE = 'dev.hypequery.cli';
 const PROFILE_FILE = 'cloud-profile.json';
+export const CLOUD_DEPLOYMENT_SCOPE = 'deploy:submit';
+const CLOUD_DEPLOYMENT_PATH = '/v1/deployments/submissions';
 
 export interface StoredCloudCredential {
   readonly cloudUrl: string;
@@ -80,8 +82,49 @@ function paths(dependencies: CloudCredentialStoreDependencies) {
   return { directory, profile: path.join(directory, PROFILE_FILE) };
 }
 
+export function normalizeCloudOrigin(input: string): string {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    throw new Error('Cloud URL must be an absolute HTTPS URL.');
+  }
+  const loopback = url.protocol === 'http:'
+    && (url.hostname === '127.0.0.1' || url.hostname === 'localhost');
+  if ((url.protocol !== 'https:' && !loopback) || url.username || url.password
+    || url.pathname !== '/' || url.search || url.hash) {
+    throw new Error('Cloud URL must be an HTTPS origin without a path, query, or credentials.');
+  }
+  return url.origin;
+}
+
+export function normalizeCloudDeploymentEndpoint(
+  input: string,
+  cloudOrigin: string,
+): string {
+  let endpoint: URL;
+  try {
+    endpoint = new URL(input);
+  } catch {
+    throw new Error('Cloud returned an invalid deployment endpoint.');
+  }
+  if (endpoint.origin !== cloudOrigin
+    || endpoint.pathname !== CLOUD_DEPLOYMENT_PATH
+    || endpoint.username
+    || endpoint.password
+    || endpoint.search
+    || endpoint.hash) {
+    throw new Error('Cloud returned an invalid deployment endpoint.');
+  }
+  return endpoint.toString();
+}
+
 function parseProfile(input: string): StoredCloudProfile {
-  const value = JSON.parse(input) as Partial<StoredCloudProfile>;
+  const parsed = JSON.parse(input) as unknown;
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('The stored Hypequery Cloud profile is invalid. Run `hypequery login` again.');
+  }
+  const value = parsed as Partial<StoredCloudProfile>;
   if (
     value.version !== 1
     || typeof value.cloudUrl !== 'string'
@@ -92,8 +135,20 @@ function parseProfile(input: string): StoredCloudProfile {
   ) {
     throw new Error('The stored Hypequery Cloud profile is invalid. Run `hypequery login` again.');
   }
+  let cloudUrl: string;
+  let deploymentEndpoint: string;
   let target: ProtocolDeploymentReleaseTarget | undefined;
   try {
+    cloudUrl = normalizeCloudOrigin(value.cloudUrl);
+    deploymentEndpoint = normalizeCloudDeploymentEndpoint(
+      value.deploymentEndpoint,
+      cloudUrl,
+    );
+    if (value.keychainAccount !== cloudUrl
+      || !Number.isFinite(Date.parse(value.expiresAt))
+      || value.scope !== CLOUD_DEPLOYMENT_SCOPE) {
+      throw new Error('profile invariant mismatch');
+    }
     target = value.target === undefined
       ? undefined
       : validateProtocolDeploymentReleaseTarget(value.target);
@@ -101,9 +156,14 @@ function parseProfile(input: string): StoredCloudProfile {
     throw new Error('The stored Hypequery Cloud profile is invalid. Run `hypequery login` again.');
   }
   return {
-    ...value,
+    version: 1,
+    cloudUrl,
+    deploymentEndpoint,
+    expiresAt: value.expiresAt,
+    scope: value.scope,
     ...(target ? { target } : {}),
-  } as StoredCloudProfile;
+    keychainAccount: value.keychainAccount,
+  };
 }
 
 async function entry(
@@ -119,34 +179,68 @@ export async function saveCloudCredential(
   dependencies: CloudCredentialStoreDependencies = {},
 ) {
   const location = paths(dependencies);
-  const keychainAccount = new URL(credential.cloudUrl).origin;
+  let previousProfile: StoredCloudProfile | null = null;
+  try {
+    previousProfile = parseProfile(await readFile(location.profile, 'utf8'));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      // A new login must be able to replace a malformed profile.
+      previousProfile = null;
+    }
+  }
+  const cloudUrl = normalizeCloudOrigin(credential.cloudUrl);
+  const deploymentEndpoint = normalizeCloudDeploymentEndpoint(
+    credential.deploymentEndpoint,
+    cloudUrl,
+  );
+  if (!Number.isFinite(Date.parse(credential.expiresAt))
+    || credential.scope !== CLOUD_DEPLOYMENT_SCOPE) {
+    throw new Error('Cannot store an invalid Hypequery Cloud credential.');
+  }
+  const keychainAccount = cloudUrl;
   const keyring = await entry(keychainAccount, dependencies);
+  const previousPassword = await Promise.resolve(keyring.getPassword());
   await Promise.resolve(keyring.setPassword(credential.token));
 
   const profile: StoredCloudProfile = {
     version: 1,
-    cloudUrl: credential.cloudUrl,
-    deploymentEndpoint: credential.deploymentEndpoint,
+    cloudUrl,
+    deploymentEndpoint,
     expiresAt: credential.expiresAt,
     scope: credential.scope,
     ...(credential.target ? { target: credential.target } : {}),
     keychainAccount,
   };
-  await mkdir(location.directory, { recursive: true, mode: 0o700 });
-  await chmod(location.directory, 0o700);
   const temporary = `${location.profile}.${randomUUID()}.tmp`;
   try {
+    await mkdir(location.directory, { recursive: true, mode: 0o700 });
+    await chmod(location.directory, 0o700);
     await writeFile(temporary, `${JSON.stringify(profile, null, 2)}\n`, {
       encoding: 'utf8',
       flag: 'wx',
       mode: 0o600,
     });
+    await chmod(temporary, 0o600);
     await rename(temporary, location.profile);
-    await chmod(location.profile, 0o600);
   } catch (error) {
     await unlink(temporary).catch(() => undefined);
-    await Promise.resolve(keyring.deletePassword()).catch(() => undefined);
+    if (previousPassword === null) {
+      await Promise.resolve(keyring.deletePassword()).catch(() => undefined);
+    } else {
+      await Promise.resolve(keyring.setPassword(previousPassword)).catch(() => undefined);
+    }
     throw error;
+  }
+  if (previousProfile && previousProfile.keychainAccount !== keychainAccount) {
+    try {
+      const previousKeyring = await entry(
+        previousProfile.keychainAccount,
+        dependencies,
+      );
+      await Promise.resolve(previousKeyring.deletePassword());
+    } catch {
+      // The new profile is already committed; the previous token will expire.
+    }
   }
 }
 

--- a/packages/cli/src/utils/cloud-credential-store.ts
+++ b/packages/cli/src/utils/cloud-credential-store.ts
@@ -2,6 +2,10 @@ import { randomUUID } from 'node:crypto';
 import { chmod, mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
+import {
+  validateProtocolDeploymentReleaseTarget,
+  type ProtocolDeploymentReleaseTarget,
+} from '@hypequery/protocol';
 
 const KEYCHAIN_SERVICE = 'dev.hypequery.cli';
 const PROFILE_FILE = 'cloud-profile.json';
@@ -11,6 +15,7 @@ export interface StoredCloudCredential {
   readonly deploymentEndpoint: string;
   readonly expiresAt: string;
   readonly scope: string;
+  readonly target?: ProtocolDeploymentReleaseTarget;
   readonly token: string;
 }
 
@@ -20,6 +25,7 @@ interface StoredCloudProfile {
   readonly deploymentEndpoint: string;
   readonly expiresAt: string;
   readonly scope: string;
+  readonly target?: ProtocolDeploymentReleaseTarget;
   readonly keychainAccount: string;
 }
 
@@ -86,7 +92,18 @@ function parseProfile(input: string): StoredCloudProfile {
   ) {
     throw new Error('The stored Hypequery Cloud profile is invalid. Run `hypequery login` again.');
   }
-  return value as StoredCloudProfile;
+  let target: ProtocolDeploymentReleaseTarget | undefined;
+  try {
+    target = value.target === undefined
+      ? undefined
+      : validateProtocolDeploymentReleaseTarget(value.target);
+  } catch {
+    throw new Error('The stored Hypequery Cloud profile is invalid. Run `hypequery login` again.');
+  }
+  return {
+    ...value,
+    ...(target ? { target } : {}),
+  } as StoredCloudProfile;
 }
 
 async function entry(
@@ -112,6 +129,7 @@ export async function saveCloudCredential(
     deploymentEndpoint: credential.deploymentEndpoint,
     expiresAt: credential.expiresAt,
     scope: credential.scope,
+    ...(credential.target ? { target: credential.target } : {}),
     keychainAccount,
   };
   await mkdir(location.directory, { recursive: true, mode: 0o700 });
@@ -153,6 +171,7 @@ export async function loadCloudCredential(
     deploymentEndpoint: profile.deploymentEndpoint,
     expiresAt: profile.expiresAt,
     scope: profile.scope,
+    ...(profile.target ? { target: profile.target } : {}),
     token,
   };
 }

--- a/packages/cli/src/utils/cloud-credential-store.ts
+++ b/packages/cli/src/utils/cloud-credential-store.ts
@@ -10,7 +10,7 @@ import {
 const KEYCHAIN_SERVICE = 'dev.hypequery.cli';
 const PROFILE_FILE = 'cloud-profile.json';
 export const CLOUD_DEPLOYMENT_SCOPE = 'deploy:submit';
-const CLOUD_DEPLOYMENT_PATH = '/v1/deployments/submissions';
+const MAX_KEYCHAIN_ACCOUNT_LENGTH = 2048;
 
 export interface StoredCloudCredential {
   readonly cloudUrl: string;
@@ -32,9 +32,15 @@ interface StoredCloudProfile {
 }
 
 interface KeyringEntry {
-  setPassword(password: string): void;
-  getPassword(): string | null;
+  setPassword(password: string): void | Promise<void>;
+  getPassword(): string | null | Promise<string | null>;
   deletePassword(): unknown;
+}
+
+interface VaultEntry {
+  setPassword(password: string): Promise<void>;
+  getPassword(): Promise<string | null>;
+  deletePassword(): Promise<unknown>;
 }
 
 export interface CloudCredentialStoreDependencies {
@@ -61,16 +67,20 @@ function defaultConfigDirectory(
   return path.join(env.XDG_CONFIG_HOME ?? path.join(homedir(), '.config'), 'hypequery');
 }
 
+function vaultUnavailable(error: unknown): Error {
+  return new Error(
+    'The operating-system credential vault is unavailable. '
+    + 'Install its keyring service or use HYPEQUERY_API_TOKEN for manual authentication.',
+    { cause: error },
+  );
+}
+
 async function defaultKeyringEntry(service: string, account: string) {
   try {
     const { Entry } = await import('@napi-rs/keyring');
     return new Entry(service, account);
   } catch (error) {
-    throw new Error(
-      'The operating-system credential vault is unavailable. '
-      + 'Install its keyring service or use HYPEQUERY_API_TOKEN for manual authentication.',
-      { cause: error },
-    );
+    throw vaultUnavailable(error);
   }
 }
 
@@ -108,8 +118,11 @@ export function normalizeCloudDeploymentEndpoint(
   } catch {
     throw new Error('Cloud returned an invalid deployment endpoint.');
   }
+  // Origin equality is what binds the token to the Cloud that issued it, and it
+  // is the only check that has to hold for a tampered profile to be harmless.
+  // Cloud owns its own path layout: pinning an exact submission path here would
+  // break every already-published CLI the day that path is versioned or moved.
   if (endpoint.origin !== cloudOrigin
-    || endpoint.pathname !== CLOUD_DEPLOYMENT_PATH
     || endpoint.username
     || endpoint.password
     || endpoint.search
@@ -169,9 +182,35 @@ function parseProfile(input: string): StoredCloudProfile {
 async function entry(
   account: string,
   dependencies: CloudCredentialStoreDependencies,
-) {
+): Promise<VaultEntry> {
   const create = dependencies.createKeyringEntry ?? defaultKeyringEntry;
-  return create(KEYCHAIN_SERVICE, account);
+  const created = await create(KEYCHAIN_SERVICE, account);
+  // Constructing an entry is lazy — the vault is only contacted on get/set/
+  // delete — so a locked keyring or a missing Secret Service surfaces here, not
+  // at construction. Translate those failures into the same actionable error.
+  return {
+    async setPassword(password: string) {
+      try {
+        await created.setPassword(password);
+      } catch (error) {
+        throw vaultUnavailable(error);
+      }
+    },
+    async getPassword() {
+      try {
+        return await created.getPassword();
+      } catch (error) {
+        throw vaultUnavailable(error);
+      }
+    },
+    async deletePassword() {
+      try {
+        return await created.deletePassword();
+      } catch (error) {
+        throw vaultUnavailable(error);
+      }
+    },
+  };
 }
 
 export async function saveCloudCredential(
@@ -182,11 +221,10 @@ export async function saveCloudCredential(
   let previousProfile: StoredCloudProfile | null = null;
   try {
     previousProfile = parseProfile(await readFile(location.profile, 'utf8'));
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-      // A new login must be able to replace a malformed profile.
-      previousProfile = null;
-    }
+  } catch {
+    // A new login must be able to replace a missing or malformed profile; the
+    // only thing lost is the chance to purge a superseded vault entry.
+    previousProfile = null;
   }
   const cloudUrl = normalizeCloudOrigin(credential.cloudUrl);
   const deploymentEndpoint = normalizeCloudDeploymentEndpoint(
@@ -199,8 +237,8 @@ export async function saveCloudCredential(
   }
   const keychainAccount = cloudUrl;
   const keyring = await entry(keychainAccount, dependencies);
-  const previousPassword = await Promise.resolve(keyring.getPassword());
-  await Promise.resolve(keyring.setPassword(credential.token));
+  const previousPassword = await keyring.getPassword();
+  await keyring.setPassword(credential.token);
 
   const profile: StoredCloudProfile = {
     version: 1,
@@ -225,9 +263,9 @@ export async function saveCloudCredential(
   } catch (error) {
     await unlink(temporary).catch(() => undefined);
     if (previousPassword === null) {
-      await Promise.resolve(keyring.deletePassword()).catch(() => undefined);
+      await keyring.deletePassword().catch(() => undefined);
     } else {
-      await Promise.resolve(keyring.setPassword(previousPassword)).catch(() => undefined);
+      await keyring.setPassword(previousPassword).catch(() => undefined);
     }
     throw error;
   }
@@ -237,7 +275,7 @@ export async function saveCloudCredential(
         previousProfile.keychainAccount,
         dependencies,
       );
-      await Promise.resolve(previousKeyring.deletePassword());
+      await previousKeyring.deletePassword();
     } catch {
       // The new profile is already committed; the previous token will expire.
     }
@@ -256,7 +294,7 @@ export async function loadCloudCredential(
     throw error;
   }
   const keyring = await entry(profile.keychainAccount, dependencies);
-  const token = await Promise.resolve(keyring.getPassword());
+  const token = await keyring.getPassword();
   if (!token) {
     throw new Error('The Hypequery Cloud token is missing from your credential vault. Run `hypequery login` again.');
   }
@@ -270,19 +308,53 @@ export async function loadCloudCredential(
   };
 }
 
+/**
+ * Recovers just the vault account from a profile that failed validation, so a
+ * corrupted profile can still be cleaned up. Only the account is salvaged, and
+ * only under our own keychain service, so the worst a tampered value can do is
+ * delete another Hypequery entry that `hypequery login` recreates.
+ */
+function salvageKeychainAccount(input: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input) as unknown;
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+  const account = (parsed as { keychainAccount?: unknown }).keychainAccount;
+  return typeof account === 'string'
+    && account.length > 0
+    && account.length <= MAX_KEYCHAIN_ACCOUNT_LENGTH
+    ? account
+    : null;
+}
+
 export async function deleteCloudCredential(
   dependencies: CloudCredentialStoreDependencies = {},
 ) {
   const location = paths(dependencies);
-  let profile: StoredCloudProfile | null = null;
+  let contents: string | null = null;
   try {
-    profile = parseProfile(await readFile(location.profile, 'utf8'));
+    contents = await readFile(location.profile, 'utf8');
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
   }
-  if (profile) {
-    const keyring = await entry(profile.keychainAccount, dependencies);
-    await Promise.resolve(keyring.deletePassword()).catch(() => undefined);
+  if (contents !== null) {
+    let account: string | null;
+    try {
+      account = parseProfile(contents).keychainAccount;
+    } catch {
+      // `logout` is what users reach for when their profile is broken, so a
+      // malformed profile has to stay removable instead of throwing here.
+      account = salvageKeychainAccount(contents);
+    }
+    if (account !== null) {
+      const keyring = await entry(account, dependencies).catch(() => null);
+      await keyring?.deletePassword().catch(() => undefined);
+    }
   }
   await unlink(location.profile).catch(error => {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;

--- a/packages/cli/src/utils/deployment-upload.test.ts
+++ b/packages/cli/src/utils/deployment-upload.test.ts
@@ -251,6 +251,10 @@ describe('deployment upload transport', () => {
       endpoint: 'https://deploy.example.test/v1/releases',
       token: 'secret-token\nInjected: header',
     })).toThrow(/HQ_UPLOAD_CONFIGURATION[\s\S]*HYPEQUERY_API_TOKEN/);
+    expect(() => createHttpDeploymentUploadTransport({
+      endpoint: 'http://127.0.0.1:3000/v1/deployments/submissions',
+      token: 'secret-token',
+    })).not.toThrow();
   });
 
   it('returns a stable rejection with bounded server detail', async () => {

--- a/packages/cli/src/utils/deployment-upload.test.ts
+++ b/packages/cli/src/utils/deployment-upload.test.ts
@@ -17,6 +17,7 @@ import {
   type DeploymentFetch,
   type DeploymentFetchInit,
 } from './deployment-upload.js';
+import { logger } from './logger.js';
 
 const temporaryDirectories: string[] = [];
 
@@ -251,10 +252,32 @@ describe('deployment upload transport', () => {
       endpoint: 'https://deploy.example.test/v1/releases',
       token: 'secret-token\nInjected: header',
     })).toThrow(/HQ_UPLOAD_CONFIGURATION[\s\S]*HYPEQUERY_API_TOKEN/);
-    expect(() => createHttpDeploymentUploadTransport({
-      endpoint: 'http://127.0.0.1:3000/v1/deployments/submissions',
-      token: 'secret-token',
-    })).not.toThrow();
+  });
+
+  it('permits a loopback HTTP endpoint but warns that the token is cleartext', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    try {
+      for (const endpoint of [
+        'http://127.0.0.1:3000/v1/deployments/submissions',
+        'http://localhost:3000/v1/deployments/submissions',
+      ]) {
+        expect(() => createHttpDeploymentUploadTransport({
+          endpoint,
+          token: 'secret-token',
+        })).not.toThrow();
+      }
+      expect(warn).toHaveBeenCalledTimes(2);
+      expect(warn.mock.calls[0]?.[0]).toMatch(/plaintext HTTP/);
+
+      warn.mockClear();
+      createHttpDeploymentUploadTransport({
+        endpoint: 'https://deploy.example.test/v1/releases',
+        token: 'secret-token',
+      });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('returns a stable rejection with bounded server detail', async () => {

--- a/packages/cli/src/utils/deployment-upload.ts
+++ b/packages/cli/src/utils/deployment-upload.ts
@@ -110,8 +110,10 @@ function endpointUrl(input: string): string {
   } catch {
     configurationError('Deployment endpoint must be an absolute HTTPS URL.');
   }
-  if (url.protocol !== 'https:') {
-    configurationError('Deployment endpoint must use HTTPS.');
+  const loopbackHttp = url.protocol === 'http:'
+    && (url.hostname === '127.0.0.1' || url.hostname === 'localhost');
+  if (url.protocol !== 'https:' && !loopbackHttp) {
+    configurationError('Deployment endpoint must use HTTPS (HTTP is allowed only for loopback development).');
   }
   if (url.username || url.password) {
     configurationError('Deployment endpoint must not contain credentials.');

--- a/packages/cli/src/utils/deployment-upload.ts
+++ b/packages/cli/src/utils/deployment-upload.ts
@@ -12,6 +12,7 @@ import {
   DEPLOYMENT_BUNDLE_MANIFEST,
   type VerifiedDeploymentBundle,
 } from './deployment-bundle.js';
+import { logger } from './logger.js';
 import type { DeploymentSubmissionResponse } from '@hypequery/deployment';
 
 export type { DeploymentSubmissionResponse } from '@hypequery/deployment';
@@ -110,10 +111,20 @@ function endpointUrl(input: string): string {
   } catch {
     configurationError('Deployment endpoint must be an absolute HTTPS URL.');
   }
+  // Loopback HTTP exists so a local Cloud instance can be developed against.
+  // It still puts the bearer token on the wire in cleartext, where any local
+  // process listening on that port can read it, so say so rather than let a
+  // production token be pointed at localhost silently.
   const loopbackHttp = url.protocol === 'http:'
     && (url.hostname === '127.0.0.1' || url.hostname === 'localhost');
   if (url.protocol !== 'https:' && !loopbackHttp) {
     configurationError('Deployment endpoint must use HTTPS (HTTP is allowed only for loopback development).');
+  }
+  if (loopbackHttp) {
+    logger.warn(
+      `Submitting to ${url.origin} over plaintext HTTP; the deployment token is `
+      + 'sent unencrypted. Use this only for local Cloud development.',
+    );
   }
   if (url.username || url.password) {
     configurationError('Deployment endpoint must not contain credentials.');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,6 @@ importers:
       '@hypequery/protocol':
         specifier: workspace:*
         version: link:../protocol
-      '@napi-rs/keyring':
-        specifier: 1.3.0
-        version: 1.3.0
       chalk:
         specifier: ^5.3.0
         version: 5.6.2
@@ -114,6 +111,10 @@ importers:
       vitest:
         specifier: ^3.2.6
         version: 3.2.6(@edge-runtime/vm@3.2.0)(@types/node@20.19.31)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+    optionalDependencies:
+      '@napi-rs/keyring':
+        specifier: 1.3.0
+        version: 1.3.0
 
   packages/clickhouse:
     dependencies:
@@ -3530,6 +3531,7 @@ snapshots:
       '@napi-rs/keyring-win32-arm64-msvc': 1.3.0
       '@napi-rs/keyring-win32-ia32-msvc': 1.3.0
       '@napi-rs/keyring-win32-x64-msvc': 1.3.0
+    optional: true
 
   '@noble/hashes@1.8.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@hypequery/protocol':
         specifier: workspace:*
         version: link:../protocol
+      '@napi-rs/keyring':
+        specifier: 1.3.0
+        version: 1.3.0
       chalk:
         specifier: ^5.3.0
         version: 5.6.2
@@ -737,6 +740,87 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    resolution: {integrity: sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    resolution: {integrity: sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    resolution: {integrity: sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    resolution: {integrity: sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    resolution: {integrity: sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    resolution: {integrity: sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    resolution: {integrity: sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    resolution: {integrity: sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    resolution: {integrity: sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    resolution: {integrity: sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    resolution: {integrity: sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.3.0':
+    resolution: {integrity: sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==}
+    engines: {node: '>= 10'}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -3395,6 +3479,57 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring@1.3.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.3.0
+      '@napi-rs/keyring-darwin-x64': 1.3.0
+      '@napi-rs/keyring-freebsd-x64': 1.3.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.3.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.3.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-musl': 1.3.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.3.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.3.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.3.0
 
   '@noble/hashes@1.8.0': {}
 


### PR DESCRIPTION
## What changed

- adds `hypequery login` using a browser loopback authorization flow with S256 PKCE
- adds `hypequery logout` with remote token revocation
- stores Cloud tokens in the native macOS Keychain, Windows Credential Manager, or Linux Secret Service through `@napi-rs/keyring`
- keeps only non-secret endpoint/expiry metadata in an owner-only `0600` profile
- makes `hypequery deploy` automatically use the logged-in Cloud profile
- preserves `HYPEQUERY_API_TOKEN` and `HYPEQUERY_DEPLOYMENT_ENDPOINT` as explicit CI/manual overrides
- permits plain HTTP deployment endpoints only on loopback for local Cloud development
- adds a minor changeset and CLI documentation

## Why

Human developers should authenticate through their existing Cloud browser session rather than copy a 90-day token into a shell. The Cloud-issued credential is target-scoped, expires after 12 hours, and can be revoked independently.

This is PR 2 in the interactive authentication series and depends operationally on hypequery/hypequery-cloud#26.

## Security properties

- random state and S256 PKCE verifier/challenge per login
- dynamic callback bound only to `127.0.0.1` on an ephemeral port
- five-minute local callback timeout
- strict validation of the returned token and same-origin deployment endpoint
- tokens never enter CLI arguments, config files, or shell history
- environment credentials retain precedence for non-interactive automation
- HTTPS remains mandatory outside explicit loopback development

## Validation

- `pnpm build` (all packages)
- `pnpm --filter @hypequery/cli test` (357 passed, 1 skipped)
- `pnpm --filter @hypequery/cli lint`
- `pnpm --filter @hypequery/cli build`
- built CLI help smoke test