### PR TITLE
Add Cloud-ready React client provider

### DIFF
--- a/.changeset/calm-cloud-clients.md
+++ b/.changeset/calm-cloud-clients.md
@@ -1,0 +1,5 @@
+---
+'@hypequery/react': minor
+---
+
+Add a reusable Hypequery client and React provider for configuring generated hooks once, resolving short-lived bearer tokens per request, refreshing authentication after a 401, and optionally sharing an existing TanStack Query client.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -21,6 +21,52 @@ npx hypequery generate:manifest analytics/api.ts \
   --output src/generated/hypequery-manifest.json
 ```
 
+## Configure Once With `HypequeryProvider`
+
+For hosted APIs and generated clients, create hooks without transport
+configuration. A provider supplies one client to the application and includes a
+TanStack Query provider by default.
+
+```tsx
+// client/hypequery.ts
+import { createHooks } from '@hypequery/react';
+import type { AnalyticsApi } from '../server/api.js';
+
+export const { useQuery, useMutation } = createHooks<AnalyticsApi>();
+```
+
+```tsx
+// app/providers.tsx
+'use client';
+
+import {
+  createHypequeryClient,
+  HypequeryProvider,
+} from '@hypequery/react';
+import type { ReactNode } from 'react';
+import type { AnalyticsApi } from '../server/api.js';
+import manifest from '../generated/hypequery-manifest.json';
+
+const client = createHypequeryClient<AnalyticsApi>({
+  baseUrl: 'https://acme.hypequery.cloud/v1/analytics/production',
+  manifest,
+  // Resolve a short-lived browser token. Never expose a server API key here.
+  token: async () => tokenStore.get(),
+  onUnauthorized: () => tokenStore.refresh(),
+});
+
+export function Providers({ children }: { children: ReactNode }) {
+  return <HypequeryProvider client={client}>{children}</HypequeryProvider>;
+}
+```
+
+Applications that already own a TanStack Query client can pass it through the
+`queryClient` prop so Hypequery shares the existing cache.
+
+## Create Dataset And Metric Hooks
+
+`createAnalyticsHooks` adds convenience wrappers for semantic endpoint names. Metrics use their endpoint name directly. Dataset endpoints are addressed as `dataset:<name>` in the API type and exposed through `useDataset(name, ...)`.
+
 ```tsx
 import { createAnalyticsHooks } from '@hypequery/react';
 import type { AnalyticsApi } from '../server/api.js';

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -63,6 +63,11 @@ export function Providers({ children }: { children: ReactNode }) {
 Applications that already own a TanStack Query client can pass it through the
 `queryClient` prop so Hypequery shares the existing cache.
 
+Each client instance receives an isolated cache scope. Create a new client when
+the deployment, tenant, or authenticated user changes. A deterministic
+`cacheKey` may be supplied when the same security context must retain cache data
+across equivalent client instances.
+
 ## Create Dataset And Metric Hooks
 
 `createAnalyticsHooks` adds convenience wrappers for semantic endpoint names. Metrics use their endpoint name directly. Dataset endpoints are addressed as `dataset:<name>` in the API type and exposed through `useDataset(name, ...)`.

--- a/packages/react/scripts/verify-dist.js
+++ b/packages/react/scripts/verify-dist.js
@@ -4,8 +4,10 @@ import path from 'node:path';
 
 const requiredFiles = [
   'index.js',
+  'client.js',
   'createHooks.js',
   'errors.js',
+  'provider.js',
   'types.js',
 ];
 

--- a/packages/react/src/analyticsHooks.tsx
+++ b/packages/react/src/analyticsHooks.tsx
@@ -53,7 +53,7 @@ export interface CreateAnalyticsHooksConfig<
 export function createAnalyticsHooks<
   Api extends Record<string, { input: any; output: any }>,
   TMetrics extends readonly Exclude<ExtractNames<Api>, `dataset:${string}`>[] = readonly Exclude<ExtractNames<Api>, `dataset:${string}`>[],
->(config: CreateAnalyticsHooksConfig<Api, TMetrics>) {
+>(config?: CreateAnalyticsHooksConfig<Api, TMetrics>) {
   const hooks = createHooks<Api>(config);
   type MetricName = TMetrics extends readonly (infer U)[]
     ? U extends string

--- a/packages/react/src/analyticsHooks.tsx
+++ b/packages/react/src/analyticsHooks.tsx
@@ -18,8 +18,8 @@ type DatasetNamesFromApi<Api> =
     : never;
 
 type QueryKey<Name extends string, Input> = Input extends never
-  ? ['hypequery', Name]
-  : ['hypequery', Name, Input];
+  ? ['hypequery', string, Name]
+  : ['hypequery', string, Name, Input];
 
 type QueryOptions<Api, Key extends ExtractNames<Api>> = Omit<
   TanstackUseQueryOptions<

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -20,6 +20,11 @@ export type TokenInput = string | (() => string | undefined | Promise<string | u
 
 export interface HypequeryClientConfig<Api extends ApiContract = ApiContract> {
   baseUrl: string;
+  /**
+   * Stable cache scope for this deployment and authentication context. Omit it
+   * to create an isolated scope for this client instance.
+   */
+  cacheKey?: string;
   fetchFn?: typeof fetch;
   headers?: HeadersInput;
   /** A bearer token or per-request token resolver. Never put a server API key in browser code. */
@@ -100,8 +105,11 @@ const resolveToken = async (token?: TokenInput) =>
 
 export interface HypequeryClient<Api extends ApiContract = ApiContract> {
   readonly config: Readonly<HypequeryClientConfig<Api>>;
+  readonly cacheKey: string;
   request(name: string, input?: unknown, defaultMethod?: string, extraHeaders?: Record<string, string>): Promise<unknown>;
 }
+
+let clientSequence = 0;
 
 export function createHypequeryClient<Api extends ApiContract = ApiContract>(
   config: HypequeryClientConfig<Api>,
@@ -116,6 +124,7 @@ export function createHypequeryClient<Api extends ApiContract = ApiContract>(
     onUnauthorized,
     api,
   } = config;
+  const cacheKey = config.cacheKey ?? `client:${++clientSequence}`;
   const finalConfig = {
     ...deriveMethodConfig(api),
     ...(manifest ? normalizeMethodConfig(manifest) : {}),
@@ -187,5 +196,9 @@ export function createHypequeryClient<Api extends ApiContract = ApiContract>(
     return response.json();
   };
 
-  return Object.freeze({ config: Object.freeze({ ...config }), request });
+  return Object.freeze({
+    cacheKey,
+    config: Object.freeze({ ...config }),
+    request,
+  });
 }

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -1,0 +1,191 @@
+import { HttpError } from './errors.js';
+
+export type ApiContract = Record<string, { input: any; output: any }>;
+
+export interface QueryMethodConfig {
+  method?: string;
+  path?: string;
+}
+
+export interface RouteManifestEntry {
+  method?: string;
+  path?: string;
+}
+
+export type RouteManifest = Record<string, RouteManifestEntry>;
+
+type HeaderMap = Record<string, string | undefined>;
+export type HeadersInput = HeaderMap | (() => HeaderMap | Promise<HeaderMap>);
+export type TokenInput = string | (() => string | undefined | Promise<string | undefined>);
+
+export interface HypequeryClientConfig<Api extends ApiContract = ApiContract> {
+  baseUrl: string;
+  fetchFn?: typeof fetch;
+  headers?: HeadersInput;
+  /** A bearer token or per-request token resolver. Never put a server API key in browser code. */
+  token?: TokenInput;
+  config?: Record<string, QueryMethodConfig>;
+  manifest?: RouteManifest;
+  /** Refresh authentication state after a 401. The request is retried once. */
+  onUnauthorized?: () => void | Promise<void>;
+  api?: Api;
+}
+
+const normalizeMethodConfig = (source?: Record<string, { method?: string; path?: string }>) => {
+  if (!source) return {};
+  return Object.fromEntries(
+    Object.entries(source).map(([key, value]) => [key, { method: value.method ?? 'GET', path: value.path }])
+  );
+};
+
+const deriveMethodConfig = (api: unknown): Record<string, QueryMethodConfig> => {
+  if (typeof api !== 'object' || api === null) return {};
+
+  if (typeof (api as Record<string, unknown>).manifest === 'function') {
+    const manifest = (api as { manifest: () => RouteManifest }).manifest();
+    if (manifest && typeof manifest === 'object') return normalizeMethodConfig(manifest);
+  }
+
+  if (
+    '_routeConfig' in api &&
+    typeof (api as Record<string, unknown>)._routeConfig === 'object' &&
+    (api as Record<string, unknown>)._routeConfig !== null
+  ) {
+    return normalizeMethodConfig((api as Record<string, Record<string, { method?: string }>>)._routeConfig);
+  }
+
+  if (
+    'queries' in api &&
+    typeof (api as Record<string, unknown>).queries === 'object' &&
+    (api as Record<string, unknown>).queries !== null
+  ) {
+    return normalizeMethodConfig((api as Record<string, Record<string, { method?: string }>>).queries);
+  }
+
+  return {};
+};
+
+const isAbsoluteHttpUrl = (value: string) => /^https?:\/\//.test(value);
+const ensureTrailingSlash = (value: string) => value.endsWith('/') ? value : `${value}/`;
+
+const buildUrl = (baseUrl: string, name: string, path?: string) => {
+  if (path) {
+    if (isAbsoluteHttpUrl(path)) return path;
+    if (isAbsoluteHttpUrl(baseUrl)) return new URL(path, ensureTrailingSlash(baseUrl)).toString();
+    if (path.startsWith('/')) return path;
+    if (!baseUrl) throw new Error('baseUrl is required');
+    return `${ensureTrailingSlash(baseUrl)}${path}`;
+  }
+  if (!baseUrl) throw new Error('baseUrl is required');
+  return `${ensureTrailingSlash(baseUrl)}${name}`;
+};
+
+const parseResponse = async (response: Response) => {
+  const text = await response.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+};
+
+const resolveHeaders = async (headers?: HeadersInput): Promise<Record<string, string>> => {
+  if (!headers) return {};
+  const raw = typeof headers === 'function' ? await headers() : headers;
+  return Object.fromEntries(Object.entries(raw).filter(([, value]) => value !== undefined)) as Record<string, string>;
+};
+
+const resolveToken = async (token?: TokenInput) =>
+  typeof token === 'function' ? token() : token;
+
+export interface HypequeryClient<Api extends ApiContract = ApiContract> {
+  readonly config: Readonly<HypequeryClientConfig<Api>>;
+  request(name: string, input?: unknown, defaultMethod?: string, extraHeaders?: Record<string, string>): Promise<unknown>;
+}
+
+export function createHypequeryClient<Api extends ApiContract = ApiContract>(
+  config: HypequeryClientConfig<Api>,
+): HypequeryClient<Api> {
+  const {
+    baseUrl,
+    fetchFn = fetch,
+    headers,
+    token,
+    config: explicitConfig = {},
+    manifest,
+    onUnauthorized,
+    api,
+  } = config;
+  const finalConfig = {
+    ...deriveMethodConfig(api),
+    ...(manifest ? normalizeMethodConfig(manifest) : {}),
+    ...explicitConfig,
+  };
+
+  const request = async (
+    name: string,
+    input?: unknown,
+    defaultMethod = 'GET',
+    extraHeaders?: Record<string, string>,
+  ) => {
+    const methodConfig = finalConfig[name];
+    if (name.includes(':') && !methodConfig?.path) {
+      throw new Error(
+        `No route configured for "${name}". Pass \`manifest\` (from the serve ` +
+        `api.manifest()) or an explicit \`config\` entry to createHypequeryClient().`
+      );
+    }
+
+    const url = buildUrl(baseUrl, name, methodConfig?.path);
+    const method = methodConfig?.method ?? defaultMethod;
+    let finalUrl = url;
+    let body: string | undefined;
+
+    if (method === 'GET' && input && typeof input === 'object') {
+      const params = new URLSearchParams();
+      for (const [key, value] of Object.entries(input)) {
+        if (value === undefined || value === null) continue;
+        if (Array.isArray(value)) value.forEach((item) => params.append(key, String(item)));
+        else params.append(key, String(value));
+      }
+      const queryString = params.toString();
+      finalUrl = queryString ? `${url}?${queryString}` : url;
+    } else if (input !== undefined) {
+      body = JSON.stringify(input);
+    }
+
+    const attempt = async () => {
+      const [resolvedHeaders, resolvedToken] = await Promise.all([
+        resolveHeaders(headers),
+        resolveToken(token),
+      ]);
+      return fetchFn(finalUrl, {
+        method,
+        headers: {
+          ...resolvedHeaders,
+          ...(resolvedToken ? { authorization: `Bearer ${resolvedToken}` } : {}),
+          ...(extraHeaders ?? {}),
+          ...(body ? { 'content-type': 'application/json' } : {}),
+        },
+        body,
+      });
+    };
+
+    let response = await attempt();
+    if (response.status === 401 && onUnauthorized) {
+      await onUnauthorized();
+      response = await attempt();
+    }
+    if (!response.ok) {
+      const errorBody = await parseResponse(response);
+      throw new HttpError(
+        `${method} request to ${finalUrl} failed with status ${response.status}`,
+        response.status,
+        errorBody,
+      );
+    }
+    return response.json();
+  };
+
+  return Object.freeze({ config: Object.freeze({ ...config }), request });
+}

--- a/packages/react/src/createHooks.tsx
+++ b/packages/react/src/createHooks.tsx
@@ -64,8 +64,8 @@ export function createHooks<Api extends ApiContract>(
   }
 
   type QueryKey<Name extends ExtractNames<Api>> = QueryInput<Api, Name> extends never
-    ? ['hypequery', Name]
-    : ['hypequery', Name, QueryInput<Api, Name>];
+    ? ['hypequery', string, Name]
+    : ['hypequery', string, Name, QueryInput<Api, Name>];
 
   type QueryOptions<Name extends ExtractNames<Api>> = Omit<
     TanstackUseQueryOptions<QueryOutput<Api, Name>, HttpError, QueryOutput<Api, Name>, QueryKey<Name>>,
@@ -102,9 +102,9 @@ export function createHooks<Api extends ApiContract>(
 
     const queryKey = ((): QueryKey<Name> => {
       if (input === undefined) {
-        return ['hypequery', name] as QueryKey<Name>;
+        return ['hypequery', client.cacheKey, name] as QueryKey<Name>;
       }
-      return ['hypequery', name, input] as QueryKey<Name>;
+      return ['hypequery', client.cacheKey, name, input] as QueryKey<Name>;
     })();
 
     return useTanstackQuery({
@@ -154,7 +154,7 @@ export function createHooks<Api extends ApiContract>(
   ): UseInfiniteQueryResult<InfiniteData<QueryOutput<Api, Name>, number>, HttpError> {
     const client = useResolvedClient();
     const initialOffset = (input as { offset?: number } | undefined)?.offset ?? 0;
-    const queryKey = ['hypequery', name, input] as QueryKey<Name>;
+    const queryKey = ['hypequery', client.cacheKey, name, input] as QueryKey<Name>;
 
     return useTanstackInfiniteQuery({
       queryKey,

--- a/packages/react/src/createHooks.tsx
+++ b/packages/react/src/createHooks.tsx
@@ -12,6 +12,13 @@ import {
 } from '@tanstack/react-query';
 import type { ExtractNames, QueryInput, QueryOutput } from './types.js';
 import { HttpError } from './errors.js';
+import {
+  createHypequeryClient,
+  type ApiContract,
+  type HypequeryClient,
+  type HypequeryClientConfig,
+} from './client.js';
+import { useOptionalHypequeryClient } from './provider.js';
 
 /** Shape of a paginated semantic response page (`{ data, meta.pagination }`). */
 interface PaginatedPage {
@@ -21,137 +28,14 @@ interface PaginatedPage {
   };
 }
 
-export interface QueryMethodConfig {
-  method?: string;
-  path?: string;
-}
-
-/** A single route as produced by `@hypequery/serve`'s `api.manifest()`. */
-export interface RouteManifestEntry {
-  method?: string;
-  path?: string;
-}
-
-/**
- * Map of query/metric/dataset keys to their HTTP method and full path. Pair
- * with `InferAPIType` and `api.manifest()` from `@hypequery/serve` to resolve
- * routes on the client without importing server code into the bundle.
- */
-export type RouteManifest = Record<string, RouteManifestEntry>;
-
-type HeaderMap = Record<string, string | undefined>;
-type HeadersInput =
-  | HeaderMap
-  | (() => HeaderMap | Promise<HeaderMap>);
-
-export interface CreateHooksConfig<TApi = Record<string, { input: unknown; output: unknown }>> {
-  baseUrl: string;
-  fetchFn?: typeof fetch;
-  /**
-   * Static headers, or a (optionally async) function returning headers. The
-   * function is invoked per request, so it can supply a fresh/short-lived token.
-   */
-  headers?: HeadersInput;
-  config?: Record<string, QueryMethodConfig>;
-  /**
-   * Route manifest from `@hypequery/serve`'s `api.manifest()`. Resolves the
-   * method and full path for each key — required for metric/dataset endpoints,
-   * which are POST routes whose paths differ from their map keys.
-   */
-  manifest?: RouteManifest;
-  /**
-   * Called when a request returns 401. Use it to refresh credentials (e.g. a
-   * token). If it resolves without throwing, the request is retried once with
-   * freshly resolved headers.
-   */
-  onUnauthorized?: () => void | Promise<void>;
-  api?: TApi;
-}
+export type CreateHooksConfig<TApi extends ApiContract = ApiContract> =
+  HypequeryClientConfig<TApi>;
 
 const OPTIONS_SYMBOL = Symbol.for('hypequery-options');
 
 export function queryOptions<T extends object>(opts: T): T & { [OPTIONS_SYMBOL]: true } {
   return { ...opts, [OPTIONS_SYMBOL]: true as const };
 }
-
-const normalizeMethodConfig = (source?: Record<string, { method?: string; path?: string }>) => {
-  if (!source) return {};
-  return Object.fromEntries(
-    Object.entries(source).map(([key, value]) => [key, { method: value.method ?? 'GET', path: value.path }])
-  );
-};
-
-const deriveMethodConfig = (api: unknown): Record<string, QueryMethodConfig> => {
-  if (typeof api !== 'object' || api === null) {
-    return {};
-  }
-
-  // Preferred: the serve API exposes a manifest() with full method + path.
-  if (typeof (api as Record<string, unknown>).manifest === 'function') {
-    const manifest = (api as { manifest: () => RouteManifest }).manifest();
-    if (manifest && typeof manifest === 'object') {
-      return normalizeMethodConfig(manifest);
-    }
-  }
-
-  if (
-    '_routeConfig' in api &&
-    typeof (api as Record<string, unknown>)._routeConfig === 'object' &&
-    (api as Record<string, unknown>)._routeConfig !== null
-  ) {
-    return normalizeMethodConfig((api as Record<string, Record<string, { method?: string }>>)._routeConfig);
-  }
-
-  if (
-    'queries' in api &&
-    typeof (api as Record<string, unknown>).queries === 'object' &&
-    (api as Record<string, unknown>).queries !== null
-  ) {
-    return normalizeMethodConfig((api as Record<string, Record<string, { method?: string }>>).queries);
-  }
-
-  return {};
-};
-
-const isAbsoluteHttpUrl = (value: string) => /^https?:\/\//.test(value);
-
-const ensureTrailingSlash = (value: string) => value.endsWith('/') ? value : `${value}/`;
-
-const buildUrl = (baseUrl: string, name: string, path?: string) => {
-  if (path) {
-    if (isAbsoluteHttpUrl(path)) {
-      return path;
-    }
-
-    if (isAbsoluteHttpUrl(baseUrl)) {
-      return new URL(path, ensureTrailingSlash(baseUrl)).toString();
-    }
-
-    if (path.startsWith('/')) {
-      return path;
-    }
-
-    if (!baseUrl) {
-      throw new Error('baseUrl is required');
-    }
-
-    return `${ensureTrailingSlash(baseUrl)}${path}`;
-  }
-
-  if (!baseUrl) {
-    throw new Error('baseUrl is required');
-  }
-  return `${ensureTrailingSlash(baseUrl)}${name}`;
-};
-
-const parseResponse = async (res: Response) => {
-  const text = await res.text();
-  try {
-    return JSON.parse(text);
-  } catch {
-    return text;
-  }
-};
 
 const isOptionsBag = (value: unknown): value is { [OPTIONS_SYMBOL]: true } => {
   return Boolean(value && typeof value === 'object' && OPTIONS_SYMBOL in (value as object));
@@ -165,97 +49,19 @@ const looksLikeQueryOptions = (value: unknown) => {
   return matches >= 2;
 };
 
-const resolveHeaders = async (headers?: HeadersInput): Promise<Record<string, string>> => {
-  if (!headers) return {};
-  const raw = typeof headers === 'function' ? await headers() : headers;
-  return Object.fromEntries(
-    Object.entries(raw).filter(([, value]) => value !== undefined)
-  ) as Record<string, string>;
-};
-
-export function createHooks<Api extends Record<string, { input: any; output: any }>>(
-  config: CreateHooksConfig<Api>
+export function createHooks<Api extends ApiContract>(
+  config?: CreateHooksConfig<Api>
 ) {
-  const { baseUrl, fetchFn = fetch, headers = {}, config: explicitConfig = {}, manifest, onUnauthorized, api } = config;
-  // Precedence: explicit config > manifest > derived from a runtime api object.
-  const finalConfig = {
-    ...deriveMethodConfig(api),
-    ...(manifest ? normalizeMethodConfig(manifest) : {}),
-    ...explicitConfig,
-  };
+  const configuredClient = config ? createHypequeryClient(config) : null;
 
-  const fetchQuery = async (
-    name: string,
-    input: unknown,
-    defaultMethod: string = 'GET',
-    extraHeaders?: Record<string, string>,
-  ): Promise<unknown> => {
-    const methodConfig = finalConfig[name];
-
-    // Semantic endpoints (dataset:<name>) live at paths that differ from their
-    // map key, so without a resolved path we'd call the wrong URL. Fail loudly
-    // instead of silently requesting `${baseUrl}/dataset:<name>`.
-    if (name.includes(':') && !methodConfig?.path) {
-      throw new Error(
-        `No route configured for "${name}". Pass \`manifest\` (from the serve ` +
-        `api.manifest()) or an explicit \`config\` entry to createHooks().`
-      );
+  function useResolvedClient(): HypequeryClient<Api> {
+    const providerClient = useOptionalHypequeryClient<Api>();
+    const client = configuredClient ?? providerClient;
+    if (!client) {
+      throw new Error('Configure createHooks() directly or render inside <HypequeryProvider>.');
     }
-
-    const url = buildUrl(baseUrl, name, methodConfig?.path);
-    const method = methodConfig?.method ?? defaultMethod;
-
-    let finalUrl = url;
-    let body: string | undefined;
-
-    if (method === 'GET' && input && typeof input === 'object') {
-      const params = new URLSearchParams();
-      for (const [key, value] of Object.entries(input)) {
-        if (value === undefined || value === null) continue;
-        if (Array.isArray(value)) {
-          value.forEach((item) => params.append(key, String(item)));
-        } else {
-          params.append(key, String(value));
-        }
-      }
-      const queryString = params.toString();
-      finalUrl = queryString ? `${url}?${queryString}` : url;
-    } else if (input !== undefined) {
-      body = JSON.stringify(input);
-    }
-
-    const attempt = async () => {
-      const resolvedHeaders = await resolveHeaders(headers);
-      return fetchFn(finalUrl, {
-        method,
-        headers: {
-          ...resolvedHeaders,
-          ...(extraHeaders ?? {}),
-          ...(body ? { 'content-type': 'application/json' } : {}),
-        },
-        body,
-      });
-    };
-
-    let res = await attempt();
-
-    // On 401, give the caller a chance to refresh credentials and retry once.
-    if (res.status === 401 && onUnauthorized) {
-      await onUnauthorized();
-      res = await attempt();
-    }
-
-    if (!res.ok) {
-      const errorBody = await parseResponse(res);
-      throw new HttpError(
-        `${method} request to ${finalUrl} failed with status ${res.status}`,
-        res.status,
-        errorBody
-      );
-    }
-
-    return res.json();
-  };
+    return client;
+  }
 
   type QueryKey<Name extends ExtractNames<Api>> = QueryInput<Api, Name> extends never
     ? ['hypequery', Name]
@@ -273,6 +79,7 @@ export function createHooks<Api extends Record<string, { input: any; output: any
   function useQuery<Name extends ExtractNames<Api>>(
     ...args: UseQueryParams<Name>
   ): UseQueryResult<QueryOutput<Api, Name>, HttpError> {
+    const client = useResolvedClient();
     const [name, potentialInputOrOptions, maybeOptions] = args as [
       Name,
       QueryInput<Api, Name> | QueryOptions<Name> | undefined,
@@ -302,7 +109,7 @@ export function createHooks<Api extends Record<string, { input: any; output: any
 
     return useTanstackQuery({
       queryKey,
-      queryFn: () => fetchQuery(name as string, input) as Promise<QueryOutput<Api, Name>>,
+      queryFn: () => client.request(name as string, input) as Promise<QueryOutput<Api, Name>>,
       ...(options ?? {}),
     });
   }
@@ -316,8 +123,9 @@ export function createHooks<Api extends Record<string, { input: any; output: any
     name: Name,
     options?: MutationOptions<Name>
   ): UseMutationResult<QueryOutput<Api, Name>, HttpError, QueryInput<Api, Name>> {
+    const client = useResolvedClient();
     return useTanstackMutation({
-      mutationFn: (input) => fetchQuery(name as string, input, 'POST') as Promise<QueryOutput<Api, Name>>,
+      mutationFn: (input) => client.request(name as string, input, 'POST') as Promise<QueryOutput<Api, Name>>,
       ...options,
     });
   }
@@ -344,6 +152,7 @@ export function createHooks<Api extends Record<string, { input: any; output: any
     input: QueryInput<Api, Name>,
     options?: InfiniteQueryOptions<Name>
   ): UseInfiniteQueryResult<InfiniteData<QueryOutput<Api, Name>, number>, HttpError> {
+    const client = useResolvedClient();
     const initialOffset = (input as { offset?: number } | undefined)?.offset ?? 0;
     const queryKey = ['hypequery', name, input] as QueryKey<Name>;
 
@@ -351,7 +160,7 @@ export function createHooks<Api extends Record<string, { input: any; output: any
       queryKey,
       initialPageParam: initialOffset,
       queryFn: ({ pageParam }) =>
-        fetchQuery(
+        client.request(
           name as string,
           { ...(input as object), offset: pageParam },
           'POST',

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,6 +1,19 @@
 export { createHooks, queryOptions } from './createHooks.js';
 export { createAnalyticsHooks } from './analyticsHooks.js';
+export { createHypequeryClient } from './client.js';
+export { HypequeryProvider, useHypequeryClient } from './provider.js';
 export { HttpError } from './errors.js';
 export type { QueryInput, QueryOutput, HttpMethod } from './types.js';
-export type { CreateHooksConfig, QueryMethodConfig } from './createHooks.js';
+export type { CreateHooksConfig } from './createHooks.js';
+export type {
+  ApiContract,
+  HeadersInput,
+  HypequeryClient,
+  HypequeryClientConfig,
+  QueryMethodConfig,
+  RouteManifest,
+  RouteManifestEntry,
+  TokenInput,
+} from './client.js';
+export type { HypequeryProviderProps } from './provider.js';
 export type { CreateAnalyticsHooksConfig } from './analyticsHooks.js';

--- a/packages/react/src/provider.test.tsx
+++ b/packages/react/src/provider.test.tsx
@@ -1,4 +1,5 @@
 import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
 import type { PropsWithChildren } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { createHypequeryClient } from './client.js';
@@ -42,5 +43,41 @@ describe('HypequeryProvider', () => {
         headers: expect.objectContaining({ authorization: 'Bearer browser-token' }),
       }),
     );
+  });
+
+  it('isolates cached responses when the provider client changes', async () => {
+    const firstFetch = vi.fn().mockResolvedValue(success({ message: 'First user' }));
+    const secondFetch = vi.fn().mockResolvedValue(success({ message: 'Second user' }));
+    const createClient = (fetchFn: typeof firstFetch) => createHypequeryClient<TestApi>({
+      baseUrl: 'https://acme.hypequery.cloud/v1/analytics/production',
+      fetchFn: fetchFn as unknown as typeof fetch,
+      manifest: { greeting: { method: 'GET', path: 'queries/greeting' } },
+    });
+    const firstClient = createClient(firstFetch);
+    const secondClient = createClient(secondFetch);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { useQuery } = createHooks<TestApi>();
+    let activeClient = firstClient;
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <HypequeryProvider client={activeClient} queryClient={queryClient}>
+        {children}
+      </HypequeryProvider>
+    );
+
+    const view = renderHook(
+      () => useQuery('greeting', { name: 'Luke' }),
+      { wrapper },
+    );
+    await waitFor(() => expect(view.result.current.data).toEqual({ message: 'First user' }));
+
+    activeClient = secondClient;
+    view.rerender();
+    await waitFor(() => expect(view.result.current.data).toEqual({ message: 'Second user' }));
+
+    expect(firstClient.cacheKey).not.toBe(secondClient.cacheKey);
+    expect(firstFetch).toHaveBeenCalledTimes(1);
+    expect(secondFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react/src/provider.test.tsx
+++ b/packages/react/src/provider.test.tsx
@@ -1,0 +1,46 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { createHypequeryClient } from './client.js';
+import { createHooks } from './createHooks.js';
+import { HypequeryProvider } from './provider.js';
+
+type TestApi = {
+  greeting: {
+    input: { name: string };
+    output: { message: string };
+  };
+};
+
+function success(data: unknown) {
+  return { ok: true, status: 200, json: async () => data } as Response;
+}
+
+describe('HypequeryProvider', () => {
+  it('configures generated hooks once and supplies their TanStack Query client', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(success({ message: 'Hello Luke' }));
+    const client = createHypequeryClient<TestApi>({
+      baseUrl: 'https://acme.hypequery.cloud/v1/analytics/production',
+      token: async () => 'browser-token',
+      fetchFn: fetchFn as unknown as typeof fetch,
+      manifest: { greeting: { method: 'GET', path: 'queries/greeting' } },
+    });
+    const { useQuery } = createHooks<TestApi>();
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <HypequeryProvider client={client}>{children}</HypequeryProvider>
+    );
+
+    const { result } = renderHook(
+      () => useQuery('greeting', { name: 'Luke' }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual({ message: 'Hello Luke' }));
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://acme.hypequery.cloud/v1/analytics/production/queries/greeting?name=Luke',
+      expect.objectContaining({
+        headers: expect.objectContaining({ authorization: 'Bearer browser-token' }),
+      }),
+    );
+  });
+});

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,0 +1,39 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createContext, useContext, useState, type ReactNode } from 'react';
+import type { ApiContract, HypequeryClient } from './client.js';
+
+const HypequeryContext = createContext<HypequeryClient<ApiContract> | null>(null);
+
+export interface HypequeryProviderProps<Api extends ApiContract = ApiContract> {
+  client: HypequeryClient<Api>;
+  children: ReactNode;
+  /** Reuse an application's existing TanStack Query client when supplied. */
+  queryClient?: QueryClient;
+}
+
+export function HypequeryProvider<Api extends ApiContract>({
+  client,
+  children,
+  queryClient,
+}: HypequeryProviderProps<Api>) {
+  const [defaultQueryClient] = useState(() => new QueryClient());
+  return (
+    <HypequeryContext.Provider value={client as HypequeryClient<ApiContract>}>
+      <QueryClientProvider client={queryClient ?? defaultQueryClient}>
+        {children}
+      </QueryClientProvider>
+    </HypequeryContext.Provider>
+  );
+}
+
+export function useHypequeryClient<Api extends ApiContract = ApiContract>() {
+  const client = useOptionalHypequeryClient<Api>();
+  if (!client) {
+    throw new Error('Hypequery hooks must be rendered inside <HypequeryProvider>.');
+  }
+  return client;
+}
+
+export function useOptionalHypequeryClient<Api extends ApiContract = ApiContract>() {
+  return useContext(HypequeryContext) as HypequeryClient<Api> | null;
+}

--- a/packages/react/type-tests/create-hooks.test-d.ts
+++ b/packages/react/type-tests/create-hooks.test-d.ts
@@ -1,4 +1,11 @@
-import { createHooks, createAnalyticsHooks, queryOptions, type QueryInput, type QueryOutput } from '../src/index.js';
+import {
+  createHooks,
+  createAnalyticsHooks,
+  createHypequeryClient,
+  queryOptions,
+  type QueryInput,
+  type QueryOutput,
+} from '../src/index.js';
 import type { Expect, Equal } from '@type-challenges/utils';
 
 type Api = {
@@ -20,6 +27,11 @@ type Api = {
 };
 
 const hooks = createHooks<Api>({ baseUrl: 'https://api.example.com' });
+const providerHooks = createHooks<Api>();
+const client = createHypequeryClient<Api>({
+  baseUrl: 'https://acme.hypequery.cloud/v1/analytics/production',
+  token: async () => 'short-lived-token',
+});
 const semantic = createAnalyticsHooks<{
   totalRevenue: {
     input: { dimensions?: string[] };
@@ -46,11 +58,13 @@ export type _StatsOutput = Expect<
 hooks.useQuery('listUsers', { search: 'Luke' });
 hooks.useQuery('listUsers', { search: 'Luke', tags: ['admin'] }, queryOptions({ enabled: true }));
 hooks.useQuery('stats');
+providerHooks.useQuery('stats');
 hooks.useQuery('stats', undefined, queryOptions({ enabled: false, staleTime: 1_000 }));
 const mutation = hooks.useMutation('createUser');
 mutation.mutate({ name: 'Leia' });
 semantic.useMetric('totalRevenue', { dimensions: ['country'] });
 semantic.useDataset('orders', { dimensions: ['country'], measures: ['revenue'] });
+client.request('stats');
 
 // Invalid usages should surface type errors
 // @ts-expect-error missing required input for listUsers


### PR DESCRIPTION
## Summary

- extract a reusable `createHypequeryClient` transport from the React hook factory
- add `HypequeryProvider` with a default or caller-supplied TanStack Query client
- support per-request short-lived bearer tokens and one-time 401 refresh
- allow generated hooks to bind to provider configuration instead of embedding URLs and auth
- document the hosted Cloud setup and add a minor changeset

## Verification

- `pnpm turbo build --filter=@hypequery/react...`
- `pnpm --filter @hypequery/react test` (51 tests)
- `pnpm --filter @hypequery/react lint`
- `git diff --check`

## Series

Foundation PR 1 of the Hypequery Cloud client DX series. Follow-ups will add generated deployment clients, the Cloud browser-token/data-plane contract, Explorer integration, and an end-to-end example.