### PR TITLE
Allow explicit Cloud login environments

### DIFF
--- a/.changeset/clean-ravens-target.md
+++ b/.changeset/clean-ravens-target.md
@@ -1,0 +1,5 @@
+---
+'@hypequery/cli': minor
+---
+
+Allow Cloud login to select a stable deployment environment independently of Git branch context.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -251,6 +251,33 @@ Options:
 
 ## Non-interactive Setup
 
+### Cloud deployment targets in CI
+
+Git branch context is only a default for interactive login. Select a stable
+target explicitly when the same branch or commit deploys to more than one
+environment:
+
+```bash
+npx hypequery login --environment development
+```
+
+For CI, create a target-scoped API key in Cloud for each environment and store
+it as a separate secret. The explicit release target and its matching key make
+the destination independent of the source branch:
+
+```bash
+HYPEQUERY_API_TOKEN="$HYPEQUERY_DEV_TOKEN" npx hypequery deploy analytics/api.ts \
+  --project acme:analytics \
+  --environment development
+
+HYPEQUERY_API_TOKEN="$HYPEQUERY_PROD_TOKEN" npx hypequery deploy analytics/api.ts \
+  --project acme:analytics \
+  --environment production
+```
+
+Set `HYPEQUERY_DEPLOYMENT_ENDPOINT` for both jobs. A key is scoped to one target,
+so a production key cannot submit a development release or vice versa.
+
 For ClickHouse, `hypequery init --no-interactive` reads:
 
 - `CLICKHOUSE_URL` or deprecated `CLICKHOUSE_HOST`

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -55,6 +55,7 @@ program
   .command('login')
   .description('Authorize this machine with Hypequery Cloud')
   .option('--cloud-url <url>', 'Cloud origin (or HYPEQUERY_CLOUD_URL)')
+  .option('--environment <environment>', 'Stable deployment target; takes precedence over the Git branch')
   .option('--no-branch', 'Do not send the current Git branch (or HYPEQUERY_CLI_SEND_BRANCH=0)')
   .action(runCommand(async (options: LoginOptions) => {
     await loginCommand(options);

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -164,6 +164,30 @@ describe('Cloud CLI authentication', () => {
     expect(getGitBranch).not.toHaveBeenCalled();
   });
 
+  it('sends an explicit deployment environment alongside source branch context', async () => {
+    const authorizeUrl = await authorizeUrlForLogin(
+      { getGitBranch: async () => 'main' },
+      { environment: 'development' },
+    );
+
+    expect(authorizeUrl?.searchParams.get('branch')).toBe('main');
+    expect(authorizeUrl?.searchParams.get('environment')).toBe('development');
+  });
+
+  it('rejects an invalid explicit deployment environment before opening a browser', async () => {
+    const openBrowser = vi.fn();
+
+    await expect(loginCommand({
+      cloudUrl: 'https://cloud.example.test',
+      environment: 'development target',
+    }, {
+      getGitBranch: async () => 'main',
+      openBrowser,
+    })).rejects.toThrow('Invalid deployment environment');
+
+    expect(openBrowser).not.toHaveBeenCalled();
+  });
+
   it('omits branch context when HYPEQUERY_CLI_SEND_BRANCH disables it', async () => {
     vi.stubEnv('HYPEQUERY_CLI_SEND_BRANCH', '0');
     try {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -33,6 +33,8 @@ export interface LoginOptions {
   readonly cloudUrl?: string;
   /** Commander sets this to false for `--no-branch`. */
   readonly branch?: boolean;
+  /** Stable Cloud deployment target. This always takes precedence over Git branch context. */
+  readonly environment?: string;
 }
 
 export interface LoginDependencies {
@@ -227,6 +229,19 @@ export async function loginCommand(
   const branch = branchContextEnabled(options)
     ? await (dependencies.getGitBranch ?? currentGitBranch)()
     : null;
+  let environment: string | undefined;
+  if (options.environment !== undefined) {
+    try {
+      environment = validateProtocolDeploymentReleaseTarget({
+        project: 'target',
+        environment: options.environment,
+      }).environment;
+    } catch {
+      throw new Error(
+        'Invalid deployment environment. Use letters, numbers, dots, underscores, colons, or hyphens.',
+      );
+    }
+  }
   const callback = await callbackServer(state, dependencies.timeoutMs ?? LOGIN_TIMEOUT_MS);
   const authorizeUrl = new URL('/cli/authorize', origin);
   authorizeUrl.searchParams.set('redirect_uri', callback.redirectUri);
@@ -234,6 +249,7 @@ export async function loginCommand(
   authorizeUrl.searchParams.set('code_challenge_method', 'S256');
   authorizeUrl.searchParams.set('state', state);
   if (branch) authorizeUrl.searchParams.set('branch', branch);
+  if (environment) authorizeUrl.searchParams.set('environment', environment);
 
   try {
     logger.info('Opening your browser to authorize Hypequery CLI…');


### PR DESCRIPTION
## What changed

- add `hypequery login --environment <environment>`
- send explicit target selection alongside optional Git branch context
- validate the environment before opening the authorization flow
- document separate target-scoped CI secrets for development and production

## Why

Git is source context, not deployment destination identity. Users must be able to deploy the same branch or commit to different stable Cloud environments.

## Validation

- 534 CLI tests passed (1 skipped)
- CLI and dependency builds passed
- monorepo lint passed