### PR TITLE
Add deployment source snapshots

### DIFF
--- a/.changeset/curvy-bundles-remember.md
+++ b/.changeset/curvy-bundles-remember.md
@@ -1,0 +1,7 @@
+---
+"@hypequery/protocol": minor
+"@hypequery/deployment": minor
+"@hypequery/cli": minor
+---
+
+Capture, verify, upload, and receive multi-file project source snapshots with deployment bundles, including the API entrypoint and optional Git revision provenance.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -174,6 +174,7 @@ program
   .option('--runtime-output <path>', 'Bundled Node runtime path (default: beside deployment JSON)')
   .option('--entrypoint-prefix <prefix>', 'Runtime entrypoint prefix (default: queries)')
   .option('--hash-output <path>', 'Deployment identity sidecar path (default: <output>.sha256)')
+  .option('--no-source', 'Exclude project source files from the deployment bundle')
   .action(runCommand(async (api: string, options: BuildDeploymentOptions) => {
     await buildDeploymentCommand(api, options);
   }));
@@ -215,6 +216,7 @@ program
   .option('--project <project>', 'Target project identifier (advanced override)')
   .option('--environment <environment>', 'Target environment identifier (advanced override)')
   .option('--release <path>', 'Submit a prebuilt bundle with this release (legacy)')
+  .option('--no-source', 'Exclude project source files from the deployment bundle')
   .option(
     '--endpoint <url>',
     'HTTPS submission endpoint; requires HYPEQUERY_API_TOKEN',

--- a/packages/cli/src/commands/deploy.test.ts
+++ b/packages/cli/src/commands/deploy.test.ts
@@ -127,6 +127,7 @@ describe('deploy command', () => {
 
     expect(buildDeployment).toHaveBeenCalledWith('analytics/api.ts', {
       bundleOutput: 'analytics/hypequery-deployment',
+      source: undefined,
     });
     expect(prepareDeploymentRelease).toHaveBeenCalledWith(
       'analytics/hypequery-deployment',
@@ -183,6 +184,7 @@ describe('deploy command', () => {
 
     expect(buildDeployment).toHaveBeenCalledWith('src/api.ts', {
       bundleOutput: 'dist/cloud-bundle',
+      source: undefined,
     });
     expect(prepareDeploymentRelease).toHaveBeenCalledWith(
       'dist/cloud-bundle',

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -37,6 +37,7 @@ export interface DeployOptions extends SubmitDeploymentOptions {
   environment?: string;
   bundleOutput?: string;
   releaseOutput?: string;
+  source?: boolean;
 }
 
 export interface SubmitDeploymentDependencies {
@@ -309,7 +310,7 @@ export async function deployCommand(
   await resolveDeploymentCredential(options.endpoint, dependencies);
 
   try {
-    await build(sourcePath, { bundleOutput: bundlePath });
+    await build(sourcePath, { bundleOutput: bundlePath, source: options.source });
   } catch (error) {
     throw withRuntimeFlagHint(error);
   }

--- a/packages/cli/src/commands/deployment.test.ts
+++ b/packages/cli/src/commands/deployment.test.ts
@@ -12,6 +12,7 @@ const mockGetDeploymentRuntimeEntrypoints = vi.hoisted(() => vi.fn());
 const mockWriteDeploymentBundle = vi.hoisted(() => vi.fn());
 const mockVerifyDeploymentBundle = vi.hoisted(() => vi.fn());
 const mockReadDeploymentRuntimeFile = vi.hoisted(() => vi.fn());
+const mockCaptureDeploymentSourceSnapshot = vi.hoisted(() => vi.fn());
 
 vi.mock('../utils/load-api.js', () => ({
   loadApiModule: mockLoadApiModule,
@@ -26,6 +27,10 @@ vi.mock('../utils/deployment-bundle.js', () => ({
   writeDeploymentBundle: mockWriteDeploymentBundle,
   verifyDeploymentBundle: mockVerifyDeploymentBundle,
   readDeploymentRuntimeFile: mockReadDeploymentRuntimeFile,
+}));
+
+vi.mock('../utils/deployment-source-snapshot.js', () => ({
+  captureDeploymentSourceSnapshot: mockCaptureDeploymentSourceSnapshot,
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -64,11 +69,19 @@ const contract = {
   queries: [],
   artifacts: [],
 };
+const sourceSnapshot = {
+  entrypoint: 'analytics/api.ts',
+  files: [{
+    path: 'analytics/api.ts',
+    bytes: new TextEncoder().encode('export const api = {};\n'),
+  }],
+};
 
 describe('deployment commands', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetDeploymentRuntimeEntrypoints.mockReturnValue([]);
+    mockCaptureDeploymentSourceSnapshot.mockResolvedValue(sourceSnapshot);
     vi.mocked(stat).mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }));
     vi.mocked(lstat).mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }));
     vi.mocked(realpath).mockImplementation(async value => path.resolve(String(value)));
@@ -167,6 +180,7 @@ describe('deployment commands', () => {
       'analytics/hypequery-deployment',
       expect.objectContaining({ contract }),
       [],
+      sourceSnapshot,
     );
     expect(writeFile).not.toHaveBeenCalled();
   });
@@ -192,6 +206,7 @@ describe('deployment commands', () => {
       'dist/bundle',
       expect.objectContaining({ contract: runtimeContract }),
       [{ runtime: 'node', sha256: ARTIFACT_SHA, bytes }],
+      sourceSnapshot,
     );
   });
 
@@ -225,6 +240,21 @@ describe('deployment commands', () => {
       'analytics/hypequery-deployment',
       expect.objectContaining({ contract: runtimeContract }),
       [{ runtime: 'python', sha256: digest, bytes }],
+      sourceSnapshot,
+    );
+  });
+
+  it('can explicitly omit project source from a bundle', async () => {
+    mockLoadApiModule.mockResolvedValue({ deploymentContract: vi.fn(() => contract) });
+
+    await buildDeploymentCommand('analytics/api.ts', { source: false });
+
+    expect(mockCaptureDeploymentSourceSnapshot).not.toHaveBeenCalled();
+    expect(mockWriteDeploymentBundle).toHaveBeenCalledWith(
+      'analytics/hypequery-deployment',
+      expect.objectContaining({ contract }),
+      [],
+      undefined,
     );
   });
 

--- a/packages/cli/src/commands/deployment.ts
+++ b/packages/cli/src/commands/deployment.ts
@@ -18,6 +18,7 @@ import {
   getDeploymentRuntimeEntrypoints,
   type NodeRuntimeArtifact,
 } from '../utils/deployment-runtime-artifact.js';
+import { captureDeploymentSourceSnapshot } from '../utils/deployment-source-snapshot.js';
 import { loadApiModule } from '../utils/load-api.js';
 import { logger } from '../utils/logger.js';
 import {
@@ -36,6 +37,7 @@ export interface BuildDeploymentOptions {
   runtimeOutput?: string;
   entrypointPrefix?: string;
   hashOutput?: string;
+  source?: boolean;
 }
 
 export interface PrepareDeploymentReleaseOptions {
@@ -204,8 +206,22 @@ export async function buildDeploymentCommand(
       }
       runtimeFiles.push({ runtime, sha256: actualSha256, bytes });
     }
-    const bundle = await writeDeploymentBundle(bundleOutput, prepared, runtimeFiles);
+    const sourceSnapshot = options.source === false
+      ? undefined
+      : await captureDeploymentSourceSnapshot(apiPath);
+    const bundle = await writeDeploymentBundle(
+      bundleOutput,
+      prepared,
+      runtimeFiles,
+      sourceSnapshot,
+    );
     logger.success(`Deployment bundle written to ${bundle.directory}`);
+    if (bundle.manifest.source) {
+      logger.info(
+        `Captured ${bundle.manifest.source.files.length} source `
+        + `${bundle.manifest.source.files.length === 1 ? 'file' : 'files'}`,
+      );
+    }
     logger.info(`Bundle identity: ${bundle.identity}`);
     logger.info(`Deployment identity: ${digest}`);
     return validated;

--- a/packages/cli/src/utils/deployment-bundle.test.ts
+++ b/packages/cli/src/utils/deployment-bundle.test.ts
@@ -114,6 +114,41 @@ describe('deployment bundle filesystem', () => {
     expect(verified.contract.artifacts[0]?.artifactSha256).toBe(digest);
   });
 
+  it('writes and verifies a multi-file source snapshot', async () => {
+    const parent = await temporaryDirectory();
+    const output = path.join(parent, 'bundle');
+    const prepared = prepareProtocolDeploymentContract(deployment());
+    const apiBytes = new TextEncoder().encode('export { Orders } from "./orders.js";\n');
+    const datasetBytes = new TextEncoder().encode('export const Orders = {};\n');
+
+    const written = await writeDeploymentBundle(output, prepared, [], {
+      entrypoint: 'analytics/api.ts',
+      files: [
+        { path: 'analytics/api.ts', bytes: apiBytes },
+        { path: 'analytics/orders.ts', bytes: datasetBytes },
+      ],
+      revision: {
+        kind: 'git',
+        commit: 'a'.repeat(40),
+        dirty: false,
+      },
+    });
+    const verified = await verifyDeploymentBundle(output);
+
+    expect(written.manifest.source?.entrypoint).toBe('analytics/api.ts');
+    expect(written.manifest.source?.revision).toEqual({
+      kind: 'git',
+      commit: 'a'.repeat(40),
+      dirty: false,
+    });
+    expect(verified.manifest.source?.files.map(file => file.path)).toEqual([
+      'analytics/api.ts',
+      'analytics/orders.ts',
+    ]);
+    expect(await readFile(path.join(output, 'source/analytics/orders.ts'), 'utf8'))
+      .toBe('export const Orders = {};\n');
+  });
+
   it('rejects tampered runtime bytes', async () => {
     const parent = await temporaryDirectory();
     const output = path.join(parent, 'bundle');

--- a/packages/cli/src/utils/deployment-bundle.ts
+++ b/packages/cli/src/utils/deployment-bundle.ts
@@ -38,6 +38,21 @@ export interface DeploymentBundleRuntimeFile {
   readonly bytes: Uint8Array;
 }
 
+export interface DeploymentBundleSourceFile {
+  readonly path: string;
+  readonly bytes: Uint8Array;
+}
+
+export interface DeploymentBundleSourceSnapshot {
+  readonly entrypoint: string;
+  readonly files: readonly DeploymentBundleSourceFile[];
+  readonly revision?: {
+    readonly kind: 'git';
+    readonly commit: string;
+    readonly dirty: boolean;
+  };
+}
+
 export interface WrittenDeploymentBundle {
   readonly directory: string;
   readonly manifest: ProtocolDeploymentBundleManifest;
@@ -54,6 +69,8 @@ function sha256(bytes: Uint8Array): string {
 function runtimeArtifactPath(runtime: 'node' | 'python', digest: string): string {
   return `artifacts/${digest}.${runtime === 'node' ? 'mjs' : 'pyz'}`;
 }
+
+const SOURCE_ROOT = 'source';
 
 function errorCode(error: unknown): string | undefined {
   return typeof error === 'object' && error !== null && 'code' in error
@@ -138,16 +155,59 @@ function requireClosedContractArtifactSet(contract: ProtocolDeploymentContract):
   }
 }
 
+function validateSourceSnapshot(
+  source: DeploymentBundleSourceSnapshot | undefined,
+): DeploymentBundleSourceSnapshot | undefined {
+  if (!source) return undefined;
+  const files = [...source.files].sort((left, right) =>
+    left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
+  if (files.length < 1
+    || files.length > DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxSourceFiles) {
+    throw new Error('Deployment source snapshot exceeds the bundle file limits.');
+  }
+  let totalBytes = 0;
+  const seen = new Set<string>();
+  for (const file of files) {
+    const portable = file.path.split(path.sep).join('/');
+    if (portable !== file.path || path.isAbsolute(file.path)
+      || file.path.split('/').some(segment => !segment || segment === '.' || segment === '..')) {
+      throw new Error(`Deployment source path must be project-relative: ${file.path}`);
+    }
+    const caseFolded = file.path.toLowerCase();
+    if (seen.has(caseFolded)) {
+      throw new Error(`Duplicate deployment source path: ${file.path}`);
+    }
+    seen.add(caseFolded);
+    if (file.bytes.byteLength > DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxSourceFileBytes) {
+      throw new Error(`Deployment source file exceeds its byte limit: ${file.path}`);
+    }
+    totalBytes += file.bytes.byteLength;
+  }
+  if (totalBytes > DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxSourceBytes) {
+    throw new Error('Deployment source snapshot exceeds its total byte limit.');
+  }
+  if (!files.some(file => file.path === source.entrypoint)) {
+    throw new Error('Deployment source snapshot does not contain its API entrypoint.');
+  }
+  return Object.freeze({
+    entrypoint: source.entrypoint,
+    files: Object.freeze(files),
+    ...(source.revision ? { revision: Object.freeze({ ...source.revision }) } : {}),
+  });
+}
+
 export async function writeDeploymentBundle(
   outputDirectory: string,
   prepared: PreparedProtocolDeploymentContract,
   runtimeFiles: readonly DeploymentBundleRuntimeFile[],
+  sourceSnapshot?: DeploymentBundleSourceSnapshot,
 ): Promise<WrittenDeploymentBundle> {
   const destination = path.resolve(outputDirectory);
   if (destination === path.parse(destination).root) {
     throw new Error('The deployment bundle output cannot be a filesystem root.');
   }
   const files = validateRuntimeFiles(prepared, runtimeFiles);
+  const source = validateSourceSnapshot(sourceSnapshot);
   const deploymentBytes = utf8Encoder.encode(`${prepared.canonical}\n`);
   const manifestInput = {
     kind: 'hypequery-deployment-bundle',
@@ -164,6 +224,18 @@ export async function writeDeploymentBundle(
       sha256: file.sha256,
       byteLength: file.bytes.byteLength,
     })),
+    ...(source ? {
+      source: {
+        root: SOURCE_ROOT,
+        entrypoint: source.entrypoint,
+        files: source.files.map(file => ({
+          path: file.path,
+          sha256: sha256(file.bytes),
+          byteLength: file.bytes.byteLength,
+        })),
+        ...(source.revision ? { revision: source.revision } : {}),
+      },
+    } : {}),
   };
   const preparedManifest = prepareProtocolDeploymentBundleManifest(manifestInput);
   const replaceExisting = await existingVerifiedBundle(destination);
@@ -179,6 +251,11 @@ export async function writeDeploymentBundle(
         file.bytes,
         { flag: 'wx' },
       );
+    }
+    for (const file of source?.files ?? []) {
+      const outputPath = path.join(staging, SOURCE_ROOT, ...file.path.split('/'));
+      await mkdir(path.dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, file.bytes, { flag: 'wx' });
     }
     await writeFile(
       path.join(staging, DEPLOYMENT_BUNDLE_MANIFEST),

--- a/packages/cli/src/utils/deployment-source-snapshot.test.ts
+++ b/packages/cli/src/utils/deployment-source-snapshot.test.ts
@@ -1,0 +1,41 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { captureDeploymentSourceSnapshot } from './deployment-source-snapshot.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(temporaryDirectories.splice(0).map(directory => (
+    rm(directory, { force: true, recursive: true })
+  )));
+});
+
+describe('deployment source snapshots', () => {
+  it('captures the project-local transitive source graph', async () => {
+    const project = await mkdtemp(path.join(tmpdir(), 'hypequery-source-snapshot-test-'));
+    temporaryDirectories.push(project);
+    await mkdir(path.join(project, 'analytics/datasets'), { recursive: true });
+    await writeFile(
+      path.join(project, 'analytics/api.ts'),
+      'export { Orders } from "./datasets/orders.js";\n',
+    );
+    await writeFile(
+      path.join(project, 'analytics/datasets/orders.ts'),
+      'export const Orders = { source: "analytics.orders" };\n',
+    );
+    vi.spyOn(process, 'cwd').mockReturnValue(project);
+
+    const snapshot = await captureDeploymentSourceSnapshot('analytics/api.ts');
+
+    expect(snapshot.entrypoint).toBe('analytics/api.ts');
+    expect(snapshot.files.map(file => file.path)).toEqual([
+      'analytics/api.ts',
+      'analytics/datasets/orders.ts',
+    ]);
+    expect(new TextDecoder().decode(snapshot.files[1]?.bytes)).toContain('analytics.orders');
+    expect(snapshot.revision).toBeUndefined();
+  });
+});

--- a/packages/cli/src/utils/deployment-source-snapshot.ts
+++ b/packages/cli/src/utils/deployment-source-snapshot.ts
@@ -1,0 +1,132 @@
+import { execFile } from 'node:child_process';
+import { constants, lstat, open, realpath } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS,
+} from '@hypequery/protocol';
+import { build } from 'esbuild';
+import type {
+  DeploymentBundleSourceFile,
+  DeploymentBundleSourceSnapshot,
+} from './deployment-bundle.js';
+import { findNearestTsconfig } from './load-api.js';
+
+function portableProjectPath(projectRoot: string, absolutePath: string): string {
+  const relative = path.relative(projectRoot, absolutePath);
+  if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`)
+    || path.isAbsolute(relative)) {
+    throw new Error('Deployment source files must remain inside the current project.');
+  }
+  return relative.split(path.sep).join('/');
+}
+
+async function readSourceFile(
+  projectRoot: string,
+  inputPath: string,
+): Promise<DeploymentBundleSourceFile> {
+  const absolutePath = path.resolve(projectRoot, inputPath);
+  const displayPath = portableProjectPath(projectRoot, absolutePath);
+  const resolvedPath = await realpath(absolutePath);
+  if (resolvedPath !== absolutePath) {
+    throw new Error(`Deployment source files must not be symbolic links: ${displayPath}`);
+  }
+  const initial = await lstat(absolutePath);
+  if (!initial.isFile() || initial.isSymbolicLink()) {
+    throw new Error(`Deployment source entry is not a regular file: ${displayPath}`);
+  }
+  if (initial.size > DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxSourceFileBytes) {
+    throw new Error(`Deployment source file exceeds its byte limit: ${displayPath}`);
+  }
+  const handle = await open(absolutePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size !== initial.size) {
+      throw new Error(`Deployment source file changed while being read: ${displayPath}`);
+    }
+    return Object.freeze({
+      path: displayPath,
+      bytes: new Uint8Array(await handle.readFile()),
+    });
+  } finally {
+    await handle.close();
+  }
+}
+
+function gitOutput(projectRoot: string, arguments_: readonly string[]): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    execFile(
+      'git',
+      [...arguments_],
+      { cwd: projectRoot, encoding: 'utf8', maxBuffer: 1024 * 1024 },
+      (error, stdout) => resolve(error ? undefined : stdout.trim()),
+    );
+  });
+}
+
+async function sourceRevision(
+  projectRoot: string,
+): Promise<DeploymentBundleSourceSnapshot['revision']> {
+  const commit = await gitOutput(projectRoot, ['rev-parse', 'HEAD']);
+  if (!commit || !/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(commit)) return undefined;
+  const status = await gitOutput(projectRoot, ['status', '--porcelain', '--untracked-files=all']);
+  if (status === undefined) return undefined;
+  return Object.freeze({
+    kind: 'git',
+    commit,
+    dirty: status.length > 0,
+  });
+}
+
+export async function captureDeploymentSourceSnapshot(
+  apiPath: string,
+): Promise<DeploymentBundleSourceSnapshot> {
+  const projectRoot = await realpath(process.cwd());
+  const entrypointAbsolute = await realpath(path.resolve(projectRoot, apiPath));
+  const entrypoint = portableProjectPath(projectRoot, entrypointAbsolute);
+  let inputs: readonly string[];
+  try {
+    const result = await build({
+      absWorkingDir: projectRoot,
+      bundle: true,
+      entryPoints: [entrypointAbsolute],
+      logLevel: 'silent',
+      metafile: true,
+      packages: 'external',
+      platform: 'node',
+      sourcemap: false,
+      tsconfig: await findNearestTsconfig(entrypointAbsolute) ?? undefined,
+      write: false,
+    });
+    inputs = Object.keys(result.metafile.inputs);
+  } catch (error) {
+    throw new Error(
+      `Could not resolve the deployment source graph from ${apiPath}.\n`
+      + `Original error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const paths = [...new Set(inputs.map(input => {
+    const absolute = path.resolve(projectRoot, input);
+    const relative = portableProjectPath(projectRoot, absolute);
+    if (relative.split('/').includes('node_modules')) {
+      throw new Error(`Deployment source graph unexpectedly included a dependency: ${relative}`);
+    }
+    return relative;
+  }))].sort();
+  if (!paths.includes(entrypoint)) paths.unshift(entrypoint);
+  if (paths.length > DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxSourceFiles) {
+    throw new Error('Deployment source graph exceeds the bundle file limit.');
+  }
+
+  const files = await Promise.all(paths.map(file => readSourceFile(projectRoot, file)));
+  const totalBytes = files.reduce((total, file) => total + file.bytes.byteLength, 0);
+  if (totalBytes > DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxSourceBytes) {
+    throw new Error('Deployment source graph exceeds the bundle byte limit.');
+  }
+  const revision = await sourceRevision(projectRoot);
+  return Object.freeze({
+    entrypoint,
+    files: Object.freeze(files),
+    ...(revision ? { revision } : {}),
+  });
+}

--- a/packages/cli/src/utils/deployment-upload.test.ts
+++ b/packages/cli/src/utils/deployment-upload.test.ts
@@ -48,6 +48,19 @@ async function verifiedBundle() {
     directory,
     prepareProtocolDeploymentContract(deployment),
     [],
+    {
+      entrypoint: 'analytics/api.ts',
+      files: [
+        {
+          path: 'analytics/api.ts',
+          bytes: new TextEncoder().encode("export { orders } from './orders.js';\n"),
+        },
+        {
+          path: 'analytics/orders.ts',
+          bytes: new TextEncoder().encode('export const orders = {};\n'),
+        },
+      ],
+    },
   );
   return verifyDeploymentBundle(directory);
 }
@@ -116,6 +129,10 @@ describe('deployment upload transport', () => {
             path.join(submission.bundle.directory, 'deployment.json'),
             'utf8',
           )).toContain('hypequery-deployment');
+          expect(await readFile(
+            path.join(submission.bundle.directory, 'source/analytics/orders.ts'),
+            'utf8',
+          )).toBe('export const orders = {};\n');
           return 'accepted';
         },
       },
@@ -174,6 +191,8 @@ describe('deployment upload transport', () => {
     expect(body).toContain('name="release"; filename="release.json"');
     expect(body).toContain('X-HypeQuery-Bundle-Path: bundle.json');
     expect(body).toContain('X-HypeQuery-Bundle-Path: deployment.json');
+    expect(body).toContain('X-HypeQuery-Bundle-Path: source/analytics/api.ts');
+    expect(body).toContain('X-HypeQuery-Bundle-Path: source/analytics/orders.ts');
     expect(body).toContain(release.canonical);
     expect(body).toContain(await readFile(
       path.join(bundle.directory, 'deployment.json'),

--- a/packages/cli/src/utils/deployment-upload.ts
+++ b/packages/cli/src/utils/deployment-upload.ts
@@ -165,6 +165,9 @@ function multipartBundlePath(input: string): string {
 function validateMultipartBundlePaths(bundle: VerifiedDeploymentBundle): void {
   multipartBundlePath(bundle.manifest.deployment.path);
   for (const artifact of bundle.manifest.artifacts) multipartBundlePath(artifact.path);
+  for (const source of bundle.manifest.source?.files ?? []) {
+    multipartBundlePath(`${bundle.manifest.source!.root}/${source.path}`);
+  }
 }
 
 function partHeader(boundary: string, part: UploadPart): Uint8Array {
@@ -223,6 +226,19 @@ function uploadParts(
       byteLength: artifact.byteLength,
       sha256: artifact.sha256,
     })),
+    ...(manifest.manifest.source?.files.map(source => {
+      const bundlePath = `${manifest.manifest.source!.root}/${source.path}`;
+      return {
+        kind: 'file' as const,
+        name: 'bundle' as const,
+        filename: path.basename(source.path),
+        contentType: 'application/octet-stream',
+        absolutePath: path.join(root, ...bundlePath.split('/')),
+        bundlePath,
+        byteLength: source.byteLength,
+        sha256: source.sha256,
+      };
+    }) ?? []),
   ]);
 }
 

--- a/packages/deployment/src/bundle.ts
+++ b/packages/deployment/src/bundle.ts
@@ -42,6 +42,7 @@ async function readBoundedRegularFile(
   root: string,
   relativePath: string,
   maximum: number,
+  allowEmpty = false,
 ): Promise<Uint8Array> {
   const absolutePath = path.join(root, ...relativePath.split('/'));
   let handle;
@@ -53,13 +54,13 @@ async function readBoundedRegularFile(
     if (!initialStat.isFile()) {
       throw new Error(`Bundle entry is not a regular file: ${relativePath}`);
     }
-    if (initialStat.size < 1 || initialStat.size > maximum) {
+    if (initialStat.size < (allowEmpty ? 0 : 1) || initialStat.size > maximum) {
       throw new Error(`Bundle entry exceeds its byte limit: ${relativePath}`);
     }
     handle = await open(absolutePath, constants.O_RDONLY | constants.O_NOFOLLOW);
     const stat = await handle.stat();
     if (!stat.isFile()) throw new Error(`Bundle entry is not a regular file: ${relativePath}`);
-    if (stat.size < 1 || stat.size > maximum) {
+    if (stat.size < (allowEmpty ? 0 : 1) || stat.size > maximum) {
       throw new Error(`Bundle entry exceeds its byte limit: ${relativePath}`);
     }
     return await handle.readFile();
@@ -92,6 +93,7 @@ async function verifyExactEntries(
     DEPLOYMENT_BUNDLE_MANIFEST,
     manifest.deployment.path,
     ...manifest.artifacts.map(artifact => artifact.path),
+    ...(manifest.source?.files.map(file => `${manifest.source!.root}/${file.path}`) ?? []),
   ]);
   const expectedDirectoryPaths = expectedDirectories([...expectedFiles]);
   const seenFiles = new Set<string>();
@@ -240,6 +242,19 @@ export async function verifyDeploymentBundle(
       DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxArtifactBytes,
     );
     verifyFile(bytes, artifact);
+  }
+  const source = preparedManifest.manifest.source;
+  if (source) {
+    for (const file of source.files) {
+      const bundlePath = `${source.root}/${file.path}`;
+      const bytes = await readBoundedRegularFile(
+        root,
+        bundlePath,
+        DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxSourceFileBytes,
+        true,
+      );
+      verifyFile(bytes, { ...file, path: bundlePath });
+    }
   }
   verifyRuntimeReferences(preparedContract.contract, preparedManifest.manifest.artifacts);
   return Object.freeze({

--- a/packages/deployment/src/intake.test.ts
+++ b/packages/deployment/src/intake.test.ts
@@ -85,6 +85,16 @@ function submissionFixture(
 ) {
   const preparedDeployment = prepareProtocolDeploymentContract(deployment());
   const deploymentBytes = Buffer.from(`${preparedDeployment.canonical}\n`);
+  const sourceFiles = [
+    {
+      path: 'analytics/api.ts',
+      bytes: Buffer.from("export { orders } from './orders.js';\n"),
+    },
+    {
+      path: 'analytics/orders.ts',
+      bytes: Buffer.from('export const orders = {};\n'),
+    },
+  ];
   const preparedManifest = prepareProtocolDeploymentBundleManifest({
     kind: 'hypequery-deployment-bundle',
     version: 1,
@@ -95,6 +105,15 @@ function submissionFixture(
       byteLength: deploymentBytes.byteLength,
     },
     artifacts: [],
+    source: {
+      root: 'source',
+      entrypoint: 'analytics/api.ts',
+      files: sourceFiles.map(file => ({
+        path: file.path,
+        sha256: sha256(file.bytes),
+        byteLength: file.bytes.byteLength,
+      })),
+    },
   });
   const release = prepareProtocolDeploymentReleaseEnvelope({
     kind: 'hypequery-deployment-release',
@@ -123,6 +142,13 @@ function submissionFixture(
       bundlePath: deploymentPath,
       bytes: deploymentBytes,
     },
+    ...sourceFiles.map(file => ({
+      name: 'bundle' as const,
+      filename: path.basename(file.path),
+      contentType: 'application/octet-stream',
+      bundlePath: `source/${file.path}`,
+      bytes: file.bytes,
+    })),
     ...extraParts,
   ];
   const boundary = 'hypequery-test-boundary';
@@ -158,6 +184,10 @@ describe('deployment intake', () => {
       expect(await readFile(
         path.join(submission.bundle.directory, 'deployment.json'),
       )).toEqual(fixture.deploymentBytes);
+      expect(await readFile(
+        path.join(submission.bundle.directory, 'source/analytics/orders.ts'),
+        'utf8',
+      )).toBe('export const orders = {};\n');
       return 'accepted';
     });
     const intake = createDeploymentIntake({

--- a/packages/deployment/src/intake.ts
+++ b/packages/deployment/src/intake.ts
@@ -146,6 +146,9 @@ function requireReconstructablePaths(manifest: PreparedProtocolDeploymentBundleM
   const files = [
     manifest.manifest.deployment.path,
     ...manifest.manifest.artifacts.map(artifact => artifact.path),
+    ...(manifest.manifest.source?.files.map(
+      file => `${manifest.manifest.source!.root}/${file.path}`,
+    ) ?? []),
   ];
   const fileSet = new Set(files);
   if (fileSet.has(DEPLOYMENT_BUNDLE_MANIFEST)) {
@@ -393,6 +396,10 @@ export function createDeploymentIntake<Principal>(
       const files = [
         manifest.prepared.manifest.deployment,
         ...manifest.prepared.manifest.artifacts,
+        ...(manifest.prepared.manifest.source?.files.map(file => ({
+          ...file,
+          path: `${manifest.prepared.manifest.source!.root}/${file.path}`,
+        })) ?? []),
       ];
       for (let index = 0; index < files.length; index += 1) {
         await receiveBundleFile(

--- a/packages/protocol/src/bundles/bundles.test.ts
+++ b/packages/protocol/src/bundles/bundles.test.ts
@@ -60,6 +60,30 @@ function baseManifest() {
   };
 }
 
+function source() {
+  return {
+    root: 'source',
+    entrypoint: 'analytics/api.ts',
+    files: [
+      {
+        path: 'analytics/api.ts',
+        sha256: '3'.repeat(64),
+        byteLength: 20,
+      },
+      {
+        path: 'analytics/datasets/orders.ts',
+        sha256: '4'.repeat(64),
+        byteLength: 40,
+      },
+    ],
+    revision: {
+      kind: 'git',
+      commit: '5'.repeat(40),
+      dirty: false,
+    },
+  };
+}
+
 function materialize(type: string): unknown {
   const value = baseManifest();
   switch (type) {
@@ -160,6 +184,38 @@ describe('deployment bundle manifest v1', () => {
       () => validateProtocolDeploymentBundleManifest(value),
       'HQ_BUNDLE_INVALID_VALUE',
       '$.artifacts',
+    );
+  });
+
+  it('accepts an immutable multi-file source snapshot', () => {
+    const manifest = validateProtocolDeploymentBundleManifest({
+      ...baseManifest(),
+      source: source(),
+    });
+    expect(manifest.source).toEqual(source());
+    expect(Object.isFrozen(manifest.source)).toBe(true);
+    expect(Object.isFrozen(manifest.source?.files)).toBe(true);
+    expect(Object.isFrozen(manifest.source?.files[0])).toBe(true);
+    expect(Object.isFrozen(manifest.source?.revision)).toBe(true);
+  });
+
+  it('requires the source entrypoint and a collision-free bundle tree', () => {
+    expectBundleError(
+      () => validateProtocolDeploymentBundleManifest({
+        ...baseManifest(),
+        source: { ...source(), entrypoint: 'analytics/missing.ts' },
+      }),
+      'HQ_BUNDLE_INVALID_REFERENCE',
+      '$.source.entrypoint',
+    );
+    expectBundleError(
+      () => validateProtocolDeploymentBundleManifest({
+        ...baseManifest(),
+        deployment: { ...baseManifest().deployment, path: 'source' },
+        source: source(),
+      }),
+      'HQ_BUNDLE_INVALID_REFERENCE',
+      '$',
     );
   });
 

--- a/packages/protocol/src/bundles/index.ts
+++ b/packages/protocol/src/bundles/index.ts
@@ -17,4 +17,6 @@ export type {
   ProtocolDeploymentBundleLimits,
   ProtocolDeploymentBundleManifest,
   ProtocolDeploymentBundleOptions,
+  ProtocolDeploymentBundleSource,
+  ProtocolDeploymentBundleSourceRevision,
 } from './types.js';

--- a/packages/protocol/src/bundles/limits.ts
+++ b/packages/protocol/src/bundles/limits.ts
@@ -6,9 +6,12 @@ import type {
 export const DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS:
 Readonly<ProtocolDeploymentBundleLimits> = Object.freeze({
   maxArtifacts: 100,
+  maxSourceFiles: 1_000,
   maxPathBytes: 1_024,
   maxDeploymentBytes: 16 * 1_024 * 1_024,
   maxArtifactBytes: 128 * 1_024 * 1_024,
+  maxSourceFileBytes: 2 * 1_024 * 1_024,
+  maxSourceBytes: 32 * 1_024 * 1_024,
   maxTotalBytes: 256 * 1_024 * 1_024,
 });
 

--- a/packages/protocol/src/bundles/types.ts
+++ b/packages/protocol/src/bundles/types.ts
@@ -12,18 +12,37 @@ export interface ProtocolDeploymentBundleArtifact extends ProtocolDeploymentBund
   readonly runtime: 'node' | 'python';
 }
 
+export interface ProtocolDeploymentBundleSourceRevision {
+  readonly kind: 'git';
+  readonly commit: string;
+  readonly dirty: boolean;
+}
+
+export interface ProtocolDeploymentBundleSource {
+  /** Directory within the closed bundle that contains project-relative source files. */
+  readonly root: string;
+  /** Project-relative API module used to build the deployment. */
+  readonly entrypoint: string;
+  readonly files: readonly ProtocolDeploymentBundleFile[];
+  readonly revision?: ProtocolDeploymentBundleSourceRevision;
+}
+
 export interface ProtocolDeploymentBundleManifest {
   readonly kind: 'hypequery-deployment-bundle';
   readonly version: 1;
   readonly deployment: ProtocolDeploymentBundleDeployment;
   readonly artifacts: readonly ProtocolDeploymentBundleArtifact[];
+  readonly source?: ProtocolDeploymentBundleSource;
 }
 
 export interface ProtocolDeploymentBundleLimits {
   readonly maxArtifacts: number;
+  readonly maxSourceFiles: number;
   readonly maxPathBytes: number;
   readonly maxDeploymentBytes: number;
   readonly maxArtifactBytes: number;
+  readonly maxSourceFileBytes: number;
+  readonly maxSourceBytes: number;
   readonly maxTotalBytes: number;
 }
 

--- a/packages/protocol/src/bundles/validate.ts
+++ b/packages/protocol/src/bundles/validate.ts
@@ -6,11 +6,14 @@ import type {
   ProtocolDeploymentBundleLimits,
   ProtocolDeploymentBundleManifest,
   ProtocolDeploymentBundleOptions,
+  ProtocolDeploymentBundleSource,
+  ProtocolDeploymentBundleSourceRevision,
 } from './types.js';
 
 type DataRecord = Record<string, unknown>;
 const textEncoder = new TextEncoder();
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const GIT_COMMIT_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
 const PATH_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const WINDOWS_RESERVED_NAME = /^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\.|$)/i;
 
@@ -54,8 +57,13 @@ function requireArray(input: unknown, path: string, maxItems: number): readonly 
   return input;
 }
 
-function exactFields(value: DataRecord, required: readonly string[], path: string): void {
-  const allowed = new Set(required);
+function exactFields(
+  value: DataRecord,
+  required: readonly string[],
+  path: string,
+  optional: readonly string[] = [],
+): void {
+  const allowed = new Set([...required, ...optional]);
   for (const key of Object.keys(value)) {
     if (!allowed.has(key)) bundleError('HQ_BUNDLE_UNKNOWN_FIELD', `${path}.${key}`);
   }
@@ -74,8 +82,13 @@ function digest(value: unknown, path: string): string {
   return value;
 }
 
-function byteLength(value: unknown, path: string, maximum: number): number {
-  if (!Number.isSafeInteger(value) || (value as number) < 1) {
+function byteLength(
+  value: unknown,
+  path: string,
+  maximum: number,
+  allowEmpty = false,
+): number {
+  if (!Number.isSafeInteger(value) || (value as number) < (allowEmpty ? 0 : 1)) {
     bundleError('HQ_BUNDLE_INVALID_VALUE', path);
   }
   if ((value as number) > maximum) bundleError('HQ_BUNDLE_TOO_LARGE', path);
@@ -130,13 +143,98 @@ function validateArtifact(
   }) as unknown as ProtocolDeploymentBundleArtifact;
 }
 
+function validateSourceRevision(
+  input: unknown,
+  path: string,
+): ProtocolDeploymentBundleSourceRevision {
+  const value = requireRecord(input, path);
+  exactFields(value, ['kind', 'commit', 'dirty'], path);
+  if (value.kind !== 'git') {
+    if (typeof value.kind !== 'string') bundleError('HQ_BUNDLE_TYPE', `${path}.kind`);
+    bundleError('HQ_BUNDLE_INVALID_VALUE', `${path}.kind`);
+  }
+  if (typeof value.commit !== 'string') bundleError('HQ_BUNDLE_TYPE', `${path}.commit`);
+  if (!GIT_COMMIT_PATTERN.test(value.commit)) {
+    bundleError('HQ_BUNDLE_INVALID_VALUE', `${path}.commit`);
+  }
+  if (typeof value.dirty !== 'boolean') bundleError('HQ_BUNDLE_TYPE', `${path}.dirty`);
+  return freezeRecord({
+    kind: 'git',
+    commit: value.commit,
+    dirty: value.dirty,
+  }) as unknown as ProtocolDeploymentBundleSourceRevision;
+}
+
+function validateSource(
+  input: unknown,
+  path: string,
+  limits: Readonly<ProtocolDeploymentBundleLimits>,
+): ProtocolDeploymentBundleSource {
+  const value = requireRecord(input, path);
+  exactFields(value, ['root', 'entrypoint', 'files'], path, ['revision']);
+  const root = relativePath(value.root, `${path}.root`, limits.maxPathBytes);
+  const entrypoint = relativePath(value.entrypoint, `${path}.entrypoint`, limits.maxPathBytes);
+  const files = Object.freeze(
+    requireArray(value.files, `${path}.files`, limits.maxSourceFiles)
+      .map((inputFile, index) => {
+        const filePath = `${path}.files[${index}]`;
+        const file = requireRecord(inputFile, filePath);
+        exactFields(file, ['path', 'sha256', 'byteLength'], filePath);
+        return freezeRecord({
+          path: relativePath(file.path, `${filePath}.path`, limits.maxPathBytes),
+          sha256: digest(file.sha256, `${filePath}.sha256`),
+          byteLength: byteLength(
+            file.byteLength,
+            `${filePath}.byteLength`,
+            limits.maxSourceFileBytes,
+            true,
+          ),
+        });
+      }),
+  ) as unknown as ProtocolDeploymentBundleSource['files'];
+  if (files.length < 1 || !files.some(file => file.path === entrypoint)) {
+    bundleError('HQ_BUNDLE_INVALID_REFERENCE', `${path}.entrypoint`);
+  }
+  const paths = files.map(file => file.path);
+  if (new Set(paths).size !== paths.length
+    || new Set(paths.map(filePath => filePath.toLowerCase())).size !== paths.length) {
+    bundleError('HQ_BUNDLE_INVALID_REFERENCE', `${path}.files`);
+  }
+  const sortedPaths = [...paths].sort();
+  if (paths.some((filePath, index) => filePath !== sortedPaths[index])) {
+    bundleError('HQ_BUNDLE_INVALID_VALUE', `${path}.files`);
+  }
+  const sourceBytes = files.reduce((total, file) => total + file.byteLength, 0);
+  if (!Number.isSafeInteger(sourceBytes) || sourceBytes > limits.maxSourceBytes) {
+    bundleError('HQ_BUNDLE_TOO_LARGE', path);
+  }
+  return freezeRecord({
+    root,
+    entrypoint,
+    files,
+    ...(value.revision === undefined
+      ? {}
+      : { revision: validateSourceRevision(value.revision, `${path}.revision`) }),
+  }) as unknown as ProtocolDeploymentBundleSource;
+}
+
+function hasTreeCollision(paths: readonly string[]): boolean {
+  const normalized = new Set(paths.map(bundlePath => bundlePath.toLowerCase()));
+  return [...normalized].some((bundlePath) => {
+    const segments = bundlePath.split('/');
+    return segments.some(
+      (_, index) => index > 0 && normalized.has(segments.slice(0, index).join('/')),
+    );
+  });
+}
+
 export function validateProtocolDeploymentBundleManifest(
   input: unknown,
   options: ProtocolDeploymentBundleOptions = {},
 ): ProtocolDeploymentBundleManifest {
   const limits = resolveDeploymentBundleLimits(options);
   const value = requireRecord(input, '$');
-  exactFields(value, ['kind', 'version', 'deployment', 'artifacts'], '$');
+  exactFields(value, ['kind', 'version', 'deployment', 'artifacts'], '$', ['source']);
   if (value.kind !== 'hypequery-deployment-bundle') {
     if (typeof value.kind !== 'string') bundleError('HQ_BUNDLE_TYPE', '$.kind');
     bundleError('HQ_BUNDLE_INVALID_VALUE', '$.kind');
@@ -149,10 +247,15 @@ export function validateProtocolDeploymentBundleManifest(
   const deployment = validateDeployment(value.deployment, '$.deployment', limits);
   const artifacts = Object.freeze(requireArray(value.artifacts, '$.artifacts', limits.maxArtifacts)
     .map((artifact, index) => validateArtifact(artifact, `$.artifacts[${index}]`, limits)));
-  const paths = [deployment.path, ...artifacts.map(artifact => artifact.path)];
+  const source = value.source === undefined
+    ? undefined
+    : validateSource(value.source, '$.source', limits);
+  const sourcePaths = source?.files.map(file => `${source.root}/${file.path}`) ?? [];
+  const paths = [deployment.path, ...artifacts.map(artifact => artifact.path), ...sourcePaths];
   if (new Set(paths).size !== paths.length
-    || new Set(paths.map(bundlePath => bundlePath.toLowerCase())).size !== paths.length) {
-    bundleError('HQ_BUNDLE_INVALID_REFERENCE', '$.artifacts');
+    || new Set(paths.map(bundlePath => bundlePath.toLowerCase())).size !== paths.length
+    || hasTreeCollision(paths)) {
+    bundleError('HQ_BUNDLE_INVALID_REFERENCE', '$');
   }
   if (new Set(artifacts.map(artifact => artifact.sha256)).size !== artifacts.length) {
     bundleError('HQ_BUNDLE_INVALID_REFERENCE', '$.artifacts');
@@ -162,7 +265,8 @@ export function validateProtocolDeploymentBundleManifest(
     bundleError('HQ_BUNDLE_INVALID_VALUE', '$.artifacts');
   }
   const totalBytes = deployment.byteLength
-    + artifacts.reduce((total, artifact) => total + artifact.byteLength, 0);
+    + artifacts.reduce((total, artifact) => total + artifact.byteLength, 0)
+    + (source?.files.reduce((total, file) => total + file.byteLength, 0) ?? 0);
   if (!Number.isSafeInteger(totalBytes) || totalBytes > limits.maxTotalBytes) {
     bundleError('HQ_BUNDLE_TOO_LARGE', '$');
   }
@@ -172,5 +276,6 @@ export function validateProtocolDeploymentBundleManifest(
     version: 1,
     deployment,
     artifacts,
+    ...(source ? { source } : {}),
   }) as unknown as ProtocolDeploymentBundleManifest;
 }


### PR DESCRIPTION
## What changed

- extends deployment bundle v1 with an optional, verified multi-file source snapshot
- records the project-relative API entrypoint and optional Git commit/dirty provenance
- captures the project-local transitive source graph in the CLI by default, with `--no-source` as an escape hatch
- streams and receives every declared source file through the existing bounded multipart deployment intake

## Why

HypeQuery Cloud needs to show the original deployed TypeScript, including multi-file implementations, instead of reconstructing an approximation from the compiled deployment contract.

The field is optional, so existing bundles remain valid. New source files are covered by the same canonical manifest identity, byte limits, SHA-256 verification, exact-file checks, and path traversal protections as deployment and runtime files.

## Validation

- `pnpm build`
- `pnpm types`
- `pnpm lint`
- `pnpm test`
- end-to-end transport coverage for build → multipart upload → intake → verified source files
