### PR TITLE
Add live deployment source workflows

### DIFF
--- a/.changeset/bright-live-source.md
+++ b/.changeset/bright-live-source.md
@@ -1,0 +1,5 @@
+---
+"@hypequery/cli": patch
+---
+
+Add live source pull and diff commands plus restore-aware deployment drift protection.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -239,15 +239,44 @@ arguments, keeping them out of shell history. The submission endpoint must not
 contain credentials or a URL fragment, and must use HTTPS except for
 `127.0.0.1`/`localhost`, which is permitted for local development and warns that
 the token is sent in cleartext. The release identity is sent as the idempotency
-key, so an unchanged release can be submitted safely again.
-
-This command submits immutable deployment inputs. Activation, status changes,
-promotion, and rollback remain control-plane operations.
+key, so an unchanged release can be submitted safely again. An accepted release
+becomes live immediately. The CLI pins the upload to the current activation
+revision, so a concurrent deploy or restore returns a conflict. If the current
+release was restored, pass `--replace-restored` to confirm that a different
+release should replace it.
 
 Options:
 
 - `--release <path>`: required target-bound release JSON
 - `--endpoint <url>`: HTTPS submission endpoint; requires `HYPEQUERY_API_TOKEN`
+- `--replace-restored`: intentionally replace a restored live release
+
+### `hypequery pull`
+
+Downloads the exact multi-file TypeScript source snapshot stored with the live
+release. Pull requires an interactive Cloud credential with source-read access;
+run `hypequery login` again if the credential predates this capability.
+
+```bash
+npx hypequery pull
+```
+
+By default the snapshot is written to a new release-specific directory under
+`.hypequery/live/<environment>/`. Use `--output <directory>` to choose another
+new directory. Pull never overwrites an existing path.
+
+### `hypequery diff [source]`
+
+Compares the local TypeScript dependency graph with the live release snapshot
+and reports added (`A`), modified (`M`), and deleted (`D`) files. The deployed
+entrypoint is used when `source` is omitted.
+
+```bash
+npx hypequery diff analytics/api.ts
+```
+
+Both commands use the target selected by `hypequery login`. Advanced and CI
+usage can pass `--project`, `--environment`, and `--endpoint` explicitly.
 
 ## Non-interactive Setup
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,6 +24,12 @@ import {
   logoutCommand,
   type LoginOptions,
 } from './commands/login.js';
+import {
+  diffCommand,
+  pullCommand,
+  type LiveSourceOptions,
+  type PullOptions,
+} from './commands/live-source.js';
 import { isPromptCancelled } from './utils/prompts.js';
 
 const program = new Command();
@@ -65,6 +71,27 @@ program
   .description('Revoke and remove the local Hypequery Cloud credential')
   .action(runCommand(async () => {
     await logoutCommand();
+  }));
+
+program
+  .command('pull')
+  .description('Download the source snapshot from the live deployment')
+  .option('-o, --output <directory>', 'New destination directory')
+  .option('--project <project>', 'Target project identifier (advanced override)')
+  .option('--environment <environment>', 'Target environment identifier (advanced override)')
+  .option('--endpoint <url>', 'HTTPS submission endpoint; requires HYPEQUERY_API_TOKEN')
+  .action(runCommand(async (options: PullOptions) => {
+    await pullCommand(options);
+  }));
+
+program
+  .command('diff [source]')
+  .description('Compare local source with the live deployment')
+  .option('--project <project>', 'Target project identifier (advanced override)')
+  .option('--environment <environment>', 'Target environment identifier (advanced override)')
+  .option('--endpoint <url>', 'HTTPS submission endpoint; requires HYPEQUERY_API_TOKEN')
+  .action(runCommand(async (source: string | undefined, options: LiveSourceOptions) => {
+    await diffCommand(source, options);
   }));
 
 function runCommand<TArgs extends unknown[]>(
@@ -205,6 +232,10 @@ program
     '--endpoint <url>',
     'HTTPS submission endpoint; requires HYPEQUERY_API_TOKEN',
   )
+  .option(
+    '--replace-restored',
+    'Intentionally replace a restored live release',
+  )
   .action(runCommand(async (bundle: string, options: SubmitDeploymentOptions) => {
     await submitDeploymentCommand(bundle, options);
   }));
@@ -221,6 +252,10 @@ program
   .option(
     '--endpoint <url>',
     'HTTPS submission endpoint; requires HYPEQUERY_API_TOKEN',
+  )
+  .option(
+    '--replace-restored',
+    'Intentionally replace a restored live release',
   )
   .action(runCommand(async (source: string, options: DeployOptions) => {
     await deployCommand(source, options);

--- a/packages/cli/src/commands/deploy.test.ts
+++ b/packages/cli/src/commands/deploy.test.ts
@@ -429,6 +429,113 @@ describe('deploy command', () => {
     }));
   });
 
+  it('pins submission to the live activation revision', async () => {
+    const release = await releaseFile();
+    const submit = vi.fn().mockResolvedValue({
+      kind: 'hypequery-deployment-submission',
+      version: 1,
+      status: 'accepted',
+      releaseIdentity: release.identity,
+      bundleIdentity: BUNDLE_IDENTITY,
+    });
+    const createTransport = vi.fn(() => ({ submit }));
+    const currentRevision = 'c'.repeat(64);
+
+    await deployCommand('dist/bundle', {
+      release: release.path,
+    }, {
+      env: {},
+      loadCredential: async () => ({
+        cloudUrl: 'https://cloud.example.test',
+        deploymentEndpoint: 'https://cloud.example.test/v1/deployments/submissions',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        scope: 'deploy:submit deploy:read-source',
+        target: { project: 'project-1', environment: 'production' },
+        token: 'secret-token',
+      }),
+      fetchLive: async () => ({
+        target: { project: 'project-1', environment: 'production' },
+        active: {
+          revision: currentRevision,
+          releaseIdentity: 'd'.repeat(64),
+          activatedAt: '2026-08-01T10:00:00.000Z',
+          restored: false,
+          hasSource: true,
+        },
+      }),
+      createTransport,
+    });
+
+    expect(createTransport).toHaveBeenCalledWith({
+      endpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      token: 'secret-token',
+      expectedActivationRevision: currentRevision,
+    });
+  });
+
+  it('requires an explicit flag before replacing a restored release', async () => {
+    const release = await releaseFile();
+    const fetchLive = vi.fn(async () => ({
+      target: { project: 'project-1', environment: 'production' },
+      active: {
+        revision: 'c'.repeat(64),
+        releaseIdentity: 'd'.repeat(64),
+        activatedAt: '2026-08-01T10:00:00.000Z',
+        restored: true,
+        hasSource: true,
+      },
+    }));
+    const createTransport = vi.fn();
+
+    await expect(deployCommand('dist/bundle', {
+      release: release.path,
+      endpoint: 'https://cloud.example.test/v1/deployments/submissions',
+    }, {
+      env: { HYPEQUERY_API_TOKEN: 'secret-token' },
+      fetchLive,
+      createTransport,
+    })).rejects.toThrow('--replace-restored');
+
+    expect(createTransport).not.toHaveBeenCalled();
+  });
+
+  it('sends the explicit restored-release replacement option', async () => {
+    const release = await releaseFile();
+    const submit = vi.fn().mockResolvedValue({
+      kind: 'hypequery-deployment-submission',
+      version: 1,
+      status: 'accepted',
+      releaseIdentity: release.identity,
+      bundleIdentity: BUNDLE_IDENTITY,
+    });
+    const createTransport = vi.fn(() => ({ submit }));
+    const currentRevision = 'c'.repeat(64);
+
+    await deployCommand('dist/bundle', {
+      release: release.path,
+      endpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      replaceRestored: true,
+    }, {
+      env: { HYPEQUERY_API_TOKEN: 'secret-token' },
+      fetchLive: async () => ({
+        target: { project: 'project-1', environment: 'production' },
+        active: {
+          revision: currentRevision,
+          releaseIdentity: 'd'.repeat(64),
+          activatedAt: '2026-08-01T10:00:00.000Z',
+          restored: true,
+          hasSource: true,
+        },
+      }),
+      createTransport,
+    });
+
+    expect(createTransport).toHaveBeenCalledWith(expect.objectContaining({
+      expectedActivationRevision: currentRevision,
+      replaceRestored: true,
+    }));
+  });
+
   it('uses the credential stored by interactive login', async () => {
     const release = await releaseFile();
     const submit = vi.fn().mockResolvedValue({
@@ -450,6 +557,7 @@ describe('deploy command', () => {
         scope: 'deploy:submit',
         token: `hqdp_v1_${'f'.repeat(43)}`,
       }),
+      fetchLive: async () => undefined,
       createTransport,
     });
 

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -15,9 +15,10 @@ import {
 } from '../utils/deployment-upload.js';
 import { logger } from '../utils/logger.js';
 import {
-  loadCloudCredential,
   type StoredCloudCredential,
 } from '../utils/cloud-credential-store.js';
+import { resolveDeploymentCredential } from '../utils/cloud-deployment-access.js';
+import { fetchLiveDeployment } from '../utils/live-deployment.js';
 import {
   buildDeploymentCommand,
   prepareDeploymentReleaseCommand,
@@ -30,6 +31,7 @@ const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 export interface SubmitDeploymentOptions {
   release?: string;
   endpoint?: string;
+  replaceRestored?: boolean;
 }
 
 export interface DeployOptions extends SubmitDeploymentOptions {
@@ -44,6 +46,7 @@ export interface SubmitDeploymentDependencies {
   readonly env?: Readonly<Record<string, string | undefined>>;
   readonly createTransport?: typeof createHttpDeploymentUploadTransport;
   readonly loadCredential?: () => Promise<StoredCloudCredential | null>;
+  readonly fetchLive?: typeof fetchLiveDeployment;
 }
 
 export interface DeployDependencies extends SubmitDeploymentDependencies {
@@ -110,56 +113,6 @@ function requiredConfiguration(
   return value;
 }
 
-interface ResolvedDeploymentCredential {
-  readonly endpoint: string;
-  readonly token: string;
-}
-
-/**
- * Resolves the submission endpoint and token. Kept separate from
- * `submitDeploymentCommand` so `deployCommand` can run it as a preflight
- * before the bundle build.
- */
-async function resolveDeploymentCredential(
-  endpointOption: string | undefined,
-  dependencies: SubmitDeploymentDependencies,
-): Promise<ResolvedDeploymentCredential> {
-  const env = dependencies.env ?? process.env;
-  let deploymentEndpoint = endpointOption ?? env.HYPEQUERY_DEPLOYMENT_ENDPOINT;
-  let token = env.HYPEQUERY_API_TOKEN;
-  const hasExplicitEndpoint = Boolean(deploymentEndpoint);
-  const hasExplicitToken = Boolean(token);
-  if (hasExplicitEndpoint !== hasExplicitToken) {
-    throw new Error(
-      hasExplicitEndpoint
-        ? 'An explicit deployment endpoint requires HYPEQUERY_API_TOKEN.'
-        : 'HYPEQUERY_API_TOKEN requires --endpoint or HYPEQUERY_DEPLOYMENT_ENDPOINT.\n\n'
-          + 'If you meant to use `hypequery login`, unset HYPEQUERY_API_TOKEN — '
-          + 'the CLI also reads it from a project .env file.',
-    );
-  }
-  if (!hasExplicitEndpoint) {
-    const credential = await (dependencies.loadCredential ?? loadCloudCredential)();
-    if (credential) {
-      if (Date.parse(credential.expiresAt) <= Date.now()) {
-        throw new Error('The stored Cloud credential has expired. Run `hypequery login` again.');
-      }
-      deploymentEndpoint = credential.deploymentEndpoint;
-      token = credential.token;
-    }
-  }
-  return {
-    endpoint: requiredConfiguration(
-      deploymentEndpoint,
-      'Missing deployment endpoint. Run `hypequery login`, pass --endpoint, or set HYPEQUERY_DEPLOYMENT_ENDPOINT.',
-    ),
-    token: requiredConfiguration(
-      token,
-      'Missing deployment credential. Run `hypequery login` or set HYPEQUERY_API_TOKEN.',
-    ),
-  };
-}
-
 export async function submitDeploymentCommand(
   bundlePath: string | undefined,
   options: SubmitDeploymentOptions = {},
@@ -206,10 +159,28 @@ export async function submitDeploymentCommand(
       'Release bundle identity does not match the verified deployment bundle.',
     );
   }
+  const live = await (dependencies.fetchLive ?? fetchLiveDeployment)({
+    endpoint: deploymentEndpoint,
+    token,
+    target: release.release.target,
+    resource: 'state',
+  });
+  if (live?.active?.restored
+    && live.active.releaseIdentity !== release.identity
+    && !options.replaceRestored) {
+    throw new Error(
+      'The live deployment is a restored release. '
+      + 'Run the command again with --replace-restored to replace it intentionally.',
+    );
+  }
   const createTransport = dependencies.createTransport ?? createHttpDeploymentUploadTransport;
   const transportOptions: HttpDeploymentUploadTransportOptions = {
     endpoint: deploymentEndpoint,
     token,
+    ...(live
+      ? { expectedActivationRevision: live.active?.revision ?? null }
+      : {}),
+    ...(options.replaceRestored ? { replaceRestored: true } : {}),
   };
   const result = await createTransport(transportOptions).submit(bundle, release);
   logger.success(
@@ -292,6 +263,7 @@ export async function deployCommand(
     return submitDeploymentCommand(sourcePath, {
       release: options.release,
       endpoint: options.endpoint,
+      replaceRestored: options.replaceRestored,
     }, dependencies);
   }
 
@@ -325,5 +297,6 @@ export async function deployCommand(
   return submit(bundlePath, {
     release: releasePath,
     endpoint: options.endpoint,
+    replaceRestored: options.replaceRestored,
   }, dependencies);
 }

--- a/packages/cli/src/commands/live-source.test.ts
+++ b/packages/cli/src/commands/live-source.test.ts
@@ -1,0 +1,134 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../utils/logger.js', () => ({
+  logger: { success: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { diffCommand, pullCommand } from './live-source.js';
+
+const directories: string[] = [];
+const target = { project: 'acme:analytics', environment: 'production' };
+const releaseIdentity = 'a'.repeat(64);
+
+function sha256(bytes: Uint8Array) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function credential(scope = 'deploy:submit deploy:read-source') {
+  return {
+    cloudUrl: 'https://cloud.example.test',
+    deploymentEndpoint: 'https://cloud.example.test/v1/deployments/submissions',
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    scope,
+    target,
+    token: 'secret-token',
+  };
+}
+
+function live(files: readonly { path: string; bytes: Uint8Array }[]) {
+  return {
+    target,
+    active: {
+      revision: 'b'.repeat(64),
+      releaseIdentity,
+      activatedAt: '2026-08-01T10:00:00.000Z',
+      restored: false,
+      hasSource: true,
+      source: {
+        entrypoint: 'analytics/api.ts',
+        files: files.map(file => ({
+          path: file.path,
+          sha256: sha256(file.bytes),
+          bytes: file.bytes,
+        })),
+      },
+    },
+  } as const;
+}
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map(directory => (
+    rm(directory, { recursive: true, force: true })
+  )));
+});
+
+describe('live source commands', () => {
+  it('pulls the exact multi-file snapshot into a new directory', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'hypequery-pull-test-'));
+    directories.push(root);
+    const destination = path.join(root, 'snapshot');
+    const api = new TextEncoder().encode('import { orders } from "./orders.js";\n');
+    const orders = new TextEncoder().encode('export const orders = {};\n');
+
+    await pullCommand({ output: destination }, {
+      env: {},
+      loadCredential: async () => credential(),
+      fetchLive: async () => live([
+        { path: 'analytics/api.ts', bytes: api },
+        { path: 'analytics/orders.ts', bytes: orders },
+      ]),
+    });
+
+    await expect(readFile(path.join(destination, 'analytics/api.ts'), 'utf8'))
+      .resolves.toBe(new TextDecoder().decode(api));
+    await expect(readFile(path.join(destination, 'analytics/orders.ts'), 'utf8'))
+      .resolves.toBe(new TextDecoder().decode(orders));
+  });
+
+  it('never overwrites an existing pull destination', async () => {
+    const destination = await mkdtemp(path.join(tmpdir(), 'hypequery-pull-existing-'));
+    directories.push(destination);
+
+    await expect(pullCommand({ output: destination }, {
+      env: {},
+      loadCredential: async () => credential(),
+      fetchLive: async () => live([{
+        path: 'analytics/api.ts',
+        bytes: new TextEncoder().encode('export {};\n'),
+      }]),
+    })).rejects.toThrow('Refusing to overwrite');
+  });
+
+  it('reports added, modified, and deleted source files', async () => {
+    const same = new TextEncoder().encode('same\n');
+    const differences = await diffCommand('analytics/api.ts', {}, {
+      env: {},
+      loadCredential: async () => credential(),
+      fetchLive: async () => live([
+        { path: 'analytics/api.ts', bytes: same },
+        { path: 'analytics/changed.ts', bytes: new TextEncoder().encode('old\n') },
+        { path: 'analytics/deleted.ts', bytes: new TextEncoder().encode('gone\n') },
+      ]),
+      captureSource: async () => ({
+        entrypoint: 'analytics/api.ts',
+        files: [
+          { path: 'analytics/api.ts', bytes: same },
+          { path: 'analytics/changed.ts', bytes: new TextEncoder().encode('new\n') },
+          { path: 'analytics/added.ts', bytes: new TextEncoder().encode('added\n') },
+        ],
+      }),
+    });
+
+    expect(differences).toEqual([
+      { status: 'A', path: 'analytics/added.ts' },
+      { status: 'M', path: 'analytics/changed.ts' },
+      { status: 'D', path: 'analytics/deleted.ts' },
+    ]);
+  });
+
+  it('asks legacy interactive credentials to login again', async () => {
+    const fetchLive = vi.fn();
+
+    await expect(diffCommand(undefined, {}, {
+      env: {},
+      loadCredential: async () => credential('deploy:submit'),
+      fetchLive,
+    })).rejects.toThrow('hypequery login');
+
+    expect(fetchLive).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/live-source.ts
+++ b/packages/cli/src/commands/live-source.ts
@@ -1,0 +1,180 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, rename, rm, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  validateProtocolDeploymentReleaseTarget,
+  type ProtocolDeploymentReleaseTarget,
+} from '@hypequery/protocol';
+import {
+  CLOUD_SOURCE_SCOPE,
+  type StoredCloudCredential,
+} from '../utils/cloud-credential-store.js';
+import {
+  resolveDeploymentCredential,
+  type CloudDeploymentAccessDependencies,
+} from '../utils/cloud-deployment-access.js';
+import { captureDeploymentSourceSnapshot } from '../utils/deployment-source-snapshot.js';
+import {
+  fetchLiveDeployment,
+  type LiveDeployment,
+} from '../utils/live-deployment.js';
+import { logger } from '../utils/logger.js';
+
+export interface LiveSourceOptions {
+  readonly endpoint?: string;
+  readonly project?: string;
+  readonly environment?: string;
+}
+
+export interface PullOptions extends LiveSourceOptions {
+  readonly output?: string;
+}
+
+export interface LiveSourceDependencies extends CloudDeploymentAccessDependencies {
+  readonly fetchLive?: typeof fetchLiveDeployment;
+  readonly captureSource?: typeof captureDeploymentSourceSnapshot;
+}
+
+export type LiveSourceDifference = {
+  readonly status: 'A' | 'M' | 'D';
+  readonly path: string;
+};
+
+function targetFromOptions(
+  options: LiveSourceOptions,
+  credential: StoredCloudCredential | undefined,
+): ProtocolDeploymentReleaseTarget {
+  if ((options.project === undefined) !== (options.environment === undefined)) {
+    throw new Error('Pass both --project and --environment, or omit both.');
+  }
+  const input = options.project === undefined
+    ? credential?.target
+    : { project: options.project, environment: options.environment };
+  if (!input) {
+    throw new Error(
+      'Missing deployment target. Run `hypequery login` or pass both '
+      + '--project and --environment.',
+    );
+  }
+  try {
+    return validateProtocolDeploymentReleaseTarget(input);
+  } catch {
+    throw new Error('The deployment target is invalid.');
+  }
+}
+
+async function liveSource(
+  options: LiveSourceOptions,
+  dependencies: LiveSourceDependencies,
+): Promise<LiveDeployment & { readonly active: NonNullable<LiveDeployment['active']> }> {
+  const access = await resolveDeploymentCredential(options.endpoint, dependencies);
+  if (access.storedCredential
+    && access.storedCredential.scope !== CLOUD_SOURCE_SCOPE) {
+    throw new Error(
+      'The stored CLI credential cannot read deployed source. Run `hypequery login` again.',
+    );
+  }
+  const target = targetFromOptions(options, access.storedCredential);
+  const live = await (dependencies.fetchLive ?? fetchLiveDeployment)({
+    endpoint: access.endpoint,
+    token: access.token,
+    target,
+    resource: 'source',
+  });
+  if (!live?.active?.source) {
+    throw new Error('The live deployment does not include a source snapshot.');
+  }
+  return live as LiveDeployment & {
+    readonly active: NonNullable<LiveDeployment['active']>;
+  };
+}
+
+function digest(bytes: Uint8Array) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+async function exists(input: string) {
+  try {
+    await stat(input);
+    return true;
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'code' in error
+      && (error as { code?: unknown }).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+export async function pullCommand(
+  options: PullOptions = {},
+  dependencies: LiveSourceDependencies = {},
+) {
+  const live = await liveSource(options, dependencies);
+  const active = live.active;
+  const source = active.source!;
+  const destination = path.resolve(
+    options.output
+      ?? path.join(
+        '.hypequery',
+        'live',
+        live.target.environment,
+        active.releaseIdentity.slice(0, 12),
+      ),
+  );
+  if (destination === path.parse(destination).root || await exists(destination)) {
+    throw new Error(`Refusing to overwrite an existing pull destination: ${destination}`);
+  }
+  const parent = path.dirname(destination);
+  await mkdir(parent, { recursive: true });
+  const staging = path.join(
+    parent,
+    `.${path.basename(destination)}.${randomUUID()}.tmp`,
+  );
+  await mkdir(staging, { mode: 0o700 });
+  try {
+    for (const file of source.files) {
+      const output = path.join(staging, ...file.path.split('/'));
+      await mkdir(path.dirname(output), { recursive: true });
+      await writeFile(output, file.bytes, { flag: 'wx' });
+    }
+    await rename(staging, destination);
+  } catch (error) {
+    await rm(staging, { recursive: true, force: true }).catch(() => undefined);
+    throw error;
+  }
+  logger.success(`Live source pulled to ${destination}`);
+  logger.info(`Release identity: ${active.releaseIdentity}`);
+  logger.info(`Entrypoint: ${source.entrypoint}`);
+  return destination;
+}
+
+export async function diffCommand(
+  sourcePath: string | undefined,
+  options: LiveSourceOptions = {},
+  dependencies: LiveSourceDependencies = {},
+): Promise<readonly LiveSourceDifference[]> {
+  const live = await liveSource(options, dependencies);
+  const active = live.active;
+  const source = active.source!;
+  const local = await (dependencies.captureSource ?? captureDeploymentSourceSnapshot)(
+    sourcePath ?? source.entrypoint,
+  );
+  const liveFiles = new Map(source.files.map(file => [file.path, file.sha256]));
+  const localFiles = new Map(local.files.map(file => [file.path, digest(file.bytes)]));
+  const paths = [...new Set([...liveFiles.keys(), ...localFiles.keys()])].sort();
+  const differences: LiveSourceDifference[] = [];
+  for (const file of paths) {
+    const liveDigest = liveFiles.get(file);
+    const localDigest = localFiles.get(file);
+    if (liveDigest === undefined) differences.push({ status: 'A', path: file });
+    else if (localDigest === undefined) differences.push({ status: 'D', path: file });
+    else if (liveDigest !== localDigest) differences.push({ status: 'M', path: file });
+  }
+  if (differences.length === 0) {
+    logger.success('Local source matches the live deployment');
+  } else {
+    for (const difference of differences) {
+      logger.info(`${difference.status} ${difference.path}`);
+    }
+  }
+  return Object.freeze(differences);
+}

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -46,7 +46,7 @@ async function authorizeUrlForLogin(
       access_token: `hqdp_v1_${'c'.repeat(43)}`,
       token_type: 'Bearer',
       expires_at: '2030-01-01T00:00:00.000Z',
-      scope: 'deploy:submit',
+      scope: 'deploy:submit deploy:read-source',
       deployment_endpoint:
         'https://cloud.example.test/v1/deployments/submissions',
       deployment_target: {
@@ -90,7 +90,7 @@ describe('Cloud CLI authentication', () => {
         access_token: `hqdp_v1_${'c'.repeat(43)}`,
         token_type: 'Bearer',
         expires_at: '2030-01-01T00:00:00.000Z',
-        scope: 'deploy:submit',
+        scope: 'deploy:submit deploy:read-source',
         deployment_endpoint:
           'https://cloud.example.test/v1/deployments/submissions',
         deployment_target: {
@@ -133,7 +133,7 @@ describe('Cloud CLI authentication', () => {
       deploymentEndpoint:
         'https://cloud.example.test/v1/deployments/submissions',
       expiresAt: '2030-01-01T00:00:00.000Z',
-      scope: 'deploy:submit',
+      scope: 'deploy:submit deploy:read-source',
       target: {
         project: 'acme:analytics',
         environment: 'production',
@@ -188,7 +188,7 @@ describe('Cloud CLI authentication', () => {
         access_token: `hqdp_v1_${'c'.repeat(43)}`,
         token_type: 'Bearer',
         expires_at: '2030-01-01T00:00:00.000Z',
-        scope: 'deploy:submit',
+        scope: 'deploy:submit deploy:read-source',
         deployment_endpoint: 'not a URL',
         deployment_target: {
           project: 'acme:analytics',
@@ -232,7 +232,7 @@ describe('Cloud CLI authentication', () => {
         access_token: `hqdp_v1_${'c'.repeat(43)}`,
         token_type: 'Bearer',
         expires_at: '2030-01-02T00:00:00.000Z',
-        scope: 'deploy:submit',
+        scope: 'deploy:submit deploy:read-source',
         deployment_endpoint:
           'https://cloud.example.test/v1/deployments/submissions',
         deployment_target: {
@@ -268,7 +268,7 @@ describe('Cloud CLI authentication', () => {
         deploymentEndpoint:
           'https://cloud.example.test/v1/deployments/submissions',
         expiresAt: '2030-01-01T00:00:00.000Z',
-        scope: 'deploy:submit',
+        scope: 'deploy:submit deploy:read-source',
         token: `hqdp_v1_${'e'.repeat(43)}`,
       }),
       deleteCredential,
@@ -321,7 +321,7 @@ describe('Cloud CLI authentication', () => {
         access_token: `hqdp_v2_${'c'.repeat(64)}`,
         token_type: 'Bearer',
         expires_at: '2030-01-01T00:00:00.000Z',
-        scope: 'deploy:submit',
+        scope: 'deploy:submit deploy:read-source',
         deployment_endpoint: 'https://cloud.example.test/v2/deploy/submissions',
         deployment_target: {
           project: 'acme:analytics',
@@ -346,7 +346,7 @@ describe('Cloud CLI authentication', () => {
         access_token: 'hqdp_short',
         token_type: 'Bearer',
         expires_at: '2030-01-01T00:00:00.000Z',
-        scope: 'deploy:submit',
+        scope: 'deploy:submit deploy:read-source',
         deployment_endpoint:
           'https://cloud.example.test/v1/deployments/submissions',
         deployment_target: {
@@ -367,7 +367,7 @@ describe('Cloud CLI authentication', () => {
         access_token: `hqdp_v1_${'c'.repeat(43)}`,
         token_type: 'Bearer',
         expires_at: '2030-01-01T00:00:00.000Z',
-        scope: 'deploy:submit',
+        scope: 'deploy:submit deploy:read-source',
         deployment_endpoint:
           'https://attacker.example.test/v1/deployments/submissions',
         deployment_target: {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -5,7 +5,7 @@ import open from 'open';
 import { validateProtocolDeploymentReleaseTarget } from '@hypequery/protocol';
 
 import {
-  CLOUD_DEPLOYMENT_SCOPE,
+  CLOUD_SOURCE_SCOPE,
   deleteCloudCredential,
   loadCloudCredential,
   normalizeCloudDeploymentEndpoint,
@@ -168,7 +168,7 @@ function tokenResponse(
     || value.token_type !== 'Bearer'
     || typeof value.expires_at !== 'string'
     || !Number.isFinite(Date.parse(value.expires_at))
-    || value.scope !== CLOUD_DEPLOYMENT_SCOPE
+    || value.scope !== CLOUD_SOURCE_SCOPE
     || typeof value.deployment_endpoint !== 'string'
     || value.deployment_target === undefined
   ) {

--- a/packages/cli/src/utils/cloud-credential-store.ts
+++ b/packages/cli/src/utils/cloud-credential-store.ts
@@ -10,6 +10,7 @@ import {
 const KEYCHAIN_SERVICE = 'dev.hypequery.cli';
 const PROFILE_FILE = 'cloud-profile.json';
 export const CLOUD_DEPLOYMENT_SCOPE = 'deploy:submit';
+export const CLOUD_SOURCE_SCOPE = 'deploy:submit deploy:read-source';
 const MAX_KEYCHAIN_ACCOUNT_LENGTH = 2048;
 
 export interface StoredCloudCredential {
@@ -159,7 +160,7 @@ function parseProfile(input: string): StoredCloudProfile {
     );
     if (value.keychainAccount !== cloudUrl
       || !Number.isFinite(Date.parse(value.expiresAt))
-      || value.scope !== CLOUD_DEPLOYMENT_SCOPE) {
+      || (value.scope !== CLOUD_DEPLOYMENT_SCOPE && value.scope !== CLOUD_SOURCE_SCOPE)) {
       throw new Error('profile invariant mismatch');
     }
     target = value.target === undefined
@@ -232,7 +233,8 @@ export async function saveCloudCredential(
     cloudUrl,
   );
   if (!Number.isFinite(Date.parse(credential.expiresAt))
-    || credential.scope !== CLOUD_DEPLOYMENT_SCOPE) {
+    || (credential.scope !== CLOUD_DEPLOYMENT_SCOPE
+      && credential.scope !== CLOUD_SOURCE_SCOPE)) {
     throw new Error('Cannot store an invalid Hypequery Cloud credential.');
   }
   const keychainAccount = cloudUrl;

--- a/packages/cli/src/utils/cloud-deployment-access.ts
+++ b/packages/cli/src/utils/cloud-deployment-access.ts
@@ -1,0 +1,66 @@
+import {
+  loadCloudCredential,
+  type StoredCloudCredential,
+} from './cloud-credential-store.js';
+
+export interface CloudDeploymentAccessDependencies {
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly loadCredential?: () => Promise<StoredCloudCredential | null>;
+}
+
+export interface ResolvedDeploymentCredential {
+  readonly endpoint: string;
+  readonly token: string;
+  readonly storedCredential?: StoredCloudCredential;
+}
+
+function requiredConfiguration(
+  value: string | undefined,
+  message: string,
+): string {
+  if (value === undefined || value.length === 0) throw new Error(message);
+  return value;
+}
+
+export async function resolveDeploymentCredential(
+  endpointOption: string | undefined,
+  dependencies: CloudDeploymentAccessDependencies,
+): Promise<ResolvedDeploymentCredential> {
+  const env = dependencies.env ?? process.env;
+  let deploymentEndpoint = endpointOption ?? env.HYPEQUERY_DEPLOYMENT_ENDPOINT;
+  let token = env.HYPEQUERY_API_TOKEN;
+  let storedCredential: StoredCloudCredential | undefined;
+  const hasExplicitEndpoint = Boolean(deploymentEndpoint);
+  const hasExplicitToken = Boolean(token);
+  if (hasExplicitEndpoint !== hasExplicitToken) {
+    throw new Error(
+      hasExplicitEndpoint
+        ? 'An explicit deployment endpoint requires HYPEQUERY_API_TOKEN.'
+        : 'HYPEQUERY_API_TOKEN requires --endpoint or HYPEQUERY_DEPLOYMENT_ENDPOINT.\n\n'
+          + 'If you meant to use `hypequery login`, unset HYPEQUERY_API_TOKEN — '
+          + 'the CLI also reads it from a project .env file.',
+    );
+  }
+  if (!hasExplicitEndpoint) {
+    const credential = await (dependencies.loadCredential ?? loadCloudCredential)();
+    if (credential) {
+      if (Date.parse(credential.expiresAt) <= Date.now()) {
+        throw new Error('The stored Cloud credential has expired. Run `hypequery login` again.');
+      }
+      deploymentEndpoint = credential.deploymentEndpoint;
+      token = credential.token;
+      storedCredential = credential;
+    }
+  }
+  return {
+    endpoint: requiredConfiguration(
+      deploymentEndpoint,
+      'Missing deployment endpoint. Run `hypequery login`, pass --endpoint, or set HYPEQUERY_DEPLOYMENT_ENDPOINT.',
+    ),
+    token: requiredConfiguration(
+      token,
+      'Missing deployment credential. Run `hypequery login` or set HYPEQUERY_API_TOKEN.',
+    ),
+    ...(storedCredential ? { storedCredential } : {}),
+  };
+}

--- a/packages/cli/src/utils/deployment-upload.test.ts
+++ b/packages/cli/src/utils/deployment-upload.test.ts
@@ -172,6 +172,8 @@ describe('deployment upload transport', () => {
     const transport = createHttpDeploymentUploadTransport({
       endpoint: 'https://deploy.example.test/v1/releases',
       token: 'secret-token',
+      expectedActivationRevision: 'c'.repeat(64),
+      replaceRestored: true,
       fetch,
     });
 
@@ -184,6 +186,9 @@ describe('deployment upload transport', () => {
     expect(request?.headers['Idempotency-Key']).toBe(release.identity);
     expect(request?.headers['X-HypeQuery-Bundle-Identity']).toBe(bundle.identity);
     expect(request?.headers['X-HypeQuery-Release-Identity']).toBe(release.identity);
+    expect(request?.headers['X-HypeQuery-Expected-Activation-Revision'])
+      .toBe('c'.repeat(64));
+    expect(request?.headers['X-HypeQuery-Replace-Restored']).toBe('true');
     expect(request?.headers['Content-Length']).toBe(String(requestBytes?.byteLength));
     expect(request?.duplex).toBe('half');
     expect(request?.redirect).toBe('error');

--- a/packages/cli/src/utils/deployment-upload.ts
+++ b/packages/cli/src/utils/deployment-upload.ts
@@ -67,6 +67,8 @@ export type DeploymentFetch = (
 export interface HttpDeploymentUploadTransportOptions {
   readonly endpoint: string;
   readonly token: string;
+  readonly expectedActivationRevision?: string | null;
+  readonly replaceRestored?: boolean;
   readonly timeoutMs?: number;
   readonly fetch?: DeploymentFetch;
 }
@@ -480,6 +482,15 @@ export function createHttpDeploymentUploadTransport(
             'Idempotency-Key': preparedRelease.identity,
             'X-HypeQuery-Bundle-Identity': manifest.identity,
             'X-HypeQuery-Release-Identity': preparedRelease.identity,
+            ...(options.expectedActivationRevision !== undefined
+              ? {
+                  'X-HypeQuery-Expected-Activation-Revision':
+                    options.expectedActivationRevision ?? 'none',
+                }
+              : {}),
+            ...(options.replaceRestored
+              ? { 'X-HypeQuery-Replace-Restored': 'true' }
+              : {}),
           },
           body: multipartBody(boundary, parts),
           duplex: 'half',

--- a/packages/cli/src/utils/live-deployment.test.ts
+++ b/packages/cli/src/utils/live-deployment.test.ts
@@ -1,0 +1,98 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import { fetchLiveDeployment } from './live-deployment.js';
+
+const target = { project: 'acme:analytics', environment: 'production' };
+const bytes = Buffer.from('export const answer = 42;\n');
+const sha256 = createHash('sha256').update(bytes).digest('hex');
+
+function response(contentsBase64 = bytes.toString('base64')) {
+  return {
+    kind: 'hypequery-live-deployment',
+    version: 1,
+    target,
+    active: {
+      revision: 'a'.repeat(64),
+      releaseIdentity: 'b'.repeat(64),
+      activatedAt: '2026-08-01T10:00:00.000Z',
+      restored: false,
+      hasSource: true,
+      source: {
+        entrypoint: 'analytics/api.ts',
+        files: [{
+          path: 'analytics/api.ts',
+          sha256,
+          byteLength: bytes.byteLength,
+          contentsBase64,
+        }],
+      },
+    },
+  };
+}
+
+describe('live deployment client', () => {
+  it('requests and verifies the target source snapshot', async () => {
+    const fetchMock = vi.fn(async () => Response.json(response()));
+
+    const live = await fetchLiveDeployment({
+      endpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      token: 'secret-token',
+      target,
+      resource: 'source',
+      fetch: fetchMock as typeof fetch,
+    });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://cloud.example.test/v1/deployments/targets/acme%3Aanalytics/production/source',
+    );
+    expect(live?.active?.source?.files[0]?.bytes).toEqual(bytes);
+  });
+
+  it('rejects source bytes that do not match their digest', async () => {
+    await expect(fetchLiveDeployment({
+      endpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      token: 'secret-token',
+      target,
+      resource: 'source',
+      fetch: (async () => Response.json(
+        response(Buffer.from('changed').toString('base64')),
+      )) as typeof fetch,
+    })).rejects.toThrow('corrupt');
+  });
+
+  it('treats a missing state route as an older provider', async () => {
+    await expect(fetchLiveDeployment({
+      endpoint: 'https://cloud.example.test/v1/deployments/submissions',
+      token: 'secret-token',
+      target,
+      resource: 'state',
+      fetch: (async () => new Response(null, { status: 404 })) as typeof fetch,
+    })).resolves.toBeUndefined();
+  });
+
+  it('does not call non-Cloud submission providers for live state', async () => {
+    const fetchMock = vi.fn();
+
+    await expect(fetchLiveDeployment({
+      endpoint: 'https://provider.example.test/v1/releases',
+      token: 'secret-token',
+      target,
+      resource: 'state',
+      fetch: fetchMock as typeof fetch,
+    })).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsafe Cloud endpoints before sending the credential', async () => {
+    const fetchMock = vi.fn();
+
+    await expect(fetchLiveDeployment({
+      endpoint: 'http://cloud.example.test/v1/deployments/submissions',
+      token: 'secret-token',
+      target,
+      resource: 'state',
+      fetch: fetchMock as typeof fetch,
+    })).rejects.toThrow('safely');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/utils/live-deployment.ts
+++ b/packages/cli/src/utils/live-deployment.ts
@@ -1,0 +1,262 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import {
+  DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS,
+  validateProtocolDeploymentReleaseTarget,
+  type ProtocolDeploymentReleaseTarget,
+} from '@hypequery/protocol';
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const MAX_RESPONSE_BYTES = Math.ceil(
+  DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxSourceBytes * 1.4,
+) + 1_000_000;
+
+export type LiveDeploymentSourceFile = {
+  readonly path: string;
+  readonly sha256: string;
+  readonly bytes: Uint8Array;
+};
+
+export type LiveDeploymentSource = {
+  readonly entrypoint: string;
+  readonly files: readonly LiveDeploymentSourceFile[];
+  readonly revision?: {
+    readonly kind: 'git';
+    readonly commit: string;
+    readonly branch?: string;
+    readonly dirty: boolean;
+  };
+};
+
+export type LiveDeployment = {
+  readonly target: ProtocolDeploymentReleaseTarget;
+  readonly active: null | {
+    readonly revision: string;
+    readonly releaseIdentity: string;
+    readonly activatedAt: string;
+    readonly restored: boolean;
+    readonly hasSource: boolean;
+    readonly source?: LiveDeploymentSource;
+  };
+};
+
+export type LiveDeploymentFetch = typeof fetch;
+
+function liveUrl(
+  endpoint: string,
+  target: ProtocolDeploymentReleaseTarget,
+  resource: 'state' | 'source',
+): string | undefined {
+  const url = new URL(endpoint);
+  if (!/\/v1\/deployments\/submissions\/?$/.test(url.pathname)) {
+    return undefined;
+  }
+  const loopbackHttp = url.protocol === 'http:'
+    && (url.hostname === '127.0.0.1' || url.hostname === 'localhost');
+  if ((url.protocol !== 'https:' && !loopbackHttp)
+    || url.username
+    || url.password
+    || url.hash) {
+    throw new Error('The deployment endpoint cannot be used to read live state safely.');
+  }
+  url.pathname = `/v1/deployments/targets/${encodeURIComponent(target.project)}`
+    + `/${encodeURIComponent(target.environment)}/${resource}`;
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
+function safePath(input: unknown): input is string {
+  return typeof input === 'string'
+    && input.length > 0
+    && input.length <= 1024
+    && input.split(path.sep).join('/') === input
+    && !path.isAbsolute(input)
+    && input.split('/').every(segment => segment && segment !== '.' && segment !== '..');
+}
+
+function decodeFile(input: unknown): LiveDeploymentSourceFile {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new Error('Cloud returned an invalid live source snapshot.');
+  }
+  const value = input as Record<string, unknown>;
+  if (!safePath(value.path)
+    || typeof value.sha256 !== 'string'
+    || !SHA256_PATTERN.test(value.sha256)
+    || !Number.isSafeInteger(value.byteLength)
+    || (value.byteLength as number) < 0
+    || (value.byteLength as number)
+      > DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxSourceFileBytes
+    || typeof value.contentsBase64 !== 'string'
+    || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+      value.contentsBase64,
+    )) {
+    throw new Error('Cloud returned an invalid live source snapshot.');
+  }
+  const bytes = Buffer.from(value.contentsBase64, 'base64');
+  if (bytes.byteLength !== value.byteLength
+    || createHash('sha256').update(bytes).digest('hex') !== value.sha256) {
+    throw new Error('Cloud returned a corrupt live source snapshot.');
+  }
+  return Object.freeze({ path: value.path, sha256: value.sha256, bytes });
+}
+
+function parseSource(input: unknown): LiveDeploymentSource {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new Error('Cloud returned an invalid live source snapshot.');
+  }
+  const value = input as Record<string, unknown>;
+  if (!safePath(value.entrypoint) || !Array.isArray(value.files)
+    || value.files.length < 1
+    || value.files.length > DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxSourceFiles) {
+    throw new Error('Cloud returned an invalid live source snapshot.');
+  }
+  const files = value.files.map(decodeFile);
+  const paths = new Set<string>();
+  let total = 0;
+  for (const file of files) {
+    const folded = file.path.toLowerCase();
+    if (paths.has(folded)) throw new Error('Cloud returned duplicate live source paths.');
+    paths.add(folded);
+    total += file.bytes.byteLength;
+  }
+  if (total > DEFAULT_PROTOCOL_DEPLOYMENT_BUNDLE_LIMITS.maxSourceBytes
+    || !files.some(file => file.path === value.entrypoint)) {
+    throw new Error('Cloud returned an invalid live source snapshot.');
+  }
+  let revision: LiveDeploymentSource['revision'];
+  if (value.revision !== undefined) {
+    if (typeof value.revision !== 'object' || value.revision === null
+      || Array.isArray(value.revision)) {
+      throw new Error('Cloud returned an invalid live source revision.');
+    }
+    const candidate = value.revision as Record<string, unknown>;
+    if (candidate.kind !== 'git'
+      || typeof candidate.commit !== 'string'
+      || !/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(candidate.commit)
+      || typeof candidate.dirty !== 'boolean'
+      || (candidate.branch !== undefined && typeof candidate.branch !== 'string')) {
+      throw new Error('Cloud returned an invalid live source revision.');
+    }
+    revision = {
+      kind: 'git',
+      commit: candidate.commit,
+      dirty: candidate.dirty,
+      ...(candidate.branch !== undefined ? { branch: candidate.branch } : {}),
+    };
+  }
+  return Object.freeze({
+    entrypoint: value.entrypoint,
+    files: Object.freeze(files),
+    ...(revision ? { revision: Object.freeze(revision) } : {}),
+  });
+}
+
+function parseResponse(
+  input: unknown,
+  expectedTarget: ProtocolDeploymentReleaseTarget,
+): LiveDeployment {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new Error('Cloud returned an invalid live deployment response.');
+  }
+  const value = input as Record<string, unknown>;
+  let target: ProtocolDeploymentReleaseTarget;
+  try {
+    target = validateProtocolDeploymentReleaseTarget(value.target);
+  } catch {
+    throw new Error('Cloud returned an invalid live deployment target.');
+  }
+  if (value.kind !== 'hypequery-live-deployment' || value.version !== 1
+    || target.project !== expectedTarget.project
+    || target.environment !== expectedTarget.environment) {
+    throw new Error('Cloud returned a mismatched live deployment response.');
+  }
+  if (value.active === null) return Object.freeze({ target, active: null });
+  if (typeof value.active !== 'object' || Array.isArray(value.active)) {
+    throw new Error('Cloud returned an invalid live deployment response.');
+  }
+  const active = value.active as Record<string, unknown>;
+  if (typeof active.revision !== 'string' || !SHA256_PATTERN.test(active.revision)
+    || typeof active.releaseIdentity !== 'string'
+    || !SHA256_PATTERN.test(active.releaseIdentity)
+    || typeof active.activatedAt !== 'string'
+    || !Number.isFinite(Date.parse(active.activatedAt))
+    || typeof active.restored !== 'boolean'
+    || typeof active.hasSource !== 'boolean'
+    || (active.source !== undefined && !active.hasSource)) {
+    throw new Error('Cloud returned an invalid live deployment response.');
+  }
+  return Object.freeze({
+    target,
+    active: Object.freeze({
+      revision: active.revision,
+      releaseIdentity: active.releaseIdentity,
+      activatedAt: active.activatedAt,
+      restored: active.restored,
+      hasSource: active.hasSource,
+      ...(active.source !== undefined ? { source: parseSource(active.source) } : {}),
+    }),
+  });
+}
+
+async function errorMessage(response: Response) {
+  try {
+    const input = await response.json() as {
+      error?: { code?: unknown; message?: unknown };
+    };
+    const code = typeof input.error?.code === 'string' ? `${input.error.code}: ` : '';
+    const message = typeof input.error?.message === 'string'
+      ? input.error.message
+      : response.statusText;
+    return `${code}${message}`;
+  } catch {
+    return response.statusText;
+  }
+}
+
+export async function fetchLiveDeployment(input: {
+  readonly endpoint: string;
+  readonly token: string;
+  readonly target: ProtocolDeploymentReleaseTarget;
+  readonly resource: 'state' | 'source';
+  readonly fetch?: LiveDeploymentFetch;
+}): Promise<LiveDeployment | undefined> {
+  if (input.token.length < 1 || input.token.length > 4096
+    || input.token.trim() !== input.token
+    || [...input.token].some(character => {
+      const code = character.charCodeAt(0);
+      return code < 0x21 || code > 0x7e;
+    })) {
+    throw new Error('The deployment credential contains invalid characters or length.');
+  }
+  const request = input.fetch ?? fetch;
+  const url = liveUrl(input.endpoint, input.target, input.resource);
+  if (!url) return undefined;
+  const response = await request(url, {
+    method: 'GET',
+    headers: { Accept: 'application/json', Authorization: `Bearer ${input.token}` },
+    redirect: 'error',
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (input.resource === 'state' && response.status === 404) return undefined;
+  if (!response.ok) {
+    throw new Error(
+      `Could not read the live deployment (${response.status}): ${await errorMessage(response)}`,
+    );
+  }
+  const contentLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(contentLength) && contentLength > MAX_RESPONSE_BYTES) {
+    throw new Error('Cloud returned an oversized live deployment response.');
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.byteLength > MAX_RESPONSE_BYTES) {
+    throw new Error('Cloud returned an oversized live deployment response.');
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes));
+  } catch {
+    throw new Error('Cloud returned an invalid live deployment response.');
+  }
+  return parseResponse(parsed, input.target);
+}


### PR DESCRIPTION
## What changed

- add `hypequery pull` to download the exact live multi-file TypeScript source snapshot without overwriting local paths
- add `hypequery diff [source]` to compare the local dependency graph with the live snapshot using A/M/D output
- preflight live activation state before deploy and send an optimistic expected-revision guard
- add `--replace-restored` to `deploy` and `deployment:submit` for intentional replacement after rollback
- accept the expanded interactive login scope while preserving existing deploy-only profiles
- add a patch changeset and CLI documentation

## Why

CLI deploy mode should remain the source-of-truth workflow for the first release while providing a clean path toward later sync. Users can now inspect exactly what is live and must explicitly acknowledge replacing a restored release.

## Dependency

Requires the Cloud state/source endpoints and drift guard in https://github.com/hypequery/hypequery-cloud/pull/57 to be deployed for the full flow. Non-Cloud and older providers remain backward compatible and continue without the new preflight.

## Validation

- `pnpm lint`
- `pnpm test` (543 CLI tests; full monorepo tests pass)
- `pnpm build`