### PR TITLE
fix(cli): install @hypequery/clickhouse instead of relying on an optional peer

### DIFF
--- a/.changeset/olive-boats-repeat.md
+++ b/.changeset/olive-boats-repeat.md
@@ -1,0 +1,9 @@
+---
+"@hypequery/cli": patch
+---
+
+Fix `ERR_MODULE_NOT_FOUND: Cannot find package '@hypequery/clickhouse'` on a clean install.
+
+`@hypequery/clickhouse` backs `hypequery init` and `hypequery generate`, but it was declared as an *optional* peer dependency while being imported statically. Package managers skipped installing it (pnpm skips peers entirely; npm skips optional ones), so every command — including `hypequery --help` — crashed before running on a fresh `npx @hypequery/cli` install. It is now a regular dependency.
+
+Type generators are also loaded on demand, so a failure to resolve one no longer takes down unrelated commands.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@clickhouse/client": "^1.18.3",
+    "@hypequery/clickhouse": "workspace:*",
     "@hypequery/deployment": "workspace:*",
     "@hypequery/protocol": "workspace:*",
     "chalk": "^5.3.0",
@@ -32,16 +33,9 @@
     "@napi-rs/keyring": "1.3.0"
   },
   "peerDependencies": {
-    "@hypequery/clickhouse": "*",
     "@hypequery/serve": "*"
   },
-  "peerDependenciesMeta": {
-    "@hypequery/clickhouse": {
-      "optional": true
-    }
-  },
   "devDependencies": {
-    "@hypequery/clickhouse": "workspace:*",
     "@hypequery/serve": "workspace:*",
     "@types/node": "^20.11.30",
     "@types/prompts": "^2.4.9",

--- a/packages/cli/src/generators/index.ts
+++ b/packages/cli/src/generators/index.ts
@@ -1,14 +1,24 @@
 import type { DatabaseType } from '../utils/detect-database.js';
-import { generateClickHouseTypes, type ClickHouseGeneratorOptions } from './clickhouse.js';
-import { generateChdbTypes, type ChdbGeneratorOptions } from './chdb.js';
+import type { ClickHouseGeneratorOptions } from './clickhouse.js';
+import type { ChdbGeneratorOptions } from './chdb.js';
 
 export type TypeGeneratorOptions = ClickHouseGeneratorOptions & ChdbGeneratorOptions;
 
 type GeneratorFn = (options: TypeGeneratorOptions) => Promise<void>;
 
+// Loaded on demand. Both generators pull in `@hypequery/clickhouse/cli`, and importing
+// that eagerly puts it on the module graph of every command — a resolution failure there
+// took down even `hypequery --help`. Deferring it keeps the blast radius on the commands
+// that actually generate types.
 const generators: Partial<Record<DatabaseType, GeneratorFn>> = {
-  clickhouse: generateClickHouseTypes,
-  chdb: generateChdbTypes,
+  clickhouse: async (options) => {
+    const { generateClickHouseTypes } = await import('./clickhouse.js');
+    await generateClickHouseTypes(options);
+  },
+  chdb: async (options) => {
+    const { generateChdbTypes } = await import('./chdb.js');
+    await generateChdbTypes(options);
+  },
 };
 
 export function getTypeGenerator(dbType: DatabaseType): GeneratorFn {

--- a/packages/cli/src/packaging.test.ts
+++ b/packages/cli/src/packaging.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { builtinModules } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const srcDir = path.dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(
+  readFileSync(path.join(srcDir, '..', 'package.json'), 'utf8')
+) as {
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+
+const declaredAtRuntime = new Set([
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.optionalDependencies ?? {}),
+]);
+
+// `fs/promises` and friends are imported bare in places, so match on the builtin root.
+const builtins = new Set(builtinModules);
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(full);
+    if (!entry.name.endsWith('.ts')) return [];
+    if (entry.name.endsWith('.test.ts') || entry.name.endsWith('.d.ts')) return [];
+    if (entry.name === 'test-utils.ts') return [];
+    return [full];
+  });
+}
+
+/**
+ * Static (non-`import type`, non-dynamic) bare specifiers. These land on the module
+ * graph of `bin/cli.js` and are resolved by Node before a single line of CLI code runs,
+ * so anything here that is only a peer dependency crashes every command on a clean
+ * `npx @hypequery/cli` install — including `--help`.
+ */
+function staticBareImports(file: string): string[] {
+  // Template literals are stripped first: the scaffolding templates emit `import ... from
+  // '@hypequery/serve'` as generated *output*, which is a string here, not an import.
+  const source = readFileSync(file, 'utf8').replace(/`(?:[^`\\]|\\[\s\S])*`/g, '``');
+  const specifiers: string[] = [];
+
+  const importRe = /^\s*import\s+(?!type\s)(?:[\s\S]*?\sfrom\s+)?['"]([^'"]+)['"]/gm;
+  const exportRe = /^\s*export\s+(?!type\s)(?:[\s\S]*?\s)?from\s+['"]([^'"]+)['"]/gm;
+
+  for (const re of [importRe, exportRe]) {
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(source)) !== null) {
+      const specifier = match[1];
+      if (specifier.startsWith('.') || specifier.startsWith('node:')) continue;
+      specifiers.push(specifier);
+    }
+  }
+
+  return specifiers;
+}
+
+/** `@scope/pkg/sub` -> `@scope/pkg`, `pkg/sub` -> `pkg` */
+function packageRoot(specifier: string): string {
+  const parts = specifier.split('/');
+  return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+}
+
+describe('runtime dependency declarations', () => {
+  it('declares every statically imported package as a real dependency', () => {
+    const undeclared = sourceFiles(srcDir).flatMap(file =>
+      staticBareImports(file)
+        .map(packageRoot)
+        .filter(name => !declaredAtRuntime.has(name) && !builtins.has(name))
+        .map(name => `${path.relative(srcDir, file)} imports "${name}"`)
+    );
+
+    expect(undeclared).toEqual([]);
+  });
+
+  it('keeps @hypequery/clickhouse installable without opt-in', () => {
+    // It backs `hypequery init` / `hypequery generate`. As an optional peer, package
+    // managers skipped it (pnpm skips peers entirely) while the code imported it anyway.
+    expect(declaredAtRuntime.has('@hypequery/clickhouse')).toBe(true);
+    expect(pkg.peerDependencies?.['@hypequery/clickhouse']).toBeUndefined();
+  });
+
+  it('loads @hypequery/serve lazily, since it must come from the user project', () => {
+    // serve is a peer on purpose: `hypequery dev` hands the user's own api object to
+    // serveDev, so the CLI must not bundle a second instance of it.
+    const staticServeImports = sourceFiles(srcDir).filter(file =>
+      staticBareImports(file).some(specifier => packageRoot(specifier) === '@hypequery/serve')
+    );
+
+    expect(staticServeImports).toEqual([]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@clickhouse/client':
         specifier: ^1.18.3
         version: 1.18.3
+      '@hypequery/clickhouse':
+        specifier: workspace:*
+        version: link:../clickhouse
       '@hypequery/deployment':
         specifier: workspace:*
         version: link:../deployment
@@ -90,9 +93,6 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
     devDependencies:
-      '@hypequery/clickhouse':
-        specifier: workspace:*
-        version: link:../clickhouse
       '@hypequery/serve':
         specifier: workspace:*
         version: link:../serve


### PR DESCRIPTION
## The bug

`npx @hypequery/cli init` — the hero command — crashes on a clean install:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@hypequery/clickhouse'
imported from .../node_modules/@hypequery/cli/dist/generators/clickhouse.js
```

Every command is affected, including `hypequery --help`. Reproduced against the published `@hypequery/cli@1.12.0`.

## Root cause

`@hypequery/clickhouse` was declared as an **optional peer dependency** but imported **statically** — `generators/clickhouse.ts` imports `generateTypes` from `@hypequery/clickhouse/cli`, and that file sits on the eager module graph of the bin entry (`cli.ts` → `commands/init.ts` → `generators/index.ts` → `generators/clickhouse.ts`). Static ESM imports resolve before any code runs, so the process died at load time.

Marking it `optional: true` told package managers not to install it. That's why `@hypequery/serve` worked (non-optional peer — npm auto-installs it) while `@hypequery/clickhouse` was simply absent. Under pnpm neither is installed, since pnpm doesn't auto-install peers at all.

Not a regression — broken since the CLI was split out in 73c9007c. The monorepo masked it: in-workspace it resolves via the `devDependency`.

## The fix

- **`@hypequery/clickhouse` → regular dependency.** It's used only for schema-introspection codegen; `generateTypes` writes a self-contained `.ts` file with zero imports, so there's no shared runtime state and no dual-instance risk.
- **`@hypequery/serve` stays a peer, deliberately.** `serveDev` receives the user's own `api` object, so bundling a second instance would break identity checks.
- **Type generators load on demand,** so a resolution failure in one generator can't take down unrelated commands again.
- **New `packaging.test.ts`** asserts every statically imported bare specifier is a declared runtime dependency. It fails against the previous manifest, so it guards the whole class of bug rather than this one instance.

## Verification

Packed the tarball and installed into clean projects:

| | result |
|---|---|
| npm install | `--help` and `init --help` work; generator resolves through to the connection step |
| pnpm install | same |
| `npm i -g` | same; only `hypequery` is linked onto PATH — transitive bins don't leak |

Also confirmed a global CLI carrying `@hypequery/clickhouse@2.5.2` does **not** interfere with a project pinned to `2.4.0` — Node resolves each from its own tree.

CLI suite: 394 passed, 1 skipped. Lint clean. Changeset included (patch).

## Follow-up

This trades ~1.1 MB of install weight to unbreak the command. Removing the dependency entirely — extracting the ~300 lines of type-gen into a small shared package both sides depend on — is a refactor worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
