### PR TITLE
feat(cli): add one-command Cloud deploy

### DIFF
--- a/.changeset/tidy-pumas-deploy.md
+++ b/.changeset/tidy-pumas-deploy.md
@@ -4,3 +4,11 @@
 
 Add a one-command deployment workflow that builds, prepares, and submits an API
 module, while exposing prebuilt uploads through `deployment:submit`.
+
+`hypequery deploy <api-module>` now orchestrates build → release → submission,
+and resolves the Cloud endpoint and token before building so a missing or
+expired login fails immediately instead of after a full bundle build.
+
+`hypequery deploy <bundle> --release <file>` still works but is deprecated and
+now prints a warning. Use `hypequery deployment:submit <bundle> --release
+<file>` instead.

--- a/.changeset/tidy-pumas-deploy.md
+++ b/.changeset/tidy-pumas-deploy.md
@@ -1,0 +1,6 @@
+---
+"@hypequery/cli": minor
+---
+
+Add a one-command deployment workflow that builds, prepares, and submits an API
+module, while exposing prebuilt uploads through `deployment:submit`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,6 +25,13 @@ Or install it once:
 npm install -D @hypequery/cli
 ```
 
+Ship it to Hypequery Cloud:
+
+```bash
+npx @hypequery/cli login
+npx @hypequery/cli deploy analytics/api.ts
+```
+
 ## Commands
 
 ### `hypequery init`
@@ -140,7 +147,9 @@ semantic keys such as `dataset:orders`.
 
 Builds a closed deployment bundle for an exported HypeQuery API. The bundle
 contains canonical deployment metadata, every referenced runtime artifact, and
-a manifest that binds their exact bytes and identities.
+a manifest that binds their exact bytes and identities. `hypequery deploy` runs
+this step for you; reach for it directly in CI pipelines that stage artifacts,
+or when you need the runtime options below.
 
 ```bash
 npx hypequery deployment:build analytics/api.ts
@@ -197,8 +206,9 @@ Use `--cloud-url <origin>` or `HYPEQUERY_CLOUD_URL` for a self-hosted or local
 Cloud instance. HTTPS is required except for loopback development origins.
 
 Once logged in, `hypequery deploy` automatically uses the stored endpoint and
-token. The deployment endpoint is returned by Cloud during the token exchange;
-it is the authenticated upload API, not the browser login endpoint. For
+token, and resolves the project and environment from the same stored profile.
+The deployment endpoint is returned by Cloud during the token exchange; it is
+the authenticated upload API, not the browser login endpoint. For
 non-interactive CI usage, set both `HYPEQUERY_API_TOKEN` and
 `HYPEQUERY_DEPLOYMENT_ENDPOINT` (or pass `--endpoint`).
 
@@ -222,6 +232,53 @@ npx hypequery logout
 
 If the stored profile is unreadable, `logout` still removes the local state and
 reports that the token was not revoked; it expires on its own.
+
+### `hypequery deploy`
+
+Builds a deployment bundle from an API module, prepares a target-bound release,
+and submits both. This is the primary Cloud workflow: sign in once, then deploy
+with one command.
+
+```bash
+npx hypequery login
+npx hypequery deploy analytics/api.ts
+```
+
+The bundle is written to `analytics/hypequery-deployment` and the release to
+`analytics/hypequery-deployment.release.json`. The target comes from the stored
+Cloud profile unless you override it:
+
+```bash
+npx hypequery deploy analytics/api.ts \
+  --project my-project \
+  --environment production
+```
+
+The deployment endpoint and token are resolved before the build, so a missing
+or expired login fails immediately rather than after bundling. The credential
+rules are the same as `hypequery deployment:submit` below.
+
+The three steps remain available individually as `deployment:build`,
+`deployment:release`, and `deployment:submit` for CI pipelines that stage
+artifacts, and for the cases `deploy` does not cover: `deploy` always builds the
+runtime artifact itself, so Python deployments and prebuilt runtime artifacts
+(`--runtime`, `--runtime-artifact`, `--runtime-file`) need `deployment:build`.
+
+Options:
+
+- `--project <project>`: target project identifier; defaults to the logged-in
+  target and must be paired with `--environment`
+- `--environment <environment>`: target environment identifier; defaults to the
+  logged-in target and must be paired with `--project`
+- `--bundle-output <directory>`: bundle directory, default
+  `analytics/hypequery-deployment`
+- `--release-output <path>`: release JSON path, default beside the bundle
+- `--endpoint <url>`: HTTPS submission endpoint; requires `HYPEQUERY_API_TOKEN`
+
+> **Deprecated:** `hypequery deploy <bundle> --release <file>` still submits a
+> prebuilt bundle and prints a deprecation warning. Use
+> `hypequery deployment:submit` instead. `--release` cannot be combined with
+> `--project`, `--environment`, `--bundle-output`, or `--release-output`.
 
 ### `hypequery deployment:release`
 
@@ -259,14 +316,16 @@ Options:
   logged-in target and must be paired with `--project`
 - `--output <path>`: release JSON path, default beside the bundle
 
-### `hypequery deploy`
+### `hypequery deployment:submit`
 
 Submits a verified deployment bundle with an already-prepared target-bound
 release. The command verifies both inputs again, requires their bundle
-identities to match, and streams only the files declared by the bundle.
+identities to match, and streams only the files declared by the bundle. Use it
+when the bundle and release were produced by an earlier pipeline step; for the
+ordinary path, use `hypequery deploy`.
 
 ```bash
-npx hypequery deploy analytics/hypequery-deployment \
+npx hypequery deployment:submit analytics/hypequery-deployment \
   --release analytics/hypequery-deployment.release.json
 ```
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,7 +15,9 @@ import {
 } from './commands/deployment.js';
 import {
   deployCommand,
+  submitDeploymentCommand,
   type DeployOptions,
+  type SubmitDeploymentOptions,
 } from './commands/deploy.js';
 import {
   loginCommand,
@@ -187,15 +189,31 @@ program
   }));
 
 program
-  .command('deploy <bundle>')
-  .description('Submit a verified deployment bundle and release')
+  .command('deployment:submit <bundle>')
+  .description('Submit a prebuilt deployment bundle and release')
   .requiredOption('--release <path>', 'Target-bound release JSON path')
   .option(
     '--endpoint <url>',
     'HTTPS submission endpoint; requires HYPEQUERY_API_TOKEN',
   )
-  .action(runCommand(async (bundle: string, options: DeployOptions) => {
-    await deployCommand(bundle, options);
+  .action(runCommand(async (bundle: string, options: SubmitDeploymentOptions) => {
+    await submitDeploymentCommand(bundle, options);
+  }));
+
+program
+  .command('deploy <source>')
+  .description('Build, prepare, and deploy a Hypequery API module')
+  .option('--bundle-output <directory>', 'Bundle directory (default: analytics/hypequery-deployment)')
+  .option('--release-output <path>', 'Release JSON path (default: beside the bundle)')
+  .option('--project <project>', 'Target project identifier (advanced override)')
+  .option('--environment <environment>', 'Target environment identifier (advanced override)')
+  .option('--release <path>', 'Submit a prebuilt bundle with this release (legacy)')
+  .option(
+    '--endpoint <url>',
+    'HTTPS submission endpoint; requires HYPEQUERY_API_TOKEN',
+  )
+  .action(runCommand(async (source: string, options: DeployOptions) => {
+    await deployCommand(source, options);
   }));
 
 // Help command

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -247,10 +247,12 @@ program.on('--help', () => {
   console.log('  hypequery generate:types --output analytics/schema.ts');
   console.log('  hypequery generate:datasets');
   console.log('  hypequery generate:manifest analytics/api.ts --output analytics/hypequery-manifest.json');
+  console.log('  hypequery deploy analytics/api.ts');
+  console.log('  hypequery deploy analytics/api.ts --project my-project --environment production');
   console.log('  hypequery deployment:build analytics/api.ts');
   console.log('  hypequery deployment:validate analytics/hypequery-deployment');
   console.log('  hypequery deployment:release analytics/hypequery-deployment --project my-project --environment production');
-  console.log('  hypequery deploy analytics/hypequery-deployment --release analytics/hypequery-deployment.release.json');
+  console.log('  hypequery deployment:submit analytics/hypequery-deployment --release analytics/hypequery-deployment.release.json');
   console.log('');
   console.log('Docs: https://hypequery.com/docs');
 });

--- a/packages/cli/src/commands/deploy.test.ts
+++ b/packages/cli/src/commands/deploy.test.ts
@@ -9,6 +9,7 @@ const mockLoggerWarn = vi.hoisted(() => vi.fn());
 
 vi.mock('../utils/deployment-bundle.js', () => ({
   verifyDeploymentBundle: mockVerifyDeploymentBundle,
+  DEPLOYMENT_BUNDLE_MANIFEST: 'bundle.json',
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -23,9 +24,25 @@ import {
   deployCommand,
   type DeployDependencies,
 } from './deploy.js';
+import type { StoredCloudCredential } from '../utils/cloud-credential-store.js';
 
 const BUNDLE_IDENTITY = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+const CI_ENVIRONMENT = {
+  HYPEQUERY_API_TOKEN: 'secret-token',
+  HYPEQUERY_DEPLOYMENT_ENDPOINT: 'https://deploy.example.test/v1/releases',
+};
 const temporaryDirectories: string[] = [];
+
+function storedCredential(): StoredCloudCredential {
+  return {
+    cloudUrl: 'https://cloud.example.test',
+    deploymentEndpoint: 'https://deploy.example.test/v1/releases',
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    scope: 'deployments:write',
+    target: { project: 'project-1', environment: 'production' },
+    token: 'secret-token',
+  };
+}
 
 async function releaseFile(bundleIdentity = BUNDLE_IDENTITY): Promise<{
   path: string;
@@ -80,7 +97,7 @@ describe('deploy command', () => {
   });
 
   it('builds, prepares, and submits an API module with one command', async () => {
-    const loadCredential = vi.fn();
+    const loadCredential = vi.fn(async () => storedCredential());
     const buildDeployment: NonNullable<DeployDependencies['buildDeployment']> =
       vi.fn(async () => bundle.contract);
     const prepareDeploymentRelease:
@@ -101,6 +118,7 @@ describe('deploy command', () => {
       }));
 
     const result = await deployCommand('analytics/api.ts', {}, {
+      env: {},
       loadCredential,
       buildDeployment,
       prepareDeploymentRelease,
@@ -117,7 +135,7 @@ describe('deploy command', () => {
         environment: undefined,
         output: 'analytics/hypequery-deployment.release.json',
       },
-      { loadCredential },
+      { loadCredential, outputFlagLabel: '--release-output' },
     );
     expect(submitDeployment).toHaveBeenCalledWith(
       'analytics/hypequery-deployment',
@@ -157,6 +175,7 @@ describe('deploy command', () => {
       environment: 'staging',
       endpoint: 'https://deploy.example.test/v1/releases',
     }, {
+      env: { HYPEQUERY_API_TOKEN: 'secret-token' },
       buildDeployment,
       prepareDeploymentRelease,
       submitDeployment,
@@ -172,7 +191,7 @@ describe('deploy command', () => {
         environment: 'staging',
         output: 'dist/cloud-release.json',
       },
-      { loadCredential: undefined },
+      { loadCredential: undefined, outputFlagLabel: '--release-output' },
     );
     expect(submitDeployment).toHaveBeenCalledWith(
       'dist/cloud-bundle',
@@ -182,6 +201,144 @@ describe('deploy command', () => {
       },
       expect.any(Object),
     );
+  });
+
+  it('defaults the release path beside a bundle output with a trailing slash', async () => {
+    const prepareDeploymentRelease:
+      NonNullable<DeployDependencies['prepareDeploymentRelease']> =
+      vi.fn(async () => prepareProtocolDeploymentReleaseEnvelope({
+        kind: 'hypequery-deployment-release',
+        version: 1,
+        bundleIdentity: BUNDLE_IDENTITY,
+        target: { project: 'project-1', environment: 'production' },
+      }).release);
+    const submitDeployment: NonNullable<DeployDependencies['submitDeployment']> =
+      vi.fn(async () => ({
+        kind: 'hypequery-deployment-submission',
+        version: 1,
+        status: 'accepted',
+        releaseIdentity: '1'.repeat(64),
+        bundleIdentity: BUNDLE_IDENTITY,
+      }));
+
+    await deployCommand('src/api.ts', { bundleOutput: 'dist/cloud-bundle/' }, {
+      env: CI_ENVIRONMENT,
+      buildDeployment: vi.fn(async () => bundle.contract),
+      prepareDeploymentRelease,
+      submitDeployment,
+    });
+
+    expect(prepareDeploymentRelease).toHaveBeenCalledWith(
+      'dist/cloud-bundle/',
+      expect.objectContaining({ output: 'dist/cloud-bundle.release.json' }),
+      expect.any(Object),
+    );
+    expect(submitDeployment).toHaveBeenCalledWith(
+      'dist/cloud-bundle/',
+      expect.objectContaining({ release: 'dist/cloud-bundle.release.json' }),
+      expect.any(Object),
+    );
+  });
+
+  it('resolves credentials before building', async () => {
+    const buildDeployment: NonNullable<DeployDependencies['buildDeployment']> =
+      vi.fn(async () => bundle.contract);
+    const loadCredential = vi.fn(async () => null);
+
+    await expect(deployCommand('analytics/api.ts', {}, {
+      env: {},
+      loadCredential,
+      buildDeployment,
+    })).rejects.toThrow(/Missing deployment endpoint/);
+
+    expect(loadCredential).toHaveBeenCalled();
+    expect(buildDeployment).not.toHaveBeenCalled();
+  });
+
+  it('rejects an expired stored credential before building', async () => {
+    const buildDeployment: NonNullable<DeployDependencies['buildDeployment']> =
+      vi.fn(async () => bundle.contract);
+
+    await expect(deployCommand('analytics/api.ts', {}, {
+      env: {},
+      loadCredential: async () => ({
+        ...storedCredential(),
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+      }),
+      buildDeployment,
+    })).rejects.toThrow(/expired/);
+
+    expect(buildDeployment).not.toHaveBeenCalled();
+  });
+
+  it('stops at a failed build without preparing or submitting', async () => {
+    const prepareDeploymentRelease:
+      NonNullable<DeployDependencies['prepareDeploymentRelease']> = vi.fn();
+    const submitDeployment: NonNullable<DeployDependencies['submitDeployment']> = vi.fn();
+
+    await expect(deployCommand('analytics/api.ts', {}, {
+      env: CI_ENVIRONMENT,
+      buildDeployment: vi.fn(async () => {
+        throw new Error('Invalid API module: analytics/api.ts');
+      }),
+      prepareDeploymentRelease,
+      submitDeployment,
+    })).rejects.toThrow(/Invalid API module/);
+
+    expect(prepareDeploymentRelease).not.toHaveBeenCalled();
+    expect(submitDeployment).not.toHaveBeenCalled();
+  });
+
+  it('points runtime build failures at deployment:build', async () => {
+    await expect(deployCommand('analytics/api.ts', {}, {
+      env: CI_ENVIRONMENT,
+      buildDeployment: vi.fn(async () => {
+        throw new Error(
+          'Automatic runtime artifact builds currently support Node only. '
+          + 'Provide --runtime-artifact for Python deployments.',
+        );
+      }),
+    })).rejects.toThrow(/hypequery deployment:build/);
+  });
+
+  it('rejects a prebuilt bundle directory as the deploy source', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'hypequery-deploy-bundle-source-'));
+    temporaryDirectories.push(directory);
+    await writeFile(path.join(directory, 'bundle.json'), '{}\n', 'utf8');
+    const buildDeployment: NonNullable<DeployDependencies['buildDeployment']> =
+      vi.fn(async () => bundle.contract);
+
+    await expect(deployCommand(directory, {}, {
+      env: CI_ENVIRONMENT,
+      buildDeployment,
+    })).rejects.toThrow(/hypequery deployment:submit/);
+
+    expect(buildDeployment).not.toHaveBeenCalled();
+  });
+
+  it('does not build in legacy prebuilt submission mode', async () => {
+    const release = await releaseFile();
+    const buildDeployment: NonNullable<DeployDependencies['buildDeployment']> =
+      vi.fn(async () => bundle.contract);
+
+    await deployCommand('/project/dist/bundle', {
+      release: release.path,
+      endpoint: 'https://deploy.example.test/v1/releases',
+    }, {
+      env: { HYPEQUERY_API_TOKEN: 'secret-token' },
+      buildDeployment,
+      createTransport: () => ({
+        submit: vi.fn().mockResolvedValue({
+          kind: 'hypequery-deployment-submission',
+          version: 1,
+          status: 'accepted',
+          releaseIdentity: release.identity,
+          bundleIdentity: BUNDLE_IDENTITY,
+        }),
+      }),
+    });
+
+    expect(buildDeployment).not.toHaveBeenCalled();
   });
 
   it('does not mix legacy prebuilt submission with orchestration options', async () => {

--- a/packages/cli/src/commands/deploy.test.ts
+++ b/packages/cli/src/commands/deploy.test.ts
@@ -5,6 +5,7 @@ import { prepareProtocolDeploymentReleaseEnvelope } from '@hypequery/protocol';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockVerifyDeploymentBundle = vi.hoisted(() => vi.fn());
+const mockLoggerWarn = vi.hoisted(() => vi.fn());
 
 vi.mock('../utils/deployment-bundle.js', () => ({
   verifyDeploymentBundle: mockVerifyDeploymentBundle,
@@ -14,10 +15,14 @@ vi.mock('../utils/logger.js', () => ({
   logger: {
     success: vi.fn(),
     info: vi.fn(),
+    warn: mockLoggerWarn,
   },
 }));
 
-import { deployCommand } from './deploy.js';
+import {
+  deployCommand,
+  type DeployDependencies,
+} from './deploy.js';
 
 const BUNDLE_IDENTITY = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
 const temporaryDirectories: string[] = [];
@@ -72,6 +77,142 @@ describe('deploy command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockVerifyDeploymentBundle.mockResolvedValue(bundle);
+  });
+
+  it('builds, prepares, and submits an API module with one command', async () => {
+    const loadCredential = vi.fn();
+    const buildDeployment: NonNullable<DeployDependencies['buildDeployment']> =
+      vi.fn(async () => bundle.contract);
+    const prepareDeploymentRelease:
+      NonNullable<DeployDependencies['prepareDeploymentRelease']> =
+      vi.fn(async () => prepareProtocolDeploymentReleaseEnvelope({
+        kind: 'hypequery-deployment-release',
+        version: 1,
+        bundleIdentity: BUNDLE_IDENTITY,
+        target: { project: 'project-1', environment: 'production' },
+      }).release);
+    const submitDeployment: NonNullable<DeployDependencies['submitDeployment']> =
+      vi.fn(async () => ({
+        kind: 'hypequery-deployment-submission',
+        version: 1,
+        status: 'accepted',
+        releaseIdentity: '1'.repeat(64),
+        bundleIdentity: BUNDLE_IDENTITY,
+      }));
+
+    const result = await deployCommand('analytics/api.ts', {}, {
+      loadCredential,
+      buildDeployment,
+      prepareDeploymentRelease,
+      submitDeployment,
+    });
+
+    expect(buildDeployment).toHaveBeenCalledWith('analytics/api.ts', {
+      bundleOutput: 'analytics/hypequery-deployment',
+    });
+    expect(prepareDeploymentRelease).toHaveBeenCalledWith(
+      'analytics/hypequery-deployment',
+      {
+        project: undefined,
+        environment: undefined,
+        output: 'analytics/hypequery-deployment.release.json',
+      },
+      { loadCredential },
+    );
+    expect(submitDeployment).toHaveBeenCalledWith(
+      'analytics/hypequery-deployment',
+      {
+        release: 'analytics/hypequery-deployment.release.json',
+        endpoint: undefined,
+      },
+      expect.objectContaining({ loadCredential }),
+    );
+    expect(result.status).toBe('accepted');
+  });
+
+  it('supports explicit outputs and target overrides in one-command mode', async () => {
+    const buildDeployment: NonNullable<DeployDependencies['buildDeployment']> =
+      vi.fn(async () => bundle.contract);
+    const prepareDeploymentRelease:
+      NonNullable<DeployDependencies['prepareDeploymentRelease']> =
+      vi.fn(async () => prepareProtocolDeploymentReleaseEnvelope({
+        kind: 'hypequery-deployment-release',
+        version: 1,
+        bundleIdentity: BUNDLE_IDENTITY,
+        target: { project: 'project-1', environment: 'staging' },
+      }).release);
+    const submitDeployment: NonNullable<DeployDependencies['submitDeployment']> =
+      vi.fn(async () => ({
+        kind: 'hypequery-deployment-submission',
+        version: 1,
+        status: 'accepted',
+        releaseIdentity: '1'.repeat(64),
+        bundleIdentity: BUNDLE_IDENTITY,
+      }));
+
+    await deployCommand('src/api.ts', {
+      bundleOutput: 'dist/cloud-bundle',
+      releaseOutput: 'dist/cloud-release.json',
+      project: 'project-1',
+      environment: 'staging',
+      endpoint: 'https://deploy.example.test/v1/releases',
+    }, {
+      buildDeployment,
+      prepareDeploymentRelease,
+      submitDeployment,
+    });
+
+    expect(buildDeployment).toHaveBeenCalledWith('src/api.ts', {
+      bundleOutput: 'dist/cloud-bundle',
+    });
+    expect(prepareDeploymentRelease).toHaveBeenCalledWith(
+      'dist/cloud-bundle',
+      {
+        project: 'project-1',
+        environment: 'staging',
+        output: 'dist/cloud-release.json',
+      },
+      { loadCredential: undefined },
+    );
+    expect(submitDeployment).toHaveBeenCalledWith(
+      'dist/cloud-bundle',
+      {
+        release: 'dist/cloud-release.json',
+        endpoint: 'https://deploy.example.test/v1/releases',
+      },
+      expect.any(Object),
+    );
+  });
+
+  it('does not mix legacy prebuilt submission with orchestration options', async () => {
+    await expect(deployCommand('dist/bundle', {
+      release: 'dist/release.json',
+      project: 'project-1',
+    })).rejects.toThrow(/--release selects prebuilt submission mode/);
+    expect(mockVerifyDeploymentBundle).not.toHaveBeenCalled();
+  });
+
+  it('warns when using the legacy prebuilt deploy syntax', async () => {
+    const release = await releaseFile();
+    const submit = vi.fn().mockResolvedValue({
+      kind: 'hypequery-deployment-submission',
+      version: 1,
+      status: 'accepted',
+      releaseIdentity: release.identity,
+      bundleIdentity: BUNDLE_IDENTITY,
+    });
+
+    await deployCommand('/project/dist/bundle', {
+      release: release.path,
+      endpoint: 'https://deploy.example.test/v1/releases',
+    }, {
+      env: { HYPEQUERY_API_TOKEN: 'secret-token' },
+      createTransport: () => ({ submit }),
+    });
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('deployment:submit'),
+    );
   });
 
   it('verifies and submits an explicit release using environment credentials', async () => {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1,8 +1,12 @@
-import { constants, open } from 'node:fs/promises';
+import { access, constants, open } from 'node:fs/promises';
+import path from 'node:path';
 import {
   prepareProtocolDeploymentReleaseEnvelope,
 } from '@hypequery/protocol';
-import { verifyDeploymentBundle } from '../utils/deployment-bundle.js';
+import {
+  DEPLOYMENT_BUNDLE_MANIFEST,
+  verifyDeploymentBundle,
+} from '../utils/deployment-bundle.js';
 import {
   createHttpDeploymentUploadTransport,
   DeploymentUploadError,
@@ -105,24 +109,22 @@ function requiredConfiguration(
   return value;
 }
 
-export async function submitDeploymentCommand(
-  bundlePath: string | undefined,
-  options: SubmitDeploymentOptions = {},
-  dependencies: SubmitDeploymentDependencies = {},
-): Promise<DeploymentSubmissionResponse> {
-  if (!bundlePath) {
-    throw new Error(
-      'Missing deployment bundle path.\n\n'
-      + 'Usage: hypequery deployment:submit analytics/hypequery-deployment '
-      + '--release analytics/hypequery-deployment.release.json',
-    );
-  }
-  const releasePath = requiredConfiguration(
-    options.release,
-    'Missing required --release <path>.',
-  );
+interface ResolvedDeploymentCredential {
+  readonly endpoint: string;
+  readonly token: string;
+}
+
+/**
+ * Resolves the submission endpoint and token. Kept separate from
+ * `submitDeploymentCommand` so `deployCommand` can run it as a preflight
+ * before the bundle build.
+ */
+async function resolveDeploymentCredential(
+  endpointOption: string | undefined,
+  dependencies: SubmitDeploymentDependencies,
+): Promise<ResolvedDeploymentCredential> {
   const env = dependencies.env ?? process.env;
-  let deploymentEndpoint = options.endpoint ?? env.HYPEQUERY_DEPLOYMENT_ENDPOINT;
+  let deploymentEndpoint = endpointOption ?? env.HYPEQUERY_DEPLOYMENT_ENDPOINT;
   let token = env.HYPEQUERY_API_TOKEN;
   const hasExplicitEndpoint = Boolean(deploymentEndpoint);
   const hasExplicitToken = Boolean(token);
@@ -145,13 +147,37 @@ export async function submitDeploymentCommand(
       token = credential.token;
     }
   }
-  deploymentEndpoint = requiredConfiguration(
-    deploymentEndpoint,
-    'Missing deployment endpoint. Run `hypequery login`, pass --endpoint, or set HYPEQUERY_DEPLOYMENT_ENDPOINT.',
+  return {
+    endpoint: requiredConfiguration(
+      deploymentEndpoint,
+      'Missing deployment endpoint. Run `hypequery login`, pass --endpoint, or set HYPEQUERY_DEPLOYMENT_ENDPOINT.',
+    ),
+    token: requiredConfiguration(
+      token,
+      'Missing deployment credential. Run `hypequery login` or set HYPEQUERY_API_TOKEN.',
+    ),
+  };
+}
+
+export async function submitDeploymentCommand(
+  bundlePath: string | undefined,
+  options: SubmitDeploymentOptions = {},
+  dependencies: SubmitDeploymentDependencies = {},
+): Promise<DeploymentSubmissionResponse> {
+  if (!bundlePath) {
+    throw new Error(
+      'Missing deployment bundle path.\n\n'
+      + 'Usage: hypequery deployment:submit analytics/hypequery-deployment '
+      + '--release analytics/hypequery-deployment.release.json',
+    );
+  }
+  const releasePath = requiredConfiguration(
+    options.release,
+    'Missing required --release <path>.',
   );
-  token = requiredConfiguration(
-    token,
-    'Missing deployment credential. Run `hypequery login` or set HYPEQUERY_API_TOKEN.',
+  const { endpoint: deploymentEndpoint, token } = await resolveDeploymentCredential(
+    options.endpoint,
+    dependencies,
   );
 
   let bundle: Awaited<ReturnType<typeof verifyDeploymentBundle>>;
@@ -195,6 +221,40 @@ export async function submitDeploymentCommand(
   return result;
 }
 
+/**
+ * `deploy` takes an API module, but the deprecated form took a bundle
+ * directory. Dropping `--release` from an existing script would otherwise hand
+ * a bundle to the module loader and fail inside esbuild.
+ */
+async function rejectBundleDirectorySource(sourcePath: string): Promise<void> {
+  try {
+    await access(path.join(sourcePath, DEPLOYMENT_BUNDLE_MANIFEST));
+  } catch {
+    return;
+  }
+  throw new Error(
+    `Cannot deploy a prebuilt bundle directory: ${sourcePath}\n\n`
+    + '`hypequery deploy` takes the API module to build, for example '
+    + '`hypequery deploy analytics/api.ts`.\n'
+    + 'To upload this bundle, use `hypequery deployment:submit '
+    + `${sourcePath} --release <file>\`.`,
+  );
+}
+
+/**
+ * `deploy` exposes no runtime flags, so a runtime error from the shared build
+ * command would otherwise point at flags this command does not accept.
+ */
+function withRuntimeFlagHint(error: unknown): unknown {
+  if (!(error instanceof Error) || !error.message.includes('--runtime')) return error;
+  return new Error(
+    `${error.message}\n\n`
+    + 'Runtime overrides are not available on `hypequery deploy`. Build with '
+    + '`hypequery deployment:build` (which accepts --runtime, --runtime-artifact, '
+    + 'and --runtime-file), then upload with `hypequery deployment:submit`.',
+  );
+}
+
 function rejectLegacyOrchestrationOptions(options: DeployOptions) {
   if (
     options.project !== undefined
@@ -234,6 +294,8 @@ export async function deployCommand(
     }, dependencies);
   }
 
+  await rejectBundleDirectorySource(sourcePath);
+
   const bundlePath = options.bundleOutput ?? DEFAULT_BUNDLE_PATH;
   const releasePath = options.releaseOutput
     ?? `${bundlePath.replace(/[\\/]+$/, '')}.release.json`;
@@ -242,13 +304,22 @@ export async function deployCommand(
     ?? prepareDeploymentReleaseCommand;
   const submit = dependencies.submitDeployment ?? submitDeploymentCommand;
 
-  await build(sourcePath, { bundleOutput: bundlePath });
+  // Resolve credentials up front. Submission is the last step, so without this
+  // a missing or expired login only surfaces after a full bundle build.
+  await resolveDeploymentCredential(options.endpoint, dependencies);
+
+  try {
+    await build(sourcePath, { bundleOutput: bundlePath });
+  } catch (error) {
+    throw withRuntimeFlagHint(error);
+  }
   await prepareRelease(bundlePath, {
     project: options.project,
     environment: options.environment,
     output: releasePath,
   }, {
     loadCredential: dependencies.loadCredential,
+    outputFlagLabel: '--release-output',
   });
   return submit(bundlePath, {
     release: releasePath,

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -14,19 +14,37 @@ import {
   loadCloudCredential,
   type StoredCloudCredential,
 } from '../utils/cloud-credential-store.js';
+import {
+  buildDeploymentCommand,
+  prepareDeploymentReleaseCommand,
+} from './deployment.js';
 
 const MAX_RELEASE_FILE_BYTES = 16 * 1024;
+const DEFAULT_BUNDLE_PATH = 'analytics/hypequery-deployment';
 const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 
-export interface DeployOptions {
+export interface SubmitDeploymentOptions {
   release?: string;
   endpoint?: string;
 }
 
-export interface DeployDependencies {
+export interface DeployOptions extends SubmitDeploymentOptions {
+  project?: string;
+  environment?: string;
+  bundleOutput?: string;
+  releaseOutput?: string;
+}
+
+export interface SubmitDeploymentDependencies {
   readonly env?: Readonly<Record<string, string | undefined>>;
   readonly createTransport?: typeof createHttpDeploymentUploadTransport;
   readonly loadCredential?: () => Promise<StoredCloudCredential | null>;
+}
+
+export interface DeployDependencies extends SubmitDeploymentDependencies {
+  readonly buildDeployment?: typeof buildDeploymentCommand;
+  readonly prepareDeploymentRelease?: typeof prepareDeploymentReleaseCommand;
+  readonly submitDeployment?: typeof submitDeploymentCommand;
 }
 
 async function readReleaseFile(releasePath: string): Promise<unknown> {
@@ -87,15 +105,15 @@ function requiredConfiguration(
   return value;
 }
 
-export async function deployCommand(
+export async function submitDeploymentCommand(
   bundlePath: string | undefined,
-  options: DeployOptions = {},
-  dependencies: DeployDependencies = {},
+  options: SubmitDeploymentOptions = {},
+  dependencies: SubmitDeploymentDependencies = {},
 ): Promise<DeploymentSubmissionResponse> {
   if (!bundlePath) {
     throw new Error(
       'Missing deployment bundle path.\n\n'
-      + 'Usage: hypequery deploy analytics/hypequery-deployment '
+      + 'Usage: hypequery deployment:submit analytics/hypequery-deployment '
       + '--release analytics/hypequery-deployment.release.json',
     );
   }
@@ -175,4 +193,65 @@ export async function deployCommand(
   logger.info(`Release identity: ${result.releaseIdentity}`);
   logger.info(`Bundle identity: ${result.bundleIdentity}`);
   return result;
+}
+
+function rejectLegacyOrchestrationOptions(options: DeployOptions) {
+  if (
+    options.project !== undefined
+    || options.environment !== undefined
+    || options.bundleOutput !== undefined
+    || options.releaseOutput !== undefined
+  ) {
+    throw new Error(
+      '--release selects prebuilt submission mode and cannot be combined with '
+      + '--project, --environment, --bundle-output, or --release-output. '
+      + 'Use `hypequery deployment:submit` for explicit prebuilt uploads.',
+    );
+  }
+}
+
+export async function deployCommand(
+  sourcePath: string | undefined,
+  options: DeployOptions = {},
+  dependencies: DeployDependencies = {},
+): Promise<DeploymentSubmissionResponse> {
+  if (!sourcePath) {
+    throw new Error(
+      'Missing API module path.\n\n'
+      + 'Usage: hypequery deploy analytics/api.ts',
+    );
+  }
+
+  if (options.release !== undefined) {
+    rejectLegacyOrchestrationOptions(options);
+    logger.warn(
+      '`hypequery deploy <bundle> --release <file>` is deprecated. '
+      + 'Use `hypequery deployment:submit <bundle> --release <file>` instead.',
+    );
+    return submitDeploymentCommand(sourcePath, {
+      release: options.release,
+      endpoint: options.endpoint,
+    }, dependencies);
+  }
+
+  const bundlePath = options.bundleOutput ?? DEFAULT_BUNDLE_PATH;
+  const releasePath = options.releaseOutput
+    ?? `${bundlePath.replace(/[\\/]+$/, '')}.release.json`;
+  const build = dependencies.buildDeployment ?? buildDeploymentCommand;
+  const prepareRelease = dependencies.prepareDeploymentRelease
+    ?? prepareDeploymentReleaseCommand;
+  const submit = dependencies.submitDeployment ?? submitDeploymentCommand;
+
+  await build(sourcePath, { bundleOutput: bundlePath });
+  await prepareRelease(bundlePath, {
+    project: options.project,
+    environment: options.environment,
+    output: releasePath,
+  }, {
+    loadCredential: dependencies.loadCredential,
+  });
+  return submit(bundlePath, {
+    release: releasePath,
+    endpoint: options.endpoint,
+  }, dependencies);
 }

--- a/packages/cli/src/commands/deployment.ts
+++ b/packages/cli/src/commands/deployment.ts
@@ -46,6 +46,11 @@ export interface PrepareDeploymentReleaseOptions {
 
 export interface PrepareDeploymentReleaseDependencies {
   loadCredential?: () => Promise<StoredCloudCredential | null>;
+  /**
+   * Flag name to quote in output-path errors. `hypequery deploy` delegates
+   * here but spells the same option `--release-output`.
+   */
+  outputFlagLabel?: string;
 }
 
 const DEFAULT_BUNDLE_OUTPUT = 'analytics/hypequery-deployment';
@@ -318,7 +323,11 @@ export async function validateDeploymentCommand(
   return contract;
 }
 
-function assertOutputOutsideBundle(bundlePath: string, outputPath: string): void {
+function assertOutputOutsideBundle(
+  bundlePath: string,
+  outputPath: string,
+  outputFlag: string,
+): void {
   const bundle = path.resolve(bundlePath);
   const output = path.resolve(outputPath);
   const relative = path.relative(bundle, output);
@@ -326,11 +335,11 @@ function assertOutputOutsideBundle(bundlePath: string, outputPath: string): void
     || relative.startsWith(`..${path.sep}`)
     || path.isAbsolute(relative);
   if (relative === '' || !outside) {
-    throw new Error('--output must be outside the closed deployment bundle directory.');
+    throw new Error(`${outputFlag} must be outside the closed deployment bundle directory.`);
   }
 }
 
-async function prospectiveRealPath(inputPath: string): Promise<string> {
+async function prospectiveRealPath(inputPath: string, outputFlag: string): Promise<string> {
   let current = path.resolve(inputPath);
   const missingSegments: string[] = [];
   for (;;) {
@@ -344,7 +353,7 @@ async function prospectiveRealPath(inputPath: string): Promise<string> {
       try {
         const stat = await lstat(current);
         if (stat.isSymbolicLink()) {
-          throw new Error('--output must not traverse a dangling symbolic link.');
+          throw new Error(`${outputFlag} must not traverse a dangling symbolic link.`);
         }
       } catch (lstatError) {
         if (!(typeof lstatError === 'object' && lstatError !== null && 'code' in lstatError
@@ -360,11 +369,14 @@ async function prospectiveRealPath(inputPath: string): Promise<string> {
   }
 }
 
-async function assertOutputIsNotSymbolicLink(outputPath: string): Promise<void> {
+async function assertOutputIsNotSymbolicLink(
+  outputPath: string,
+  outputFlag: string,
+): Promise<void> {
   try {
     const outputStat = await lstat(outputPath);
     if (outputStat.isSymbolicLink()) {
-      throw new Error('--output must not be a symbolic link.');
+      throw new Error(`${outputFlag} must not be a symbolic link.`);
     }
   } catch (error) {
     if (!(typeof error === 'object' && error !== null && 'code' in error
@@ -409,8 +421,9 @@ export async function prepareDeploymentReleaseCommand(
       );
     }
   }
+  const outputFlag = dependencies.outputFlagLabel ?? '--output';
   const outputPath = options.output ?? `${bundlePath.replace(/[\\/]+$/, '')}.release.json`;
-  assertOutputOutsideBundle(bundlePath, outputPath);
+  assertOutputOutsideBundle(bundlePath, outputPath, outputFlag);
 
   let bundle: Awaited<ReturnType<typeof verifyDeploymentBundle>>;
   try {
@@ -423,7 +436,8 @@ export async function prepareDeploymentReleaseCommand(
   }
   assertOutputOutsideBundle(
     bundle.directory,
-    await prospectiveRealPath(outputPath),
+    await prospectiveRealPath(outputPath, outputFlag),
+    outputFlag,
   );
   const prepared = prepareProtocolDeploymentReleaseEnvelope({
     kind: 'hypequery-deployment-release',
@@ -435,7 +449,7 @@ export async function prepareDeploymentReleaseCommand(
     },
   });
   await mkdir(path.dirname(outputPath), { recursive: true });
-  await assertOutputIsNotSymbolicLink(outputPath);
+  await assertOutputIsNotSymbolicLink(outputPath, outputFlag);
   await writeFile(outputPath, `${prepared.canonical}\n`, 'utf8');
   logger.success(`Deployment release written to ${outputPath}`);
   logger.info(`Target: ${project}/${environment}`);


### PR DESCRIPTION
## What

- make `hypequery deploy <api-module>` orchestrate build → release preparation → submission
- add `hypequery deployment:submit <bundle> --release <file>` as the explicit prebuilt-artifact primitive
- preserve the old `deploy <bundle> --release <file>` form temporarily with a deprecation warning
- add target/output overrides and a CLI changeset

## Why

The primary Cloud workflow should match user intent: sign in once, then deploy the API module with one command. Build and release remain available as composable lower-level commands for CI and debugging without dominating onboarding.

## Compatibility

Existing deploy scripts using `--release` continue to work and now point users toward `deployment:submit`. Mixing legacy `--release` mode with orchestration flags fails explicitly.

## Checks

- `pnpm build`
- `pnpm --filter @hypequery/cli test` — 384 passed, 1 skipped
- `pnpm --filter @hypequery/cli lint`
- `git diff --check`