### PR TITLE
Send Git branch during Cloud login

### DIFF
--- a/.changeset/quiet-pandas-branch.md
+++ b/.changeset/quiet-pandas-branch.md
@@ -2,4 +2,4 @@
 '@hypequery/cli': minor
 ---
 
-Send the current Git branch during Cloud login so deployments receive a branch-scoped target.
+Send the current Git branch during Cloud login so deployments receive a branch-scoped target. Opt out with `--no-branch` or `HYPEQUERY_CLI_SEND_BRANCH=0`. Login now also reports the project and environment Cloud issued the credential for.

--- a/.changeset/quiet-pandas-branch.md
+++ b/.changeset/quiet-pandas-branch.md
@@ -1,0 +1,5 @@
+---
+'@hypequery/cli': minor
+---
+
+Send the current Git branch during Cloud login so deployments receive a branch-scoped target.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,13 +25,6 @@ Or install it once:
 npm install -D @hypequery/cli
 ```
 
-Ship it to Hypequery Cloud:
-
-```bash
-npx @hypequery/cli login
-npx @hypequery/cli deploy analytics/api.ts
-```
-
 ## Commands
 
 ### `hypequery init`
@@ -156,9 +149,9 @@ semantic keys such as `dataset:orders`.
 
 Builds a closed deployment bundle for an exported HypeQuery API. The bundle
 contains canonical deployment metadata, every referenced runtime artifact, and
-a manifest that binds their exact bytes and identities. `hypequery deploy` runs
-this step for you; reach for it directly in CI pipelines that stage artifacts,
-or when you need the runtime options below.
+a manifest that binds their exact bytes and identities. It is the first step of
+a deployment pipeline, and produces the input `deployment:release` binds to a
+target.
 
 ```bash
 npx hypequery deployment:build analytics/api.ts
@@ -200,129 +193,16 @@ are still accepted for metadata-only validation.
 npx hypequery deployment:validate analytics/hypequery-deployment
 ```
 
-### `hypequery login`
-
-Authorizes the local CLI through your existing Hypequery Cloud browser
-session. The command uses an S256 PKCE loopback flow, then stores the
-target-scoped deployment token in the operating-system credential vault.
-Tokens expire after 12 hours.
-
-When run inside a Git repository, login sends the current branch name to Cloud.
-Cloud creates or selects the matching branch-backed deployment target under
-the project selected in the dashboard. A detached HEAD or non-Git directory
-falls back to the currently selected Cloud branch.
-
-```bash
-npx hypequery login
-```
-
-Cloud, not the CLI, decides the final target, so login prints the project and
-environment the credential was actually issued for. `hypequery deploy` uses
-that target.
-
-Branch names can carry internal detail. Pass `--no-branch`, or set
-`HYPEQUERY_CLI_SEND_BRANCH=0`, to keep the branch local and use the currently
-selected Cloud branch instead.
-
-```bash
-npx hypequery login --no-branch
-```
-
-Use `--cloud-url <origin>` or `HYPEQUERY_CLOUD_URL` for a self-hosted or local
-Cloud instance. HTTPS is required except for loopback development origins.
-
-Once logged in, `hypequery deploy` automatically uses the stored endpoint and
-token, and resolves the project and environment from the same stored profile.
-The deployment endpoint is returned by Cloud during the token exchange; it is
-the authenticated upload API, not the browser login endpoint. For
-non-interactive CI usage, set both `HYPEQUERY_API_TOKEN` and
-`HYPEQUERY_DEPLOYMENT_ENDPOINT` (or pass `--endpoint`).
-
-Because the CLI also loads a project `.env`, a `HYPEQUERY_API_TOKEN` left there
-takes precedence over the login flow and is rejected unless it is paired with an
-endpoint. Unset it to use `hypequery login`.
-
-Token storage requires an operating-system credential vault (Keychain,
-Credential Manager, or a Secret Service implementation such as
-gnome-keyring/KWallet). Headless environments without one should use
-`HYPEQUERY_API_TOKEN` instead of `hypequery login`.
-
-### `hypequery logout`
-
-Revokes the current Cloud token and removes it from the operating-system
-credential vault:
-
-```bash
-npx hypequery logout
-```
-
-If the stored profile is unreadable, `logout` still removes the local state and
-reports that the token was not revoked; it expires on its own.
-
-### `hypequery deploy`
-
-Builds a deployment bundle from an API module, prepares a target-bound release,
-and submits both. This is the primary Cloud workflow: sign in once, then deploy
-with one command.
-
-```bash
-npx hypequery login
-npx hypequery deploy analytics/api.ts
-```
-
-The bundle is written to `analytics/hypequery-deployment` and the release to
-`analytics/hypequery-deployment.release.json`. The target comes from the stored
-Cloud profile unless you override it:
-
-```bash
-npx hypequery deploy analytics/api.ts \
-  --project my-project \
-  --environment production
-```
-
-The deployment endpoint and token are resolved before the build, so a missing
-or expired login fails immediately rather than after bundling. The credential
-rules are the same as `hypequery deployment:submit` below.
-
-The three steps remain available individually as `deployment:build`,
-`deployment:release`, and `deployment:submit` for CI pipelines that stage
-artifacts, and for the cases `deploy` does not cover: `deploy` always builds the
-runtime artifact itself, so Python deployments and prebuilt runtime artifacts
-(`--runtime`, `--runtime-artifact`, `--runtime-file`) need `deployment:build`.
-
-Options:
-
-- `--project <project>`: target project identifier; defaults to the logged-in
-  target and must be paired with `--environment`
-- `--environment <environment>`: target environment identifier; defaults to the
-  logged-in target and must be paired with `--project`
-- `--bundle-output <directory>`: bundle directory, default
-  `analytics/hypequery-deployment`
-- `--release-output <path>`: release JSON path, default beside the bundle
-- `--endpoint <url>`: HTTPS submission endpoint; requires `HYPEQUERY_API_TOKEN`
-
-> **Deprecated:** `hypequery deploy <bundle> --release <file>` still submits a
-> prebuilt bundle and prints a deprecation warning. Use
-> `hypequery deployment:submit` instead. `--release` cannot be combined with
-> `--project`, `--environment`, `--bundle-output`, or `--release-output`.
-
 ### `hypequery deployment:release`
 
 Prepares a deterministic release request from a verified deployment bundle and
 a project/environment target. This command does not upload, authorize, or
 execute the release.
 
-After `hypequery login` the target is read from the stored Cloud profile, and
-the resolved target is printed alongside the release identity:
-
-```bash
-npx hypequery deployment:release analytics/hypequery-deployment
-```
-
-To target something other than the logged-in project and environment, pass both
-flags. A half-specified override is rejected rather than completed from the
-stored profile, so an unset shell variable fails loudly instead of silently
-retargeting the release:
+Pass the target as both flags. A half-specified target is rejected rather than
+completed from anywhere else, so an unset shell variable fails loudly instead of
+silently retargeting the release. The resolved target is printed alongside the
+release identity:
 
 ```bash
 npx hypequery deployment:release analytics/hypequery-deployment \
@@ -336,36 +216,30 @@ invalidate bundle verification.
 
 Options:
 
-- `--project <project>`: target project identifier; defaults to the logged-in
-  target and must be paired with `--environment`
-- `--environment <environment>`: target environment identifier; defaults to the
-  logged-in target and must be paired with `--project`
+- `--project <project>`: target project identifier; must be paired with
+  `--environment`
+- `--environment <environment>`: target environment identifier; must be paired
+  with `--project`
 - `--output <path>`: release JSON path, default beside the bundle
 
 ### `hypequery deployment:submit`
 
 Submits a verified deployment bundle with an already-prepared target-bound
 release. The command verifies both inputs again, requires their bundle
-identities to match, and streams only the files declared by the bundle. Use it
-when the bundle and release were produced by an earlier pipeline step; for the
-ordinary path, use `hypequery deploy`.
+identities to match, and streams only the files declared by the bundle.
 
 ```bash
 npx hypequery deployment:submit analytics/hypequery-deployment \
   --release analytics/hypequery-deployment.release.json
 ```
 
-For local development, run `hypequery login` first; the CLI reads the endpoint
-and token from its secure Cloud profile. For CI and manual credentials, set
-`HYPEQUERY_API_TOKEN` together with either `--endpoint` or
-`HYPEQUERY_DEPLOYMENT_ENDPOINT`. The CLI never combines one explicit value with
-the other value from the stored profile. Tokens are never accepted as
-command-line arguments, keeping them out of shell history. The submission
-endpoint must not contain credentials or a URL fragment, and must use HTTPS
-except for `127.0.0.1`/`localhost`, which is permitted for local Cloud
-development and warns that the token is sent in cleartext. The release identity
-is sent as the idempotency key, so an unchanged release can be submitted safely
-again.
+Set `HYPEQUERY_API_TOKEN` together with either `--endpoint` or
+`HYPEQUERY_DEPLOYMENT_ENDPOINT`. Tokens are never accepted as command-line
+arguments, keeping them out of shell history. The submission endpoint must not
+contain credentials or a URL fragment, and must use HTTPS except for
+`127.0.0.1`/`localhost`, which is permitted for local development and warns that
+the token is sent in cleartext. The release identity is sent as the idempotency
+key, so an unchanged release can be submitted safely again.
 
 This command submits immutable deployment inputs. Activation, status changes,
 promotion, and rollback remain control-plane operations.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -207,13 +207,25 @@ session. The command uses an S256 PKCE loopback flow, then stores the
 target-scoped deployment token in the operating-system credential vault.
 Tokens expire after 12 hours.
 
-When run from a Git worktree, login sends the current branch name to Cloud.
+When run inside a Git repository, login sends the current branch name to Cloud.
 Cloud creates or selects the matching branch-backed deployment target under
 the project selected in the dashboard. A detached HEAD or non-Git directory
 falls back to the currently selected Cloud branch.
 
 ```bash
 npx hypequery login
+```
+
+Cloud, not the CLI, decides the final target, so login prints the project and
+environment the credential was actually issued for. `hypequery deploy` uses
+that target.
+
+Branch names can carry internal detail. Pass `--no-branch`, or set
+`HYPEQUERY_CLI_SEND_BRANCH=0`, to keep the branch local and use the currently
+selected Cloud branch instead.
+
+```bash
+npx hypequery login --no-branch
 ```
 
 Use `--cloud-url <origin>` or `HYPEQUERY_CLOUD_URL` for a self-hosted or local

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -207,6 +207,11 @@ session. The command uses an S256 PKCE loopback flow, then stores the
 target-scoped deployment token in the operating-system credential vault.
 Tokens expire after 12 hours.
 
+When run from a Git worktree, login sends the current branch name to Cloud.
+Cloud creates or selects the matching branch-backed deployment target under
+the project selected in the dashboard. A detached HEAD or non-Git directory
+falls back to the currently selected Cloud branch.
+
 ```bash
 npx hypequery login
 ```

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -55,6 +55,7 @@ program
   .command('login')
   .description('Authorize this machine with Hypequery Cloud')
   .option('--cloud-url <url>', 'Cloud origin (or HYPEQUERY_CLOUD_URL)')
+  .option('--no-branch', 'Do not send the current Git branch (or HYPEQUERY_CLI_SEND_BRANCH=0)')
   .action(runCommand(async (options: LoginOptions) => {
     await loginCommand(options);
   }));

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../utils/logger.js', () => ({
   logger: {
@@ -9,7 +9,13 @@ vi.mock('../utils/logger.js', () => ({
   },
 }));
 
-import { loginCommand, logoutCommand } from './login.js';
+import { logger } from '../utils/logger.js';
+import {
+  loginCommand,
+  logoutCommand,
+  type LoginDependencies,
+  type LoginOptions,
+} from './login.js';
 
 const TOKEN_RESPONSE_NOW = Date.parse('2029-12-31T12:00:00.000Z');
 
@@ -26,7 +32,47 @@ function authorizeInBrowser(input: string) {
   return fetch(callback);
 }
 
+/**
+ * Runs a successful login against a stub Cloud and returns the authorize URL
+ * the browser was handed, so branch-context cases assert on one variable.
+ */
+async function authorizeUrlForLogin(
+  dependencies: LoginDependencies = {},
+  options: LoginOptions = {},
+): Promise<URL | undefined> {
+  let authorizeUrl: URL | undefined;
+  await loginCommand({ cloudUrl: 'https://cloud.example.test', ...options }, {
+    fetch: vi.fn(async () => new Response(JSON.stringify({
+      access_token: `hqdp_v1_${'c'.repeat(43)}`,
+      token_type: 'Bearer',
+      expires_at: '2030-01-01T00:00:00.000Z',
+      scope: 'deploy:submit',
+      deployment_endpoint:
+        'https://cloud.example.test/v1/deployments/submissions',
+      deployment_target: {
+        project: 'acme:analytics',
+        environment: 'preview-customer-retention',
+      },
+    }), { status: 200 })) as typeof fetch,
+    now: () => TOKEN_RESPONSE_NOW,
+    openBrowser: async (input) => {
+      authorizeUrl = new URL(input);
+      await authorizeInBrowser(input);
+    },
+    saveCredential: vi.fn(),
+    timeoutMs: 2_000,
+    ...dependencies,
+  });
+  return authorizeUrl;
+}
+
 describe('Cloud CLI authentication', () => {
+  beforeEach(() => {
+    vi.mocked(logger.info).mockClear();
+    vi.mocked(logger.success).mockClear();
+    vi.mocked(logger.warn).mockClear();
+  });
+
   it('completes a browser loopback PKCE flow and stores the returned token', async () => {
     let authorizeUrl: URL | undefined;
     const saveCredential = vi.fn();
@@ -99,32 +145,59 @@ describe('Cloud CLI authentication', () => {
     });
   });
 
-  it('omits branch context when Git is detached or unavailable', async () => {
-    let authorizeUrl: URL | undefined;
-    await loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
-      fetch: vi.fn(async () => new Response(JSON.stringify({
-        access_token: `hqdp_v1_${'c'.repeat(43)}`,
-        token_type: 'Bearer',
-        expires_at: '2030-01-01T00:00:00.000Z',
-        scope: 'deploy:submit',
-        deployment_endpoint:
-          'https://cloud.example.test/v1/deployments/submissions',
-        deployment_target: {
-          project: 'acme:analytics',
-          environment: 'main',
-        },
-      }), { status: 200 })) as typeof fetch,
+  it('omits branch context when the branch cannot be resolved', async () => {
+    const authorizeUrl = await authorizeUrlForLogin({
       getGitBranch: async () => null,
-      now: () => TOKEN_RESPONSE_NOW,
-      openBrowser: async (input) => {
-        authorizeUrl = new URL(input);
-        await authorizeInBrowser(input);
-      },
-      saveCredential: vi.fn(),
-      timeoutMs: 2_000,
     });
 
     expect(authorizeUrl?.searchParams.has('branch')).toBe(false);
+  });
+
+  it('omits branch context when --no-branch is passed', async () => {
+    const getGitBranch = vi.fn(async () => 'feature/customer-retention');
+    const authorizeUrl = await authorizeUrlForLogin(
+      { getGitBranch },
+      { branch: false },
+    );
+
+    expect(authorizeUrl?.searchParams.has('branch')).toBe(false);
+    expect(getGitBranch).not.toHaveBeenCalled();
+  });
+
+  it('omits branch context when HYPEQUERY_CLI_SEND_BRANCH disables it', async () => {
+    vi.stubEnv('HYPEQUERY_CLI_SEND_BRANCH', '0');
+    try {
+      const getGitBranch = vi.fn(async () => 'feature/customer-retention');
+      const authorizeUrl = await authorizeUrlForLogin({ getGitBranch });
+
+      expect(authorizeUrl?.searchParams.has('branch')).toBe(false);
+      expect(getGitBranch).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('reports the deployment target Cloud resolved for the login', async () => {
+    await authorizeUrlForLogin({
+      getGitBranch: async () => 'feature/customer-retention',
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'Deployments target acme:analytics / preview-customer-retention',
+    );
+  });
+
+  it('never opens the loopback server when branch resolution fails', async () => {
+    const openBrowser = vi.fn();
+    await expect(loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
+      getGitBranch: async () => {
+        throw new Error('git exploded');
+      },
+      openBrowser,
+      timeoutMs: 2_000,
+    })).rejects.toThrow('git exploded');
+
+    expect(openBrowser).not.toHaveBeenCalled();
   });
 
   it('reports a non-object token response as an invalid Cloud response', async () => {

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -58,6 +58,9 @@ describe('Cloud CLI authentication', () => {
     });
     const openBrowser = vi.fn(async (input: string) => {
       authorizeUrl = new URL(input);
+      expect(authorizeUrl.searchParams.get('branch')).toBe(
+        'feature/customer-retention',
+      );
       const callback = new URL(
         authorizeUrl.searchParams.get('redirect_uri') as string,
       );
@@ -74,6 +77,7 @@ describe('Cloud CLI authentication', () => {
 
     await loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
       fetch: fetchMock as typeof fetch,
+      getGitBranch: async () => 'feature/customer-retention',
       now: () => TOKEN_RESPONSE_NOW,
       openBrowser,
       saveCredential,
@@ -93,6 +97,34 @@ describe('Cloud CLI authentication', () => {
       },
       token: `hqdp_v1_${'c'.repeat(43)}`,
     });
+  });
+
+  it('omits branch context when Git is detached or unavailable', async () => {
+    let authorizeUrl: URL | undefined;
+    await loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
+      fetch: vi.fn(async () => new Response(JSON.stringify({
+        access_token: `hqdp_v1_${'c'.repeat(43)}`,
+        token_type: 'Bearer',
+        expires_at: '2030-01-01T00:00:00.000Z',
+        scope: 'deploy:submit',
+        deployment_endpoint:
+          'https://cloud.example.test/v1/deployments/submissions',
+        deployment_target: {
+          project: 'acme:analytics',
+          environment: 'main',
+        },
+      }), { status: 200 })) as typeof fetch,
+      getGitBranch: async () => null,
+      now: () => TOKEN_RESPONSE_NOW,
+      openBrowser: async (input) => {
+        authorizeUrl = new URL(input);
+        await authorizeInBrowser(input);
+      },
+      saveCredential: vi.fn(),
+      timeoutMs: 2_000,
+    });
+
+    expect(authorizeUrl?.searchParams.has('branch')).toBe(false);
   });
 
   it('reports a non-object token response as an invalid Cloud response', async () => {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,6 +1,8 @@
 import { createHash, randomBytes } from 'node:crypto';
+import { execFile } from 'node:child_process';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import { promisify } from 'node:util';
 import open from 'open';
 import { validateProtocolDeploymentReleaseTarget } from '@hypequery/protocol';
 
@@ -27,6 +29,7 @@ const MAX_TOKEN_LIFETIME_MS = 13 * 60 * 60_000;
 // CLI the day Cloud rotates its token format.
 const TOKEN_PATTERN = /^hqdp_[A-Za-z0-9_-]{16,512}$/;
 const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
+const execFileAsync = promisify(execFile);
 
 export interface LoginOptions {
   readonly cloudUrl?: string;
@@ -34,11 +37,31 @@ export interface LoginOptions {
 
 export interface LoginDependencies {
   readonly fetch?: typeof fetch;
+  readonly getGitBranch?: () => Promise<string | null>;
   readonly openBrowser?: (url: string) => Promise<unknown>;
   readonly now?: () => number;
   readonly requestTimeoutMs?: number;
   readonly saveCredential?: typeof saveCloudCredential;
   readonly timeoutMs?: number;
+}
+
+export async function currentGitBranch(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['symbolic-ref', '--quiet', '--short', 'HEAD'],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        timeout: 5_000,
+        windowsHide: true,
+      },
+    );
+    const branch = stdout.trim();
+    return branch.length > 0 ? branch : null;
+  } catch {
+    return null;
+  }
 }
 
 export interface LogoutDependencies {
@@ -212,6 +235,8 @@ export async function loginCommand(
   authorizeUrl.searchParams.set('code_challenge', challenge);
   authorizeUrl.searchParams.set('code_challenge_method', 'S256');
   authorizeUrl.searchParams.set('state', state);
+  const branch = await (dependencies.getGitBranch ?? currentGitBranch)();
+  if (branch) authorizeUrl.searchParams.set('branch', branch);
 
   try {
     logger.info('Opening your browser to authorize Hypequery CLI…');

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -1,8 +1,6 @@
 import { createHash, randomBytes } from 'node:crypto';
-import { execFile } from 'node:child_process';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { promisify } from 'node:util';
 import open from 'open';
 import { validateProtocolDeploymentReleaseTarget } from '@hypequery/protocol';
 
@@ -15,6 +13,7 @@ import {
   saveCloudCredential,
   type StoredCloudCredential,
 } from '../utils/cloud-credential-store.js';
+import { currentGitBranch } from '../utils/git-branch.js';
 import { logger } from '../utils/logger.js';
 
 const DEFAULT_CLOUD_URL = 'https://cloud.hypequery.com';
@@ -29,10 +28,11 @@ const MAX_TOKEN_LIFETIME_MS = 13 * 60 * 60_000;
 // CLI the day Cloud rotates its token format.
 const TOKEN_PATTERN = /^hqdp_[A-Za-z0-9_-]{16,512}$/;
 const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
-const execFileAsync = promisify(execFile);
 
 export interface LoginOptions {
   readonly cloudUrl?: string;
+  /** Commander sets this to false for `--no-branch`. */
+  readonly branch?: boolean;
 }
 
 export interface LoginDependencies {
@@ -45,23 +45,15 @@ export interface LoginDependencies {
   readonly timeoutMs?: number;
 }
 
-export async function currentGitBranch(): Promise<string | null> {
-  try {
-    const { stdout } = await execFileAsync(
-      'git',
-      ['symbolic-ref', '--quiet', '--short', 'HEAD'],
-      {
-        cwd: process.cwd(),
-        encoding: 'utf8',
-        timeout: 5_000,
-        windowsHide: true,
-      },
-    );
-    const branch = stdout.trim();
-    return branch.length > 0 ? branch : null;
-  } catch {
-    return null;
-  }
+/**
+ * Branch names carry internal detail (customer names, embargoed identifiers),
+ * so both an explicit `--no-branch` and the environment variable suppress the
+ * parameter. The flag wins because it is the more specific signal.
+ */
+function branchContextEnabled(options: LoginOptions): boolean {
+  if (options.branch === false) return false;
+  const configured = process.env.HYPEQUERY_CLI_SEND_BRANCH?.trim().toLowerCase();
+  return configured !== '0' && configured !== 'false' && configured !== 'no';
 }
 
 export interface LogoutDependencies {
@@ -229,13 +221,18 @@ export async function loginCommand(
   const state = randomBytes(24).toString('base64url');
   const verifier = randomBytes(32).toString('base64url');
   const challenge = createHash('sha256').update(verifier).digest('base64url');
+  // Resolve branch context before the loopback listener opens: shelling out to
+  // git should not hold a server socket, and a caller-supplied resolver that
+  // rejects must not leak one.
+  const branch = branchContextEnabled(options)
+    ? await (dependencies.getGitBranch ?? currentGitBranch)()
+    : null;
   const callback = await callbackServer(state, dependencies.timeoutMs ?? LOGIN_TIMEOUT_MS);
   const authorizeUrl = new URL('/cli/authorize', origin);
   authorizeUrl.searchParams.set('redirect_uri', callback.redirectUri);
   authorizeUrl.searchParams.set('code_challenge', challenge);
   authorizeUrl.searchParams.set('code_challenge_method', 'S256');
   authorizeUrl.searchParams.set('state', state);
-  const branch = await (dependencies.getGitBranch ?? currentGitBranch)();
   if (branch) authorizeUrl.searchParams.set('branch', branch);
 
   try {
@@ -271,6 +268,13 @@ export async function loginCommand(
     );
     await (dependencies.saveCredential ?? saveCloudCredential)(credential);
     logger.success('Logged in to Hypequery Cloud');
+    // Cloud resolves the target, and branch context only expresses intent, so
+    // print what was actually issued rather than what was requested.
+    if (credential.target) {
+      logger.info(
+        `Deployments target ${credential.target.project} / ${credential.target.environment}`,
+      );
+    }
     logger.info(`Credential expires ${new Date(credential.expiresAt).toLocaleString()}`);
   } finally {
     callback.close();

--- a/packages/cli/src/utils/git-branch.test.ts
+++ b/packages/cli/src/utils/git-branch.test.ts
@@ -1,0 +1,73 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { currentGitBranch } from './git-branch.js';
+
+function git(cwd: string, ...args: string[]) {
+  execFileSync('git', args, {
+    cwd,
+    stdio: 'ignore',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'hypequery',
+      GIT_AUTHOR_EMAIL: 'cli@hypequery.test',
+      GIT_COMMITTER_NAME: 'hypequery',
+      GIT_COMMITTER_EMAIL: 'cli@hypequery.test',
+    },
+  });
+}
+
+describe('currentGitBranch', () => {
+  let root: string;
+  let repo: string;
+  let plain: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'hypequery-git-branch-'));
+    repo = join(root, 'repo');
+    plain = join(root, 'plain');
+    mkdirSync(repo, { recursive: true });
+    mkdirSync(plain, { recursive: true });
+    git(repo, 'init', '--initial-branch=main', '.');
+    git(repo, 'commit', '--allow-empty', '-m', 'initial');
+  });
+
+  afterAll(() => {
+    rmSync(root, { force: true, recursive: true });
+  });
+
+  it('returns the checked-out branch name', async () => {
+    await expect(currentGitBranch(repo)).resolves.toBe('main');
+  });
+
+  it('returns branch names containing slashes verbatim', async () => {
+    git(repo, 'checkout', '-b', 'feature/customer-retention');
+    try {
+      await expect(currentGitBranch(repo)).resolves.toBe(
+        'feature/customer-retention',
+      );
+    } finally {
+      git(repo, 'checkout', 'main');
+    }
+  });
+
+  it('returns null on a detached HEAD', async () => {
+    git(repo, 'checkout', '--detach');
+    try {
+      await expect(currentGitBranch(repo)).resolves.toBeNull();
+    } finally {
+      git(repo, 'checkout', 'main');
+    }
+  });
+
+  it('returns null outside a Git repository', async () => {
+    await expect(currentGitBranch(plain)).resolves.toBeNull();
+  });
+
+  it('returns null when the working directory does not exist', async () => {
+    await expect(currentGitBranch(join(root, 'missing'))).resolves.toBeNull();
+  });
+});

--- a/packages/cli/src/utils/git-branch.ts
+++ b/packages/cli/src/utils/git-branch.ts
@@ -1,0 +1,34 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const GIT_TIMEOUT_MS = 5_000;
+
+/**
+ * Resolves the checked-out branch name, or null when there isn't one.
+ *
+ * `git symbolic-ref` exits non-zero on a detached HEAD and outside a
+ * repository, and the binary may be missing entirely, so every failure mode
+ * collapses to "no branch context" rather than an error the caller must handle.
+ */
+export async function currentGitBranch(
+  cwd: string = process.cwd(),
+): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['symbolic-ref', '--quiet', '--short', 'HEAD'],
+      {
+        cwd,
+        encoding: 'utf8',
+        timeout: GIT_TIMEOUT_MS,
+        windowsHide: true,
+      },
+    );
+    const branch = stdout.trim();
+    return branch.length > 0 ? branch : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What changed

- detect the current Git branch with `git symbolic-ref --quiet --short HEAD`
- send the branch as optional context in the browser PKCE authorization URL
- omit the parameter for detached HEAD and non-Git directories, preserving the existing selected-target behavior
- report the project and environment Cloud issued the credential for, so the resolved target is visible at login rather than at deploy time
- add `--no-branch` and `HYPEQUERY_CLI_SEND_BRANCH=0` for repositories whose branch names carry internal detail
- resolve the branch before the loopback listener opens, so shelling out to git never holds a server socket
- remove Cloud documentation from the CLI README: `login`, `logout`, `deploy`, and the Quick Start ship-it block describe a flow that is not live yet
- add a CLI minor changeset

## Why

Cloud deployment credentials are target-scoped. Supplying branch context during interactive login lets Cloud idempotently create or select the correct branch-backed target before issuing the credential, without weakening target authorization.

Because Cloud, not the CLI, resolves the final target, branch context only expresses intent — so login now prints what was actually issued.

The commands are shipping ahead of the public Cloud launch, so the README documents only the local deployment pipeline: `deployment:build`, `deployment:release` against an explicit `--project`/`--environment`, and `deployment:submit` with an explicit endpoint and `HYPEQUERY_API_TOKEN`. The Cloud commands still work and are discoverable through `--help`.

## Compatibility

The new parameter is optional. Detached HEAD, non-Git directories, `--no-branch`, and older Cloud versions continue through the existing selected-target flow. No command or flag was removed — the README change is documentation only.

## Validation

- all 533 CLI tests pass (1 skipped)
- `currentGitBranch` is covered against a real temporary repository: attached branch, slash-containing branch name, detached HEAD, non-repository directory, and missing working directory
- CLI TypeScript build passes
- CLI lint passes
- coordinated browser E2E against the Cloud implementation created and listed `feature/customer-retention`
