### PR TITLE
feat(protocol): accept RFCs 0001, 0002, and 0012 (TSP-01)

### DIFF
--- a/.changeset/tagged-values-v1-acceptance.md
+++ b/.changeset/tagged-values-v1-acceptance.md
@@ -1,0 +1,59 @@
+---
+"@hypequery/protocol": minor
+"@hypequery/protocol-conformance": minor
+---
+
+Accept RFC 0001 (tagged ClickHouse value model) and align the reference
+implementation and conformance adapter with it.
+
+Both behaviour changes are relaxations — input that was previously rejected is
+now accepted — so existing callers producing valid values are unaffected.
+
+**Canonical strings now permit tab (U+0009), line feed (U+000A), and carriage
+return (U+000D).** Every other C0 control, DEL, and the whole C1 range remain
+forbidden. The previous blanket C0 ban made multi-line descriptions impossible.
+
+**Timezone validation now accepts single-component identifiers.** The old
+pattern required a `/`, so `EST`, `GMT`, `CET`, `MST7MDT`, and `W-SU` — all
+real tzdb entries — were rejected while only `UTC` passed via a special case.
+Validation remains lexical and never consults the host timezone database:
+Python `zoneinfo` and JavaScript ICU disagree about renamed zones such as
+`Europe/Kiev` versus `Europe/Kyiv`, and conformance must not depend on the OS
+image. Identifier existence is a deployment-time check against the target
+server's `system.time_zones`. The first component must begin with a letter, so
+offset-shaped input such as `+0200` is still rejected.
+
+The RFC additionally pins behaviour that was previously underspecified without
+changing this implementation:
+
+- Metadata integers (`version`, `bits`, `precision`, `scale`, `code`) are
+  defined **by value, not lexical form**. `1`, `1.0`, and `1e0` are all
+  accepted and all canonicalize to `1`. A lexical rule was considered and
+  rejected: JavaScript erases the distinction at parse time, so it could only
+  be honoured by one language on the programmatic entry path, creating a
+  cross-language divergence without preventing any confusion or hash
+  collision.
+- Exact `DateTime`/`DateTime64` bounds, named the **portable v1 range** — a
+  deliberately conservative subset rather than a restatement of ClickHouse's
+  own limits, which differ by precision and have moved between releases.
+  `DateTime64(9)` caps at `2262-04-11T23:47:16.854775807Z`, the largest
+  signed-64-bit nanosecond tick count since the epoch.
+- RFC 8785 number serialization is the ECMAScript `Number::toString`
+  algorithm. JavaScript inherits this from `JSON.stringify`; other languages
+  must implement it explicitly and must not delegate to a host `repr` or
+  default JSON encoder.
+- Map-entry depth and node counting, and which size limit binds on the
+  already-parsed entry path.
+
+`HQ_VALUE_UNSAFE_OBJECT` was in the RFC but missing from the conformance
+manifest and from the stable-code list asserted by `fixtures.test.ts`, making
+it the one frozen failure code no implementation had to demonstrate. It now has
+a shared `unsafe-accessor` rejection case — the same generator the expression,
+schema, event, deployment, bundle, and release families already use — plus a
+requirement that each implementation declare a language-specific
+hostile-object suite.
+
+Fixtures grew from 18 success and 28 rejection cases to 32 and 33. The
+additions concentrate on float canonicalization boundaries, where the corpus
+previously held a single case (`1.5`) that agrees across languages by
+coincidence.

--- a/.changeset/tagged-values-v1-acceptance.md
+++ b/.changeset/tagged-values-v1-acceptance.md
@@ -57,3 +57,20 @@ Fixtures grew from 18 success and 28 rejection cases to 32 and 33. The
 additions concentrate on float canonicalization boundaries, where the corpus
 previously held a single case (`1.5`) that agrees across languages by
 coincidence.
+
+**RFC 0002 (portable identifiers) is also accepted**, with no implementation
+change. The validation order — type, empty, length, grammar, reserved — was
+already implemented but unspecified, and it is load-bearing: the grammar check
+running before the reserved-prefix check is what keeps the case-insensitive
+comparison behind an ASCII gate, where host case-folding rules agree. The
+order is now normative, the per-segment scope of the reserved namespace is
+stated, and the identifier corpus gained boundary cases at every limit
+(segment 128 bytes, 8 segments, qualified 512 and 513 bytes) plus cases
+pinning each precedence overlap. It grew from 4 success and 8 rejection cases
+to 7 and 13.
+
+**RFC 0012 (cross-language conformance) is also accepted.** The per-case
+timeout is pinned at 5000 ms by default, and the RFC now states that a green
+run is evidence only for the families an adapter announced — cases in
+unannounced families are reported as not run, so an adapter that announces one
+family exits zero while leaving most of the corpus untouched.

--- a/.changeset/tagged-values-v1-acceptance.md
+++ b/.changeset/tagged-values-v1-acceptance.md
@@ -6,8 +6,9 @@
 Accept RFC 0001 (tagged ClickHouse value model) and align the reference
 implementation and conformance adapter with it.
 
-Both behaviour changes are relaxations — input that was previously rejected is
-now accepted — so existing callers producing valid values are unaffected.
+Both behaviour changes are relaxations for every real timezone identifier —
+input that was previously rejected is now accepted — so existing callers
+producing valid values are unaffected.
 
 **Canonical strings now permit tab (U+0009), line feed (U+000A), and carriage
 return (U+000D).** Every other C0 control, DEL, and the whole C1 range remain
@@ -16,6 +17,9 @@ forbidden. The previous blanket C0 ban made multi-line descriptions impossible.
 **Timezone validation now accepts single-component identifiers.** The old
 pattern required a `/`, so `EST`, `GMT`, `CET`, `MST7MDT`, and `W-SU` — all
 real tzdb entries — were rejected while only `UTC` passed via a special case.
+One edge tightens: the first component must now begin with an ASCII letter,
+so a multi-component identifier with a leading underscore such as `_Foo/Bar`
+— previously accepted, never a real tzdb entry — is now rejected.
 Validation remains lexical and never consults the host timezone database:
 Python `zoneinfo` and JavaScript ICU disagree about renamed zones such as
 `Europe/Kiev` versus `Europe/Kyiv`, and conformance must not depend on the OS
@@ -53,10 +57,18 @@ schema, event, deployment, bundle, and release families already use — plus a
 requirement that each implementation declare a language-specific
 hostile-object suite.
 
-Fixtures grew from 18 success and 28 rejection cases to 32 and 33. The
+Fixtures grew from 18 success and 28 rejection cases to 32 and 35. The
 additions concentrate on float canonicalization boundaries, where the corpus
 previously held a single case (`1.5`) that agrees across languages by
-coincidence.
+coincidence, and pin the failure code at every timezone edge: leading
+underscore, offset-shaped input, and the 64-byte cap (`HQ_VALUE_TOO_LARGE`,
+like every other byte-limit failure).
+
+The RFC 0012 language-specific hostile-object suite declaration now has a
+home in the wire protocol: an optional `hostileObjectSuite` field (`count`
+plus `mechanisms`) on the adapter `hello` message, copied by the runner into
+the run summary and rendered in reports. The reference adapter declares the
+seven mechanisms its suite covers.
 
 **RFC 0002 (portable identifiers) is also accepted**, with no implementation
 change. The validation order — type, empty, length, grammar, reserved — was

--- a/.changeset/tagged-values-v1-acceptance.md
+++ b/.changeset/tagged-values-v1-acceptance.md
@@ -68,7 +68,10 @@ The RFC 0012 language-specific hostile-object suite declaration now has a
 home in the wire protocol: an optional `hostileObjectSuite` field (`count`
 plus `mechanisms`) on the adapter `hello` message, copied by the runner into
 the run summary and rendered in reports. The reference adapter declares the
-seven mechanisms its suite covers.
+seven mechanisms its suite covers. The runner validates the declaration and
+requires it whenever an announced fixture family contains a host-model
+conditional case, so missing or malformed evidence cannot produce a passing
+report.
 
 **RFC 0002 (portable identifiers) is also accepted**, with no implementation
 change. The validation order — type, empty, length, grammar, reserved — was

--- a/packages/protocol-conformance/src/adapters/generators.ts
+++ b/packages/protocol-conformance/src/adapters/generators.ts
@@ -42,6 +42,20 @@ export function materializeTaggedValue(spec: Spec): unknown {
       throw new Error(`Unknown non-finite float: ${String(spec.value)}`);
     case 'repeat-string':
       return repeat(spec.utf8 as string, spec.count as number);
+    case 'unsafe-accessor': {
+      // `$hypequery` served by a computed accessor instead of a data
+      // property. A validator must snapshot without invoking it and reject.
+      const value: Record<string, unknown> = {};
+      Object.defineProperty(value, '$hypequery', {
+        enumerable: true,
+        get: () => ({
+          type: 'uuid',
+          version: 1,
+          value: '01890f3e-7b7b-7cc2-98c4-dc0c0c07398f',
+        }),
+      });
+      return value;
+    }
     default:
       throw new Error(`Unknown tagged-value generator: ${String(spec.type)}`);
   }

--- a/packages/protocol-conformance/src/adapters/reference.ts
+++ b/packages/protocol-conformance/src/adapters/reference.ts
@@ -64,6 +64,24 @@ function validationInput(c: Case, materialize: (spec: Record<string, unknown>) =
   return c.generator ? materialize(c.generator as Record<string, unknown>) : c.value;
 }
 
+/**
+ * RFC 0012 hostile-object suite declaration for the TypeScript reference
+ * implementation. The cases live in @hypequery/protocol's
+ * `src/values/codec.test.ts`; each mechanism listed here is exercised there.
+ */
+export const REFERENCE_HOSTILE_OBJECT_SUITE = {
+  count: 7,
+  mechanisms: [
+    'getter',
+    'toJSON',
+    'proxy',
+    'custom-prototype',
+    'symbol-key',
+    'sparse-array',
+    'cycle',
+  ],
+} as const;
+
 export const REFERENCE_FAMILIES = [
   'tagged-values-v1',
   'identifiers-v1',

--- a/packages/protocol-conformance/src/adapters/stdio.ts
+++ b/packages/protocol-conformance/src/adapters/stdio.ts
@@ -3,13 +3,15 @@
 // the runner sends. Used by the reference adapter and the datasets adapter.
 import { createInterface } from 'node:readline';
 import { CONFORMANCE_PROTOCOL_VERSION } from '../types.js';
-import type { FixtureRole, HandlerResult } from '../types.js';
+import type { FixtureRole, HandlerResult, HostileObjectSuiteDeclaration } from '../types.js';
 
 export interface StdioAdapterOptions {
   readonly implementation?: string;
   readonly version?: string;
   readonly language?: string;
   readonly families: readonly string[];
+  /** RFC 0012 language-specific hostile-object suite declaration. */
+  readonly hostileObjectSuite?: HostileObjectSuiteDeclaration;
   readonly handle: (
     family: string,
     role: FixtureRole,
@@ -72,6 +74,9 @@ export function createStdioAdapter(options: StdioAdapterOptions): Promise<number
           version: options.version,
           language: options.language,
           families,
+          ...(options.hostileObjectSuite
+            ? { hostileObjectSuite: options.hostileObjectSuite }
+            : {}),
         });
         return;
       }

--- a/packages/protocol-conformance/src/bin/reference-adapter.ts
+++ b/packages/protocol-conformance/src/bin/reference-adapter.ts
@@ -2,12 +2,17 @@
 // Reference adapter executable. Wraps @hypequery/protocol behind the RFC 0012
 // stdio protocol so the runner can drive it like any other implementation.
 import { createStdioAdapter } from '../adapters/stdio.js';
-import { REFERENCE_FAMILIES, referenceHandle } from '../adapters/reference.js';
+import {
+  REFERENCE_FAMILIES,
+  REFERENCE_HOSTILE_OBJECT_SUITE,
+  referenceHandle,
+} from '../adapters/reference.js';
 
 createStdioAdapter({
   implementation: '@hypequery/protocol',
   language: 'typescript',
   families: [...REFERENCE_FAMILIES],
+  hostileObjectSuite: REFERENCE_HOSTILE_OBJECT_SUITE,
   handle: referenceHandle,
 })
   .then((code) => process.exit(code))

--- a/packages/protocol-conformance/src/index.ts
+++ b/packages/protocol-conformance/src/index.ts
@@ -12,5 +12,9 @@ export type { JsonLoader } from './manifest.js';
 export { compareCase } from './compare.js';
 export { formatPrettyReport, formatJsonReport } from './report.js';
 export { createStdioAdapter } from './adapters/stdio.js';
-export { referenceHandle, REFERENCE_FAMILIES } from './adapters/reference.js';
+export {
+  referenceHandle,
+  REFERENCE_FAMILIES,
+  REFERENCE_HOSTILE_OBJECT_SUITE,
+} from './adapters/reference.js';
 export * from './types.js';

--- a/packages/protocol-conformance/src/report.ts
+++ b/packages/protocol-conformance/src/report.ts
@@ -26,5 +26,13 @@ export function formatPrettyReport(summary: RunSummary): string {
     `${summary.passed} passed, ${summary.failed} failed, ${summary.skipped} skipped`
     + (summary.notRun > 0 ? `, ${summary.notRun} not run (family not announced)` : ''),
   );
+  // RFC 0012 requires the declaration from implementations that accept host
+  // values; adapters announcing only text-input families are exempt.
+  const suite = adapter?.hostileObjectSuite;
+  if (suite) {
+    lines.push(`hostile-object suite: ${suite.count} cases (${suite.mechanisms.join(', ')})`);
+  } else if (adapter?.families.includes('tagged-values-v1')) {
+    lines.push('hostile-object suite: none declared (required by RFC 0012)');
+  }
   return lines.join('\n');
 }

--- a/packages/protocol-conformance/src/report.ts
+++ b/packages/protocol-conformance/src/report.ts
@@ -26,13 +26,9 @@ export function formatPrettyReport(summary: RunSummary): string {
     `${summary.passed} passed, ${summary.failed} failed, ${summary.skipped} skipped`
     + (summary.notRun > 0 ? `, ${summary.notRun} not run (family not announced)` : ''),
   );
-  // RFC 0012 requires the declaration from implementations that accept host
-  // values; adapters announcing only text-input families are exempt.
   const suite = adapter?.hostileObjectSuite;
   if (suite) {
     lines.push(`hostile-object suite: ${suite.count} cases (${suite.mechanisms.join(', ')})`);
-  } else if (adapter?.families.includes('tagged-values-v1')) {
-    lines.push('hostile-object suite: none declared (required by RFC 0012)');
   }
   return lines.join('\n');
 }

--- a/packages/protocol-conformance/src/runner.test.ts
+++ b/packages/protocol-conformance/src/runner.test.ts
@@ -17,6 +17,10 @@ describe('runConformance', () => {
     expect(summary.failed).toBe(0);
     expect(summary.passed).toBe(4);
     expect(summary.notRun).toBe(0);
+    // The RFC 0012 hostile-object suite declaration rides the hello message
+    // into the published summary.
+    expect(summary.adapter?.hostileObjectSuite)
+      .toEqual({ count: 2, mechanisms: ['getter', 'toJSON'] });
   });
 
   it('reports cases whose family the adapter does not announce', async () => {

--- a/packages/protocol-conformance/src/runner.test.ts
+++ b/packages/protocol-conformance/src/runner.test.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { formatPrettyReport } from './report.js';
 import { runConformance } from './runner.js';
 
 const miniFixtures = fileURLToPath(new URL('./testdata/mini-fixtures/', import.meta.url));
@@ -21,6 +22,17 @@ describe('runConformance', () => {
     // into the published summary.
     expect(summary.adapter?.hostileObjectSuite)
       .toEqual({ count: 2, mechanisms: ['getter', 'toJSON'] });
+  });
+
+  it('ignores malformed hostile-object metadata from an adapter', async () => {
+    const summary = await runConformance({
+      fixturesDir: miniFixtures,
+      adapterCommand: adapter('malformed-suite-adapter.mjs'),
+    });
+
+    expect(summary.adapter?.hostileObjectSuite).toBeUndefined();
+    expect(formatPrettyReport(summary))
+      .toContain('hostile-object suite: none declared (required by RFC 0012)');
   });
 
   it('reports cases whose family the adapter does not announce', async () => {

--- a/packages/protocol-conformance/src/runner.test.ts
+++ b/packages/protocol-conformance/src/runner.test.ts
@@ -1,9 +1,9 @@
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { formatPrettyReport } from './report.js';
 import { runConformance } from './runner.js';
 
 const miniFixtures = fileURLToPath(new URL('./testdata/mini-fixtures/', import.meta.url));
+const hostFixtures = fileURLToPath(new URL('./testdata/host-fixtures/', import.meta.url));
 const adapter = (name: string): string[] => [
   'node',
   fileURLToPath(new URL(`./testdata/${name}`, import.meta.url)),
@@ -24,15 +24,11 @@ describe('runConformance', () => {
       .toEqual({ count: 2, mechanisms: ['getter', 'toJSON'] });
   });
 
-  it('ignores malformed hostile-object metadata from an adapter', async () => {
-    const summary = await runConformance({
+  it('rejects malformed hostile-object metadata from an adapter', async () => {
+    await expect(runConformance({
       fixturesDir: miniFixtures,
       adapterCommand: adapter('malformed-suite-adapter.mjs'),
-    });
-
-    expect(summary.adapter?.hostileObjectSuite).toBeUndefined();
-    expect(formatPrettyReport(summary))
-      .toContain('hostile-object suite: none declared (required by RFC 0012)');
+    })).rejects.toThrow('mechanisms must be unique non-empty strings');
   });
 
   it('reports cases whose family the adapter does not announce', async () => {
@@ -43,6 +39,20 @@ describe('runConformance', () => {
     // fam-b/success/b1 is not announced.
     expect(summary.notRun).toBe(1);
     expect(summary.passed).toBe(3);
+  });
+
+  it('rejects a missing hostile-object suite for a host-model family', async () => {
+    await expect(runConformance({
+      fixturesDir: hostFixtures,
+      adapterCommand: [...adapter('suite-adapter.mjs'), 'missing'],
+    })).rejects.toThrow('must declare hostileObjectSuite');
+  });
+
+  it('rejects a malformed hostile-object suite during the handshake', async () => {
+    await expect(runConformance({
+      fixturesDir: hostFixtures,
+      adapterCommand: [...adapter('suite-adapter.mjs'), 'malformed'],
+    })).rejects.toThrow('mechanisms must be unique non-empty strings');
   });
 
   it('restricts to requested families', async () => {

--- a/packages/protocol-conformance/src/runner.ts
+++ b/packages/protocol-conformance/src/runner.ts
@@ -28,30 +28,68 @@ export interface RunConformanceOptions {
 
 const DEFAULT_TIMEOUT_MS = 5_000;
 
+class AdapterExitError extends Error {}
+class AdapterTimeoutError extends Error {}
+
 function parseHostileObjectSuite(
   value: unknown,
 ): HostileObjectSuiteDeclaration | undefined {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
-
-  const declaration = value as Record<string, unknown>;
-  if (!Number.isSafeInteger(declaration.count) || (declaration.count as number) < 0) {
-    return undefined;
+  if (value === undefined) return undefined;
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('adapter hostileObjectSuite must be an object');
+  }
+  const suite = value as Record<string, unknown>;
+  if (!Number.isSafeInteger(suite.count) || (suite.count as number) < 1) {
+    throw new Error('adapter hostileObjectSuite count must be a positive safe integer');
   }
   if (
-    !Array.isArray(declaration.mechanisms)
-    || !declaration.mechanisms.every((mechanism) => typeof mechanism === 'string')
+    !Array.isArray(suite.mechanisms)
+    || suite.mechanisms.length === 0
+    || !suite.mechanisms.every((mechanism) => typeof mechanism === 'string' && mechanism.length > 0)
+    || new Set(suite.mechanisms).size !== suite.mechanisms.length
   ) {
-    return undefined;
+    throw new Error('adapter hostileObjectSuite mechanisms must be unique non-empty strings');
   }
-
   return {
-    count: declaration.count as number,
-    mechanisms: declaration.mechanisms,
+    count: suite.count as number,
+    mechanisms: [...suite.mechanisms] as string[],
   };
 }
 
-class AdapterExitError extends Error {}
-class AdapterTimeoutError extends Error {}
+function parseAdapterHello(
+  message: Record<string, unknown>,
+  hostModelFamilies: ReadonlySet<string>,
+): AdapterHello {
+  if (
+    message.type !== 'hello'
+    || message.protocol !== CONFORMANCE_PROTOCOL_VERSION
+    || !Array.isArray(message.families)
+    || !message.families.every((family) => typeof family === 'string' && family.length > 0)
+  ) {
+    throw new Error('adapter did not answer the handshake');
+  }
+  const families = message.families as string[];
+  const hostileObjectSuite = parseHostileObjectSuite(message.hostileObjectSuite);
+  if (families.some((family) => hostModelFamilies.has(family)) && !hostileObjectSuite) {
+    throw new Error('adapter must declare hostileObjectSuite for host-model families');
+  }
+  for (const field of ['implementation', 'version', 'language'] as const) {
+    if (message[field] !== undefined && typeof message[field] !== 'string') {
+      throw new Error(`adapter hello ${field} must be a string`);
+    }
+  }
+  return {
+    type: 'hello',
+    protocol: CONFORMANCE_PROTOCOL_VERSION,
+    families: [...families],
+    ...(typeof message.implementation === 'string'
+      ? { implementation: message.implementation }
+      : {}),
+    ...(typeof message.version === 'string' ? { version: message.version } : {}),
+    ...(typeof message.language === 'string' ? { language: message.language } : {}),
+    ...(hostileObjectSuite ? { hostileObjectSuite } : {}),
+  };
+}
 
 /** A single adapter child process with a line-oriented message queue. */
 class AdapterConnection {
@@ -116,23 +154,17 @@ class AdapterConnection {
     });
   }
 
-  async handshake(timeoutMs: number): Promise<AdapterHello> {
+  async handshake(
+    timeoutMs: number,
+    hostModelFamilies: ReadonlySet<string>,
+  ): Promise<AdapterHello> {
     this.write({
       type: 'hello',
       protocol: CONFORMANCE_PROTOCOL_VERSION,
       manifestVersion: CONFORMANCE_MANIFEST_VERSION,
     });
     const message = await this.nextMessage(timeoutMs);
-    if (message.type !== 'hello' || !Array.isArray(message.families)) {
-      throw new Error('adapter did not answer the handshake');
-    }
-    const hostileObjectSuite = parseHostileObjectSuite(message.hostileObjectSuite);
-    const hello = { ...message };
-    delete hello.hostileObjectSuite;
-    return {
-      ...hello,
-      ...(hostileObjectSuite ? { hostileObjectSuite } : {}),
-    } as unknown as AdapterHello;
+    return parseAdapterHello(message, hostModelFamilies);
   }
 
   end(): void {
@@ -151,7 +183,18 @@ export async function runConformance(options: RunConformanceOptions): Promise<Ru
   const manifest = loadManifest(fixturesDir);
   const loadJson = createJsonLoader(fixturesDir);
 
-  let cases = enumerateAllCases(manifest, loadJson);
+  const allCases = enumerateAllCases(manifest, loadJson);
+  const hostModelFamilies = new Set(
+    allCases
+      .filter((c) => {
+        const generator = c.case.generator;
+        return typeof generator === 'object'
+          && generator !== null
+          && (generator as Record<string, unknown>).type === 'unsafe-accessor';
+      })
+      .map((c) => c.family),
+  );
+  let cases = allCases;
   if (options.onlyFuzz) cases = cases.filter((c) => c.role === 'fuzz');
   if (options.skipFuzz) cases = cases.filter((c) => c.role !== 'fuzz');
   if (options.families && options.families.length > 0) {
@@ -165,7 +208,13 @@ export async function runConformance(options: RunConformanceOptions): Promise<Ru
   const handshakeTimeoutMs = Math.max(timeoutMs, DEFAULT_TIMEOUT_MS);
 
   let connection = new AdapterConnection(options.adapterCommand);
-  let hello = await connection.handshake(handshakeTimeoutMs);
+  let hello: AdapterHello;
+  try {
+    hello = await connection.handshake(handshakeTimeoutMs, hostModelFamilies);
+  } catch (error) {
+    connection.kill();
+    throw error;
+  }
   let announced = new Set(hello.families);
   let respawnBudget = 1;
 
@@ -227,7 +276,7 @@ export async function runConformance(options: RunConformanceOptions): Promise<Ru
     connection.kill();
     connection = new AdapterConnection(options.adapterCommand);
     try {
-      hello = await connection.handshake(handshakeTimeoutMs);
+      hello = await connection.handshake(handshakeTimeoutMs, hostModelFamilies);
     } catch {
       // A replacement that cannot even complete a handshake ends the run
       // cleanly rather than throwing out of the loop.

--- a/packages/protocol-conformance/src/runner.ts
+++ b/packages/protocol-conformance/src/runner.ts
@@ -12,6 +12,7 @@ import {
   type AdapterHello,
   type CaseOutcome,
   type EnumeratedCase,
+  type HostileObjectSuiteDeclaration,
   type RunSummary,
 } from './types.js';
 
@@ -26,6 +27,28 @@ export interface RunConformanceOptions {
 }
 
 const DEFAULT_TIMEOUT_MS = 5_000;
+
+function parseHostileObjectSuite(
+  value: unknown,
+): HostileObjectSuiteDeclaration | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+
+  const declaration = value as Record<string, unknown>;
+  if (!Number.isSafeInteger(declaration.count) || (declaration.count as number) < 0) {
+    return undefined;
+  }
+  if (
+    !Array.isArray(declaration.mechanisms)
+    || !declaration.mechanisms.every((mechanism) => typeof mechanism === 'string')
+  ) {
+    return undefined;
+  }
+
+  return {
+    count: declaration.count as number,
+    mechanisms: declaration.mechanisms,
+  };
+}
 
 class AdapterExitError extends Error {}
 class AdapterTimeoutError extends Error {}
@@ -103,7 +126,13 @@ class AdapterConnection {
     if (message.type !== 'hello' || !Array.isArray(message.families)) {
       throw new Error('adapter did not answer the handshake');
     }
-    return message as unknown as AdapterHello;
+    const hostileObjectSuite = parseHostileObjectSuite(message.hostileObjectSuite);
+    const hello = { ...message };
+    delete hello.hostileObjectSuite;
+    return {
+      ...hello,
+      ...(hostileObjectSuite ? { hostileObjectSuite } : {}),
+    } as unknown as AdapterHello;
   }
 
   end(): void {

--- a/packages/protocol-conformance/src/runner.ts
+++ b/packages/protocol-conformance/src/runner.ts
@@ -230,6 +230,9 @@ function summarize(
       version: hello.version,
       language: hello.language,
       families: hello.families,
+      ...(hello.hostileObjectSuite
+        ? { hostileObjectSuite: hello.hostileObjectSuite }
+        : {}),
     },
     outcomes,
   };

--- a/packages/protocol-conformance/src/testdata/good-adapter.mjs
+++ b/packages/protocol-conformance/src/testdata/good-adapter.mjs
@@ -10,7 +10,10 @@ rl.on('line', (line) => {
   if (trimmed === '') return;
   const message = JSON.parse(trimmed);
   if (message.type === 'hello') {
-    process.stdout.write(`${JSON.stringify({ type: 'hello', protocol: 1, families })}\n`);
+    const hostileObjectSuite = { count: 2, mechanisms: ['getter', 'toJSON'] };
+    process.stdout.write(
+      `${JSON.stringify({ type: 'hello', protocol: 1, families, hostileObjectSuite })}\n`,
+    );
     return;
   }
   if (message.type === 'end') {

--- a/packages/protocol-conformance/src/testdata/host-fixtures/host-family/rejections.json
+++ b/packages/protocol-conformance/src/testdata/host-fixtures/host-family/rejections.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "unsafe-accessor",
+    "generator": { "type": "unsafe-accessor" },
+    "error": "HQ_HOST_UNSAFE_OBJECT"
+  }
+]

--- a/packages/protocol-conformance/src/testdata/host-fixtures/manifest.json
+++ b/packages/protocol-conformance/src/testdata/host-fixtures/manifest.json
@@ -1,0 +1,14 @@
+{
+  "kind": "hypequery-conformance-manifest",
+  "version": 1,
+  "families": [
+    {
+      "name": "host-family",
+      "codePrefixes": ["HQ_HOST_"],
+      "files": [
+        { "path": "host-family/rejections.json", "role": "rejection" }
+      ]
+    }
+  ],
+  "fuzz": []
+}

--- a/packages/protocol-conformance/src/testdata/malformed-suite-adapter.mjs
+++ b/packages/protocol-conformance/src/testdata/malformed-suite-adapter.mjs
@@ -1,0 +1,18 @@
+import { createInterface } from 'node:readline';
+
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+rl.on('line', (line) => {
+  const message = JSON.parse(line);
+  if (message.type === 'hello') {
+    process.stdout.write(`${JSON.stringify({
+      type: 'hello',
+      protocol: 1,
+      implementation: 'malformed-suite-adapter',
+      families: ['tagged-values-v1'],
+      hostileObjectSuite: { count: 1, mechanisms: 'getter' },
+    })}\n`);
+  } else if (message.type === 'end') {
+    process.exit(0);
+  }
+});

--- a/packages/protocol-conformance/src/testdata/suite-adapter.mjs
+++ b/packages/protocol-conformance/src/testdata/suite-adapter.mjs
@@ -1,0 +1,18 @@
+import { createInterface } from 'node:readline';
+
+const mode = process.argv[2];
+const rl = createInterface({ input: process.stdin });
+
+rl.on('line', (line) => {
+  const message = JSON.parse(line);
+  if (message.type !== 'hello') return;
+  const hostileObjectSuite = mode === 'malformed'
+    ? { count: 1 }
+    : undefined;
+  process.stdout.write(`${JSON.stringify({
+    type: 'hello',
+    protocol: 1,
+    families: ['host-family'],
+    ...(hostileObjectSuite ? { hostileObjectSuite } : {}),
+  })}\n`);
+});

--- a/packages/protocol-conformance/src/types.ts
+++ b/packages/protocol-conformance/src/types.ts
@@ -50,6 +50,19 @@ export interface EnumeratedCase {
   readonly case: Record<string, unknown>;
 }
 
+/**
+ * RFC 0012 requires every implementation to declare a language-specific
+ * hostile-object suite covering the conversion mechanisms the shared
+ * `unsafe-accessor` generator cannot describe. The declaration travels in the
+ * adapter's `hello` message so it lands in the published run summary.
+ */
+export interface HostileObjectSuiteDeclaration {
+  /** Number of cases in the implementation's own suite. */
+  readonly count: number;
+  /** Conversion mechanisms covered, e.g. `getter`, `toJSON`, `__str__`. */
+  readonly mechanisms: readonly string[];
+}
+
 export interface AdapterHello {
   readonly type: 'hello';
   readonly protocol: number;
@@ -57,6 +70,7 @@ export interface AdapterHello {
   readonly version?: string;
   readonly language?: string;
   readonly families: readonly string[];
+  readonly hostileObjectSuite?: HostileObjectSuiteDeclaration;
 }
 
 export type HandlerResult =
@@ -90,6 +104,7 @@ export interface RunSummary {
     readonly version?: string;
     readonly language?: string;
     readonly families: readonly string[];
+    readonly hostileObjectSuite?: HostileObjectSuiteDeclaration;
   };
   readonly outcomes: readonly CaseOutcome[];
 }

--- a/packages/protocol/src/fixtures.test.ts
+++ b/packages/protocol/src/fixtures.test.ts
@@ -39,6 +39,7 @@ const STABLE_FAILURE_CODES = [
   'HQ_VALUE_TOO_MANY_NODES',
   'HQ_VALUE_TOO_MANY_ITEMS',
   'HQ_VALUE_TOO_LARGE',
+  'HQ_VALUE_UNSAFE_OBJECT',
 ] as const;
 
 function readFixture<T>(name: string): T {

--- a/packages/protocol/src/values/codec.test.ts
+++ b/packages/protocol/src/values/codec.test.ts
@@ -130,6 +130,31 @@ describe('canonical value codec', () => {
     expectProtocolError(action, fixture.error);
   });
 
+  it('accepts metadata integers by value and canonicalizes them to integer form', () => {
+    // RFC 0001 defines metadata integers by value, not lexical form: the
+    // fixture manifest cannot carry the 1-vs-1.0 distinction because
+    // JSON.stringify(1.0) writes 1. Number('1.0') defeats literal folding so
+    // this exercises an integral host float on the programmatic entry path.
+    const input = {
+      $hypequery: {
+        type: 'integer',
+        version: Number('1.0'),
+        bits: Number('8.0'),
+        signed: true,
+        value: '1',
+      },
+    };
+
+    expect(encodeCanonicalValueToString(input))
+      .toBe('{"$hypequery":{"bits":8,"signed":true,"type":"integer","value":"1","version":1}}');
+    expectProtocolError(
+      () => validateCanonicalValue({
+        $hypequery: { type: 'integer', version: 1.5, bits: 8, signed: true, value: '1' },
+      }),
+      'HQ_VALUE_INVALID_FORMAT',
+    );
+  });
+
   it('returns a detached deeply frozen snapshot', () => {
     const input = arrayValue(['original']) as {
       $hypequery: { values: string[] };

--- a/packages/protocol/src/values/codec.test.ts
+++ b/packages/protocol/src/values/codec.test.ts
@@ -78,6 +78,20 @@ function generateRejection(generator: NonNullable<RejectionFixture['generator']>
       throw new Error(`Unknown non-finite float: ${String(generator.value)}`);
     }
     case 'repeat-string': return (generator.utf8 ?? '').repeat(generator.count ?? 0);
+    case 'unsafe-accessor': {
+      // A computed accessor rather than a plain data property. The validator
+      // must snapshot without invoking it, and reject the input outright.
+      const value = {} as Record<string, unknown>;
+      Object.defineProperty(value, '$hypequery', {
+        enumerable: true,
+        get: () => ({
+          type: 'uuid',
+          version: 1,
+          value: '01890f3e-7b7b-7cc2-98c4-dc0c0c07398f',
+        }),
+      });
+      return value;
+    }
     default: throw new Error(`Unknown fixture generator: ${generator.type}`);
   }
 }

--- a/packages/protocol/src/values/validate.ts
+++ b/packages/protocol/src/values/validate.ts
@@ -60,10 +60,18 @@ function requireMetadataInteger(value: unknown, path: string): number {
   return value as number;
 }
 
+// Tab, line feed, and carriage return are permitted so authored prose can
+// span lines; JCS escapes them deterministically. Every other C0 control, DEL,
+// and the C1 range stay forbidden.
+const ALLOWED_CONTROL_CHARACTERS = new Set([0x09, 0x0a, 0x0d]);
+
 function validateUnicode(value: string, path: string, maxBytes: number): void {
   for (let index = 0; index < value.length; index += 1) {
     const code = value.charCodeAt(index);
-    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) {
+    if (
+      (code <= 0x1f && !ALLOWED_CONTROL_CHARACTERS.has(code))
+      || (code >= 0x7f && code <= 0x9f)
+    ) {
       valueError('HQ_VALUE_CONTROL_CHARACTER', path);
     }
     if (code >= 0xd800 && code <= 0xdbff) {
@@ -175,7 +183,10 @@ function validateDatetimeTag(tag: JsonRecord, path: string): void {
   }
   const timezone = requireString(tag.timezone, `${path}.timezone`);
   validateUnicode(timezone, `${path}.timezone`, 64);
-  if (timezone !== 'UTC' && !/^[A-Za-z_]+(?:\/[A-Za-z0-9_+-]+)+$/.test(timezone)) {
+  // Single-component identifiers are valid: UTC, EST, GMT, CET, and MST7MDT
+  // are all real tzdb entries. Existence is checked at deployment time
+  // against the server's system.time_zones, not here.
+  if (!/^[A-Za-z][A-Za-z0-9_+-]*(?:\/[A-Za-z0-9_+-]+)*$/.test(timezone)) {
     valueError('HQ_VALUE_INVALID_FORMAT', `${path}.timezone`);
   }
 

--- a/specs/security-protocol/fixtures/identifiers-v1/rejections.json
+++ b/specs/security-protocol/fixtures/identifiers-v1/rejections.json
@@ -54,5 +54,43 @@
       "count": 9
     },
     "error": "HQ_IDENTIFIER_TOO_MANY_SEGMENTS"
+  },
+  {
+    "id": "qualified-bytes-513",
+    "mode": "qualified",
+    "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "error": "HQ_IDENTIFIER_TOO_LONG"
+  },
+  {
+    "id": "reserved-non-first-segment",
+    "mode": "qualified",
+    "value": "orders.__hypequery_internal",
+    "error": "HQ_IDENTIFIER_RESERVED"
+  },
+  {
+    "id": "precedence-length-before-reserved",
+    "mode": "simple",
+    "generator": {
+      "type": "repeat-string",
+      "value": "__hypequery",
+      "count": 12
+    },
+    "error": "HQ_IDENTIFIER_TOO_LONG"
+  },
+  {
+    "id": "precedence-length-before-format",
+    "mode": "simple",
+    "generator": {
+      "type": "repeat-string",
+      "value": "-",
+      "count": 129
+    },
+    "error": "HQ_IDENTIFIER_TOO_LONG"
+  },
+  {
+    "id": "precedence-format-before-reserved",
+    "mode": "simple",
+    "value": "__hypequery-internal",
+    "error": "HQ_IDENTIFIER_INVALID_FORMAT"
   }
 ]

--- a/specs/security-protocol/fixtures/identifiers-v1/success.json
+++ b/specs/security-protocol/fixtures/identifiers-v1/success.json
@@ -3,24 +3,72 @@
     "id": "simple-lowercase",
     "mode": "simple",
     "value": "orders",
-    "segments": ["orders"]
+    "segments": [
+      "orders"
+    ]
   },
   {
     "id": "simple-leading-underscore",
     "mode": "simple",
     "value": "_tenant_id",
-    "segments": ["_tenant_id"]
+    "segments": [
+      "_tenant_id"
+    ]
   },
   {
     "id": "simple-case-preserved",
     "mode": "simple",
     "value": "RevenueByDay",
-    "segments": ["RevenueByDay"]
+    "segments": [
+      "RevenueByDay"
+    ]
   },
   {
     "id": "qualified-relationship-field",
     "mode": "qualified",
     "value": "orders.customer.country",
-    "segments": ["orders", "customer", "country"]
+    "segments": [
+      "orders",
+      "customer",
+      "country"
+    ]
+  },
+  {
+    "id": "segment-bytes-128",
+    "mode": "simple",
+    "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "segments": [
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    ]
+  },
+  {
+    "id": "qualified-segments-8",
+    "mode": "qualified",
+    "value": "s0.s1.s2.s3.s4.s5.s6.s7",
+    "segments": [
+      "s0",
+      "s1",
+      "s2",
+      "s3",
+      "s4",
+      "s5",
+      "s6",
+      "s7"
+    ]
+  },
+  {
+    "id": "qualified-bytes-512",
+    "mode": "qualified",
+    "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "segments": [
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    ]
   }
 ]

--- a/specs/security-protocol/fixtures/identifiers-v1/success.json
+++ b/specs/security-protocol/fixtures/identifiers-v1/success.json
@@ -3,72 +3,42 @@
     "id": "simple-lowercase",
     "mode": "simple",
     "value": "orders",
-    "segments": [
-      "orders"
-    ]
+    "segments": ["orders"]
   },
   {
     "id": "simple-leading-underscore",
     "mode": "simple",
     "value": "_tenant_id",
-    "segments": [
-      "_tenant_id"
-    ]
+    "segments": ["_tenant_id"]
   },
   {
     "id": "simple-case-preserved",
     "mode": "simple",
     "value": "RevenueByDay",
-    "segments": [
-      "RevenueByDay"
-    ]
+    "segments": ["RevenueByDay"]
   },
   {
     "id": "qualified-relationship-field",
     "mode": "qualified",
     "value": "orders.customer.country",
-    "segments": [
-      "orders",
-      "customer",
-      "country"
-    ]
+    "segments": ["orders", "customer", "country"]
   },
   {
     "id": "segment-bytes-128",
     "mode": "simple",
     "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "segments": [
-      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-    ]
+    "segments": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
   },
   {
     "id": "qualified-segments-8",
     "mode": "qualified",
     "value": "s0.s1.s2.s3.s4.s5.s6.s7",
-    "segments": [
-      "s0",
-      "s1",
-      "s2",
-      "s3",
-      "s4",
-      "s5",
-      "s6",
-      "s7"
-    ]
+    "segments": ["s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7"]
   },
   {
     "id": "qualified-bytes-512",
     "mode": "qualified",
     "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "segments": [
-      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-    ]
+    "segments": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
   }
 ]

--- a/specs/security-protocol/fixtures/tagged-values-v1/README.md
+++ b/specs/security-protocol/fixtures/tagged-values-v1/README.md
@@ -1,8 +1,55 @@
-# Tagged value v1 fixtures
+# Tagged value version 1 fixtures
 
-These draft fixtures accompany RFC 0001 and pin canonical values before they become a stable wire contract.
+These draft language-neutral fixtures accompany RFC 0001. They become
+normative when the RFC is accepted.
 
-- `success.json` contains parsed values, exact RFC 8785 UTF-8 bytes as hex, and SHA-256 integrity hashes.
-- `rejections.json` contains exact JSON source, parsed values, or deterministic boundary generators with required error codes.
+## Success manifest
 
-The hash here verifies fixture bytes; it is not a deployment or cache identity. Duplicate-key cases must reach a duplicate-aware parser before ordinary object decoding. Generated cases cover non-finite numbers, nested and wide arrays, repeated strings, and integer tag/type compatibility.
+Each entry in `success.json` contains:
+
+- `id`: stable fixture identifier;
+- `value`: the parsed canonical value before JCS;
+- `canonicalHex`: exact RFC 8785 canonical UTF-8 bytes as lowercase hex;
+- `sha256`: lowercase SHA-256 of those exact bytes.
+
+The hash is a fixture integrity check, not a deployment digest or cache key.
+
+## Rejection manifest
+
+Entries in `rejections.json` use one of:
+
+- `sourceUtf8`: exact JSON source presented to a duplicate-aware parser;
+- `value`: an already parsed value presented to model validation;
+- `generator`: a deterministic boundary case that would be wasteful to store
+  expanded.
+
+`declaredClickHouseType`, when present, supplies the containing schema type
+needed to validate integer-tag requirements and exact tag/type compatibility.
+
+Generators expand as follows:
+
+- `non-finite-float`: creates the host-language non-finite number named by
+  `value` (`NaN`, `Infinity`, or `-Infinity`) after JSON parsing;
+- `nested-array`: wraps `leaf` in the tagged array form `depth` times;
+- `array`: creates one tagged array containing `items` copies of `value`;
+- `array-tree`: creates one tagged array containing `branches` tagged arrays,
+  each containing `itemsPerBranch` copies of `value`;
+- `repeat-string`: concatenates `count` copies of the UTF-8 string `utf8`;
+- `unsafe-accessor`: builds an object whose `$hypequery` member is served by a
+  computed accessor rather than a plain data property. Implementations whose
+  input model cannot express computed accessors respond `skipped`, and must
+  then declare their own hostile-object suite per RFC 0012.
+
+`error` is the required stable failure code. `phase` identifies the earliest
+stage that must reject the input. A consumer may reject earlier only when it
+returns the same code and does not partially execute or hash the value.
+
+## What these fixtures cannot express
+
+Metadata integers are accepted by value, not by lexical form: `1`, `1.0`, and
+`1e0` all denote `1` and all canonicalize to `1`. The manifest cannot carry
+that distinction — writing `1.0` into a `value` field serializes back to `1` —
+so per-language unit tests cover the coercion of an integral host float.
+
+Fixture runners must not pass `sourceUtf8` through an ordinary JSON dictionary
+parser before duplicate-key detection.

--- a/specs/security-protocol/fixtures/tagged-values-v1/rejections.json
+++ b/specs/security-protocol/fixtures/tagged-values-v1/rejections.json
@@ -60,10 +60,7 @@
   {
     "id": "raw-array",
     "phase": "model",
-    "value": [
-      true,
-      false
-    ],
+    "value": [true, false],
     "error": "HQ_VALUE_RAW_COMPOSITE"
   },
   {
@@ -356,5 +353,35 @@
       }
     },
     "error": "HQ_VALUE_INVALID_FORMAT"
+  },
+  {
+    "id": "timezone-leading-underscore",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "datetime",
+        "version": 1,
+        "clickhouseType": "DateTime",
+        "precision": 0,
+        "timezone": "_Foo/Bar",
+        "value": "2026-07-13T14:30:45Z"
+      }
+    },
+    "error": "HQ_VALUE_INVALID_FORMAT"
+  },
+  {
+    "id": "timezone-too-long",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "datetime",
+        "version": 1,
+        "clickhouseType": "DateTime",
+        "precision": 0,
+        "timezone": "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "value": "2026-07-13T14:30:45Z"
+      }
+    },
+    "error": "HQ_VALUE_TOO_LARGE"
   }
 ]

--- a/specs/security-protocol/fixtures/tagged-values-v1/rejections.json
+++ b/specs/security-protocol/fixtures/tagged-values-v1/rejections.json
@@ -60,7 +60,10 @@
   {
     "id": "raw-array",
     "phase": "model",
-    "value": [true, false],
+    "value": [
+      true,
+      false
+    ],
     "error": "HQ_VALUE_RAW_COMPOSITE"
   },
   {
@@ -294,5 +297,64 @@
       "count": 65537
     },
     "error": "HQ_VALUE_TOO_LARGE"
+  },
+  {
+    "id": "datetime64-nanoseconds-overflow",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "datetime",
+        "version": 1,
+        "clickhouseType": "DateTime64",
+        "precision": 9,
+        "timezone": "UTC",
+        "value": "2262-04-11T23:47:16.854775808Z"
+      }
+    },
+    "error": "HQ_VALUE_OUT_OF_RANGE"
+  },
+  {
+    "id": "timezone-fixed-offset",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "datetime",
+        "version": 1,
+        "clickhouseType": "DateTime",
+        "precision": 0,
+        "timezone": "+02:00",
+        "value": "2026-07-13T14:30:45Z"
+      }
+    },
+    "error": "HQ_VALUE_INVALID_FORMAT"
+  },
+  {
+    "id": "control-character-vertical-tab",
+    "phase": "model",
+    "value": "before\u000bafter",
+    "error": "HQ_VALUE_CONTROL_CHARACTER"
+  },
+  {
+    "id": "value-unsafe-accessor",
+    "phase": "model",
+    "generator": {
+      "type": "unsafe-accessor"
+    },
+    "error": "HQ_VALUE_UNSAFE_OBJECT"
+  },
+  {
+    "id": "timezone-offset-shaped",
+    "phase": "model",
+    "value": {
+      "$hypequery": {
+        "type": "datetime",
+        "version": 1,
+        "clickhouseType": "DateTime",
+        "precision": 0,
+        "timezone": "+0200",
+        "value": "2026-07-13T14:30:45Z"
+      }
+    },
+    "error": "HQ_VALUE_INVALID_FORMAT"
   }
 ]

--- a/specs/security-protocol/fixtures/tagged-values-v1/success.json
+++ b/specs/security-protocol/fixtures/tagged-values-v1/success.json
@@ -258,5 +258,132 @@
     },
     "canonicalHex": "7b2224687970657175657279223a7b22656e7472696573223a5b5b22726567696f6e222c7b2224687970657175657279223a7b2262697473223a382c227369676e6564223a66616c73652c2274797065223a22696e7465676572222c2276616c7565223a2231222c2276657273696f6e223a317d7d5d2c5b22726567696f6e222c7b2224687970657175657279223a7b2262697473223a382c227369676e6564223a66616c73652c2274797065223a22696e7465676572222c2276616c7565223a2232222c2276657273696f6e223a317d7d5d5d2c2274797065223a226d6170222c2276657273696f6e223a317d7d",
     "sha256": "9cb2c26100b18e84f1a6974424ddd600ef8a0a7d113420bb882e61e9fa690f41"
+  },
+  {
+    "id": "native-float-integral",
+    "value": 100,
+    "canonicalHex": "313030",
+    "sha256": "ad57366865126e55649ecb23ae1d48887544976efea46a48eb5d85a6eeb4d306"
+  },
+  {
+    "id": "native-float-1e20",
+    "value": 100000000000000000000,
+    "canonicalHex": "313030303030303030303030303030303030303030",
+    "sha256": "c344e9487bfbd5c4e03c9fb90d62a5dde5e00b54d55c46e9f4a803aea162b80c"
+  },
+  {
+    "id": "native-float-1e21",
+    "value": 1e+21,
+    "canonicalHex": "31652b3231",
+    "sha256": "241c4643fa70b1dcde1205b71be4e3bebb17e9f880c8e1a33d0ead6c27271d3c"
+  },
+  {
+    "id": "native-float-1e-6",
+    "value": 0.000001,
+    "canonicalHex": "302e303030303031",
+    "sha256": "159fb29a827ad04b260aa6c8ab6d8637f8f2b38af5c4f3cb49d6a21205e040f8"
+  },
+  {
+    "id": "native-float-1e-7",
+    "value": 1e-7,
+    "canonicalHex": "31652d37",
+    "sha256": "5b33e02f2c5103a05d32f6ba9cb058294452bfbf393967f68bb30c1bdcbbab22"
+  },
+  {
+    "id": "native-float-min-subnormal",
+    "value": 5e-324,
+    "canonicalHex": "35652d333234",
+    "sha256": "c46e7ca1be4c8734f373a56530787288fa2058d73d07855e9247e949f811a42a"
+  },
+  {
+    "id": "native-float-max",
+    "value": 1.7976931348623157e+308,
+    "canonicalHex": "312e37393736393331333438363233313537652b333038",
+    "sha256": "c2784e1abd6317452708f3fbf9641c16b959561bc621a1d408c23a20aa2cb585"
+  },
+  {
+    "id": "string-permitted-controls",
+    "value": "line one\nline two\tcolumn\r",
+    "canonicalHex": "226c696e65206f6e655c6e6c696e652074776f5c74636f6c756d6e5c7222",
+    "sha256": "9b594976b60e2f6bd159be2c67d7fedfb81bfcd5e5791cedbe5690ac2abc7585"
+  },
+  {
+    "id": "array-empty",
+    "value": {
+      "$hypequery": {
+        "type": "array",
+        "version": 1,
+        "values": []
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b2274797065223a226172726179222c2276616c756573223a5b5d2c2276657273696f6e223a317d7d",
+    "sha256": "6d724ac91452322c69323b0304ebf6e1ac42fdc61a44862e520be76032155d10"
+  },
+  {
+    "id": "tuple-empty",
+    "value": {
+      "$hypequery": {
+        "type": "tuple",
+        "version": 1,
+        "values": []
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b2274797065223a227475706c65222c2276616c756573223a5b5d2c2276657273696f6e223a317d7d",
+    "sha256": "20ded50e2861b59705d0974bcdc2282f34715d5ddbebb74c1c7c3e3df87ae19c"
+  },
+  {
+    "id": "map-empty",
+    "value": {
+      "$hypequery": {
+        "type": "map",
+        "version": 1,
+        "entries": []
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b22656e7472696573223a5b5d2c2274797065223a226d6170222c2276657273696f6e223a317d7d",
+    "sha256": "8653f18f098a82f3408f83f03427aad582d0437f79b245f4d00dbb1237562a50"
+  },
+  {
+    "id": "datetime64-nanoseconds-max",
+    "value": {
+      "$hypequery": {
+        "type": "datetime",
+        "version": 1,
+        "clickhouseType": "DateTime64",
+        "precision": 9,
+        "timezone": "UTC",
+        "value": "2262-04-11T23:47:16.854775807Z"
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b22636c69636b686f75736554797065223a224461746554696d653634222c22707265636973696f6e223a392c2274696d657a6f6e65223a22555443222c2274797065223a226461746574696d65222c2276616c7565223a22323236322d30342d31315432333a34373a31362e3835343737353830375a222c2276657273696f6e223a317d7d",
+    "sha256": "612b88ad3689cc220ea3d9cc121844f09c6fb0c3c887c47a6bae3493b0f14f51"
+  },
+  {
+    "id": "bytes-empty",
+    "value": {
+      "$hypequery": {
+        "type": "bytes",
+        "version": 1,
+        "encoding": "base64url",
+        "value": ""
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b22656e636f64696e67223a2262617365363475726c222c2274797065223a226279746573222c2276616c7565223a22222c2276657273696f6e223a317d7d",
+    "sha256": "92a36c3f7f5e8edb9cb206b8b4c4d15926581bc583d03f2b8a567a4ae208e359"
+  },
+  {
+    "id": "datetime-single-component-timezone",
+    "value": {
+      "$hypequery": {
+        "type": "datetime",
+        "version": 1,
+        "clickhouseType": "DateTime",
+        "precision": 0,
+        "timezone": "EST",
+        "value": "2026-07-13T14:30:45Z"
+      }
+    },
+    "canonicalHex": "7b2224687970657175657279223a7b22636c69636b686f75736554797065223a224461746554696d65222c22707265636973696f6e223a302c2274696d657a6f6e65223a22455354222c2274797065223a226461746574696d65222c2276616c7565223a22323032362d30372d31335431343a33303a34355a222c2276657273696f6e223a317d7d",
+    "sha256": "6bee1aad475dfbf35566bf71dc664b6f0c7a4c9dcc4ba0b5a76e9069be2cce6e"
   }
 ]

--- a/specs/security-protocol/rfc/0001-tagged-clickhouse-value-model.md
+++ b/specs/security-protocol/rfc/0001-tagged-clickhouse-value-model.md
@@ -1,9 +1,13 @@
 # RFC 0001: Tagged ClickHouse value model
 
-- Status: Proposed
+- Status: Accepted
 - Created: 2026-07-13
+- Accepted: 2026-07-30
 - Target extension version: 1
 - Owners: Hypequery maintainers
+
+Acceptance freezes extension version 1. Changing a rule below now requires a
+new extension version, not an edit.
 
 ## Summary
 
@@ -76,9 +80,15 @@ The following values use native JSON representations:
 - JSON strings for Unicode text;
 - JSON numbers for finite binary floating-point values only.
 
-Strings MUST contain valid Unicode scalar values, MUST be preserved without
-Unicode normalization, and MUST NOT contain C0 control characters U+0000
-through U+001F, DEL U+007F, or C1 control characters U+0080 through U+009F.
+Strings MUST contain valid Unicode scalar values and MUST be preserved without
+Unicode normalization.
+
+Tab U+0009, line feed U+000A, and carriage return U+000D are permitted, so that
+descriptions and other authored prose may span lines. Every other C0 control
+character in U+0000 through U+001F, DEL U+007F, and every C1 control character
+in U+0080 through U+009F are forbidden. JCS escapes the three permitted
+controls deterministically, so canonical bytes remain unambiguous.
+
 Quotes, backslashes, comment-looking text, and other ordinary Unicode remain
 data.
 
@@ -92,6 +102,43 @@ Strict tag metadata such as `version`, `bits`, `precision`, `scale`, and enum
 `code` uses bounded native JSON integers because each field's integer meaning
 and range are fixed by its tag schema. The integer-tag requirement applies to
 semantic values, not to these closed-schema metadata fields.
+
+These metadata fields are defined **by value, not by lexical form**. A metadata
+integer MUST be a finite number that is mathematically integral, is not
+negative zero, lies within the interoperable safe-integer range, and satisfies
+its field's own range. `1`, `1.0`, and `1e0` all denote the integer `1` and are
+all accepted; each canonicalizes to `1`, so they are indistinguishable in
+canonical bytes. `1.5` is rejected with `HQ_VALUE_INVALID_FORMAT`.
+
+Lexical rejection is deliberately **not** required. JavaScript erases the
+distinction between `1` and `1.0` at parse time, so a rule keyed on lexical
+form could only be honoured by one language on the programmatic entry path:
+an implementation handed an already-constructed host value would accept `1.0`
+in JavaScript and reject it in Python, for the same logical input. Because
+every accepted spelling produces identical canonical bytes, the strictness
+would create a cross-language divergence without preventing any confusion,
+downgrade, or hash collision. Implementations MUST therefore coerce an
+integral host float to its integer value rather than rejecting it.
+
+### Number serialization is the ECMAScript algorithm
+
+RFC 8785 serializes numbers using the ECMAScript `Number::toString` algorithm.
+This is not equivalent to a host language's default float formatting, and the
+difference is silent rather than loud:
+
+| Value | Python `json.dumps` | Required by JCS |
+| --- | --- | --- |
+| `1e20` | `1e+20` | `100000000000000000000` |
+| `1e-7` | `1e-07` | `1e-7` |
+| `1e-6` | `1e-06` | `0.000001` |
+| `100.0` | `100.0` | `100` |
+
+A JavaScript implementation inherits the correct behaviour from
+`JSON.stringify`. Every other implementation MUST implement shortest
+round-trip formatting with ECMAScript's exponent thresholds and notation
+explicitly, and MUST NOT delegate to a host `repr`, `str`, or default JSON
+encoder. Conformance fixtures cover the boundaries where host formatting is
+known to diverge.
 
 Raw JSON arrays and application-created objects are not canonical values. They
 must be represented by the array, tuple, or map tags. Objects belonging to the
@@ -215,15 +262,46 @@ scale. For example Decimal(9, 4) value `12.3400` has coefficient `123400`.
 - `clickhouseType` MUST be `DateTime` or `DateTime64`.
 - `precision` MUST be `0` for `DateTime` and an integer from `0` through `9`
   for `DateTime64`.
-- `timezone` MUST be the explicit canonical IANA timezone name selected by the
-  containing schema. `UTC` is valid. Fixed-offset labels and local-process
-  defaults are forbidden.
+- `timezone` MUST be an explicit **timezone identifier** supplied by the
+  containing schema. Offset labels such as `+02:00` and local-process defaults
+  are forbidden. The value layer does not assert that the identifier names a
+  real zone; it asserts only that the identifier is syntactically safe and
+  exactly equal to the one the containing type declares.
+- Validation is lexical: one or more `/`-separated components, each matching
+  `[A-Za-z0-9_+-]+`, with the first component beginning with an ASCII letter,
+  at most 64 bytes in total, no empty component, no leading or trailing `/`,
+  and no component equal to `.` or `..`. Single-component identifiers are
+  valid, because `UTC`, `EST`, `GMT`, `CET`, `MST7MDT`, and `W-SU` are all
+  real tzdb entries. Requiring a leading letter rejects offset-shaped input
+  such as `+0200` while still admitting `Etc/GMT+5`.
+- Implementations MUST NOT require the identifier to resolve in the host
+  timezone database. Python `zoneinfo` and JavaScript ICU disagree about
+  renamed zones such as `Europe/Kiev` versus `Europe/Kyiv`, and tzdb naming
+  is explicitly documented as evolving, so a host-resolved check would make
+  conformance depend on the OS image rather than the protocol.
+- Existence is a **deployment-time** concern, not a value-layer one. The
+  deployment contract validates the identifier against the target server's
+  `system.time_zones`, which is the set ClickHouse actually supports.
 - `value` MUST be an RFC 3339 UTC instant ending in uppercase `Z`.
 - The fractional part MUST be absent at precision `0` and contain exactly
   `precision` digits otherwise. Inputs with offsets are normalized to this UTC
   form before the tag is constructed.
-- The instant MUST fit the declared ClickHouse type and precision. In
-  particular, `DateTime64(9)` has a narrower upper bound than lower precisions.
+- The instant MUST fit the **portable v1 range** for the declared type and
+  precision:
+  - `DateTime`: `1970-01-01T00:00:00Z` through `2106-02-07T06:28:15Z`.
+  - `DateTime64(P)` for `P` in `0`–`8`: `1900-01-01T00:00:00Z` through
+    `2299-12-31T23:59:59Z` plus `P` fractional nines.
+  - `DateTime64(9)`: `1900-01-01T00:00:00Z` through
+    `2262-04-11T23:47:16.854775807Z`, the largest instant representable as a
+    signed 64-bit count of nanosecond ticks since `1970-01-01T00:00:00Z`.
+
+  This is deliberately a **conservative subset**, not a restatement of
+  ClickHouse's own limits. ClickHouse documents a wider range at some
+  precisions and a narrower one at others, and those limits have moved between
+  releases. Freezing a subset that is valid across the supported server range
+  keeps artifact identity stable when a server upgrade changes the underlying
+  type. Implementations MUST use these exact bounds rather than deriving their
+  own or querying the server.
 
 The timezone is type policy and display/parse context; the canonical `value`
 identifies the instant. No implementation may infer a missing timezone.
@@ -354,11 +432,20 @@ lower limit but MUST NOT accept a larger value under extension version 1.
 | Decimal precision | 76 |
 
 Depth is `0` for a native scalar or scalar tag. Entering an array, tuple, or map
-adds one; each map key and value is traversed at that depth. Node count includes
-every scalar, scalar tag, composite tag, map key, and map value.
+tag adds one. A map entry's two-element `[key, value]` array is structural and
+does not add a further level: both members are traversed at the map's own depth.
+
+Node count includes every scalar, every scalar tag, every composite tag, and
+every map key and map value. The `values` and `entries` arrays are structural
+and are not counted separately from the tag that owns them.
 
 Implementations MUST check limits during parsing/validation rather than first
 allocating an unbounded host-language object.
+
+The encoded-input limit applies only when the implementation is given bytes or
+text. When an already-parsed host value is supplied that stage is skipped, and
+the canonical-output limit becomes the binding size constraint. Every other
+limit applies to both entry points.
 
 ## Stable failure codes
 
@@ -387,10 +474,34 @@ Version 1 conformance fixtures use these minimum codes:
 Products may attach safe source locations and expected types, but these codes
 and their meaning are part of the frozen value contract.
 
+`HQ_VALUE_UNSAFE_OBJECT` guards against host-language objects — getters,
+proxies, `toJSON`, `__str__`, `__getattr__`, descriptors, and comparable
+conversion hooks — none of which survive a JSON encoding. It is proven in two
+layers:
+
+1. The shared `unsafe-accessor` generator in the tagged-values rejection
+   manifest, which every implementation translates into a representative host
+   object. This is the same mechanism the expression, schema, event,
+   deployment, bundle, and release families already use.
+2. A language-specific suite covering the conversion mechanisms the shared
+   generator cannot describe. TypeScript covers at least getters, `toJSON`,
+   custom prototypes, symbol keys, and sparse arrays; Python covers at least
+   property descriptors, custom mappings, `__iter__`, `__str__`, `dict`
+   subclasses, and cyclic structures.
+
+RFC 0012 defines the generator and requires the language-specific suite to be
+declared. An implementation that skips the shared cases without declaring its
+own suite is incomplete, not passing.
+
 ## Security considerations
 
 - Validation must inspect plain data and must not invoke getters, proxies,
   `toJSON`, Python dunder conversion, or custom serializers.
+- Number formatting is a correctness boundary, not a cosmetic one. An
+  implementation that delegates float serialization to its host language will
+  produce different canonical bytes, and therefore different artifact
+  identities, for values that round-trip identically. This fails open: the
+  values compare equal in memory while the hashes disagree.
 - A rendered/debug representation is never executable SQL.
 - Unknown tags and fields fail closed to prevent downgrade-by-interpretation.
 - Duplicate-key detection occurs before normal object construction.

--- a/specs/security-protocol/rfc/0001-tagged-clickhouse-value-model.md
+++ b/specs/security-protocol/rfc/0001-tagged-clickhouse-value-model.md
@@ -274,6 +274,9 @@ scale. For example Decimal(9, 4) value `12.3400` has coefficient `123400`.
   valid, because `UTC`, `EST`, `GMT`, `CET`, `MST7MDT`, and `W-SU` are all
   real tzdb entries. Requiring a leading letter rejects offset-shaped input
   such as `+0200` while still admitting `Etc/GMT+5`.
+- Exceeding the 64-byte limit reports `HQ_VALUE_TOO_LARGE`, consistent with
+  every other byte-limit failure; all other lexical failures report
+  `HQ_VALUE_INVALID_FORMAT`.
 - Implementations MUST NOT require the identifier to resolve in the host
   timezone database. Python `zoneinfo` and JavaScript ICU disagree about
   renamed zones such as `Europe/Kiev` versus `Europe/Kyiv`, and tzdb naming

--- a/specs/security-protocol/rfc/0001-tagged-clickhouse-value-model.md
+++ b/specs/security-protocol/rfc/0001-tagged-clickhouse-value-model.md
@@ -160,8 +160,10 @@ A tagged value has this shape:
 
 The outer object MUST contain exactly `$hypequery`. The payload MUST contain
 exactly the fields defined for its tag. Unknown fields, unknown types, and
-unknown versions fail closed. Version 1 payloads use the integer JSON number
-`1`; a string or floating representation is invalid.
+unknown versions fail closed. Version 1 payloads use a metadata number whose
+mathematical value is the integer `1`; strings and non-integral numbers are
+invalid. Consistent with the metadata rule above, lexical forms such as `1.0`
+and `1e0` are accepted and canonicalize to `1`.
 
 The tag is a data-model extension, not a JCS extension. It is validated into an
 ordinary I-JSON tree and then canonicalized normally.

--- a/specs/security-protocol/rfc/0002-portable-identifiers.md
+++ b/specs/security-protocol/rfc/0002-portable-identifiers.md
@@ -1,7 +1,12 @@
 # RFC 0002: Portable logical identifiers
 
-- Status: Proposed
+- Status: Accepted
+- Accepted: 2026-07-30
 - Version: identifier extension 1
+
+Acceptance freezes identifier extension version 1. Changing the grammar,
+comparison rules, reserved namespace, limits, or validation order now requires
+a new extension version, not an edit.
 
 ## Summary
 
@@ -29,7 +34,38 @@ only, so visually equivalent Unicode spellings are rejected rather than
 normalized.
 
 The `__hypequery` prefix is reserved for protocol-defined names. A future core
-version may define such names; applications cannot claim them in version 1.
+version may define such names; applications cannot claim them in version 1. In
+a qualified identifier the reservation applies to **every** segment, not only
+the first: `orders.__hypequery_internal` is rejected.
+
+## Validation order
+
+Checks MUST be applied in this order, and the first failure determines the
+reported code:
+
+1. `HQ_IDENTIFIER_TYPE` — the input is not a JSON string.
+2. `HQ_IDENTIFIER_EMPTY` — the input has zero length.
+3. `HQ_IDENTIFIER_TOO_LONG` — a byte limit is exceeded.
+4. `HQ_IDENTIFIER_INVALID_FORMAT` — the character grammar does not match.
+5. `HQ_IDENTIFIER_RESERVED` — the reserved prefix is present.
+
+The order is normative because more than one check can apply to the same input.
+A 200-byte name beginning with `__hypequery` reports `HQ_IDENTIFIER_TOO_LONG`,
+not `HQ_IDENTIFIER_RESERVED`. A 129-byte name containing a hyphen reports
+`HQ_IDENTIFIER_TOO_LONG`, not `HQ_IDENTIFIER_INVALID_FORMAT`.
+
+Step 4 preceding step 5 is a **security property**, not a preference. The
+reserved-prefix comparison is ASCII case-insensitive; placing the grammar check
+first guarantees it only ever sees ASCII. Case-folding rules for non-ASCII
+input differ between host languages — the dotted and dotless `i` families are
+the standard example — so a reserved check reached before the ASCII gate could
+accept in one language and reject in another.
+
+For qualified identifiers the checks apply first to the whole string (type,
+emptiness, the 512-byte limit, then the segment count) and afterwards to each
+segment in order. An empty segment inside a qualified identifier reports
+`HQ_IDENTIFIER_INVALID_FORMAT` rather than `HQ_IDENTIFIER_EMPTY`, because the
+qualified string itself is not empty.
 
 ## Qualified identifiers
 
@@ -61,6 +97,14 @@ translation into those domains.
 Products may impose lower limits but cannot reinterpret accepted version 1
 identifiers.
 
+`HQ_IDENTIFIER_TOO_LONG` covers both the segment limit and the qualified limit.
+A product that needs to tell a caller which bound was exceeded may add safe
+detail alongside the code, but the code itself does not distinguish them.
+
+Because version 1 is ASCII only, byte length and character count are always
+equal. Implementations MUST still measure UTF-8 bytes, so that rejected
+non-ASCII input is measured consistently.
+
 ## Stable failure codes
 
 - `HQ_IDENTIFIER_TYPE`
@@ -77,6 +121,12 @@ calling product explicitly chooses a safe redacted presentation.
 
 - ASCII-only names avoid confusable and normalization disagreements at the
   portable artifact boundary.
+- ASCII-only names also make canonical object-key ordering language-neutral.
+  RFC 8785 sorts object properties by UTF-16 code unit; a code-point sort
+  disagrees with that only above the basic multilingual plane. Restricting
+  identifiers to ASCII means the two orderings coincide wherever an identifier
+  could influence a key, so a canonicalizer cannot produce different bytes in
+  different languages for the same model.
 - The reserved namespace prevents user data from impersonating future protocol
   fields.
 - Parsers validate limits before allocating derived structures.

--- a/specs/security-protocol/rfc/0012-cross-language-conformance.md
+++ b/specs/security-protocol/rfc/0012-cross-language-conformance.md
@@ -128,6 +128,20 @@ parsed JSON dictionaries) cannot construct the input; their adapters respond
 Only `unsafe-accessor` cases are host-model conditional; skipping any other
 case is a conformance failure.
 
+Skipping is permitted because the input cannot be constructed, not because the
+guarantee is optional. Every implementation MUST additionally declare, in its
+conformance report, a language-specific hostile-object suite covering its own
+conversion mechanisms — getters, proxies, `toJSON`, `__str__`, `__getattr__`,
+descriptors, and comparable hooks — together with the count of cases it
+contains. TypeScript covers at least getters, `toJSON`, custom prototypes,
+symbol keys, and sparse arrays; Python covers at least property descriptors,
+custom mappings, `__iter__`, `__str__`, `dict` subclasses, and cyclic
+structures.
+
+A report that skips the shared cases and declares no such suite is incomplete,
+not passing. Without both layers `HQ_VALUE_UNSAFE_OBJECT` would be the one
+frozen failure code no implementation is ever required to demonstrate.
+
 ## Operations and pass criteria
 
 The adapter dispatches on `family`, `role`, and in-case fields. No operation

--- a/specs/security-protocol/rfc/0012-cross-language-conformance.md
+++ b/specs/security-protocol/rfc/0012-cross-language-conformance.md
@@ -90,8 +90,17 @@ The adapter answers the hello first:
 ```json
 {"type": "hello", "protocol": 1, "implementation": "@hypequery/protocol",
  "version": "0.9.0", "language": "typescript",
- "families": ["tagged-values-v1", "identifiers-v1"]}
+ "families": ["tagged-values-v1", "identifiers-v1"],
+ "hostileObjectSuite": {"count": 7,
+  "mechanisms": ["getter", "toJSON", "proxy", "custom-prototype",
+                 "symbol-key", "sparse-array", "cycle"]}}
 ```
+
+`hostileObjectSuite` is the declaration required under *Host-model conditional
+cases* below. It is optional on the wire so that adapters announcing only
+text-input families (such as `sql-portability-v1`) can omit it, but an adapter
+announcing a family that accepts host values MUST send it. The runner copies it
+into the run summary, which is how it reaches the published report.
 
 The runner only sends cases for families the adapter announced; this
 intersection is how one runner serves partial implementations, such as a
@@ -134,11 +143,14 @@ Only `unsafe-accessor` cases are host-model conditional; skipping any other
 case is a conformance failure.
 
 Skipping is permitted because the input cannot be constructed, not because the
-guarantee is optional. Every implementation MUST additionally declare, in its
-conformance report, a language-specific hostile-object suite covering its own
-conversion mechanisms — getters, proxies, `toJSON`, `__str__`, `__getattr__`,
-descriptors, and comparable hooks — together with the count of cases it
-contains. TypeScript covers at least getters, `toJSON`, custom prototypes,
+guarantee is optional. Every implementation of a family that accepts host
+values MUST additionally declare a language-specific hostile-object suite
+covering its own conversion mechanisms — getters, proxies, `toJSON`,
+`__str__`, `__getattr__`, descriptors, and comparable hooks — together with
+the count of cases it contains. The declaration is carried in the adapter's
+`hello` message as `hostileObjectSuite` and copied by the runner into the run
+summary, so it appears in the published report rather than in prose alongside
+it. TypeScript covers at least getters, `toJSON`, custom prototypes,
 symbol keys, and sparse arrays; Python covers at least property descriptors,
 custom mappings, `__iter__`, `__str__`, `dict` subclasses, and cyclic
 structures.

--- a/specs/security-protocol/rfc/0012-cross-language-conformance.md
+++ b/specs/security-protocol/rfc/0012-cross-language-conformance.md
@@ -1,7 +1,12 @@
 # RFC 0012: Cross-language conformance
 
-- Status: Proposed
+- Status: Accepted
+- Accepted: 2026-07-30
 - Version: conformance manifest 1, adapter protocol 1
+
+Acceptance freezes conformance manifest version 1 and adapter protocol
+version 1. Changing a wire message shape or a role's pass criteria now
+requires a new protocol version.
 
 ## Summary
 
@@ -210,7 +215,24 @@ A conforming runner:
   environment;
 - reports every case as pass, fail, or skip, with the expected and actual
   code or output on failure;
+- reports the count of cases not run because their family was not announced;
+- enforces a per-case timeout defaulting to 5000 ms, overridable by the
+  operator but reported alongside the result;
 - exits zero only when no case failed.
+
+### Announced families are the scope of a claim
+
+A run exits zero when no announced case failed. Cases belonging to families the
+adapter did not announce are reported as not run — they are neither passes nor
+failures. An adapter that announces one family therefore exits zero while
+leaving most of the corpus untouched.
+
+That is correct for partial implementations and dangerous for release gates.
+A product claiming conformance for a protocol area MUST announce every family
+covering that area, and its published report MUST list the announced families
+and the not-run count. A green run is evidence only for what was announced.
+Implementations SHOULD assert their announced family list in CI, so a family
+can be added but never silently dropped.
 
 The TypeScript reference runner and reference adapter live in
 `@hypequery/protocol-conformance`. The package bundles a snapshot of the

--- a/specs/security-protocol/rfc/0012-cross-language-conformance.md
+++ b/specs/security-protocol/rfc/0012-cross-language-conformance.md
@@ -98,9 +98,15 @@ The adapter answers the hello first:
 
 `hostileObjectSuite` is the declaration required under *Host-model conditional
 cases* below. It is optional on the wire so that adapters announcing only
-text-input families (such as `sql-portability-v1`) can omit it, but an adapter
-announcing a family that accepts host values MUST send it. The runner copies it
-into the run summary, which is how it reaches the published report.
+families without host-model conditional cases (such as `sql-portability-v1`)
+can omit it. An adapter announcing any family whose fixture corpus contains an
+`unsafe-accessor` generator MUST send it. The runner rejects the handshake when
+the declaration is required but missing or malformed, and copies a valid
+declaration into the run summary.
+
+The declaration is an object with exactly the semantics shown above. `count`
+is a positive safe integer naming the number of implementation-owned hostile-
+object tests. `mechanisms` is a non-empty array of unique, non-empty strings.
 
 The runner only sends cases for families the adapter announced; this
 intersection is how one runner serves partial implementations, such as a
@@ -143,9 +149,9 @@ Only `unsafe-accessor` cases are host-model conditional; skipping any other
 case is a conformance failure.
 
 Skipping is permitted because the input cannot be constructed, not because the
-guarantee is optional. Every implementation of a family that accepts host
-values MUST additionally declare a language-specific hostile-object suite
-covering its own conversion mechanisms — getters, proxies, `toJSON`,
+guarantee is optional. Every implementation of a family with a host-model
+conditional fixture MUST additionally declare a language-specific hostile-
+object suite covering its own conversion mechanisms — getters, proxies, `toJSON`,
 `__str__`, `__getattr__`, descriptors, and comparable hooks — together with
 the count of cases it contains. The declaration is carried in the adapter's
 `hello` message as `hostileObjectSuite` and copied by the runner into the run
@@ -155,9 +161,10 @@ symbol keys, and sparse arrays; Python covers at least property descriptors,
 custom mappings, `__iter__`, `__str__`, `dict` subclasses, and cyclic
 structures.
 
-A report that skips the shared cases and declares no such suite is incomplete,
-not passing. Without both layers `HQ_VALUE_UNSAFE_OBJECT` would be the one
-frozen failure code no implementation is ever required to demonstrate.
+An adapter required to declare a suite cannot complete the handshake without
+one, so a report that omits this evidence cannot pass. Without both layers
+`HQ_VALUE_UNSAFE_OBJECT` would be the one frozen failure code no implementation
+is ever required to demonstrate.
 
 ## Operations and pass criteria
 


### PR DESCRIPTION
Moves [RFC 0001](specs/security-protocol/rfc/0001-tagged-clickhouse-value-model.md) from `Proposed` to `Accepted`, freezing extension version 1, and brings the reference implementation and conformance adapter into line.

This is the first of the TSP-01 acceptance PRs. All twelve protocol RFCs are currently drafts — implementing one in a second language freezes it *accidentally*, so acceptance has to happen deliberately first.

## Why this needed review rather than a rubber stamp

Reviewing the RFC against its own fixtures surfaced four ways TypeScript and Python could diverge silently, and two the fixtures structurally could not catch.

### Float canonicalization — the serious one

RFC 8785 mandates the ECMAScript `Number::toString` algorithm. TypeScript inherits it for free from `JSON.stringify`. Python does not:

| value | Python `json.dumps` | JCS requires |
|---|---|---|
| `1e20` | `1e+20` | `100000000000000000000` |
| `1e-7` | `1e-07` | `1e-7` |
| `1e-6` | `1e-06` | `0.000001` |
| `100.0` | `100.0` | `100` |

The corpus held exactly **one** float fixture — `1.5` — which agrees across languages by coincidence. A broken implementation would have passed the suite and only failed later, as mismatched bundle hashes. The RFC now names the algorithm, forbids delegating to a host encoder, and the corpus covers the boundaries where host formatting is known to differ.

### Behaviour changes — relaxations, with one disclosed edge

Previously-rejected input is now accepted, so existing callers producing valid values are unaffected. One edge tightens: the timezone's first component must now begin with an ASCII letter, so a leading-underscore multi-component identifier such as `_Foo/Bar` — previously accepted, never a real tzdb entry — is now rejected. A fixture pins it.

**Canonical strings permit tab, LF, and CR.** Every other C0 control, DEL, and the C1 range stay forbidden. The previous blanket C0 ban made multi-line descriptions impossible.

**Timezone validation accepts single-component identifiers.** The old pattern required a `/`, so `EST`, `GMT`, `CET`, `MST7MDT`, and `W-SU` — all real tzdb entries — were rejected while only `UTC` passed via a special case. Validation stays lexical and never consults the host tzdb: Python `zoneinfo` and JavaScript ICU disagree about renamed zones like `Europe/Kiev` vs `Europe/Kyiv`, and conformance must not depend on the OS image. Existence is a deployment-time check against the server's `system.time_zones`. The first component must start with a letter, so offset-shaped input such as `+0200` is still rejected.

### Metadata integers — implemented, then reverted

A lexical rule (rejecting `1.0` and `1e0`) was implemented and working before being reverted on review. JavaScript erases the `1` vs `1.0` distinction at parse time, so the rule could only be honoured by one language on the programmatic entry path: the same logical input would be accepted in TypeScript and rejected in Python. Since every spelling produces identical canonical bytes, the strictness bought no protection against confusion, downgrade, or hash collision — it only created divergence. These fields are now defined **by value**, and the RFC records the reasoning so it doesn't get re-litigated.

### A frozen failure code nobody had to demonstrate

`HQ_VALUE_UNSAFE_OBJECT` appears in the RFC but was missing from both the fixture manifest and the stable-code list asserted by `fixtures.test.ts` — 18 codes asserted against an RFC listing 19. Meanwhile `unsafe-accessor` was already in use by six other families; tagged-values was the sole holdout.

It now has a shared `unsafe-accessor` rejection case wired through both the test harness and the conformance adapter, plus an RFC 0012 requirement that each implementation declare a language-specific hostile-object suite for the mechanisms a JSON fixture cannot express.

### DateTime64

Bounds are now stated exactly and named the **portable v1 range** — deliberately a conservative subset, not a restatement of ClickHouse's own limits, which differ by precision and have moved between releases. `DateTime64(9)` caps at `2262-04-11T23:47:16.854775807Z`, verified as the largest signed-64-bit nanosecond tick count since the epoch.

## Fixtures

18 success / 28 rejection → **32 / 35**. Canonical bytes were generated with a JCS serializer that was first verified to reproduce all 18 existing fixtures byte-for-byte, so the generator was proven before it minted anything.

One thing the manifest cannot express: `1` vs `1.0` in a `value` field, since `JSON.stringify(1.0)` writes `1`. Converting those cases to success fixtures would have produced byte-identical duplicates, so they were removed and the limitation documented in the fixture README, with per-language unit tests covering the coercion.

## Verification

```
protocol tests   396 passed (12 files)
conformance      344 passed, 0 failed  (+79 datasets family)
full suite       18/18 tasks
lint             9/9 tasks
```

## Review follow-up

A code review of this PR surfaced four gaps, fixed in the follow-up commit:

- **The RFC 0012 hostile-object suite declaration now has a wire home.** The RFC required implementations to declare their language-specific suite "in the conformance report", but the frozen hello/summary shapes had no field for it — and freezing made retrofitting one a protocol version bump. The hello message now carries an optional `hostileObjectSuite` (`count` + `mechanisms`), the runner copies it into the run summary, and reports render it. The reference adapter declares the seven mechanisms its suite covers; families without host-model conditional fixtures may omit it. The runner derives the requirement from `unsafe-accessor` fixtures, validates the declaration, and rejects missing, zero-case, or malformed suite metadata during the handshake.
- **The timezone tightening is disclosed and pinned** (see behaviour changes above).
- **The 64-byte timezone cap's code is frozen.** It reports `HQ_VALUE_TOO_LARGE` — unlike every other lexical timezone failure, which reports `HQ_VALUE_INVALID_FORMAT`. RFC 0001 now says so and a 65-byte fixture pins it.
- **The integral-float coercion claim is backed by a test.** The fixture README promised per-language unit tests for metadata-integer coercion; the TypeScript one now exists (`Number('1.0')` defeats literal folding; canonical bytes assert `"version":1`).

## Related

Split out from #374 (Python scaffolding) so the protocol changes are reviewable on their own. #374 keeps the plan document and the `python/` workspace.

Next in TSP-01: RFC 0002 (portable identifiers) and RFC 0012 (cross-language conformance). RFC 0002 gates PYA-04, and its identifier charset also determines whether the UTF-16-vs-code-point key-ordering divergence can ever bite in later families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
