### PR TITLE
docs: compare ClickHouse Cloud and Tinybird

### DIFF
--- a/website-next/content/blog/2026-08-22-clickhouse-cloud-vs-tinybird.md
+++ b/website-next/content/blog/2026-08-22-clickhouse-cloud-vs-tinybird.md
@@ -1,0 +1,262 @@
+---
+title: "ClickHouse Cloud vs Tinybird: Managed Database + hypequery or Managed Analytics Backend?"
+description: "Compare ClickHouse Cloud plus hypequery with Tinybird for real-time analytics APIs, then build a typed endpoint on ClickHouse Cloud step by step."
+seoTitle: "ClickHouse Cloud vs Tinybird — Architecture and TypeScript Implementation"
+seoDescription: "ClickHouse Cloud + hypequery vs Tinybird: compare architecture, API ownership, TypeScript workflow, operations, and implement a typed ClickHouse Cloud endpoint."
+pubDate: 2026-08-22
+heroImage: ""
+slug: clickhouse-cloud-vs-tinybird
+status: published
+---
+
+ClickHouse Cloud and Tinybird can both power low-latency analytics APIs, but they are not the same kind of product.
+
+[ClickHouse Cloud](https://clickhouse.com/cloud) is a managed ClickHouse database. It operates the database infrastructure while leaving you free to connect with standard ClickHouse tools and build the application layer you want. In the TypeScript stack on this page, hypequery generates types from that live database, builds queries in application code, and exposes selected queries over HTTP.
+
+[Tinybird](https://www.tinybird.co/docs/forward/core-concepts) is a managed analytics backend. A Tinybird Workspace contains data sources, connections, Pipes, endpoints, materialized views, and tokens. The current Tinybird workflow is code-friendly: projects can live in Git, run in Tinybird Local or Cloud Branches, and be authored with datafiles or a TypeScript SDK.
+
+The real choice is therefore not "managed versus self-hosted." Both options can be managed. It is whether you want a managed database that your application talks to directly, or a managed data platform that also owns the endpoint runtime.
+
+## The short answer
+
+Choose **Tinybird** when the shortest path from ingestion to a hosted analytics endpoint matters most. It bundles the data project, deployment workflow, endpoint hosting, scoped tokens, and operational controls.
+
+Choose **ClickHouse Cloud + hypequery** when ClickHouse should remain a directly accessible database and the analytics contract should live inside an existing TypeScript application. You keep standard ClickHouse access, generate types from the live schema, and integrate analytics routes with the same auth, deployment, logging, and review process as the rest of your backend.
+
+Neither answer is universally better. Tinybird removes more assembly. ClickHouse Cloud plus hypequery leaves more of the architecture under your control.
+
+## Side-by-side comparison
+
+| Dimension | ClickHouse Cloud + hypequery | Tinybird |
+|---|---|---|
+| Product boundary | Managed database plus open-source TypeScript libraries | Managed analytics backend |
+| Data model | Native ClickHouse databases, tables, views, and SQL | Tinybird data sources and platform resources backed by ClickHouse |
+| Query definition | Typed TypeScript in your application repository | SQL or TypeScript SDK resources in a Tinybird project |
+| Schema types | Generated from the live ClickHouse schema | Inferred from data sources, endpoint parameters, and output types authored with the Tinybird SDK |
+| API runtime | Runs in your application or a service you deploy | Hosted by Tinybird |
+| Authentication and rate limits | Integrate hypequery with your application middleware | Tokens and platform controls are built into the hosted API workflow |
+| Precomputation | ClickHouse materialized views and projections that you configure directly | Materialized views defined as Tinybird project resources |
+| Direct database access | Yes, through standard ClickHouse protocols and clients | Consumers normally use Tinybird APIs and project resources |
+| Portability | ClickHouse schema and queries can move between compatible ClickHouse deployments | Project files are version-controlled, but target the Tinybird runtime |
+| Operational responsibility | ClickHouse runs the database; you run the API process | Tinybird runs both the analytics data plane and endpoint plane |
+
+## What ClickHouse Cloud + hypequery gives you
+
+ClickHouse Cloud removes database operations such as manual sharding, replication management, upgrades, and backups. It does not decide how your product exposes analytics. That boundary is useful when your team already has an application platform.
+
+hypequery fills the application-side gap:
+
+1. the CLI introspects the live ClickHouse Cloud schema
+2. generated TypeScript types reflect ClickHouse's actual wire values, including 64-bit integers represented as strings
+3. the query builder restricts tables, columns, filters, and result shapes to that schema
+4. `@hypequery/serve` turns selected queries into validated HTTP contracts with OpenAPI output
+5. the same query can execute in-process from a job or server-rendered page without making an HTTP round trip
+
+The tradeoff is ownership. Your team deploys the API and decides how authentication, rate limiting, caching, observability, and tenant isolation fit the rest of the product.
+
+## What Tinybird gives you
+
+Tinybird owns a larger portion of the path from data to API. You define data sources and processing logic, publish endpoints, grant token scopes, and call the managed API. Its [development workflow](https://www.tinybird.co/docs/forward/development-workflow) supports local builds, cloud branches, deployment checks, and CI/CD, so it should not be dismissed as a dashboard-only or UI-only workflow.
+
+That integrated boundary is Tinybird's main advantage. A small data team can ship an endpoint without first choosing an application server, wiring an HTTP adapter, or implementing token infrastructure.
+
+The same boundary is also its main tradeoff. Your endpoint executes as a Tinybird resource rather than as ordinary code inside your application runtime. If product authorization depends on an existing session model, queries are composed deeply with TypeScript business logic, or services need direct access to the underlying ClickHouse database, the ClickHouse Cloud stack is usually easier to fit into the existing system.
+
+## Implementation: ClickHouse Cloud + hypequery
+
+This example creates a small event analytics endpoint. It assumes you have created a ClickHouse Cloud service and copied its HTTPS connection details from the Cloud console.
+
+### 1. Create the ClickHouse table
+
+Run the following in the ClickHouse Cloud SQL console:
+
+```sql
+CREATE DATABASE IF NOT EXISTS analytics;
+
+CREATE TABLE IF NOT EXISTS analytics.events
+(
+  event_id UUID DEFAULT generateUUIDv4(),
+  tenant_id String,
+  event_name LowCardinality(String),
+  occurred_at DateTime64(3, 'UTC') DEFAULT now64(3)
+)
+ENGINE = MergeTree
+ORDER BY (tenant_id, occurred_at, event_id);
+```
+
+The ordering key supports the common access pattern: restrict a request to one tenant and a bounded time range, then aggregate its events.
+
+For a real service, create a dedicated database user with only the privileges the application needs. Schema generation needs to see the tables and columns it will type; the running API generally needs `SELECT` on only its serving tables.
+
+### 2. Install hypequery
+
+```bash
+npm install @hypequery/clickhouse @hypequery/serve zod
+npm install --save-dev @hypequery/cli
+```
+
+Add the ClickHouse Cloud connection values to `.env` and keep the file out of source control:
+
+```bash
+CLICKHOUSE_URL=https://your-service.your-region.clickhouse.cloud:8443
+CLICKHOUSE_DATABASE=analytics
+CLICKHOUSE_USERNAME=hypequery_api
+CLICKHOUSE_PASSWORD=replace-me
+```
+
+The URL is the HTTPS endpoint from the ClickHouse Cloud **Connect** dialog, including the protocol and port.
+
+### 3. Generate schema types from ClickHouse Cloud
+
+```bash
+npx hypequery generate
+```
+
+By default, the command writes `analytics/schema.ts`. Re-run it whenever a database migration changes the contract your application queries.
+
+Create the shared client:
+
+```typescript
+// analytics/client.ts
+import { createQueryBuilder } from '@hypequery/clickhouse';
+import type { IntrospectedSchema } from './schema.js';
+
+export const db = createQueryBuilder<IntrospectedSchema>({
+  url: process.env.CLICKHOUSE_URL!,
+  database: process.env.CLICKHOUSE_DATABASE!,
+  username: process.env.CLICKHOUSE_USERNAME!,
+  password: process.env.CLICKHOUSE_PASSWORD!,
+});
+```
+
+At this point, `.table('events')`, the selected columns, filter values, and inferred result rows are checked against the schema generated from the actual Cloud service.
+
+### 4. Define and serve a typed endpoint
+
+```typescript
+// analytics/api.ts
+import { initServe } from '@hypequery/serve';
+import { z } from 'zod';
+import { db } from './client.js';
+
+const { query, serve } = initServe({
+  context: () => ({ db }),
+  basePath: '/api/analytics',
+});
+
+const eventSummary = query({
+  description: 'Event totals for one tenant and time range',
+  input: z.object({
+    tenantId: z.string().min(1),
+    from: z.string().min(1),
+    to: z.string().min(1),
+    limit: z.number().int().min(1).max(100).default(20),
+  }),
+  output: z.array(z.object({
+    event_name: z.string(),
+    events: z.string(),
+  })),
+  query: ({ ctx, input }) =>
+    ctx.db
+      .table('events')
+      .select(['event_name'])
+      .count('event_id', 'events')
+      .where('tenant_id', 'eq', input.tenantId)
+      .where('occurred_at', 'gte', input.from)
+      .where('occurred_at', 'lt', input.to)
+      .groupBy(['event_name'])
+      .orderBy('events', 'DESC')
+      .limit(input.limit)
+      .execute(),
+});
+
+export const api = serve({
+  queries: { eventSummary },
+});
+
+api.route('/event-summary', api.queries.eventSummary, {
+  method: 'POST',
+});
+```
+
+The `events` field is deliberately a string. ClickHouse serializes `count()` as a 64-bit integer in JSON, and hypequery preserves that runtime-safe representation instead of claiming JavaScript can represent every possible value precisely.
+
+For a quick local test, run the built-in development server:
+
+```bash
+npx hypequery dev analytics/api.ts
+```
+
+With the configured base path, the endpoint, documentation, and OpenAPI document are available at:
+
+```text
+POST http://localhost:4000/api/analytics/event-summary
+GET  http://localhost:4000/api/analytics/docs
+GET  http://localhost:4000/api/analytics/openapi.json
+```
+
+Call the endpoint:
+
+```bash
+curl --request POST \
+  --header 'content-type: application/json' \
+  --data '{
+    "tenantId": "acme",
+    "from": "2026-08-01 00:00:00",
+    "to": "2026-09-01 00:00:00",
+    "limit": 10
+  }' \
+  http://localhost:4000/api/analytics/event-summary
+```
+
+That is the complete vertical slice: a ClickHouse Cloud table, schema-generated TypeScript, a checked aggregation, runtime input and output validation, an HTTP route, and generated API documentation.
+
+### 5. Harden the production boundary
+
+The example accepts `tenantId` so it is easy to run, but a public multi-tenant endpoint must not trust a tenant identifier supplied by the browser. Resolve the tenant from your authenticated server session and inject it through hypequery's trusted runtime context. The [multi-tenancy guide](/docs/multi-tenancy) covers the fail-closed pattern.
+
+Before shipping, also:
+
+- restrict the ClickHouse Cloud network allow-list or private connectivity to the environments that need database access
+- use separate least-privilege credentials for schema generation and the runtime API
+- keep ClickHouse credentials server-side; browsers call your endpoint, never ClickHouse directly
+- add application authentication and request limits through `@hypequery/serve` middleware
+- decide whether repeated aggregates belong in an application cache, ClickHouse query cache, or a materialized view
+- tag and observe production queries so a slow analytics request is traceable from the API to ClickHouse
+
+These are responsibilities Tinybird packages into its platform boundary. In the ClickHouse Cloud stack, they remain explicit parts of your application architecture.
+
+## How the development loops differ
+
+With ClickHouse Cloud plus hypequery, database migrations change ClickHouse first. Schema generation then updates the TypeScript view of that database, and the compiler exposes application code that no longer matches. Query and endpoint changes deploy with the application.
+
+With Tinybird, data sources, Pipes, endpoints, and tokens are project resources. Tinybird Local or Cloud Branches validate those resources, and a Tinybird deployment publishes them to the Workspace. The application consumes the resulting hosted endpoint.
+
+Both workflows can use Git and CI. The meaningful difference is the deployment target: your application runtime or the Tinybird platform.
+
+## When to choose ClickHouse Cloud + hypequery
+
+- Your product backend is already TypeScript and analytics belongs in that codebase
+- You want types generated from the live ClickHouse schema
+- Services, jobs, notebooks, or BI tools also need direct ClickHouse access
+- Product authorization should reuse your existing application identity and policy model
+- You want the option to move between ClickHouse Cloud and another compatible ClickHouse deployment
+- Your team is comfortable operating a small API service even though it does not want to operate the database
+
+## When to choose Tinybird
+
+- You want one vendor boundary from ingestion through hosted analytics endpoints
+- Shipping and operating an API layer would be meaningful overhead for the team
+- SQL-centric data developers own the analytics workflow
+- Built-in token management, endpoint documentation, branches, and deployment controls are more valuable than direct database access
+- Your consumers are happy to integrate through platform endpoints
+
+## The decision that usually settles it
+
+Ask where the analytics contract should live.
+
+If it should be a product capability—reviewed with the backend, typed from the database, authorized through application context, and callable in-process—ClickHouse Cloud plus hypequery is the cleaner boundary.
+
+If it should be a managed data product—built from platform resources and published as hosted endpoints—Tinybird is the cleaner boundary.
+
+If the ClickHouse Cloud path matches your architecture, continue with the [hypequery quick start](/docs/quick-start) and replace the sample `events` table with one real query from your own schema. That implementation test will tell you more than another feature checklist.

--- a/website-next/src/app/compare/[slug]/page.tsx
+++ b/website-next/src/app/compare/[slug]/page.tsx
@@ -242,8 +242,12 @@ export default async function ComparePage({
           </div>
           <div className="grid gap-8 lg:grid-cols-[0.7fr_1.3fr_1.3fr]">
             <div className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Dimension</div>
-            <div className="text-xs font-semibold uppercase tracking-[0.2em] text-indigo-300">hypequery</div>
-            <div className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Alternative</div>
+            <div className="text-xs font-semibold uppercase tracking-[0.2em] text-indigo-300">
+              {comparePage.primaryLabel ?? 'hypequery'}
+            </div>
+            <div className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+              {comparePage.alternativeLabel ?? 'Alternative'}
+            </div>
             {comparePage.rows.map((row) => (
               <Fragment key={row.label}>
                 <div className="border-t border-slate-800 pt-4 text-sm font-semibold text-white">

--- a/website-next/src/data/compare-pages.ts
+++ b/website-next/src/data/compare-pages.ts
@@ -6,6 +6,7 @@ export type ComparePageConfig = {
     | 'hypequery-vs-prisma'
     | 'hypequery-vs-cube'
     | 'hypequery-vs-tinybird'
+    | 'clickhouse-cloud-vs-tinybird'
     | 'cube-vs-tinybird-vs-hypequery'
     | 'hypequery-vs-moose'
     | 'hypequery-vs-dbt'
@@ -17,6 +18,8 @@ export type ComparePageConfig = {
   href: string;
   title: string;
   verdict: string;
+  primaryLabel?: string;
+  alternativeLabel?: string;
   rows: Array<{ label: string; hypequery: string; alternative: string }>;
   faq: Array<{ question: string; answer: string }>;
 };
@@ -245,6 +248,64 @@ export const comparePages: ComparePageConfig[] = [
         question: 'When should I choose Tinybird over hypequery?',
         answer:
           'Choose Tinybird when you have no ops team to manage ClickHouse, need a fast path from raw data to a public API, and data residency or vendor lock-in are not concerns. It is also a good fit when your team is more SQL-fluent than TypeScript-fluent and you want built-in rate limiting and caching without writing any middleware.',
+      },
+    ],
+  },
+  {
+    slug: 'clickhouse-cloud-vs-tinybird',
+    href: '/compare/clickhouse-cloud-vs-tinybird',
+    title: 'ClickHouse Cloud + hypequery vs Tinybird',
+    verdict:
+      'Choose Tinybird when you want ingestion, data modelling, and hosted API endpoints as one managed product. Choose ClickHouse Cloud with hypequery when you want a managed ClickHouse database while keeping the typed query and API layer in your TypeScript application.',
+    primaryLabel: 'ClickHouse Cloud + hypequery',
+    alternativeLabel: 'Tinybird',
+    rows: [
+      {
+        label: 'Product shape',
+        hypequery: 'Managed ClickHouse database plus an open-source TypeScript application layer',
+        alternative: 'Managed analytics backend with data sources, Pipes, endpoints, and tokens',
+      },
+      {
+        label: 'Query ownership',
+        hypequery: 'Typed query definitions live and deploy with your application',
+        alternative: 'SQL or SDK resources deploy to a Tinybird Workspace',
+      },
+      {
+        label: 'TypeScript contract',
+        hypequery: 'Generated from the live ClickHouse schema and reused by the API layer',
+        alternative: 'TypeScript SDK authors platform resources; clients consume hosted endpoints',
+      },
+      {
+        label: 'API operations',
+        hypequery: 'You deploy the API and integrate your own auth, caching, and rate limits',
+        alternative: 'Tinybird hosts endpoints and provides scoped tokens and platform controls',
+      },
+      {
+        label: 'Portability',
+        hypequery: 'ClickHouse schema, SQL, and application code remain independently deployable',
+        alternative: 'Data project is version-controlled, but executes on the Tinybird runtime',
+      },
+      {
+        label: 'Best fit',
+        hypequery: 'TypeScript product teams that want direct ClickHouse control',
+        alternative: 'Teams that want the shortest managed path from ingestion to a hosted data API',
+      },
+    ],
+    faq: [
+      {
+        question: 'Is ClickHouse Cloud a direct replacement for Tinybird?',
+        answer:
+          'No. ClickHouse Cloud manages the database; Tinybird manages a broader analytics-backend workflow that includes data resources and hosted API endpoints. Adding hypequery supplies the typed query and API layer on top of ClickHouse Cloud, but your team still owns that application deployment.',
+      },
+      {
+        question: 'Does the ClickHouse Cloud option require running ClickHouse yourself?',
+        answer:
+          'No. ClickHouse Cloud operates the database service, including scaling, replication, upgrades, and backups. You operate the comparatively thin application or API process that uses hypequery.',
+      },
+      {
+        question: 'Which option is better for a TypeScript product team?',
+        answer:
+          'ClickHouse Cloud with hypequery is usually the stronger fit when analytics is part of an existing TypeScript product and schema-derived types, direct database access, and application-level control matter. Tinybird is usually stronger when the team values a bundled, hosted endpoint platform more than owning the serving layer.',
       },
     ],
   },

--- a/website-next/src/data/seo-links.ts
+++ b/website-next/src/data/seo-links.ts
@@ -56,6 +56,7 @@ export const seoFooterGroups: SeoLinkGroup[] = [
       { label: 'vs Prisma', href: '/compare/hypequery-vs-prisma' },
       { label: 'vs Cube', href: '/compare/hypequery-vs-cube' },
       { label: 'vs Tinybird', href: '/compare/hypequery-vs-tinybird' },
+      { label: 'ClickHouse Cloud vs Tinybird', href: '/compare/clickhouse-cloud-vs-tinybird' },
       { label: 'vs Moose', href: '/compare/hypequery-vs-moose' },
       { label: 'vs dbt', href: '/compare/hypequery-vs-dbt' },
       { label: 'vs Propel', href: '/compare/hypequery-vs-propel' },


### PR DESCRIPTION
## Summary

- add a dedicated ClickHouse Cloud + hypequery vs Tinybird comparison page
- include a complete ClickHouse Cloud schema-to-typed-endpoint implementation
- add comparison-specific column labels and footer discovery
- reflect Tinybird current Git, Local/Branches, and TypeScript SDK workflow

## Validation

- `npx eslint "src/app/compare/[slug]/page.tsx" src/data/compare-pages.ts src/data/seo-links.ts`
- `BLOB_READ_WRITE_TOKEN=vercel_blob_rw_placeholder npm run build` (seed-content fallback; 293 pages generated)
- local `pnpm check:seo-health` (203 sitemap URLs and 185 important routes)
- HTTP smoke test: `GET /compare/clickhouse-cloud-vs-tinybird` returned 200 and rendered the implementation section

## Known unrelated issue

The repository-wide website lint command still reports existing errors in `ThemeToggle.tsx`, several homepage components, and legacy blog test scripts. The files changed in this PR pass targeted ESLint.