### PR TITLE
feat(cli): complete interactive init flow

### DIFF
--- a/.changeset/calm-databases-prompt.md
+++ b/.changeset/calm-databases-prompt.md
@@ -1,0 +1,7 @@
+---
+"@hypequery/cli": minor
+---
+
+Complete the interactive `init` path with database-driver and authentication
+choices, skip unused ClickHouse credential questions, and warn before
+scaffolding outside a directory containing `package.json`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,6 +42,15 @@ Scaffolds the standard hypequery setup.
 npx hypequery init
 ```
 
+Interactive setup asks which database driver to use, whether to include
+request-context authentication scaffolding, where to write the generated
+files, and which API style to create. Selecting chDB replaces the remote
+credential questions with an embedded-storage choice.
+
+Run `init` from the project directory that contains `package.json`. If no
+package manifest is found, interactive setup asks for confirmation before
+writing files and dependency installation must be completed manually.
+
 It will:
 
 - connect to ClickHouse or start an embedded chDB session

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -77,6 +77,39 @@ describe('init command - graceful failure handling', () => {
   });
 
   describe('User cancellation scenarios', () => {
+    it('stops before scaffolding when package.json is missing and the user declines', async () => {
+      vi.mocked(readFile).mockRejectedValueOnce(new Error('File not found'));
+      vi.mocked(prompts.confirmWithoutPackageJson).mockResolvedValue(false);
+
+      await initCommand({});
+
+      expect(prompts.confirmWithoutPackageJson).toHaveBeenCalledWith(process.cwd());
+      expect(prompts.promptInitDatabase).not.toHaveBeenCalled();
+      expect(writeFile).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        'Setup cancelled. Run init from your project directory.',
+      );
+    });
+
+    it('continues scaffolding when package.json is missing and the user confirms', async () => {
+      vi.mocked(readFile).mockRejectedValueOnce(new Error('File not found'));
+      vi.mocked(prompts.confirmWithoutPackageJson).mockResolvedValue(true);
+      vi.mocked(prompts.promptInitDatabase).mockResolvedValue('clickhouse');
+      vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue(null);
+      vi.mocked(prompts.promptOutputDirectory).mockResolvedValue('analytics');
+      vi.mocked(prompts.promptInitStyle).mockResolvedValue('queries');
+      vi.mocked(prompts.promptInitAuthMode).mockResolvedValue('none');
+
+      await initCommand({});
+
+      expect(prompts.confirmWithoutPackageJson).toHaveBeenCalledWith(process.cwd());
+      expect(prompts.promptInitDatabase).toHaveBeenCalled();
+      expect(writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('analytics/queries.ts'),
+        expect.any(String),
+      );
+    });
+
     it('should continue when user skips connection details', async () => {
       vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue(null);
       vi.mocked(prompts.promptOutputDirectory).mockResolvedValue('analytics');
@@ -324,7 +357,10 @@ describe('init command - graceful failure handling', () => {
         path: 'analytics',
       });
 
+      expect(prompts.confirmWithoutPackageJson).not.toHaveBeenCalled();
+      expect(prompts.promptInitDatabase).not.toHaveBeenCalled();
       expect(prompts.promptOutputDirectory).not.toHaveBeenCalled();
+      expect(prompts.promptInitAuthMode).not.toHaveBeenCalled();
       expect(prompts.promptGenerateExample).not.toHaveBeenCalled();
       expect(prompts.promptTableSelection).not.toHaveBeenCalled();
       expect(prompts.confirmOverwrite).not.toHaveBeenCalled();
@@ -372,6 +408,24 @@ describe('init command - graceful failure handling', () => {
   });
 
   describe('Style scaffolds', () => {
+    it('prompts for a database driver before connection details', async () => {
+      vi.mocked(prompts.promptInitDatabase).mockResolvedValue('chdb');
+      vi.mocked(prompts.promptChdbStorage).mockResolvedValue(undefined);
+      vi.mocked(prompts.promptOutputDirectory).mockResolvedValue('analytics');
+      vi.mocked(prompts.promptInitStyle).mockResolvedValue('queries');
+      vi.mocked(prompts.promptInitAuthMode).mockResolvedValue('none');
+      vi.mocked(detectDb.validateConnection).mockResolvedValue(true);
+      vi.mocked(detectDb.getTableCount).mockResolvedValue(0);
+      vi.mocked(detectDb.getTables).mockResolvedValue([]);
+
+      await initCommand({});
+
+      expect(prompts.promptInitDatabase).toHaveBeenCalled();
+      expect(prompts.promptClickHouseConnection).not.toHaveBeenCalled();
+      expect(prompts.promptChdbStorage).toHaveBeenCalled();
+      expect(installScaffoldDependencies).toHaveBeenCalledWith('queries', 'chdb');
+    });
+
     it('prompts for style in interactive mode and defaults to query files', async () => {
       vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue(null);
       vi.mocked(prompts.promptOutputDirectory).mockResolvedValue('analytics');
@@ -384,6 +438,22 @@ describe('init command - graceful failure handling', () => {
       expect(writeFile).toHaveBeenCalledWith(
         expect.stringContaining('analytics/queries.ts'),
         expect.stringContaining('initServe'),
+      );
+    });
+
+    it('prompts for authentication scaffolding in interactive mode', async () => {
+      vi.mocked(prompts.promptInitDatabase).mockResolvedValue('clickhouse');
+      vi.mocked(prompts.promptClickHouseConnection).mockResolvedValue(null);
+      vi.mocked(prompts.promptOutputDirectory).mockResolvedValue('analytics');
+      vi.mocked(prompts.promptInitStyle).mockResolvedValue('queries');
+      vi.mocked(prompts.promptInitAuthMode).mockResolvedValue('context');
+
+      await initCommand({});
+
+      expect(prompts.promptInitAuthMode).toHaveBeenCalled();
+      expect(writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('analytics/queries.ts'),
+        expect.stringContaining('fromContext'),
       );
     });
 
@@ -601,6 +671,7 @@ describe('init command - graceful failure handling', () => {
 
       await initCommand({ database: 'chdb' });
 
+      expect(prompts.promptInitDatabase).not.toHaveBeenCalled();
       expect(prompts.promptChdbStorage).toHaveBeenCalled();
       const clientWrite = vi.mocked(writeFile).mock.calls.find(
         ([file]) => typeof file === 'string' && file.endsWith('client.ts'),

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,12 +4,15 @@ import ora from 'ora';
 import { logger } from '../utils/logger.js';
 import {
   promptClickHouseConnection,
+  promptInitDatabase,
   promptChdbStorage,
   promptOutputDirectory,
   promptInitStyle,
+  promptInitAuthMode,
   promptGenerateExample,
   promptTableSelection,
   promptDatasetTableSelection,
+  confirmWithoutPackageJson,
   confirmOverwrite,
   promptRetry,
   promptContinueWithoutDb,
@@ -139,6 +142,15 @@ async function resolveConnectionConfig(options: InitOptions): Promise<Connection
   return promptClickHouseConnection();
 }
 
+async function hasProjectPackageJson(): Promise<boolean> {
+  try {
+    await readFile(path.join(process.cwd(), 'package.json'), 'utf8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 type ChdbTestResult = { ok: true } | { ok: false; reason: 'not-installed' | 'engine-error' };
 
 async function testChdbConnection(chdbPath: string | undefined): Promise<ChdbTestResult> {
@@ -208,10 +220,23 @@ async function testConnection(
 
 export async function initCommand(options: InitOptions = {}) {
   const noInteractive = options.noInteractive === true || (options as InitOptions & { interactive?: boolean }).interactive === false;
-  const database = normalizeInitDatabase(options.database);
 
   logger.newline();
   logger.header('Welcome to hypequery!');
+
+  if (!noInteractive && !(await hasProjectPackageJson())) {
+    logger.warn(`package.json not found in ${process.cwd()}`);
+    const shouldContinue = await confirmWithoutPackageJson(process.cwd());
+    if (!shouldContinue) {
+      logger.info('Setup cancelled. Run init from your project directory.');
+      return;
+    }
+    logger.newline();
+  }
+
+  const database = normalizeInitDatabase(
+    options.database ?? (noInteractive ? undefined : await promptInitDatabase()),
+  );
   logger.info(
     database === 'chdb'
       ? "Let's set up your analytics layer on embedded ClickHouse (chDB)."
@@ -253,7 +278,7 @@ export async function initCommand(options: InitOptions = {}) {
 
         const retry = await promptRetry('Try again?');
         if (retry) {
-          return initCommand(options);
+          return initCommand({ ...options, database });
         }
 
         const continueWithout = await promptContinueWithoutDb();
@@ -282,9 +307,12 @@ export async function initCommand(options: InitOptions = {}) {
   const resolvedOutputDir = path.resolve(process.cwd(), outputDir);
 
   let style = normalizeInitStyle(options.style);
-  const auth = normalizeAuthMode(options.auth);
   if (!options.style && !noInteractive) {
     style = await promptInitStyle();
+  }
+  let auth = normalizeAuthMode(options.auth);
+  if (!options.auth && !noInteractive) {
+    auth = normalizeAuthMode(await promptInitAuthMode());
   }
 
   // Step 5: Check for existing files

--- a/packages/cli/src/utils/dependency-installer.test.ts
+++ b/packages/cli/src/utils/dependency-installer.test.ts
@@ -73,6 +73,17 @@ describe('dependency installer', () => {
     ]);
   });
 
+  it('includes chdb in manual install guidance when package.json is missing', async () => {
+    vi.mocked(readFile).mockRejectedValue(new Error('File not found'));
+
+    await installScaffoldDependencies('queries', 'chdb');
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('@hypequery/clickhouse, @hypequery/serve, zod, chdb'),
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
   it('pins sibling packages to the same canary version', () => {
     expect(resolveScaffoldPackages('0.0.0-canary-20260506195711')).toEqual([
       '@hypequery/clickhouse@0.0.0-canary-20260506195711',

--- a/packages/cli/src/utils/dependency-installer.ts
+++ b/packages/cli/src/utils/dependency-installer.ts
@@ -158,8 +158,14 @@ export async function installScaffoldDependencies(
     readCliPackageJson(),
   ]);
   if (!pkgJson) {
-    const extra = style === 'datasets' ? ', @hypequery/datasets' : '';
-    logger.warn(`package.json not found. Install @hypequery/clickhouse, @hypequery/serve${extra}, and zod manually.`);
+    const packages = [
+      '@hypequery/clickhouse',
+      '@hypequery/serve',
+      ...(style === 'datasets' ? ['@hypequery/datasets'] : []),
+      'zod',
+      ...(database === 'chdb' ? ['chdb'] : []),
+    ];
+    logger.warn(`package.json not found. Install ${packages.join(', ')} manually.`);
     return;
   }
 

--- a/packages/cli/src/utils/prompts.test.ts
+++ b/packages/cli/src/utils/prompts.test.ts
@@ -2,12 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import prompts from 'prompts';
 import {
   promptClickHouseConnection,
+  promptInitDatabase,
   promptChdbStorage,
   promptOutputDirectory,
   promptInitStyle,
+  promptInitAuthMode,
   promptGenerateExample,
   promptTableSelection,
   promptDatasetTableSelection,
+  confirmWithoutPackageJson,
   confirmOverwrite,
   promptRetry,
   promptContinueWithoutDb,
@@ -31,7 +34,13 @@ describe('prompts', () => {
         password: 'secret',
       };
 
-      vi.mocked(prompts).mockResolvedValue(mockConnection);
+      vi.mocked(prompts)
+        .mockResolvedValueOnce({ host: mockConnection.host })
+        .mockResolvedValueOnce({
+          database: mockConnection.database,
+          username: mockConnection.username,
+          password: mockConnection.password,
+        });
 
       const result = await promptClickHouseConnection();
 
@@ -44,6 +53,7 @@ describe('prompts', () => {
       const result = await promptClickHouseConnection();
 
       expect(result).toBeNull();
+      expect(prompts).toHaveBeenCalledTimes(1);
     });
 
     it('should use environment variables as defaults', async () => {
@@ -56,21 +66,26 @@ describe('prompts', () => {
         CLICKHOUSE_PASSWORD: 'test_pass',
       };
 
-      vi.mocked(prompts).mockResolvedValue({
-        host: 'http://test:8123',
-        database: 'test_db',
-        username: 'test_user',
-        password: 'test_pass',
-      });
+      vi.mocked(prompts)
+        .mockResolvedValueOnce({ host: 'http://test:8123' })
+        .mockResolvedValueOnce({
+          database: 'test_db',
+          username: 'test_user',
+          password: 'test_pass',
+        });
 
       await promptClickHouseConnection();
 
-      expect(prompts).toHaveBeenCalledWith(
+      expect(prompts).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          name: 'host',
+          initial: 'http://test:8123',
+        }),
+      );
+      expect(prompts).toHaveBeenNthCalledWith(
+        2,
         expect.arrayContaining([
-          expect.objectContaining({
-            name: 'host',
-            initial: 'http://test:8123',
-          }),
           expect.objectContaining({
             name: 'database',
             initial: 'test_db',
@@ -98,23 +113,45 @@ describe('prompts', () => {
       delete process.env.CLICKHOUSE_USERNAME;
       delete process.env.CLICKHOUSE_PASSWORD;
 
-      vi.mocked(prompts).mockResolvedValue({
-        host: 'http://localhost:8123',
-        database: 'default',
-        username: 'default',
-        password: '',
-      });
+      vi.mocked(prompts)
+        .mockResolvedValueOnce({ host: 'http://localhost:8123' })
+        .mockResolvedValueOnce({
+          database: 'default',
+          username: 'default',
+          password: '',
+        });
 
       await promptClickHouseConnection();
 
-      expect(prompts).toHaveBeenCalledWith(
+      expect(prompts).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          name: 'host',
+          initial: '',
+        }),
+      );
+      expect(prompts).toHaveBeenNthCalledWith(
+        2,
         expect.arrayContaining([
-          expect.objectContaining({ initial: '' }),
           expect.objectContaining({ initial: '' }),
         ])
       );
 
       process.env = originalEnv;
+    });
+  });
+
+  describe('promptInitDatabase', () => {
+    it('returns the selected database driver', async () => {
+      vi.mocked(prompts).mockResolvedValue({ database: 'chdb' });
+
+      await expect(promptInitDatabase()).resolves.toBe('chdb');
+    });
+
+    it('defaults to ClickHouse when cancelled', async () => {
+      vi.mocked(prompts).mockResolvedValue({});
+
+      await expect(promptInitDatabase()).resolves.toBe('clickhouse');
     });
   });
 
@@ -219,6 +256,34 @@ describe('prompts', () => {
         expect.objectContaining({
           name: 'style',
           initial: 0,
+        }),
+      );
+    });
+  });
+
+  describe('promptInitAuthMode', () => {
+    it('returns context authentication when selected', async () => {
+      vi.mocked(prompts).mockResolvedValue({ auth: 'context' });
+
+      await expect(promptInitAuthMode()).resolves.toBe('context');
+    });
+
+    it('defaults to no auth when cancelled', async () => {
+      vi.mocked(prompts).mockResolvedValue({});
+
+      await expect(promptInitAuthMode()).resolves.toBe('none');
+    });
+  });
+
+  describe('confirmWithoutPackageJson', () => {
+    it('defaults to cancelling when package.json is missing', async () => {
+      vi.mocked(prompts).mockResolvedValue({});
+
+      await expect(confirmWithoutPackageJson('/tmp/project')).resolves.toBe(false);
+      expect(prompts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('/tmp/project'),
+          initial: false,
         }),
       );
     });

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -15,13 +15,20 @@ export async function promptClickHouseConnection(): Promise<{
   username: string;
   password: string;
 } | null> {
-  const response = await prompts([
-    {
-      type: 'text',
-      name: 'host',
-      message: 'ClickHouse URL (or skip to configure later):',
-      initial: process.env.CLICKHOUSE_URL ?? process.env.CLICKHOUSE_HOST ?? '',
-    },
+  const hostResponse = await prompts({
+    type: 'text',
+    name: 'host',
+    message: 'ClickHouse URL (or skip to configure later):',
+    initial: process.env.CLICKHOUSE_URL ?? process.env.CLICKHOUSE_HOST ?? '',
+  });
+
+  // Do not ask for credentials when the user has chosen to configure the
+  // connection later.
+  if (!hostResponse.host) {
+    return null;
+  }
+
+  const credentials = await prompts([
     {
       type: 'text',
       name: 'database',
@@ -42,12 +49,32 @@ export async function promptClickHouseConnection(): Promise<{
     },
   ]);
 
-  // If user cancelled or skipped
-  if (!response.host) {
-    return null;
-  }
+  return {
+    host: hostResponse.host,
+    database: credentials.database ?? '',
+    username: credentials.username ?? '',
+    password: credentials.password ?? '',
+  };
+}
 
-  return response;
+export type InitDatabase = 'clickhouse' | 'chdb';
+
+/**
+ * Choose between a remote ClickHouse server and embedded chDB.
+ */
+export async function promptInitDatabase(): Promise<InitDatabase> {
+  const response = await prompts({
+    type: 'select',
+    name: 'database',
+    message: 'Choose your database',
+    choices: [
+      { title: 'ClickHouse server or Cloud', value: 'clickhouse' },
+      { title: 'chDB (embedded, no server)', value: 'chdb' },
+    ],
+    initial: 0,
+  });
+
+  return response.database ?? 'clickhouse';
 }
 
 /**
@@ -134,6 +161,40 @@ export async function promptInitStyle(): Promise<InitStyle> {
   });
 
   return response.style ?? 'queries';
+}
+
+export type InitAuthMode = 'none' | 'context';
+
+/**
+ * Choose whether generated routes include request-context auth scaffolding.
+ */
+export async function promptInitAuthMode(): Promise<InitAuthMode> {
+  const response = await prompts({
+    type: 'select',
+    name: 'auth',
+    message: 'Choose authentication scaffolding',
+    choices: [
+      { title: 'None (add later)', value: 'none' },
+      { title: 'Request context authentication', value: 'context' },
+    ],
+    initial: 0,
+  });
+
+  return response.auth ?? 'none';
+}
+
+/**
+ * Confirm scaffolding when init is run outside a Node project.
+ */
+export async function confirmWithoutPackageJson(directory: string): Promise<boolean> {
+  const response = await prompts({
+    type: 'confirm',
+    name: 'continue',
+    message: `package.json was not found in ${directory}. Continue scaffolding here?`,
+    initial: false,
+  });
+
+  return response.continue ?? false;
 }
 
 /**

--- a/testing/cli-testing-spec.md
+++ b/testing/cli-testing-spec.md
@@ -7,12 +7,11 @@ flag-by-flag coverage.
 
 - **Package under test:** `@hypequery/cli` (bin: `hypequery`)
 - **Commands:** `init`, `dev [file]`, `generate`, `generate:types`, `generate:datasets`, `help [command]`
-- **Peer packages it scaffolds/uses:** `@hypequery/clickhouse`, `@hypequery/serve`, `@hypequery/datasets`, `zod`
+- **Peer packages it scaffolds/uses:** `@hypequery/clickhouse`, `@hypequery/serve`, `@hypequery/datasets`, `zod`, and optionally `chdb`
 
-> ⚠️ Before running, read **Appendix A — Docs accuracy report**. Several documented
-> flags don't exist, several real flags are undocumented, and a few options are
-> accepted but currently ignored. The expected results below describe **actual CLI
-> behavior**, which in places differs from `reference/api/cli.mdx`.
+> ⚠️ Before running, read **Appendix A — Docs accuracy report**. It records both
+> resolved documentation gaps and remaining follow-ups. The expected results below
+> describe **actual CLI behavior**.
 
 ---
 
@@ -48,7 +47,7 @@ export CLICKHOUSE_PASSWORD=<password>
 ```
 
 ### 0.4 Useful test-only env vars
-- `HYPEQUERY_SKIP_INSTALL=1` — skips the automatic `npm/pnpm/yarn/bun add` step in `init`. Set it to make `init` fast and deterministic when network/registry isn't desired, then install manually. (Undocumented; verify it works — see T1.7.)
+- `HYPEQUERY_SKIP_INSTALL=1` — skips the automatic `npm/pnpm/yarn/bun add` step in `init`. Set it to make `init` fast and deterministic when network/registry isn't desired, then install manually. See T1.9.
 
 ### 0.5 How to invoke the CLI under test
 Pick ONE and note it in the report:
@@ -65,15 +64,16 @@ Throughout this doc, `hq` = whichever invocation you chose.
 Real-world goal: "scaffold an analytics layer in my project."
 
 **Actual options (from source):**
-`--path <dir>`, `--style <queries|datasets>`, `--auth <none|context>`,
+`--path <dir>`, `--style <queries|datasets>`,
+`--database <clickhouse|chdb>`, `--chdb-path <path>`,
+`--auth <none|context>`,
 `--all-tables`, `--tables <names>`, `--exclude-tables <names>`,
 `--no-example`, `--no-interactive`, `--force`, `--skip-connection`.
-(There is **no** `--database` flag on `init`, despite the docs.)
 
 ### T1.1 — Interactive happy path (queries style)
 **Pre:** empty repo with a `package.json` (`npm init -y`), env vars **unset** (force prompts).
 **Run:** `hq init`
-**Walk the prompts:** ClickHouse URL → database → username → password → output dir (`analytics/`) → style (`Query builder routes`) → "Generate an example query?" yes → pick a table `E` from the list.
+**Walk the prompts:** database driver (`ClickHouse server or Cloud`) → ClickHouse URL → database name → username → password → output dir (`analytics/`) → style (`Query builder routes`) → auth scaffold (`None (add later)`) → "Generate an example query?" yes → pick a table `E` from the list.
 **Expect:**
 - Spinner: `Testing connection...` → `Connected successfully (T tables found)` where `T` matches your database (§0.2).
 - Files created at repo root: `.env`, `.gitignore` (created or updated).
@@ -117,6 +117,7 @@ Real-world goal: "scaffold an analytics layer in my project."
 ### T1.7 — Auth scaffold mode
 **Run:** `hq init --no-interactive --auth context --path analytics`
 **Expect:** generated `queries.ts`/`api.ts` import `fromContext` and include host/user auth helper scaffolding. Invalid value `--auth bogus` must throw `Unsupported auth mode "bogus". Use "none" or "context".` (exit 1).
+**Interactive variant:** omit `--auth`, choose `Request context authentication`, and confirm the generated scaffold matches `--auth context`.
 
 ### T1.8 — Existing files / `--force`
 **Pre:** run T1.1 once so `analytics/` exists.
@@ -126,12 +127,26 @@ Real-world goal: "scaffold an analytics layer in my project."
 
 ### T1.9 — Skip install via env
 **Run:** `HYPEQUERY_SKIP_INSTALL=1 hq init --no-interactive --skip-connection --path analytics` in a dir with `package.json`.
-**Expect:** no `npm/pnpm/... add` subprocess runs; no scaffold deps added to `package.json`. (Confirms the documented-nowhere escape hatch.)
+**Expect:** no `npm/pnpm/... add` subprocess runs; no scaffold deps added to `package.json`. (Confirms the documented escape hatch.)
 
 ### T1.10 — No `package.json`
 **Pre:** dir without `package.json`.
-**Run:** `hq init --no-interactive --skip-connection`
-**Expect:** warning `package.json not found. Install @hypequery/clickhouse, @hypequery/serve, and zod manually.`; files still scaffolded; exit 0.
+**Run interactively:** `hq init`
+**Expect:** warning identifying the current directory, followed by `Continue scaffolding here?` defaulting to no. Declining prints `Setup cancelled. Run init from your project directory.` and writes no files. Confirming continues to the database-driver prompt.
+**Run non-interactively:** `hq init --no-interactive --skip-connection`
+**Expect:** no confirmation prompt; warning `package.json not found. Install @hypequery/clickhouse, @hypequery/serve, zod manually.`; files still scaffolded; exit 0.
+
+### T1.11 — Interactive chDB path
+**Pre:** fresh project with `package.json`; platform supported by `chdb`.
+**Run:** `hq init`
+**Walk the prompts:** database driver (`chDB (embedded, no server)`) → storage (`In-memory`, local directory, or custom path) → output dir → style → auth scaffold.
+**Expect:**
+- No ClickHouse URL, database-name, username, or password prompts.
+- No `.env` is created or updated.
+- `chdb` is installed with the scaffold dependencies.
+- `client.ts` imports `Session` and `chdbAdapter` and binds the selected storage path.
+- A project-local persistent path is added to `.gitignore`; an in-memory session is not.
+- For a persistent session containing tables, later generation succeeds with `hq generate --database chdb --chdb-path <same-path>`.
 
 ---
 
@@ -140,7 +155,7 @@ Real-world goal: "scaffold an analytics layer in my project."
 Real-world goal: "my ClickHouse schema changed — refresh my types."
 `generate:types` is an alias that only differs in the header label (`hypequery generate:types`).
 
-**Actual options:** `-o, --output <path>`, `--path <path>`, `--tables <names>`, `--database <type>`.
+**Actual options:** `-o, --output <path>`, `--path <path>`, `--tables <names>`, `--database <clickhouse|chdb>`, `--chdb-path <path>`.
 
 ### T2.1 — Generate into existing project
 **Pre:** project from T1.1 (so `analytics/schema.ts` exists), env vars set.
@@ -157,7 +172,7 @@ Real-world goal: "my ClickHouse schema changed — refresh my types."
 **Run:** `hq generate --output types/ch.ts` → writes `types/ch.ts`; `Updated types/ch.ts`.
 
 ### T2.4 — `--path` derives `<path>/schema.ts`
-**Run:** `hq generate --path src/analytics` → writes `src/analytics/schema.ts`. (This flag is **undocumented** — verify it works.)
+**Run:** `hq generate --path src/analytics` → writes `src/analytics/schema.ts`.
 
 ### T2.5 — `--tables` subset
 **Run:** `hq generate --tables E,E2`
@@ -357,33 +372,40 @@ expected behavior above, and separately confirm/deny each item in Appendix A.
 Source compared: `website-next/docs/reference/api/cli.mdx` and `packages/cli/README.md`
 vs. `packages/cli/src/**`. **Fix the docs and/or the code for each:**
 
-**A.1 `init --database` is documented but does not exist.**
-`cli.mdx` lists `--database <type>` under `hypequery init`. The `init` command defines no such option (only `generate`/`generate:types`/`generate:datasets` accept `--database`). → Remove from init docs.
+**A.1 `init --database` (FIXED).**
+`init` accepts `--database clickhouse|chdb`, and interactive mode exposes the same
+choice before connection details.
 
-**A.2 Real `init` options are undocumented.**
-Missing from docs: `--style <queries|datasets>`, `--auth <none|context>`,
-`--all-tables`, `--tables <names>`, `--exclude-tables <names>`. The entire
-**datasets scaffold flow** is therefore undocumented at the CLI-reference level.
+**A.2 Real `init` options (FIXED).**
+The CLI reference now documents `--style`, `--database`, `--chdb-path`, `--auth`,
+the dataset table-selection flags, and the remaining init controls.
 
-**A.3 Whole commands are undocumented.**
-`generate:types`, `generate:datasets`, and `help [command]` do not appear in the CLI
-reference (the "Commands at a glance" table only shows `init`, `dev`, `generate`).
+**A.3 Whole commands (FIXED).**
+The commands-at-a-glance table now includes `generate:types`, `generate:datasets`,
+and `help [command]`.
 
-**A.4 `dev` options: undocumented + non-functional.**
-- Undocumented but real: `--path <path>`, `--cors`, `--cache <provider>`, `--no-cache`, `--redis-url <url>`.
-- **Non-functional:** `--cache`, `--redis-url`, `--cors` are parsed into `DevOptions` but `devCommand` only forwards `port`/`hostname`/`quiet` to `serveDev`. They currently do nothing. Either wire them through or remove them. (README advertises `--cache`/`--cors` as if functional.)
+**A.4 Remaining `dev` option follow-ups.**
+`--path` is documented and functional. The CLI also parses `--cors`,
+`--cache <provider>`, `--no-cache`, and `--redis-url <url>`, but does not forward
+them to `serveDev`; they remain intentionally undocumented until wired through
+or removed.
 
-**A.5 `generate --path` is undocumented.**
-`generate`/`generate:types` accept `--path <dir>` (derives `<dir>/schema.ts`); docs omit it. Docs' description of the default `--output` ("Defaults to your existing analytics/schema.ts or analytics/schema.ts if not found") is also muddled — actual logic searches `analytics/schema.ts`, `src/analytics/schema.ts`, `schema.ts`, `src/schema.ts`, falling back to `analytics/schema.ts`.
+**A.5 `generate --path` and output discovery (FIXED).**
+The CLI reference documents `--path <dir>` and the actual schema search order
+before the `analytics/schema.ts` fallback.
 
 **A.6 `--version` (FIXED).**
 `cli.ts` previously hardcoded `.version('0.0.1')`. Now reads `version` from `package.json` at runtime, so `--version` reports the real installed version. No action needed; T5.3 verifies it.
 
-**A.7 `dev` default file detection list is incomplete/misordered in docs.**
-Docs say it defaults to `analytics/queries.ts`, `src/analytics/queries.ts`, or nearest `hypequery.ts`. Actual search order: `hypequery.ts`, `analytics/api.ts`, `src/analytics/api.ts`, `api.ts`, `src/api.ts`, `analytics/queries.ts`, `src/analytics/queries.ts`, `queries.ts`, `src/queries.ts` — i.e. `api.ts` variants are checked **before** `queries.ts`.
+**A.7 `dev` default file detection order (FIXED).**
+The CLI reference documents the complete search order, including every `api.ts`
+variant before the `queries.ts` variants.
 
-**A.8 `init` installs `zod` (+ `@hypequery/datasets` for datasets style).**
-`cli.mdx` says it "installs the scaffold dependencies" but doesn't name them; README does mention `zod`. Worth stating explicitly, plus the `HYPEQUERY_SKIP_INSTALL=1` escape hatch (currently undocumented).
+**A.8 Scaffold dependencies (FIXED).**
+The CLI reference names the installed packages, including `zod`,
+`@hypequery/datasets` for dataset scaffolds, and `chdb` for the embedded driver.
+It also documents the `HYPEQUERY_SKIP_INSTALL=1` escape hatch.
 
-**A.9 Accepted entry-export forms.**
-`dev` accepts an `api` **or** `default` export and validates `typeof api.handler === 'function'`. Docs' troubleshooting only shows the `initServe`/`serve` form; the `createAPI` datasets form is equally valid (the error message itself shows both).
+**A.9 Accepted entry-export forms (FIXED).**
+The troubleshooting guide documents named `api` and default exports and shows
+both the `initServe`/`serve` and `createAPI` entry styles.

--- a/website-next/docs/chdb.mdx
+++ b/website-next/docs/chdb.mdx
@@ -53,6 +53,9 @@ npx hypequery init --database chdb
 
 </CodeBlock>
 
+You can also run `npx hypequery init` and choose **chDB (embedded, no server)**
+from the interactive database prompt.
+
 The scaffolded `client.ts` uses the adapter instead of an HTTP connection, `chdb` is installed as a dependency automatically, and the credential prompts are skipped. Choose an on-disk session directory (e.g. `./analytics.chdb`) to persist data between runs, or stay in-memory for a throwaway runtime sandbox. After creating tables in an on-disk session, pass that same directory when refreshing types:
 
 <CodeBlock>

--- a/website-next/docs/reference/api/cli.mdx
+++ b/website-next/docs/reference/api/cli.mdx
@@ -137,6 +137,14 @@ npx @hypequery/cli init --style datasets --all-tables --auth context
 ```
 </CodeBlock>
 
+Interactive mode first asks whether to use a ClickHouse server/Cloud or
+embedded chDB. It then asks for the selected driver's connection or storage
+details, the output directory, API style, and authentication scaffold. If the
+ClickHouse URL is left blank, the remaining credential questions are skipped
+and placeholder configuration is generated. Run the command from the project
+directory containing `package.json`; otherwise the CLI asks for confirmation
+before it writes any files.
+
 ## `hypequery dev [file]`
 
 <CodeBlock>


### PR DESCRIPTION
## Summary

- add an interactive database-driver choice for ClickHouse server/Cloud or embedded chDB
- add an interactive authentication-scaffold choice
- stop asking for ClickHouse database credentials when the URL is skipped
- warn before interactive scaffolding outside a directory containing `package.json`
- include `chdb` in manual dependency guidance and document the completed flow
- refresh the manual CLI testing spec with ClickHouse, chDB, auth, and missing-project scenarios

## Why

chDB support was available only through `--database chdb`, so the default getting-started path silently selected ClickHouse. The interactive path also silently defaulted auth to `none`, continued through credential questions after the URL was skipped, and did not warn until after files were written when run outside a project.

## Impact

A bare `npx @hypequery/cli init` now exposes the supported database and auth choices, adapts its follow-up questions to the selected driver, and prevents accidental scaffolding in the wrong directory. Explicit flags and non-interactive behavior remain unchanged.

## Validation

- `pnpm --filter @hypequery/cli test` — 404 passed, 1 existing skipped
- `pnpm --filter @hypequery/cli build`
- `pnpm --filter @hypequery/cli lint`
- `pnpm smoke:cli`
- `pnpm smoke:cli-chdb`
- manual compiled-CLI walkthroughs for ClickHouse, chDB, skipped URL, auth choice, and missing `package.json`
- `git diff --check`

## Additional checks

The website build compiled the updated MDX successfully, then stopped during page-data collection because production requires `BLOB_READ_WRITE_TOKEN`. Website lint currently reports pre-existing errors in unrelated components; neither issue is introduced by this PR.