### PR TITLE
Add type-safe FROM-clause subqueries

### DIFF
--- a/.changeset/quiet-rivers-query.md
+++ b/.changeset/quiet-rivers-query.md
@@ -1,0 +1,5 @@
+---
+"@hypequery/clickhouse": minor
+---
+
+Add type-safe subqueries in the `FROM` clause with `db.from(queryBuilder)`, preserving nested parameters and exposing only the subquery output columns to the outer builder.

--- a/packages/clickhouse/src/core/dialects/clickhouse-dialect.ts
+++ b/packages/clickhouse/src/core/dialects/clickhouse-dialect.ts
@@ -1,4 +1,4 @@
-import type { CompiledQuery, SelectQueryNode } from '../../types/index.js';
+import type { CompiledQuery, SelectQueryNode, SourceNode } from '../../types/index.js';
 import { SQLFormatter } from '../formatters/sql-formatter.js';
 import { formatIntervalLiteral } from '../utils/sql-literals.js';
 import type { CompileQueryContext, SqlDialect } from './sql-dialect.js';
@@ -16,7 +16,12 @@ export class ClickHouseDialect implements SqlDialect {
     }
 
     parts.push(`SELECT ${this.formatter.formatSelect(query)}`);
-    parts.push(`FROM ${this.formatter.formatFrom(query.from ?? { kind: 'table', name: context.tableName })}`);
+    const compiledSource = this.compileSource(
+      query.from ?? { kind: 'table', name: context.tableName },
+      context,
+    );
+    parts.push(`FROM ${compiledSource.query}`);
+    parameters.push(...compiledSource.parameters);
 
     if (query.arrayJoins?.length) {
       parts.push(this.formatter.formatArrayJoins(query));
@@ -82,5 +87,20 @@ export class ClickHouseDialect implements SqlDialect {
     return Object.entries(settings)
       .map(([key, value]) => `${key}=${value}`)
       .join(', ');
+  }
+
+  private compileSource(source: SourceNode, context: CompileQueryContext): CompiledQuery {
+    if (source.kind === 'table') {
+      return {
+        query: this.formatter.formatFrom(source),
+        parameters: [],
+      };
+    }
+
+    const compiled = this.compileQuery(source.query, context);
+    return {
+      query: `(${compiled.query})`,
+      parameters: compiled.parameters,
+    };
   }
 }

--- a/packages/clickhouse/src/core/features/aggregations.ts
+++ b/packages/clickhouse/src/core/features/aggregations.ts
@@ -4,7 +4,7 @@ import type { SelectQueryNode, SelectionNode } from '../../types/index.js';
 
 export class AggregationFeature<
   Schema extends SchemaDefinition<Schema>,
-  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>>
+  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>, any, any>
 > {
   private static readonly TRAILING_ALIAS_PATTERN = /\s+AS\s+[A-Za-z_][A-Za-z0-9_]*$/i;
   private static readonly LEADING_AGGREGATE_CALL_PATTERN =

--- a/packages/clickhouse/src/core/features/analytics.ts
+++ b/packages/clickhouse/src/core/features/analytics.ts
@@ -9,7 +9,7 @@ import type { SelectQueryNode } from '../../types/index.js';
 
 export class AnalyticsFeature<
   Schema extends SchemaDefinition<Schema>,
-  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>>
+  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>, any, any>
 > {
   constructor(private builder: QueryBuilder<Schema, State>) { }
 

--- a/packages/clickhouse/src/core/features/cross-filtering.ts
+++ b/packages/clickhouse/src/core/features/cross-filtering.ts
@@ -16,7 +16,7 @@ function isFilterCondition<Schema extends SchemaDefinition<Schema>>(
 
 export class CrossFilteringFeature<
   Schema extends SchemaDefinition<Schema>,
-  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>>
+  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>, any, any>
 > {
   constructor(private builder: QueryBuilder<Schema, State>) { }
 

--- a/packages/clickhouse/src/core/features/executor.ts
+++ b/packages/clickhouse/src/core/features/executor.ts
@@ -10,7 +10,7 @@ interface ExecutorRunOptions {
 
 export class ExecutorFeature<
   Schema extends SchemaDefinition<Schema>,
-  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>>
+  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>, any, any>
 > {
   constructor(private builder: QueryBuilder<Schema, State>) { }
 

--- a/packages/clickhouse/src/core/features/filtering.ts
+++ b/packages/clickhouse/src/core/features/filtering.ts
@@ -30,7 +30,7 @@ function appendExpression(
 
 export class FilteringFeature<
   Schema extends SchemaDefinition<Schema>,
-  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>>
+  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>, any, any>
 > {
   constructor(private builder: QueryBuilder<Schema, State>) { }
 

--- a/packages/clickhouse/src/core/features/joins.ts
+++ b/packages/clickhouse/src/core/features/joins.ts
@@ -46,7 +46,7 @@ function buildOnExpression(conditions: JoinConditionInput | JoinConditionInput[]
 
 export class JoinFeature<
   Schema extends SchemaDefinition<Schema>,
-  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>>
+  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>, any, any>
 > {
   constructor(private builder: QueryBuilder<Schema, State>) { }
 

--- a/packages/clickhouse/src/core/features/query-modifiers.ts
+++ b/packages/clickhouse/src/core/features/query-modifiers.ts
@@ -4,7 +4,7 @@ import { OrderDirection, type SelectQueryNode } from '../../types/index.js';
 
 export class QueryModifiersFeature<
   Schema extends SchemaDefinition<Schema>,
-  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>>
+  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>, any, any>
 > {
   constructor(private builder: QueryBuilder<Schema, State>) { }
 

--- a/packages/clickhouse/src/core/formatters/sql-formatter.ts
+++ b/packages/clickhouse/src/core/formatters/sql-formatter.ts
@@ -34,6 +34,8 @@ export class SQLFormatter {
     switch (source.kind) {
       case 'table':
         return `${source.name}${source.final ? ' FINAL' : ''}`;
+      case 'subquery':
+        throw new Error('Subquery sources must be compiled by the SQL dialect.');
       default:
         throw new Error(`Unsupported source kind: ${String((source as { kind?: string }).kind)}`);
     }

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -10,6 +10,7 @@ import {
   JoinType,
   type JoinConditionInput,
   type SelectQueryNode,
+  type SourceNode,
 } from '../types/index.js';
 import { AnySchema, ColumnType } from '../types/schema.js';
 import { AggregationFeature } from './features/aggregations.js';
@@ -41,7 +42,7 @@ import type { QueryRuntimeContext } from './cache/runtime-context.js';
 import { executeWithCache } from './cache/cache-manager.js';
 import { mergeCacheOptionsPartial, initializeCacheRuntime } from './cache/utils.js';
 import { InsertBuilder, type InsertQB } from './insert-builder.js';
-import type { InitialInsertState } from './types/builder-state.js';
+import { SUBQUERY_SOURCE_TABLE, type InitialInsertState } from './types/builder-state.js';
 import { normalizeFilterApplication } from './utils/filter-application.js';
 import { assertSafeIdentifier } from './utils/insert-identifiers.js';
 import { toLegacyQueryConfig } from './utils/query-config-compat.js';
@@ -56,7 +57,8 @@ import type {
   AppendToOutput,
   BaseRow,
   AddAlias,
-  AddScalar
+  AddScalar,
+  FromSubqueryState,
 } from './types/builder-state.js';
 import {
   SelectableItem,
@@ -70,7 +72,7 @@ type WhereColumn<State extends AnyBuilderState> = SelectableColumn<State>;
 
 type ColumnOperatorValue<
   Schema extends SchemaDefinition<Schema>,
-  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>>,
+  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>, any, any>,
   Column extends WhereColumn<State>,
   Op extends keyof OperatorValueMap<any, Schema>
 > = OperatorValueMap<ColumnSelectionValue<State, Column>, Schema>[Op];
@@ -161,7 +163,7 @@ export function isClientConfig(config: ClickHouseConfig): config is ClickHouseCl
  */
 export class QueryBuilder<
   Schema extends SchemaDefinition<Schema>,
-  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>>
+  State extends BuilderState<Schema, string, any, keyof Schema, Partial<Record<string, keyof Schema>>, any, any>
 > {
   private static relationships: JoinRelationships<any>;
 
@@ -186,11 +188,12 @@ export class QueryBuilder<
     state: State,
     runtime: QueryRuntimeContext,
     adapter: DatabaseAdapter,
-    dialect: SqlDialect
+    dialect: SqlDialect,
+    source?: SourceNode,
   ) {
     this.tableName = tableName;
     this.query = createSelectQueryNode({
-      from: {
+      from: source ?? {
         kind: 'table',
         name: tableName,
       },
@@ -214,7 +217,9 @@ export class QueryBuilder<
       string,
       any,
       State['baseTable'],
-      Partial<Record<string, keyof Schema>>
+      Partial<Record<string, keyof Schema>>,
+      any,
+      State['base']
     >
   >(
     state: NextState,
@@ -229,7 +234,9 @@ export class QueryBuilder<
       string,
       any,
       State['baseTable'],
-      Partial<Record<string, keyof Schema>>
+      Partial<Record<string, keyof Schema>>,
+      any,
+      State['base']
     >
   >(
     state: NextState,
@@ -268,7 +275,9 @@ export class QueryBuilder<
       string,
       any,
       State['baseTable'],
-      Partial<Record<string, keyof Schema>>
+      Partial<Record<string, keyof Schema>>,
+      any,
+      State['base']
     >
   >(aliases: NextState['aliases']): NextState {
     return {
@@ -427,11 +436,17 @@ export class QueryBuilder<
   }
 
   final(): this {
+    if (this.query.from?.kind === 'subquery') {
+      throw new Error(
+        'FINAL can only be applied to a table source. Apply final() to the inner query before passing it to db.from().'
+      );
+    }
+
     return this.updateQuery(query => ({
       ...query,
       from: {
         kind: 'table',
-        name: this.tableName,
+        name: query.from?.kind === 'table' ? query.from.name : this.tableName,
         final: true,
       },
     }));
@@ -626,6 +641,10 @@ export class QueryBuilder<
   // Make needed properties accessible to features
   getTableName() {
     return this.tableName;
+  }
+
+  getBaseTable(): State['baseTable'] {
+    return this.state.baseTable;
   }
 
   getRuntimeContext() {
@@ -1268,6 +1287,47 @@ export function createQueryBuilder<Schema extends SchemaDefinition<Schema>>(
         runtime,
         resolvedAdapter,
         resolvedDialect,
+      );
+    },
+    /**
+     * Starts a type-safe query whose source is another select query.
+     * Only columns produced by the subquery are visible to the outer query.
+     *
+     * @example
+     * ```ts
+     * const totals = db.table('orders')
+     *   .select(['customer_id'])
+     *   .sum('amount', 'total_amount')
+     *   .groupBy('customer_id');
+     *
+     * const query = db.from(totals)
+     *   .select(['customer_id', 'total_amount']);
+     * ```
+     */
+    from<SubqueryState extends BuilderState<Schema, string, any, keyof Schema, any, any, any>>(
+      subquery: QueryBuilder<Schema, SubqueryState>
+    ): QueryBuilder<Schema, FromSubqueryState<Schema, SubqueryState>> {
+      type NextState = FromSubqueryState<Schema, SubqueryState>;
+      const state: NextState = {
+        schema: {} as Schema,
+        tables: SUBQUERY_SOURCE_TABLE,
+        output: {} as SubqueryState['output'],
+        baseTable: subquery.getBaseTable(),
+        base: {} as SubqueryState['output'],
+        aliases: {},
+        scalars: {},
+      };
+
+      return new QueryBuilder<Schema, NextState>(
+        subquery.getTableName(),
+        state,
+        runtime,
+        resolvedAdapter,
+        resolvedDialect,
+        {
+          kind: 'subquery',
+          query: subquery.toQueryNode(),
+        },
       );
     }
   };

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -77,6 +77,9 @@ type ColumnOperatorValue<
   Op extends keyof OperatorValueMap<any, Schema>
 > = OperatorValueMap<ColumnSelectionValue<State, Column>, Schema>[Op];
 
+type TableSourceMethodThis<State extends AnyBuilderState, Builder> =
+  Extract<State['tables'], typeof SUBQUERY_SOURCE_TABLE> extends never ? Builder : never;
+
 // Union type that accepts either client type
 type ClickHouseClient = NodeClickHouseClient | WebClickHouseClient;
 type ScalarAlias<Alias extends string> = Alias extends `${string} ${string}` ? never : Alias;
@@ -269,6 +272,14 @@ export class QueryBuilder<
     return this.assignQuery(this.cloneMutable(), updater(this.query));
   }
 
+  private assertTableSource(feature: 'FINAL' | 'PREWHERE', innerMethod: 'final()' | 'prewhere()'): void {
+    if (this.query.from?.kind === 'subquery') {
+      throw new Error(
+        `${feature} can only be applied to a table source. Apply ${innerMethod} to the inner query before passing it to db.from().`
+      );
+    }
+  }
+
   private withAliasesState<
     NextState extends BuilderState<
       Schema,
@@ -436,11 +447,7 @@ export class QueryBuilder<
   }
 
   final(): this {
-    if (this.query.from?.kind === 'subquery') {
-      throw new Error(
-        'FINAL can only be applied to a table source. Apply final() to the inner query before passing it to db.from().'
-      );
-    }
+    this.assertTableSource('FINAL', 'final()');
 
     return this.updateQuery(query => ({
       ...query,
@@ -741,6 +748,10 @@ export class QueryBuilder<
     operator?: FilterOperator,
     value?: any
   ): this {
+    if (clause === 'prewhere') {
+      this.assertTableSource('PREWHERE', 'prewhere()');
+    }
+
     const normalized = normalizeFilterApplication(
       clause,
       conjunction,
@@ -831,14 +842,17 @@ export class QueryBuilder<
   }
 
   prewhere(
+    this: TableSourceMethodThis<State, this>,
     expressionBuilder: (expr: PredicateBuilder<State>) => PredicateExpression
   ): this;
   prewhere<Column extends WhereColumn<State>, Op extends keyof OperatorValueMap<any, Schema>>(
+    this: TableSourceMethodThis<State, this>,
     columnOrColumns: Column | Column[],
     operator: Op,
     value: ColumnOperatorValue<Schema, State, Column, Op>
   ): this;
   prewhere<Column extends WhereColumn<State>>(
+    this: TableSourceMethodThis<State, this>,
     columns: Column[],
     operator: 'inTuple' | 'globalInTuple',
     value: any
@@ -852,14 +866,17 @@ export class QueryBuilder<
   }
 
   orPrewhere(
+    this: TableSourceMethodThis<State, this>,
     expressionBuilder: (expr: PredicateBuilder<State>) => PredicateExpression
   ): this;
   orPrewhere<Column extends WhereColumn<State>>(
+    this: TableSourceMethodThis<State, this>,
     column: Column,
     operator: FilterOperator,
     value: any
   ): this;
   orPrewhere<Column extends WhereColumn<State>>(
+    this: TableSourceMethodThis<State, this>,
     columns: Column[],
     operator: 'inTuple' | 'globalInTuple',
     value: any
@@ -996,11 +1013,21 @@ export class QueryBuilder<
     return this.updateQuery(() => this.filtering.addCondition('where', 'OR', String(column), 'isNotNull', null));
   }
 
+  prewhereNull<Column extends WhereColumn<State>>(
+    this: TableSourceMethodThis<State, this>,
+    column: Column
+  ): this;
   prewhereNull<Column extends WhereColumn<State>>(column: Column): this {
+    this.assertTableSource('PREWHERE', 'prewhere()');
     return this.updateQuery(() => this.filtering.addCondition('prewhere', 'AND', String(column), 'isNull', null));
   }
 
+  prewhereNotNull<Column extends WhereColumn<State>>(
+    this: TableSourceMethodThis<State, this>,
+    column: Column
+  ): this;
   prewhereNotNull<Column extends WhereColumn<State>>(column: Column): this {
+    this.assertTableSource('PREWHERE', 'prewhere()');
     return this.updateQuery(() => this.filtering.addCondition('prewhere', 'AND', String(column), 'isNotNull', null));
   }
 
@@ -1308,6 +1335,7 @@ export function createQueryBuilder<Schema extends SchemaDefinition<Schema>>(
       subquery: QueryBuilder<Schema, SubqueryState>
     ): QueryBuilder<Schema, FromSubqueryState<Schema, SubqueryState>> {
       type NextState = FromSubqueryState<Schema, SubqueryState>;
+      const subqueryNode = subquery.toQueryNode();
       const state: NextState = {
         schema: {} as Schema,
         tables: SUBQUERY_SOURCE_TABLE,
@@ -1318,7 +1346,7 @@ export function createQueryBuilder<Schema extends SchemaDefinition<Schema>>(
         scalars: {},
       };
 
-      return new QueryBuilder<Schema, NextState>(
+      const builder = new QueryBuilder<Schema, NextState>(
         subquery.getTableName(),
         state,
         runtime,
@@ -1326,9 +1354,13 @@ export function createQueryBuilder<Schema extends SchemaDefinition<Schema>>(
         resolvedDialect,
         {
           kind: 'subquery',
-          query: subquery.toQueryNode(),
+          query: subqueryNode,
         },
       );
+
+      return subqueryNode.settings
+        ? builder.settings(subqueryNode.settings)
+        : builder;
     }
   };
 }

--- a/packages/clickhouse/src/core/query-node.ts
+++ b/packages/clickhouse/src/core/query-node.ts
@@ -4,7 +4,22 @@ import type {
   InsertQueryNode,
   QueryConfig,
   SelectQueryNode,
+  SourceNode,
 } from '../types/index.js';
+
+function cloneSourceNode(source: SourceNode): SourceNode {
+  switch (source.kind) {
+    case 'table':
+      return { ...source };
+    case 'subquery':
+      return {
+        kind: 'subquery',
+        query: cloneSelectQueryNode(source.query),
+      };
+    default:
+      throw new Error(`Unsupported source kind: ${String((source as { kind?: string }).kind)}`);
+  }
+}
 
 function cloneConditionValue(value: ConditionValueNode): ConditionValueNode {
   if (typeof value === 'string') {
@@ -55,7 +70,7 @@ export function createSelectQueryNode<TOutput, TSchema>(
 ): SelectQueryNode<TOutput, TSchema> {
   return {
     kind: 'select-query',
-    from: config.from ? { ...config.from } : undefined,
+    from: config.from ? cloneSourceNode(config.from) : undefined,
     select: config.select ? config.select.map(item => ({ ...item })) : undefined,
     arrayJoins: config.arrayJoins ? config.arrayJoins.map(item => ({ ...item })) : undefined,
     prewhere: cloneExprNode(config.prewhere),

--- a/packages/clickhouse/src/core/tests/integration/subqueries.test.ts
+++ b/packages/clickhouse/src/core/tests/integration/subqueries.test.ts
@@ -1,0 +1,95 @@
+// @ts-nocheck
+import { rawAs } from '../../../index.js';
+import {
+  initializeTestConnection,
+  setupTestDatabase,
+  TEST_DATA,
+} from './setup.js';
+import { SKIP_INTEGRATION_TESTS, SETUP_TIMEOUT } from './test-config.js';
+
+describe('Integration Tests - Subqueries', () => {
+  (SKIP_INTEGRATION_TESTS ? describe.skip : describe)('ClickHouse Integration', () => {
+    let db: Awaited<ReturnType<typeof initializeTestConnection>>;
+
+    beforeAll(async () => {
+      db = await initializeTestConnection();
+      await setupTestDatabase();
+    }, SETUP_TIMEOUT);
+
+    test('executes a typed aggregate subquery in the FROM clause', async () => {
+      const totalsByProduct = db.table('orders')
+        .where('created_at', 'gte', '2023-01-10')
+        .select([
+          'user_id',
+          'product_id',
+          rawAs<string, 'sum_value'>('SUM(total - 30)', 'sum_value'),
+        ])
+        .groupBy(['user_id', 'product_id']);
+
+      const query = db.from(totalsByProduct)
+        .select([
+          'user_id',
+          rawAs<string, 'negative_sum_value'>(
+            'sumIf(sum_value, sum_value < 0)',
+            'negative_sum_value',
+          ),
+          rawAs<string, 'positive_sum_value'>(
+            'sumIf(sum_value, sum_value > 0)',
+            'positive_sum_value',
+          ),
+        ])
+        .groupBy('user_id')
+        .orderBy('user_id', 'ASC');
+
+      expect(query.toSQLWithParams()).toEqual({
+        sql:
+          'SELECT user_id, ' +
+          'sumIf(sum_value, sum_value < 0) AS negative_sum_value, ' +
+          'sumIf(sum_value, sum_value > 0) AS positive_sum_value ' +
+          'FROM (SELECT user_id, product_id, SUM(total - 30) AS sum_value ' +
+          'FROM orders WHERE created_at >= ? GROUP BY user_id, product_id) ' +
+          'GROUP BY user_id ORDER BY user_id ASC',
+        parameters: ['2023-01-10'],
+      });
+
+      const result = await query.execute();
+      const productTotals = TEST_DATA.orders
+        .filter(order => order.created_at >= '2023-01-10')
+        .reduce((byProduct, order) => {
+          const key = `${order.user_id}:${order.product_id}`;
+          const current = byProduct.get(key) ?? {
+            user_id: order.user_id,
+            sum_value: 0,
+          };
+          current.sum_value += order.total - 30;
+          byProduct.set(key, current);
+          return byProduct;
+        }, new Map());
+
+      const expected = Array.from(productTotals.values())
+        .reduce((byUser, productTotal) => {
+          const current = byUser.get(productTotal.user_id) ?? {
+            user_id: productTotal.user_id,
+            negative_sum_value: 0,
+            positive_sum_value: 0,
+          };
+          if (productTotal.sum_value < 0) {
+            current.negative_sum_value += productTotal.sum_value;
+          } else if (productTotal.sum_value > 0) {
+            current.positive_sum_value += productTotal.sum_value;
+          }
+          byUser.set(productTotal.user_id, current);
+          return byUser;
+        }, new Map());
+
+      const expectedRows = Array.from(expected.values())
+        .sort((left, right) => left.user_id - right.user_id);
+
+      expect(result.map(row => ({
+        user_id: Number(row.user_id),
+        negative_sum_value: Number(row.negative_sum_value),
+        positive_sum_value: Number(row.positive_sum_value),
+      }))).toEqual(expectedRows);
+    });
+  });
+});

--- a/packages/clickhouse/src/core/tests/integration/subqueries.test.ts
+++ b/packages/clickhouse/src/core/tests/integration/subqueries.test.ts
@@ -91,5 +91,23 @@ describe('Integration Tests - Subqueries', () => {
         positive_sum_value: Number(row.positive_sum_value),
       }))).toEqual(expectedRows);
     });
+
+    test('applies settings inherited from the nested query', async () => {
+      const configured = db.table('orders')
+        .settings({ max_threads: 23 })
+        .select([
+          rawAs<string, 'configured_max_threads'>(
+            "getSetting('max_threads')",
+            'configured_max_threads',
+          ),
+        ])
+        .limit(1);
+
+      const result = await db.from(configured)
+        .select(['configured_max_threads'])
+        .execute();
+
+      expect(result.map(row => Number(row.configured_max_threads))).toEqual([23]);
+    });
   });
 });

--- a/packages/clickhouse/src/core/tests/query-builder.subquery.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.subquery.test.ts
@@ -1,0 +1,103 @@
+import type { DatabaseAdapter } from '../adapters/database-adapter.js';
+import { ClickHouseDialect } from '../dialects/clickhouse-dialect.js';
+import { createQueryBuilder } from '../query-builder.js';
+import { substituteParameters } from '../utils.js';
+import { rawAs } from '../utils/sql-expressions.js';
+import type { TestSchema } from './test-utils.js';
+
+const adapter: DatabaseAdapter = {
+  name: 'subquery-tests',
+  query: async () => {
+    throw new Error('Subquery tests do not execute queries.');
+  },
+  render: (sql, params = []) => substituteParameters(sql, params),
+};
+
+function setupDb() {
+  return createQueryBuilder<TestSchema>({
+    adapter,
+    dialect: new ClickHouseDialect(),
+  });
+}
+
+describe('QueryBuilder - subquery sources', () => {
+  it('builds a nested FROM query from the subquery output columns', () => {
+    const db = setupDb();
+    const totals = db.table('test_table')
+      .where('created_at', 'gte', '2026-06-06')
+      .select(['id', 'created_by'])
+      .sum('price', 'sum_value')
+      .groupBy(['id', 'created_by']);
+
+    const query = db.from(totals)
+      .select([
+        'id',
+        rawAs<string, 'negative_sum_value'>(
+          'sumIf(sum_value, sum_value < 0)',
+          'negative_sum_value',
+        ),
+        rawAs<string, 'positive_sum_value'>(
+          'sumIf(sum_value, sum_value > 0)',
+          'positive_sum_value',
+        ),
+      ])
+      .groupBy('id');
+
+    expect(query.toSQL()).toBe(
+      'SELECT id, ' +
+      'sumIf(sum_value, sum_value < 0) AS negative_sum_value, ' +
+      'sumIf(sum_value, sum_value > 0) AS positive_sum_value ' +
+      "FROM (SELECT id, created_by, SUM(price) AS sum_value FROM test_table WHERE created_at >= '2026-06-06' GROUP BY id, created_by) " +
+      'GROUP BY id'
+    );
+  });
+
+  it('preserves nested placeholders before outer-query placeholders', () => {
+    const db = setupDb();
+    const filtered = db.table('test_table')
+      .select(['id', 'category'])
+      .where('created_at', 'gte', '2026-06-06')
+      .where('active', 'eq', 1);
+
+    const { sql, parameters } = db.from(filtered)
+      .select(['id'])
+      .where('category', 'eq', 'premium')
+      .toSQLWithParams();
+
+    expect(sql).toBe(
+      'SELECT id FROM (SELECT id, category FROM test_table WHERE created_at >= ? AND active = ?) WHERE category = ?'
+    );
+    expect(parameters).toEqual(['2026-06-06', 1, 'premium']);
+    expect(db.from(filtered)
+      .select(['id'])
+      .where('category', 'eq', 'premium')
+      .getConfig().parameters
+    ).toEqual(['2026-06-06', 1, 'premium']);
+  });
+
+  it('snapshots the nested query when creating the outer builder', () => {
+    const db = setupDb();
+    const inner = db.table('test_table').select(['id']);
+    const outer = db.from(inner).select(['id']);
+    const node = outer.getQueryNode();
+
+    expect(node.from?.kind).toBe('subquery');
+    if (node.from?.kind === 'subquery') {
+      node.from.query.select?.push({ kind: 'selection', selection: 'name' });
+    }
+
+    expect(outer.toSQL()).toBe('SELECT id FROM (SELECT id FROM test_table)');
+  });
+
+  it('requires FINAL to be applied to the inner table query', () => {
+    const db = setupDb();
+    const inner = db.table('test_table').select(['id']);
+
+    expect(() => db.from(inner).final()).toThrow(
+      'Apply final() to the inner query before passing it to db.from().'
+    );
+    expect(db.from(inner.final()).select(['id']).toSQL()).toBe(
+      'SELECT id FROM (SELECT id FROM test_table FINAL)'
+    );
+  });
+});

--- a/packages/clickhouse/src/core/tests/query-builder.subquery.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.subquery.test.ts
@@ -75,6 +75,30 @@ describe('QueryBuilder - subquery sources', () => {
     ).toEqual(['2026-06-06', 1, 'premium']);
   });
 
+  it('recursively compiles multiple subquery levels and their parameters', () => {
+    const db = setupDb();
+    const activeProducts = db.table('test_table')
+      .select(['id', 'category'])
+      .where('active', 'eq', 1);
+    const premiumProducts = db.from(activeProducts)
+      .select(['id', 'category'])
+      .where('category', 'eq', 'premium');
+
+    const { sql, parameters } = db.from(premiumProducts)
+      .select(['id'])
+      .where('id', 'gt', 10)
+      .toSQLWithParams();
+
+    expect(sql).toBe(
+      'SELECT id FROM ' +
+      '(SELECT id, category FROM ' +
+      '(SELECT id, category FROM test_table WHERE active = ?) ' +
+      'WHERE category = ?) ' +
+      'WHERE id > ?'
+    );
+    expect(parameters).toEqual([1, 'premium', 10]);
+  });
+
   it('snapshots the nested query when creating the outer builder', () => {
     const db = setupDb();
     const inner = db.table('test_table').select(['id']);

--- a/packages/clickhouse/src/core/tests/query-builder.subquery.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder.subquery.test.ts
@@ -124,4 +124,62 @@ describe('QueryBuilder - subquery sources', () => {
       'SELECT id FROM (SELECT id FROM test_table FINAL)'
     );
   });
+
+  it('rejects PREWHERE clauses on a derived source', () => {
+    const db = setupDb();
+    const inner = db.table('test_table').select(['id', 'optional_name']);
+    const derived = db.from(inner);
+    const expectedMessage =
+      'PREWHERE can only be applied to a table source. Apply prewhere() to the inner query before passing it to db.from().';
+
+    expect(() => Reflect.apply(derived.prewhere, derived, ['id', 'eq', 1]))
+      .toThrow(expectedMessage);
+    expect(() => Reflect.apply(derived.orPrewhere, derived, ['id', 'eq', 1]))
+      .toThrow(expectedMessage);
+    expect(() => Reflect.apply(derived.prewhereNull, derived, ['optional_name']))
+      .toThrow(expectedMessage);
+    expect(() => Reflect.apply(derived.prewhereNotNull, derived, ['optional_name']))
+      .toThrow(expectedMessage);
+
+    expect(db.from(inner.prewhere('id', 'eq', 1)).select(['id']).toSQL()).toBe(
+      'SELECT id FROM (SELECT id, optional_name FROM test_table PREWHERE id = 1)'
+    );
+  });
+
+  it('promotes nested settings for execution and lets outer settings override them', async () => {
+    let executedSettings: unknown;
+    const settingsAdapter: DatabaseAdapter = {
+      ...adapter,
+      query: async (_sql, _parameters, options) => {
+        executedSettings = options?.clickhouseSettings;
+        return [];
+      },
+    };
+    const db = createQueryBuilder<TestSchema>({
+      adapter: settingsAdapter,
+      dialect: new ClickHouseDialect(),
+    });
+    const inner = db.table('test_table')
+      .settings({ final: 1, max_execution_time: 10 })
+      .select(['id']);
+    const outer = db.from(inner)
+      .settings({ max_execution_time: 20 })
+      .select(['id']);
+
+    expect(outer.getQueryNode().settings).toEqual({
+      final: 1,
+      max_execution_time: 20,
+    });
+    expect(inner.getQueryNode().settings).toEqual({
+      final: 1,
+      max_execution_time: 10,
+    });
+
+    await outer.execute();
+
+    expect(executedSettings).toEqual({
+      final: 1,
+      max_execution_time: 20,
+    });
+  });
 });

--- a/packages/clickhouse/src/core/types/builder-state.ts
+++ b/packages/clickhouse/src/core/types/builder-state.ts
@@ -6,29 +6,32 @@ export type SchemaDefinition<Schema extends Record<string, any> = Record<string,
   [K in keyof Schema]: Record<string, ColumnType>;
 };
 
+export const SUBQUERY_SOURCE_TABLE = '__hypequery_internal_subquery_source__' as const;
+
 export type BuilderState<
   Schema extends SchemaDefinition<Schema>,
   VisibleTables extends string,
   OutputRow,
   BaseTable extends keyof Schema,
   Aliases extends Partial<Record<string, keyof Schema>> = {},
-  Scalars extends Record<string, unknown> = {}
+  Scalars extends Record<string, unknown> = {},
+  BaseShape extends Record<string, unknown> = Schema[BaseTable]
 > = {
   schema: Schema;
   tables: VisibleTables;
   output: OutputRow;
   baseTable: BaseTable;
-  base: Schema[BaseTable];
+  base: BaseShape;
   aliases: Aliases;
   scalars: Scalars;
 };
 
-export type AnyBuilderState = BuilderState<any, any, any, any, any>;
+export type AnyBuilderState = BuilderState<any, any, any, any, any, any, any>;
 
 export type BaseRow<State extends AnyBuilderState> = Simplify<{
   [K in keyof State['base']]: State['base'][K] extends ColumnType
   ? InferColumnType<State['base'][K]>
-  : never;
+  : State['base'][K];
 }>;
 
 export type WidenTables<
@@ -40,7 +43,8 @@ export type WidenTables<
   State['output'],
   State['baseTable'],
   State['aliases'],
-  State['scalars']
+  State['scalars'],
+  State['base']
 >;
 
 export type UpdateOutput<
@@ -52,7 +56,8 @@ export type UpdateOutput<
   Output,
   State['baseTable'],
   State['aliases'],
-  State['scalars']
+  State['scalars'],
+  State['base']
 >;
 
 export type InitialState<
@@ -87,7 +92,8 @@ export type AddAlias<
   State['output'],
   State['baseTable'],
   State['aliases'] & Record<Alias, Table>,
-  State['scalars']
+  State['scalars'],
+  State['base']
 >;
 
 export type AddScalar<
@@ -100,7 +106,21 @@ export type AddScalar<
   State['output'],
   State['baseTable'],
   State['aliases'],
-  State['scalars'] & Record<Alias, Value>
+  State['scalars'] & Record<Alias, Value>,
+  State['base']
+>;
+
+export type FromSubqueryState<
+  Schema extends SchemaDefinition<Schema>,
+  SubqueryState extends BuilderState<Schema, string, any, keyof Schema, any, any, any>
+> = BuilderState<
+  Schema,
+  typeof SUBQUERY_SOURCE_TABLE,
+  SubqueryState['output'],
+  SubqueryState['baseTable'],
+  {},
+  {},
+  SubqueryState['output']
 >;
 
 export type InsertState<

--- a/packages/clickhouse/src/core/utils/query-config-compat.ts
+++ b/packages/clickhouse/src/core/utils/query-config-compat.ts
@@ -6,6 +6,7 @@ import type {
   JoinType,
   OrderDirection,
   SelectQueryNode,
+  SourceNode,
   ValueNode,
 } from '../../types/index.js';
 
@@ -28,7 +29,7 @@ export type LegacyWhereCondition = LegacyStandardWhereCondition | LegacyExpressi
 
 export type LegacyQueryConfig<T> = {
   select?: Array<keyof T | string>;
-  from?: { kind: 'table'; name: string; final?: boolean };
+  from?: SourceNode;
   where?: LegacyWhereCondition[];
   prewhere?: LegacyWhereCondition[];
   groupBy?: string[];
@@ -113,6 +114,18 @@ function collectExprParameters(expr?: ExprNode): any[] {
     default:
       return [];
   }
+}
+
+function collectQueryParameters(queryNode: SelectQueryNode<any, any>): any[] {
+  return [
+    ...(queryNode.from?.kind === 'subquery'
+      ? collectQueryParameters(queryNode.from.query)
+      : []),
+    ...(queryNode.joins?.flatMap(join => collectExprParameters(join.on)) || []),
+    ...collectExprParameters(queryNode.prewhere),
+    ...collectExprParameters(queryNode.where),
+    ...(queryNode.having?.flatMap(item => item.parameters?.map(unwrapValueNode) || []) || []),
+  ];
 }
 
 function flattenExprToLegacyConditions(
@@ -204,12 +217,7 @@ export function toLegacyQueryConfig<T, Schema>(
       alias: join.alias,
       on: join.on,
     })),
-    parameters: [
-      ...(queryNode.joins?.flatMap(join => collectExprParameters(join.on)) || []),
-      ...collectExprParameters(queryNode.prewhere),
-      ...collectExprParameters(queryNode.where),
-      ...(queryNode.having?.flatMap(item => item.parameters?.map(unwrapValueNode) || []) || []),
-    ],
+    parameters: collectQueryParameters(queryNode),
     ctes: queryNode.ctes?.map(item => item.expression),
     unionQueries: queryNode.unionQueries ? [...queryNode.unionQueries] : undefined,
     settings: queryNode.settings ? { ...queryNode.settings } : undefined,

--- a/packages/clickhouse/src/types/base.ts
+++ b/packages/clickhouse/src/types/base.ts
@@ -91,7 +91,12 @@ export interface TableSourceNode {
   final?: boolean;
 }
 
-export type SourceNode = TableSourceNode;
+export interface SubquerySourceNode {
+  kind: 'subquery';
+  query: SelectQueryNode<any, any>;
+}
+
+export type SourceNode = TableSourceNode | SubquerySourceNode;
 
 export interface GroupByItemNode {
   kind: 'group-by-item';

--- a/packages/clickhouse/type-tests/query-builder-types.test.ts
+++ b/packages/clickhouse/type-tests/query-builder-types.test.ts
@@ -35,11 +35,43 @@ type FromSubqueryExpected = {
 }[];
 type AssertFromSubquery = Expect<Equal<FromSubqueryResult, FromSubqueryExpected>>;
 
+const allFromSubquery = db.from(totalsSubquery).select('*');
+type AllFromSubqueryResult = Awaited<ReturnType<typeof allFromSubquery.execute>>;
+type AllFromSubqueryExpected = {
+  id: number;
+  created_by: number;
+  sum_value: string;
+}[];
+type AssertAllFromSubquery = Expect<Equal<AllFromSubqueryResult, AllFromSubqueryExpected>>;
+
+const reaggregatedSubquery = db.from(totalsSubquery)
+  .select(['id'])
+  .sum('sum_value', 'combined_sum')
+  .groupBy('id');
+type ReaggregatedSubqueryResult = Awaited<ReturnType<typeof reaggregatedSubquery.execute>>;
+type ReaggregatedSubqueryExpected = { id: number; combined_sum: string }[];
+type AssertReaggregatedSubquery = Expect<
+  Equal<ReaggregatedSubqueryResult, ReaggregatedSubqueryExpected>
+>;
+
+const joinedFromSubquery = db.from(totalsSubquery)
+  .innerJoin('users', 'created_by', 'users.id')
+  .select(['id', 'sum_value', 'users.email']);
+type JoinedFromSubqueryResult = Awaited<ReturnType<typeof joinedFromSubquery.execute>>;
+type JoinedFromSubqueryExpected = { id: number; sum_value: string; email: string }[];
+type AssertJoinedFromSubquery = Expect<
+  Equal<JoinedFromSubqueryResult, JoinedFromSubqueryExpected>
+>;
+
 db.from(totalsSubquery).where('sum_value', 'lt', '0').groupBy('id');
 // @ts-expect-error - unselected source-table columns are not visible outside the subquery
 db.from(totalsSubquery).select(['name']);
 // @ts-expect-error - unselected source-table columns cannot be filtered outside the subquery
 db.from(totalsSubquery).where('category', 'eq', 'premium');
+// @ts-expect-error - the original table qualifier is not in scope for an unaliased derived source
+db.from(totalsSubquery).select(['test_table.id']);
+// @ts-expect-error - aggregate aliases not produced by the inner query are not visible
+db.from(totalsSubquery).select(['missing_sum']);
 
 const crossFilter = new CrossFilter();
 builder.applyCrossFilters(crossFilter);

--- a/packages/clickhouse/type-tests/query-builder-types.test.ts
+++ b/packages/clickhouse/type-tests/query-builder-types.test.ts
@@ -1,4 +1,4 @@
-import { QueryBuilder } from '../src/core/query-builder.js';
+import { createQueryBuilder, QueryBuilder } from '../src/core/query-builder.js';
 import { CrossFilter } from '../src/core/cross-filter.js';
 import { JoinRelationships } from '../src/core/join-relationships.js';
 import { setupTestBuilder, setupUsersBuilder, TestSchema, TEST_SCHEMAS } from '../src/core/tests/test-utils.js';
@@ -8,6 +8,38 @@ import type { Equal, Expect } from '@type-challenges/utils';
 
 const builder = setupTestBuilder();
 type BuilderStateType = typeof builder extends QueryBuilder<any, infer S> ? S : never;
+
+const db = createQueryBuilder<TestSchema>({
+  adapter: builder.getAdapter(),
+  dialect: builder.getDialect(),
+});
+
+const totalsSubquery = builder
+  .select(['id', 'created_by'])
+  .sum('price', 'sum_value')
+  .groupBy(['id', 'created_by']);
+const queryFromSubquery = db.from(totalsSubquery)
+  .select([
+    'id',
+    'sum_value',
+    rawAs<string, 'negative_sum_value'>(
+      'sumIf(sum_value, sum_value < 0)',
+      'negative_sum_value',
+    ),
+  ]);
+type FromSubqueryResult = Awaited<ReturnType<typeof queryFromSubquery.execute>>;
+type FromSubqueryExpected = {
+  id: number;
+  sum_value: string;
+  negative_sum_value: string;
+}[];
+type AssertFromSubquery = Expect<Equal<FromSubqueryResult, FromSubqueryExpected>>;
+
+db.from(totalsSubquery).where('sum_value', 'lt', '0').groupBy('id');
+// @ts-expect-error - unselected source-table columns are not visible outside the subquery
+db.from(totalsSubquery).select(['name']);
+// @ts-expect-error - unselected source-table columns cannot be filtered outside the subquery
+db.from(totalsSubquery).where('category', 'eq', 'premium');
 
 const crossFilter = new CrossFilter();
 builder.applyCrossFilters(crossFilter);

--- a/packages/clickhouse/type-tests/query-builder-types.test.ts
+++ b/packages/clickhouse/type-tests/query-builder-types.test.ts
@@ -72,6 +72,20 @@ db.from(totalsSubquery).where('category', 'eq', 'premium');
 db.from(totalsSubquery).select(['test_table.id']);
 // @ts-expect-error - aggregate aliases not produced by the inner query are not visible
 db.from(totalsSubquery).select(['missing_sum']);
+const derivedSource = db.from(totalsSubquery);
+// @ts-expect-error - PREWHERE is only valid for table sources
+derivedSource.prewhere('id', 'eq', 1);
+// @ts-expect-error - PREWHERE is only valid for table sources
+derivedSource.orPrewhere('id', 'eq', 1);
+// @ts-expect-error - PREWHERE null helpers are only valid for table sources
+derivedSource.prewhereNull('sum_value');
+// @ts-expect-error - PREWHERE null helpers are only valid for table sources
+derivedSource.prewhereNotNull('sum_value');
+
+builder.prewhere('id', 'eq', 1);
+builder.orPrewhere('id', 'eq', 1);
+builder.prewhereNull('optional_name');
+builder.prewhereNotNull('optional_name');
 
 const crossFilter = new CrossFilter();
 builder.applyCrossFilters(crossFilter);

--- a/website-next/docs/capabilities.mdx
+++ b/website-next/docs/capabilities.mdx
@@ -8,7 +8,7 @@ import { CodeBlock } from 'fumadocs-ui/components/codeblock';
 
 # What hypequery supports today
 
-This page records the shipped surface of hypequery as of **11 August 2026**. It is a capability matrix, not a roadmap: “native” means a public typed method exists, “expression” means the feature is supported through an explicit SQL expression inside an otherwise typed query, and “semantic” means it can be declared and executed through `@hypequery/datasets`.
+This page records the shipped surface of hypequery as of **21 August 2026**. It is a capability matrix, not a roadmap: “native” means a public typed method exists, “expression” means the feature is supported through an explicit SQL expression inside an otherwise typed query, and “semantic” means it can be declared and executed through `@hypequery/datasets`.
 
 <Callout type="info" title="Short version">
   `argMax`, `argMin`, percentiles, median, standard deviation, variance, `final()`, `limitBy()`, array joins, `PREWHERE`, CTEs, and window expressions are supported today. The tables below show the exact public syntax.
@@ -29,6 +29,7 @@ This page records the shipped surface of hypequery as of **11 August 2026**. It 
 | Array expansion | Native | `arrayJoin()`, `leftArrayJoin()` |
 | Totals and distinct results | Native | `withTotals()`, `distinct()` |
 | CTEs | Native | `withCTE()` with a builder or SQL body |
+| Subqueries in `FROM` | Native | `from(queryBuilder)` with the nested output as the outer typed column scope |
 | ClickHouse settings | Native | `settings()` |
 | Streaming | Native | `stream()`, `streamForEach()` |
 | Query SQL inspection | Native | `toSQL()`, `toSQLWithParams()` |

--- a/website-next/docs/query-building/subqueries-ctes.mdx
+++ b/website-next/docs/query-building/subqueries-ctes.mdx
@@ -8,11 +8,50 @@ import { CodeBlock } from 'fumadocs-ui/components/codeblock';
 
 # Subqueries & CTEs
 
-hypequery provides support for Common Table Expressions (CTEs) and raw SQL capabilities that allow you to create complex queries with subqueries.
+hypequery supports typed subqueries in the `FROM` clause, Common Table Expressions (CTEs), and raw SQL escape hatches for complex queries.
 
 <Callout type="info" title="Query builder syntax">
   These examples use a typed standalone `db` client so the query builder stays the focus.
 </Callout>
+
+## Subqueries in `FROM`
+
+Pass a query builder to `db.from()` to use its result as the source of another query. The outer builder only exposes columns produced by the inner query, including aggregate aliases.
+
+<CodeBlock>
+
+```typescript
+import { rawAs } from '@hypequery/clickhouse';
+
+const totalsByUser = db
+  .table('orders')
+  .where('created_at', 'gte', '2026-06-06')
+  .select(['account_id', 'user_id'])
+  .sum('amount', 'total_amount')
+  .groupBy(['account_id', 'user_id']);
+
+const totalsByAccount = await db
+  .from(totalsByUser)
+  .select([
+    'account_id',
+    rawAs<string, 'negative_total'>(
+      'sumIf(total_amount, total_amount < 0)',
+      'negative_total',
+    ),
+    rawAs<string, 'positive_total'>(
+      'sumIf(total_amount, total_amount > 0)',
+      'positive_total',
+    ),
+  ])
+  .groupBy('account_id')
+  .execute();
+```
+
+</CodeBlock>
+
+The generated SQL nests the inner builder directly in the `FROM` clause. Parameters remain bound rather than being interpolated, and their order is preserved across the inner and outer queries.
+
+Typed methods on the outer builder reject source-table columns that the inner query did not select. SQL inside `rawAs()` remains an explicit trusted expression; provide its result type when you want the alias reflected precisely in the returned row type.
 
 ## Common Table Expressions (CTEs)
 

--- a/website-next/docs/reference/api/query-builder.mdx
+++ b/website-next/docs/reference/api/query-builder.mdx
@@ -33,6 +33,20 @@ db.table('users')
 
 Starts a query from a typed table.
 
+### `from()`
+
+<CodeBlock>
+```ts
+const totals = db.table('orders')
+  .select(['customer_id'])
+  .sum('amount', 'total_amount');
+
+db.from(totals).select(['customer_id', 'total_amount']);
+```
+</CodeBlock>
+
+Starts a query from another query builder. The nested query's output columns become the typed column scope of the outer query.
+
 ### `select()`
 
 <CodeBlock>
@@ -109,6 +123,7 @@ See [Joins](/docs/query-building/joins) for patterns and examples.
 - `raw()`
 - `rawQuery()`
 - `withCTE()`
+- `from()`
 - `toSQL()`
 - `toSQLWithParams()`
 


### PR DESCRIPTION
## Summary
- add db.from(queryBuilder) with the nested output as the outer typed column scope
- compile nested query ASTs without interpolating inner parameters
- preserve immutable query snapshots and reject FINAL and PREWHERE on derived sources
- promote nested ClickHouse settings to execution, with explicit outer settings taking precedence
- document the API and add a minor release changeset

## Test coverage
- unit: nested SQL generation, parameter ordering, immutability, source-specific validation, settings propagation, and recursive subqueries
- integration: execute grouped aggregates and inherited settings against ClickHouse
- types: infer selected derived columns and joins, reject hidden columns, and disallow PREWHERE on derived sources

## Verification
- pnpm --filter @hypequery/clickhouse test (33 files, 629 tests)
- pnpm --filter @hypequery/clickhouse test:integration (10 files, 68 tests)
- pnpm --filter @hypequery/clickhouse test:types
- pnpm --filter @hypequery/clickhouse lint
- pnpm --filter @hypequery/clickhouse build
- pnpm test
- pnpm lint
- pnpm types
- pnpm smoke:docs-snippets

Closes #392