### PR TITLE
Capture Git provenance during deployment

### DIFF
--- a/.changeset/quiet-branches-deploy.md
+++ b/.changeset/quiet-branches-deploy.md
@@ -1,0 +1,6 @@
+---
+"@hypequery/cli": patch
+"@hypequery/protocol": patch
+---
+
+Capture the checked-out Git branch alongside commit and dirty state in deployment source snapshots. Cloud login no longer reads or sends Git branch context; project and environment remain the only deployment-target inputs.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -253,9 +253,10 @@ Options:
 
 ### Cloud deployment targets in CI
 
-Git branch context is only a default for interactive login. Select a stable
-target explicitly when the same branch or commit deploys to more than one
-environment:
+Login selects a stable Cloud deployment target. The deployment itself captures
+the checked-out Git branch, commit, and dirty state as source provenance; none
+of those values select or create an environment. Select the destination
+explicitly when the same branch or commit deploys to more than one environment:
 
 ```bash
 npx hypequery login --environment development

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -55,8 +55,7 @@ program
   .command('login')
   .description('Authorize this machine with Hypequery Cloud')
   .option('--cloud-url <url>', 'Cloud origin (or HYPEQUERY_CLOUD_URL)')
-  .option('--environment <environment>', 'Stable deployment target; takes precedence over the Git branch')
-  .option('--no-branch', 'Do not send the current Git branch (or HYPEQUERY_CLI_SEND_BRANCH=0)')
+  .option('--environment <environment>', 'Stable deployment target')
   .action(runCommand(async (options: LoginOptions) => {
     await loginCommand(options);
   }));

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -34,7 +34,7 @@ function authorizeInBrowser(input: string) {
 
 /**
  * Runs a successful login against a stub Cloud and returns the authorize URL
- * the browser was handed, so branch-context cases assert on one variable.
+ * the browser was handed so authorization parameters can be asserted directly.
  */
 async function authorizeUrlForLogin(
   dependencies: LoginDependencies = {},
@@ -104,9 +104,7 @@ describe('Cloud CLI authentication', () => {
     });
     const openBrowser = vi.fn(async (input: string) => {
       authorizeUrl = new URL(input);
-      expect(authorizeUrl.searchParams.get('branch')).toBe(
-        'feature/customer-retention',
-      );
+      expect(authorizeUrl.searchParams.has('branch')).toBe(false);
       const callback = new URL(
         authorizeUrl.searchParams.get('redirect_uri') as string,
       );
@@ -123,7 +121,6 @@ describe('Cloud CLI authentication', () => {
 
     await loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
       fetch: fetchMock as typeof fetch,
-      getGitBranch: async () => 'feature/customer-retention',
       now: () => TOKEN_RESPONSE_NOW,
       openBrowser,
       saveCredential,
@@ -145,32 +142,10 @@ describe('Cloud CLI authentication', () => {
     });
   });
 
-  it('omits branch context when the branch cannot be resolved', async () => {
-    const authorizeUrl = await authorizeUrlForLogin({
-      getGitBranch: async () => null,
-    });
+  it('sends an explicit deployment environment without source context', async () => {
+    const authorizeUrl = await authorizeUrlForLogin({}, { environment: 'development' });
 
     expect(authorizeUrl?.searchParams.has('branch')).toBe(false);
-  });
-
-  it('omits branch context when --no-branch is passed', async () => {
-    const getGitBranch = vi.fn(async () => 'feature/customer-retention');
-    const authorizeUrl = await authorizeUrlForLogin(
-      { getGitBranch },
-      { branch: false },
-    );
-
-    expect(authorizeUrl?.searchParams.has('branch')).toBe(false);
-    expect(getGitBranch).not.toHaveBeenCalled();
-  });
-
-  it('sends an explicit deployment environment alongside source branch context', async () => {
-    const authorizeUrl = await authorizeUrlForLogin(
-      { getGitBranch: async () => 'main' },
-      { environment: 'development' },
-    );
-
-    expect(authorizeUrl?.searchParams.get('branch')).toBe('main');
     expect(authorizeUrl?.searchParams.get('environment')).toBe('development');
   });
 
@@ -181,47 +156,18 @@ describe('Cloud CLI authentication', () => {
       cloudUrl: 'https://cloud.example.test',
       environment: 'development target',
     }, {
-      getGitBranch: async () => 'main',
       openBrowser,
     })).rejects.toThrow('Invalid deployment environment');
 
     expect(openBrowser).not.toHaveBeenCalled();
   });
 
-  it('omits branch context when HYPEQUERY_CLI_SEND_BRANCH disables it', async () => {
-    vi.stubEnv('HYPEQUERY_CLI_SEND_BRANCH', '0');
-    try {
-      const getGitBranch = vi.fn(async () => 'feature/customer-retention');
-      const authorizeUrl = await authorizeUrlForLogin({ getGitBranch });
-
-      expect(authorizeUrl?.searchParams.has('branch')).toBe(false);
-      expect(getGitBranch).not.toHaveBeenCalled();
-    } finally {
-      vi.unstubAllEnvs();
-    }
-  });
-
   it('reports the deployment target Cloud resolved for the login', async () => {
-    await authorizeUrlForLogin({
-      getGitBranch: async () => 'feature/customer-retention',
-    });
+    await authorizeUrlForLogin();
 
     expect(logger.info).toHaveBeenCalledWith(
       'Deployments target acme:analytics / preview-customer-retention',
     );
-  });
-
-  it('never opens the loopback server when branch resolution fails', async () => {
-    const openBrowser = vi.fn();
-    await expect(loginCommand({ cloudUrl: 'https://cloud.example.test' }, {
-      getGitBranch: async () => {
-        throw new Error('git exploded');
-      },
-      openBrowser,
-      timeoutMs: 2_000,
-    })).rejects.toThrow('git exploded');
-
-    expect(openBrowser).not.toHaveBeenCalled();
   });
 
   it('reports a non-object token response as an invalid Cloud response', async () => {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -13,7 +13,6 @@ import {
   saveCloudCredential,
   type StoredCloudCredential,
 } from '../utils/cloud-credential-store.js';
-import { currentGitBranch } from '../utils/git-branch.js';
 import { logger } from '../utils/logger.js';
 
 const DEFAULT_CLOUD_URL = 'https://cloud.hypequery.com';
@@ -31,31 +30,17 @@ const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 
 export interface LoginOptions {
   readonly cloudUrl?: string;
-  /** Commander sets this to false for `--no-branch`. */
-  readonly branch?: boolean;
-  /** Stable Cloud deployment target. This always takes precedence over Git branch context. */
+  /** Stable Cloud deployment target. */
   readonly environment?: string;
 }
 
 export interface LoginDependencies {
   readonly fetch?: typeof fetch;
-  readonly getGitBranch?: () => Promise<string | null>;
   readonly openBrowser?: (url: string) => Promise<unknown>;
   readonly now?: () => number;
   readonly requestTimeoutMs?: number;
   readonly saveCredential?: typeof saveCloudCredential;
   readonly timeoutMs?: number;
-}
-
-/**
- * Branch names carry internal detail (customer names, embargoed identifiers),
- * so both an explicit `--no-branch` and the environment variable suppress the
- * parameter. The flag wins because it is the more specific signal.
- */
-function branchContextEnabled(options: LoginOptions): boolean {
-  if (options.branch === false) return false;
-  const configured = process.env.HYPEQUERY_CLI_SEND_BRANCH?.trim().toLowerCase();
-  return configured !== '0' && configured !== 'false' && configured !== 'no';
 }
 
 export interface LogoutDependencies {
@@ -223,12 +208,6 @@ export async function loginCommand(
   const state = randomBytes(24).toString('base64url');
   const verifier = randomBytes(32).toString('base64url');
   const challenge = createHash('sha256').update(verifier).digest('base64url');
-  // Resolve branch context before the loopback listener opens: shelling out to
-  // git should not hold a server socket, and a caller-supplied resolver that
-  // rejects must not leak one.
-  const branch = branchContextEnabled(options)
-    ? await (dependencies.getGitBranch ?? currentGitBranch)()
-    : null;
   let environment: string | undefined;
   if (options.environment !== undefined) {
     try {
@@ -248,7 +227,6 @@ export async function loginCommand(
   authorizeUrl.searchParams.set('code_challenge', challenge);
   authorizeUrl.searchParams.set('code_challenge_method', 'S256');
   authorizeUrl.searchParams.set('state', state);
-  if (branch) authorizeUrl.searchParams.set('branch', branch);
   if (environment) authorizeUrl.searchParams.set('environment', environment);
 
   try {
@@ -284,8 +262,8 @@ export async function loginCommand(
     );
     await (dependencies.saveCredential ?? saveCloudCredential)(credential);
     logger.success('Logged in to Hypequery Cloud');
-    // Cloud resolves the target, and branch context only expresses intent, so
-    // print what was actually issued rather than what was requested.
+    // Cloud resolves the target, so print what was actually issued rather than
+    // what was requested.
     if (credential.target) {
       logger.info(
         `Deployments target ${credential.target.project} / ${credential.target.environment}`,

--- a/packages/cli/src/utils/deployment-bundle.ts
+++ b/packages/cli/src/utils/deployment-bundle.ts
@@ -50,6 +50,7 @@ export interface DeploymentBundleSourceSnapshot {
     readonly kind: 'git';
     readonly commit: string;
     readonly dirty: boolean;
+    readonly branch?: string;
   };
 }
 

--- a/packages/cli/src/utils/deployment-source-snapshot.test.ts
+++ b/packages/cli/src/utils/deployment-source-snapshot.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -5,6 +6,20 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { captureDeploymentSourceSnapshot } from './deployment-source-snapshot.js';
 
 const temporaryDirectories: string[] = [];
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'hypequery',
+      GIT_AUTHOR_EMAIL: 'cli@hypequery.test',
+      GIT_COMMITTER_NAME: 'hypequery',
+      GIT_COMMITTER_EMAIL: 'cli@hypequery.test',
+    },
+  }).trim();
+}
 
 afterEach(async () => {
   vi.restoreAllMocks();
@@ -37,5 +52,27 @@ describe('deployment source snapshots', () => {
     ]);
     expect(new TextDecoder().decode(snapshot.files[1]?.bytes)).toContain('analytics.orders');
     expect(snapshot.revision).toBeUndefined();
+  });
+
+  it('captures Git branch and commit provenance during deployment builds', async () => {
+    const project = await mkdtemp(path.join(tmpdir(), 'hypequery-source-revision-test-'));
+    temporaryDirectories.push(project);
+    await mkdir(path.join(project, 'analytics'), { recursive: true });
+    await writeFile(path.join(project, 'analytics/api.ts'), 'export const api = {}\n');
+    git(project, 'init', '--initial-branch=main', '.');
+    git(project, 'add', 'analytics/api.ts');
+    git(project, 'commit', '-m', 'initial');
+    git(project, 'checkout', '-b', 'feature/customer-retention');
+    const commit = git(project, 'rev-parse', 'HEAD');
+    vi.spyOn(process, 'cwd').mockReturnValue(project);
+
+    const snapshot = await captureDeploymentSourceSnapshot('analytics/api.ts');
+
+    expect(snapshot.revision).toEqual({
+      kind: 'git',
+      branch: 'feature/customer-retention',
+      commit,
+      dirty: false,
+    });
   });
 });

--- a/packages/cli/src/utils/deployment-source-snapshot.ts
+++ b/packages/cli/src/utils/deployment-source-snapshot.ts
@@ -9,6 +9,7 @@ import type {
   DeploymentBundleSourceFile,
   DeploymentBundleSourceSnapshot,
 } from './deployment-bundle.js';
+import { currentGitBranch } from './git-branch.js';
 import { findNearestTsconfig } from './load-api.js';
 
 function portableProjectPath(projectRoot: string, absolutePath: string): string {
@@ -66,7 +67,10 @@ function gitOutput(projectRoot: string, arguments_: readonly string[]): Promise<
 async function sourceRevision(
   projectRoot: string,
 ): Promise<DeploymentBundleSourceSnapshot['revision']> {
-  const commit = await gitOutput(projectRoot, ['rev-parse', 'HEAD']);
+  const [commit, branch] = await Promise.all([
+    gitOutput(projectRoot, ['rev-parse', 'HEAD']),
+    currentGitBranch(projectRoot),
+  ]);
   if (!commit || !/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(commit)) return undefined;
   const status = await gitOutput(projectRoot, ['status', '--porcelain', '--untracked-files=all']);
   if (status === undefined) return undefined;
@@ -74,6 +78,7 @@ async function sourceRevision(
     kind: 'git',
     commit,
     dirty: status.length > 0,
+    ...(branch ? { branch } : {}),
   });
 }
 

--- a/packages/protocol/src/bundles/bundles.test.ts
+++ b/packages/protocol/src/bundles/bundles.test.ts
@@ -80,6 +80,7 @@ function source() {
       kind: 'git',
       commit: '5'.repeat(40),
       dirty: false,
+      branch: 'feature/customer-retention',
     },
   };
 }
@@ -197,6 +198,27 @@ describe('deployment bundle manifest v1', () => {
     expect(Object.isFrozen(manifest.source?.files)).toBe(true);
     expect(Object.isFrozen(manifest.source?.files[0])).toBe(true);
     expect(Object.isFrozen(manifest.source?.revision)).toBe(true);
+  });
+
+  it('accepts detached revisions and rejects invalid branch provenance', () => {
+    const detached = source();
+    delete (detached.revision as { branch?: string }).branch;
+    expect(validateProtocolDeploymentBundleManifest({
+      ...baseManifest(),
+      source: detached,
+    }).source?.revision).toEqual(detached.revision);
+
+    expectBundleError(
+      () => validateProtocolDeploymentBundleManifest({
+        ...baseManifest(),
+        source: {
+          ...source(),
+          revision: { ...source().revision, branch: 'feature/../production' },
+        },
+      }),
+      'HQ_BUNDLE_INVALID_VALUE',
+      '$.source.revision.branch',
+    );
   });
 
   it('requires the source entrypoint and a collision-free bundle tree', () => {

--- a/packages/protocol/src/bundles/types.ts
+++ b/packages/protocol/src/bundles/types.ts
@@ -16,6 +16,8 @@ export interface ProtocolDeploymentBundleSourceRevision {
   readonly kind: 'git';
   readonly commit: string;
   readonly dirty: boolean;
+  /** Checked-out branch at build time; absent for detached HEADs. */
+  readonly branch?: string;
 }
 
 export interface ProtocolDeploymentBundleSource {

--- a/packages/protocol/src/bundles/validate.ts
+++ b/packages/protocol/src/bundles/validate.ts
@@ -146,9 +146,10 @@ function validateArtifact(
 function validateSourceRevision(
   input: unknown,
   path: string,
+  limits: Readonly<ProtocolDeploymentBundleLimits>,
 ): ProtocolDeploymentBundleSourceRevision {
   const value = requireRecord(input, path);
-  exactFields(value, ['kind', 'commit', 'dirty'], path);
+  exactFields(value, ['kind', 'commit', 'dirty'], path, ['branch']);
   if (value.kind !== 'git') {
     if (typeof value.kind !== 'string') bundleError('HQ_BUNDLE_TYPE', `${path}.kind`);
     bundleError('HQ_BUNDLE_INVALID_VALUE', `${path}.kind`);
@@ -158,10 +159,32 @@ function validateSourceRevision(
     bundleError('HQ_BUNDLE_INVALID_VALUE', `${path}.commit`);
   }
   if (typeof value.dirty !== 'boolean') bundleError('HQ_BUNDLE_TYPE', `${path}.dirty`);
+  let branch: string | undefined;
+  if (value.branch !== undefined) {
+    if (typeof value.branch !== 'string') bundleError('HQ_BUNDLE_TYPE', `${path}.branch`);
+    if (textEncoder.encode(value.branch).byteLength > limits.maxPathBytes) {
+      bundleError('HQ_BUNDLE_TOO_LARGE', `${path}.branch`);
+    }
+    const invalidCharacter = [...value.branch].some(character => {
+      const code = character.charCodeAt(0);
+      return code <= 0x20 || code === 0x7f || '~^:?*[\\'.includes(character);
+    });
+    const segments = value.branch.split('/');
+    if (!value.branch || value.branch === '@' || value.branch.startsWith('-')
+      || value.branch.startsWith('/') || value.branch.endsWith('/')
+      || value.branch.endsWith('.') || value.branch.includes('//')
+      || value.branch.includes('..') || value.branch.includes('@{')
+      || invalidCharacter
+      || segments.some(segment => segment.startsWith('.') || segment.endsWith('.lock'))) {
+      bundleError('HQ_BUNDLE_INVALID_VALUE', `${path}.branch`);
+    }
+    branch = value.branch;
+  }
   return freezeRecord({
     kind: 'git',
     commit: value.commit,
     dirty: value.dirty,
+    ...(branch ? { branch } : {}),
   }) as unknown as ProtocolDeploymentBundleSourceRevision;
 }
 
@@ -214,7 +237,7 @@ function validateSource(
     files,
     ...(value.revision === undefined
       ? {}
-      : { revision: validateSourceRevision(value.revision, `${path}.revision`) }),
+      : { revision: validateSourceRevision(value.revision, `${path}.revision`, limits) }),
   }) as unknown as ProtocolDeploymentBundleSource;
 }
 


### PR DESCRIPTION
## What changed

- capture the checked-out Git branch alongside the existing commit and dirty state in deployment source snapshots
- omit branch provenance for detached HEAD deployments
- remove Git branch discovery, the `branch` authorization parameter, `--no-branch`, and `HYPEQUERY_CLI_SEND_BRANCH` handling from `hypequery login`
- keep project and environment as the only deployment-target inputs
- add patch changesets for the CLI and protocol packages

## Why

Git state describes the source revision being deployed; it must not select or create a Cloud environment. Capturing provenance in the immutable deployment bundle keeps the same Git branch deployable to development and production while preserving useful audit context.

## User impact

`hypequery deploy` continues to target an explicit project/environment and now records branch, commit, and dirty state by default when source snapshots are enabled. `hypequery login` no longer reads or sends repository branch data.

## Validation

- `pnpm test`
- `pnpm types`
- `pnpm lint`
- `pnpm build`