### PR TITLE
fix(cli): abort init on Ctrl+C and unblock canary chDB scaffolding

### DIFF
--- a/.changeset/quiet-pugs-shave.md
+++ b/.changeset/quiet-pugs-shave.md
@@ -1,0 +1,9 @@
+---
+"@hypequery/cli": patch
+---
+
+Fix two `hypequery init` defects found while regression-testing the interactive flow.
+
+**Ctrl+C now aborts.** `prompts.override({ onCancel })` was a no-op — `override` maps question *names* to pre-supplied answers, not options — so an aborted prompt was indistinguishable from an unanswered one and each caller's `?? default` answered on the user's behalf. Pressing Ctrl+C at every prompt still scaffolded a full project and printed "Setup complete!". Prompts now receive a real `onCancel` handler that raises `PromptCancelledError`, which the CLI reports as `Cancelled.` and exits `130`.
+
+**chDB scaffolding works on the canary channel.** Canary builds pin siblings to `0.0.0-canary-*`, which cannot satisfy `chdb`'s `peerOptional @hypequery/clickhouse@">=2.1.2"`, so npm aborted the scaffold install with `ERESOLVE` and `hypequery init --database chdb` ended with "chdb is not installed". Canary installs on npm now pass `--legacy-peer-deps`; stable installs and other package managers are unchanged.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,6 +24,7 @@ import {
   logoutCommand,
   type LoginOptions,
 } from './commands/login.js';
+import { isPromptCancelled } from './utils/prompts.js';
 
 const program = new Command();
 
@@ -72,6 +73,12 @@ function runCommand<TArgs extends unknown[]>(
     try {
       await action(...args);
     } catch (error) {
+      // Ctrl+C at a prompt is a deliberate abort, not a failure: report it as
+      // the interrupt it is instead of dumping an error and exiting 1.
+      if (isPromptCancelled(error)) {
+        console.log('\nCancelled.');
+        process.exit(130);
+      }
       console.error(error instanceof Error ? error.message : error);
       process.exit(1);
     }

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -91,6 +91,23 @@ describe('init command - graceful failure handling', () => {
       );
     });
 
+    it('propagates a prompt abort instead of scaffolding with defaults', async () => {
+      // Ctrl+C must reach the CLI entrypoint, which turns it into a clean
+      // "Cancelled." exit. If init swallowed it, the remaining prompts would
+      // fall back to their defaults and write a project the user abandoned.
+      const { PromptCancelledError } = await vi.importActual<typeof prompts>(
+        '../utils/prompts.js',
+      );
+      vi.mocked(prompts.promptInitDatabase).mockRejectedValue(new PromptCancelledError());
+
+      await expect(initCommand({})).rejects.toBeInstanceOf(PromptCancelledError);
+
+      expect(prompts.promptClickHouseConnection).not.toHaveBeenCalled();
+      expect(prompts.promptOutputDirectory).not.toHaveBeenCalled();
+      expect(writeFile).not.toHaveBeenCalled();
+      expect(mkdir).not.toHaveBeenCalled();
+    });
+
     it('continues scaffolding when package.json is missing and the user confirms', async () => {
       vi.mocked(readFile).mockRejectedValueOnce(new Error('File not found'));
       vi.mocked(prompts.confirmWithoutPackageJson).mockResolvedValue(true);

--- a/packages/cli/src/utils/dependency-installer.test.ts
+++ b/packages/cli/src/utils/dependency-installer.test.ts
@@ -222,6 +222,107 @@ describe('dependency installer', () => {
     );
   });
 
+  it('relaxes npm peer resolution for canary installs', async () => {
+    // chdb declares `peerOptional @hypequery/clickhouse@">=2.1.2"`, which a
+    // 0.0.0-canary-* pin can never satisfy; without the flag npm aborts with
+    // ERESOLVE and the scaffold is left without chdb.
+    process.env.npm_config_user_agent = 'npm/10.9.4 node/v22.0.0';
+    vi.mocked(readFile)
+      .mockResolvedValueOnce(JSON.stringify({
+        name: 'fixture-app',
+        dependencies: {},
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        name: '@hypequery/cli',
+        version: '0.0.0-canary-20260506195711',
+      }));
+
+    await installScaffoldDependencies('queries', 'chdb');
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'npm',
+      [
+        'install',
+        '--legacy-peer-deps',
+        '@hypequery/clickhouse@0.0.0-canary-20260506195711',
+        '@hypequery/serve@0.0.0-canary-20260506195711',
+        'zod@^3.23.8',
+        'chdb@^3.2.0',
+      ],
+      expect.objectContaining({ cwd: '/tmp/project', stdio: 'inherit' }),
+    );
+  });
+
+  it('keeps strict npm peer resolution for stable installs', async () => {
+    process.env.npm_config_user_agent = 'npm/10.9.4 node/v22.0.0';
+    vi.mocked(readFile)
+      .mockResolvedValueOnce(JSON.stringify({
+        name: 'fixture-app',
+        dependencies: {},
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        name: '@hypequery/cli',
+        version: '1.12.1',
+      }));
+
+    await installScaffoldDependencies('queries', 'chdb');
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'npm',
+      [
+        'install',
+        '@hypequery/clickhouse',
+        '@hypequery/serve',
+        'zod@^3.23.8',
+        'chdb@^3.2.0',
+      ],
+      expect.any(Object),
+    );
+  });
+
+  it('leaves non-npm managers untouched on canary, since they do not fail on peer conflicts', async () => {
+    vi.mocked(readFile)
+      .mockResolvedValueOnce(JSON.stringify({
+        name: 'fixture-app',
+        packageManager: 'pnpm@10.0.0',
+        dependencies: {},
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        name: '@hypequery/cli',
+        version: '0.0.0-canary-20260506195711',
+      }));
+
+    await installScaffoldDependencies('queries', 'chdb');
+
+    const args = spawnMock.mock.calls[0][1] as string[];
+    expect(args).not.toContain('--legacy-peer-deps');
+    expect(args[0]).toBe('add');
+  });
+
+  it('repeats the peer flag in the manual fallback command so it can be copy-pasted', async () => {
+    process.env.npm_config_user_agent = 'npm/10.9.4 node/v22.0.0';
+    spawnMock.mockImplementation(() => {
+      const child = new EventEmitter();
+      queueMicrotask(() => child.emit('close', 1));
+      return child;
+    });
+    vi.mocked(readFile)
+      .mockResolvedValueOnce(JSON.stringify({
+        name: 'fixture-app',
+        dependencies: {},
+      }))
+      .mockResolvedValueOnce(JSON.stringify({
+        name: '@hypequery/cli',
+        version: '0.0.0-canary-20260506195711',
+      }));
+
+    await installScaffoldDependencies('queries', 'chdb');
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('npm install --legacy-peer-deps @hypequery/clickhouse@'),
+    );
+  });
+
   it('upgrades incompatible zod versions to the scaffold-compatible range', async () => {
     vi.mocked(readFile)
       .mockResolvedValueOnce(JSON.stringify({

--- a/packages/cli/src/utils/dependency-installer.ts
+++ b/packages/cli/src/utils/dependency-installer.ts
@@ -82,22 +82,43 @@ function detectPackageManager(pkgJson: PackageJson | null): PackageManager {
   return 'npm';
 }
 
-function getInstallArgs(manager: PackageManager, packages: string[]) {
+export function isCanaryVersion(version: string | undefined): boolean {
+  return version?.includes('canary') === true;
+}
+
+/**
+ * Canary builds pin every hypequery package to a `0.0.0-canary-*` version, which
+ * sorts below every published semver range. Any third-party peer range on a
+ * hypequery package is therefore unsatisfiable — `chdb` declares
+ * `peerOptional @hypequery/clickhouse@">=2.1.2"` — and npm aborts the whole
+ * install with ERESOLVE, leaving the scaffold without its dependencies.
+ *
+ * Only npm needs this: pnpm (strict-peer-dependencies defaults to false), yarn
+ * and bun all install through peer conflicts rather than failing. Stable
+ * installs keep strict peer checking on every manager.
+ */
+function getPeerRelaxFlags(manager: PackageManager, canary: boolean): string[] {
+  return canary && manager === 'npm' ? ['--legacy-peer-deps'] : [];
+}
+
+function getInstallArgs(manager: PackageManager, packages: string[], canary = false) {
+  const relaxFlags = getPeerRelaxFlags(manager, canary);
+
   switch (manager) {
     case 'pnpm':
-      return ['add', ...packages];
+      return ['add', ...relaxFlags, ...packages];
     case 'yarn':
-      return ['add', ...packages];
+      return ['add', ...relaxFlags, ...packages];
     case 'bun':
-      return ['add', ...packages];
+      return ['add', ...relaxFlags, ...packages];
     case 'npm':
     default:
-      return ['install', ...packages];
+      return ['install', ...relaxFlags, ...packages];
   }
 }
 
-function formatManualCommand(manager: PackageManager, packages: string[]) {
-  return `${MANUAL_COMMANDS[manager]} ${packages.join(' ')}`;
+function formatManualCommand(manager: PackageManager, packages: string[], canary = false) {
+  return [MANUAL_COMMANDS[manager], ...getPeerRelaxFlags(manager, canary), ...packages].join(' ');
 }
 
 export function resolveScaffoldPackages(
@@ -108,7 +129,7 @@ export function resolveScaffoldPackages(
   const includeDatasets = style === 'datasets';
   const includeChdb = database === 'chdb';
 
-  if (cliVersion?.includes('canary')) {
+  if (isCanaryVersion(cliVersion)) {
     return [
       `@hypequery/clickhouse@${cliVersion}`,
       `@hypequery/serve@${cliVersion}`,
@@ -175,9 +196,10 @@ export async function installScaffoldDependencies(
     return;
   }
 
+  const canary = isCanaryVersion(cliPkgJson?.version);
   const manager = detectPackageManager(pkgJson);
   const command = manager === 'npm' ? 'npm' : manager;
-  const args = getInstallArgs(manager, missing);
+  const args = getInstallArgs(manager, missing, canary);
 
   logger.info(`Installing ${missing.join(', ')} with ${manager}...`);
   try {
@@ -198,7 +220,7 @@ export async function installScaffoldDependencies(
     logger.success(`Installed ${missing.join(', ')}`);
   } catch (error) {
     logger.warn('Failed to install hypequery packages automatically.');
-    logger.info(`Run manually: ${formatManualCommand(manager, missing)}`);
+    logger.info(`Run manually: ${formatManualCommand(manager, missing, canary)}`);
     if (error instanceof Error && error.message) {
       logger.info(error.message);
     }

--- a/packages/cli/src/utils/prompts.test.ts
+++ b/packages/cli/src/utils/prompts.test.ts
@@ -14,15 +14,86 @@ import {
   confirmOverwrite,
   promptRetry,
   promptContinueWithoutDb,
+  PromptCancelledError,
+  isPromptCancelled,
 } from './prompts.js';
 import { logger } from './logger.js';
 
 vi.mock('prompts');
 vi.mock('./logger.js');
 
+type PromptOptions = { onCancel?: () => void };
+
+/**
+ * Make the mocked `prompts` behave like a genuinely aborted prompt: invoke the
+ * `onCancel` callback it was handed, then resolve without the answer key.
+ */
+function mockUserCancels() {
+  vi.mocked(prompts).mockImplementation((async (_questions: unknown, options?: PromptOptions) => {
+    options?.onCancel?.();
+    return {};
+  }) as unknown as typeof prompts);
+}
+
 describe('prompts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('cancellation', () => {
+    // Ctrl+C has to abort the command. Before this was wired up, an aborted
+    // prompt was indistinguishable from an unanswered one, so every caller's
+    // `?? default` answered on the user's behalf and init scaffolded a project
+    // the user was trying to bail out of.
+    const cases: Array<[string, () => Promise<unknown>]> = [
+      ['promptClickHouseConnection', () => promptClickHouseConnection()],
+      ['promptInitDatabase', () => promptInitDatabase()],
+      ['promptChdbStorage', () => promptChdbStorage()],
+      ['promptOutputDirectory', () => promptOutputDirectory()],
+      ['promptInitStyle', () => promptInitStyle()],
+      ['promptInitAuthMode', () => promptInitAuthMode()],
+      ['confirmWithoutPackageJson', () => confirmWithoutPackageJson('/tmp/project')],
+      ['promptGenerateExample', () => promptGenerateExample()],
+      ['promptTableSelection', () => promptTableSelection(['users'])],
+      ['promptDatasetTableSelection', () => promptDatasetTableSelection(['users'])],
+      ['confirmOverwrite', () => confirmOverwrite(['file.ts'])],
+      ['promptRetry', () => promptRetry('Retry?')],
+      ['promptContinueWithoutDb', () => promptContinueWithoutDb()],
+    ];
+
+    it.each(cases)('%s rejects when the user aborts', async (_name, run) => {
+      mockUserCancels();
+
+      await expect(run()).rejects.toBeInstanceOf(PromptCancelledError);
+    });
+
+    it('aborts when credentials are cancelled after the URL was answered', async () => {
+      vi.mocked(prompts)
+        .mockImplementationOnce((async () => ({ host: 'http://localhost:8123' })) as unknown as typeof prompts)
+        .mockImplementationOnce((async (_questions: unknown, options?: PromptOptions) => {
+          options?.onCancel?.();
+          return {};
+        }) as unknown as typeof prompts);
+
+      await expect(promptClickHouseConnection()).rejects.toBeInstanceOf(PromptCancelledError);
+    });
+
+    it('identifies cancellation errors and ignores unrelated ones', () => {
+      expect(isPromptCancelled(new PromptCancelledError())).toBe(true);
+      expect(isPromptCancelled(new Error('connection refused'))).toBe(false);
+      expect(isPromptCancelled(undefined)).toBe(false);
+    });
+
+    it('hands prompts an onCancel handler', async () => {
+      vi.mocked(prompts).mockResolvedValue({ style: 'queries' });
+
+      await promptInitStyle();
+
+      expect(prompts).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ onCancel: expect.any(Function) }),
+      );
+    });
   });
 
   describe('promptClickHouseConnection', () => {
@@ -82,6 +153,7 @@ describe('prompts', () => {
           name: 'host',
           initial: 'http://test:8123',
         }),
+        expect.anything(),
       );
       expect(prompts).toHaveBeenNthCalledWith(
         2,
@@ -98,7 +170,8 @@ describe('prompts', () => {
             name: 'password',
             initial: 'test_pass',
           }),
-        ])
+        ]),
+        expect.anything(),
       );
 
       process.env = originalEnv;
@@ -129,12 +202,14 @@ describe('prompts', () => {
           name: 'host',
           initial: '',
         }),
+        expect.anything(),
       );
       expect(prompts).toHaveBeenNthCalledWith(
         2,
         expect.arrayContaining([
           expect.objectContaining({ initial: '' }),
-        ])
+        ]),
+        expect.anything(),
       );
 
       process.env = originalEnv;
@@ -148,7 +223,7 @@ describe('prompts', () => {
       await expect(promptInitDatabase()).resolves.toBe('chdb');
     });
 
-    it('defaults to ClickHouse when cancelled', async () => {
+    it('defaults to ClickHouse when the prompt yields no answer', async () => {
       vi.mocked(prompts).mockResolvedValue({});
 
       await expect(promptInitDatabase()).resolves.toBe('clickhouse');
@@ -156,7 +231,7 @@ describe('prompts', () => {
   });
 
   describe('promptChdbStorage', () => {
-    it('defaults to an in-memory session when the prompt is cancelled', async () => {
+    it('defaults to an in-memory session when the prompt yields no answer', async () => {
       vi.mocked(prompts).mockResolvedValue({});
 
       await expect(promptChdbStorage()).resolves.toBeUndefined();
@@ -168,7 +243,7 @@ describe('prompts', () => {
       await expect(promptChdbStorage()).resolves.toBe('./analytics.chdb');
     });
 
-    it('returns a custom path and falls back when the path prompt is cancelled', async () => {
+    it('returns a custom path and falls back when the path prompt yields no answer', async () => {
       vi.mocked(prompts)
         .mockResolvedValueOnce({ storage: 'custom' })
         .mockResolvedValueOnce({ path: './data/my.chdb' });
@@ -221,7 +296,7 @@ describe('prompts', () => {
       expect(result).toBe('analytics');
     });
 
-    it('should return default if user cancels', async () => {
+    it('should return default when the prompt yields no answer', async () => {
       vi.mocked(prompts).mockResolvedValue({});
 
       const result = await promptOutputDirectory();
@@ -239,7 +314,7 @@ describe('prompts', () => {
       expect(result).toBe('datasets');
     });
 
-    it('should default to query style when user cancels', async () => {
+    it('should default to query style when the prompt yields no answer', async () => {
       vi.mocked(prompts).mockResolvedValue({});
 
       const result = await promptInitStyle();
@@ -257,6 +332,7 @@ describe('prompts', () => {
           name: 'style',
           initial: 0,
         }),
+        expect.anything(),
       );
     });
   });
@@ -268,7 +344,7 @@ describe('prompts', () => {
       await expect(promptInitAuthMode()).resolves.toBe('context');
     });
 
-    it('defaults to no auth when cancelled', async () => {
+    it('defaults to no auth when the prompt yields no answer', async () => {
       vi.mocked(prompts).mockResolvedValue({});
 
       await expect(promptInitAuthMode()).resolves.toBe('none');
@@ -276,7 +352,7 @@ describe('prompts', () => {
   });
 
   describe('confirmWithoutPackageJson', () => {
-    it('defaults to cancelling when package.json is missing', async () => {
+    it('defaults to declining when the prompt yields no answer', async () => {
       vi.mocked(prompts).mockResolvedValue({});
 
       await expect(confirmWithoutPackageJson('/tmp/project')).resolves.toBe(false);
@@ -285,6 +361,7 @@ describe('prompts', () => {
           message: expect.stringContaining('/tmp/project'),
           initial: false,
         }),
+        expect.anything(),
       );
     });
   });
@@ -306,7 +383,7 @@ describe('prompts', () => {
       expect(result).toBe(false);
     });
 
-    it('should return false when user cancels', async () => {
+    it('should return false when the prompt yields no answer', async () => {
       vi.mocked(prompts).mockResolvedValue({});
 
       const result = await promptGenerateExample();
@@ -322,7 +399,8 @@ describe('prompts', () => {
       expect(prompts).toHaveBeenCalledWith(
         expect.objectContaining({
           initial: true,
-        })
+        }),
+        expect.anything(),
       );
     });
   });
@@ -366,7 +444,8 @@ describe('prompts', () => {
             expect.objectContaining({ value: 'table_9' }),
             expect.objectContaining({ title: 'Skip example', value: null }),
           ]),
-        })
+        }),
+        expect.anything(),
       );
 
       const call = vi.mocked(prompts).mock.calls[0][0] as any;
@@ -385,7 +464,8 @@ describe('prompts', () => {
           choices: expect.arrayContaining([
             expect.objectContaining({ title: 'Skip example', value: null }),
           ]),
-        })
+        }),
+        expect.anything(),
       );
     });
   });
@@ -421,10 +501,11 @@ describe('prompts', () => {
             }),
           ]),
         }),
+        expect.anything(),
       );
     });
 
-    it('should default to no tables when user cancels', async () => {
+    it('should default to no tables when the prompt yields no answer', async () => {
       vi.mocked(prompts).mockResolvedValue({});
 
       const result = await promptDatasetTableSelection(['orders']);
@@ -469,17 +550,20 @@ describe('prompts', () => {
       expect(prompts).toHaveBeenCalledWith(
         expect.objectContaining({
           message: expect.stringContaining('• file1.ts'),
-        })
+        }),
+        expect.anything(),
       );
       expect(prompts).toHaveBeenCalledWith(
         expect.objectContaining({
           message: expect.stringContaining('• file2.ts'),
-        })
+        }),
+        expect.anything(),
       );
       expect(prompts).toHaveBeenCalledWith(
         expect.objectContaining({
           message: expect.stringContaining('• file3.ts'),
-        })
+        }),
+        expect.anything(),
       );
     });
 
@@ -491,11 +575,12 @@ describe('prompts', () => {
       expect(prompts).toHaveBeenCalledWith(
         expect.objectContaining({
           initial: false,
-        })
+        }),
+        expect.anything(),
       );
     });
 
-    it('should return false when user cancels', async () => {
+    it('should return false when the prompt yields no answer', async () => {
       vi.mocked(prompts).mockResolvedValue({});
 
       const result = await confirmOverwrite(['file.ts']);
@@ -529,7 +614,8 @@ describe('prompts', () => {
       expect(prompts).toHaveBeenCalledWith(
         expect.objectContaining({
           message: 'Custom retry message?',
-        })
+        }),
+        expect.anything(),
       );
     });
 
@@ -541,11 +627,12 @@ describe('prompts', () => {
       expect(prompts).toHaveBeenCalledWith(
         expect.objectContaining({
           initial: true,
-        })
+        }),
+        expect.anything(),
       );
     });
 
-    it('should return false when user cancels', async () => {
+    it('should return false when the prompt yields no answer', async () => {
       vi.mocked(prompts).mockResolvedValue({});
 
       const result = await promptRetry('Retry?');
@@ -579,11 +666,12 @@ describe('prompts', () => {
       expect(prompts).toHaveBeenCalledWith(
         expect.objectContaining({
           initial: true,
-        })
+        }),
+        expect.anything(),
       );
     });
 
-    it('should return false when user cancels', async () => {
+    it('should return false when the prompt yields no answer', async () => {
       vi.mocked(prompts).mockResolvedValue({});
 
       const result = await promptContinueWithoutDb();

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -1,10 +1,47 @@
 import prompts from 'prompts';
 import { logger } from './logger.js';
 
-const noop = () => undefined;
+/**
+ * Raised when the user aborts a prompt with Ctrl+C or Esc.
+ */
+export class PromptCancelledError extends Error {
+  constructor() {
+    super('Prompt cancelled');
+    this.name = 'PromptCancelledError';
+  }
+}
 
-// Configure prompts to not exit on cancel
-prompts.override({ onCancel: noop });
+export function isPromptCancelled(error: unknown): error is PromptCancelledError {
+  return error instanceof PromptCancelledError;
+}
+
+/**
+ * Ask a question and turn an aborted prompt into a thrown PromptCancelledError.
+ *
+ * `prompts` only reports cancellation through the `onCancel` callback passed as
+ * its second argument — the resolved answers simply omit the cancelled key. So
+ * without this wrapper Ctrl+C is indistinguishable from an unanswered question,
+ * and each caller's `?? default` silently answers on the user's behalf.
+ */
+async function ask<T extends string = string>(
+  questions: prompts.PromptObject<T> | Array<prompts.PromptObject<T>>,
+): Promise<prompts.Answers<T>> {
+  let cancelled = false;
+
+  const answers = await prompts(questions, {
+    onCancel: () => {
+      cancelled = true;
+      // Returning false stops any remaining questions in the same chain.
+      return false;
+    },
+  });
+
+  if (cancelled) {
+    throw new PromptCancelledError();
+  }
+
+  return answers;
+}
 
 /**
  * Prompt for ClickHouse connection details
@@ -15,7 +52,7 @@ export async function promptClickHouseConnection(): Promise<{
   username: string;
   password: string;
 } | null> {
-  const hostResponse = await prompts({
+  const hostResponse = await ask({
     type: 'text',
     name: 'host',
     message: 'ClickHouse URL (or skip to configure later):',
@@ -28,7 +65,7 @@ export async function promptClickHouseConnection(): Promise<{
     return null;
   }
 
-  const credentials = await prompts([
+  const credentials = await ask([
     {
       type: 'text',
       name: 'database',
@@ -63,7 +100,7 @@ export type InitDatabase = 'clickhouse' | 'chdb';
  * Choose between a remote ClickHouse server and embedded chDB.
  */
 export async function promptInitDatabase(): Promise<InitDatabase> {
-  const response = await prompts({
+  const response = await ask({
     type: 'select',
     name: 'database',
     message: 'Choose your database',
@@ -83,7 +120,7 @@ export async function promptInitDatabase(): Promise<InitDatabase> {
  * or undefined for in-memory.
  */
 export async function promptChdbStorage(): Promise<string | undefined> {
-  const response = await prompts({
+  const response = await ask({
     type: 'select',
     name: 'storage',
     message: 'Where should embedded chDB store data?',
@@ -100,7 +137,7 @@ export async function promptChdbStorage(): Promise<string | undefined> {
   }
 
   if (response.storage === 'custom') {
-    const customResponse = await prompts({
+    const customResponse = await ask({
       type: 'text',
       name: 'path',
       message: 'Enter chDB data directory:',
@@ -116,7 +153,7 @@ export async function promptChdbStorage(): Promise<string | undefined> {
  * Prompt for output directory
  */
 export async function promptOutputDirectory(): Promise<string> {
-  const response = await prompts({
+  const response = await ask({
     type: 'select',
     name: 'directory',
     message: 'Where should we create your analytics files?',
@@ -133,7 +170,7 @@ export async function promptOutputDirectory(): Promise<string> {
   }
 
   if (response.directory === 'custom') {
-    const customResponse = await prompts({
+    const customResponse = await ask({
       type: 'text',
       name: 'path',
       message: 'Enter custom path:',
@@ -149,7 +186,7 @@ export async function promptOutputDirectory(): Promise<string> {
 export type InitStyle = 'queries' | 'datasets';
 
 export async function promptInitStyle(): Promise<InitStyle> {
-  const response = await prompts({
+  const response = await ask({
     type: 'select',
     name: 'style',
     message: 'Choose your dev API style',
@@ -169,7 +206,7 @@ export type InitAuthMode = 'none' | 'context';
  * Choose whether generated routes include request-context auth scaffolding.
  */
 export async function promptInitAuthMode(): Promise<InitAuthMode> {
-  const response = await prompts({
+  const response = await ask({
     type: 'select',
     name: 'auth',
     message: 'Choose authentication scaffolding',
@@ -187,7 +224,7 @@ export async function promptInitAuthMode(): Promise<InitAuthMode> {
  * Confirm scaffolding when init is run outside a Node project.
  */
 export async function confirmWithoutPackageJson(directory: string): Promise<boolean> {
-  const response = await prompts({
+  const response = await ask({
     type: 'confirm',
     name: 'continue',
     message: `package.json was not found in ${directory}. Continue scaffolding here?`,
@@ -201,7 +238,7 @@ export async function confirmWithoutPackageJson(directory: string): Promise<bool
  * Prompt for example query generation
  */
 export async function promptGenerateExample(): Promise<boolean> {
-  const response = await prompts({
+  const response = await ask({
     type: 'confirm',
     name: 'generate',
     message: 'Generate an example query?',
@@ -231,7 +268,7 @@ export async function promptTableSelection(tables: string[]): Promise<string | n
     { title: 'Skip example', value: null },
   ];
 
-  const response = await prompts({
+  const response = await ask({
     type: 'select',
     name: 'table',
     message: 'Which table should we use for the example?',
@@ -261,7 +298,7 @@ export async function promptDatasetTableSelection(
   }
 
   const defaults = new Set(defaultTables);
-  const response = await prompts({
+  const response = await ask({
     type: 'multiselect',
     name: 'tables',
     message: 'Which tables should we scaffold as datasets?',
@@ -281,7 +318,7 @@ export async function promptDatasetTableSelection(
  * Confirm overwrite of existing files
  */
 export async function confirmOverwrite(files: string[]): Promise<boolean> {
-  const response = await prompts({
+  const response = await ask({
     type: 'confirm',
     name: 'overwrite',
     message: `The following files will be overwritten:\n${files.map(f => `  • ${f}`).join('\n')}\n\nContinue?`,
@@ -295,7 +332,7 @@ export async function confirmOverwrite(files: string[]): Promise<boolean> {
  * Retry prompt for failed operations
  */
 export async function promptRetry(message: string): Promise<boolean> {
-  const response = await prompts({
+  const response = await ask({
     type: 'confirm',
     name: 'retry',
     message,
@@ -309,7 +346,7 @@ export async function promptRetry(message: string): Promise<boolean> {
  * Ask if user wants to continue without DB connection
  */
 export async function promptContinueWithoutDb(): Promise<boolean> {
-  const response = await prompts({
+  const response = await ask({
     type: 'confirm',
     name: 'continue',
     message: 'Continue setup without database connection?',


### PR DESCRIPTION
## Summary

Two defects found while regression-testing every `hypequery init` path against the canary channel (`0.0.0-canary-20260730071004`). Neither was introduced by #369 or #370 — both are pre-existing — but the first blocks the chDB path on canary entirely and the second was extended by #369's two new prompts.

### 1. Ctrl+C did not abort init

[`prompts.ts`](packages/cli/src/utils/prompts.ts) called `prompts.override({ onCancel: noop })`, which is a no-op: `prompts.override` maps question **names** to pre-supplied answers, not options. No cancel handler was ever registered, so an aborted prompt was indistinguishable from an unanswered one and every caller's `?? default` answered on the user's behalf.

Pressing Ctrl+C at *every* prompt still scaffolded a complete project and printed "Setup complete!" with exit 0:

```
? Choose your database › ...
✖ Choose your database › ClickHouse server or Cloud     <- Ctrl+C
✓  Created .env (configure your credentials)
✓  Created placeholder schema (analytics/schema.ts)
...
Setup complete!
```

Prompts now route through an `ask()` wrapper that passes a real `onCancel` and raises `PromptCancelledError`. `runCommand` treats it as the deliberate interrupt it is — prints `Cancelled.` and exits `130` — rather than dumping an error and exiting 1.

### 2. chDB scaffolding was broken on the canary channel

Canary builds pin siblings to `0.0.0-canary-*`, which can never satisfy chdb's `peerOptional @hypequery/clickhouse@">=2.1.2"`. npm aborted the whole scaffold install with `ERESOLVE`, so `chdb` never landed and init ended at "chdb is not installed" — the embedded path was unusable on canary.

Canary installs on npm now pass `--legacy-peer-deps`, and the manual fallback command repeats the flag so it stays copy-pasteable. Stable installs keep strict peer resolution, and pnpm/yarn/bun are untouched — npm is the only manager that hard-fails on peer conflicts (pnpm's `strict-peer-dependencies` already defaults to `false`).

## Test plan

- `vitest run` — 516 tests; the two failures (`load-api`, `dataset-generator` timeout) reproduce on `main` with these changes stashed and are unrelated
- `pnpm --filter @hypequery/cli lint` and `build` clean
- 22 new/updated unit tests: every prompt helper rejects on abort, `isPromptCancelled` discriminates, init propagates the abort without writing files, and the installer's canary/stable/non-npm/manual-fallback arg shapes
- Renamed 9 existing test titles that said "when cancelled" but actually cover the empty-answer fallback

Verified end-to-end by driving the real compiled CLI through a PTY, with this build overlaid on a genuine canary install tree:

- **chDB on canary** — `Installed @hypequery/clickhouse@0.0.0-canary-…, @hypequery/serve@…, zod@^3.23.8, chdb@^3.2.0` then `Embedded chDB ready (0 tables in ./analytics.chdb)`. Previously: `Failed to install` → `chdb is not installed`
- **Ctrl+C at the first prompt** — `Cancelled.`, exit 130, zero files written
- **Ctrl+C at a late prompt** (after URL/output-dir/style) — same, zero files written
- **Normal flow unchanged** — full prompt chain completes, files written, and the #369 credential-skip behaviour still holds (no Database/Username/Password prompts when the URL is skipped)

The live-ClickHouse happy path was re-verified earlier in the regression against published canary; Docker was stopped before the final re-run, so that last check used the no-connection path instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)