### PR TITLE
fix(serve,datasets): declare zod as an optional peer dependency

### DIFF
--- a/.changeset/tidy-pugs-shave.md
+++ b/.changeset/tidy-pugs-shave.md
@@ -1,0 +1,17 @@
+---
+"@hypequery/datasets": patch
+"@hypequery/serve": patch
+---
+
+Declare `zod` as an optional peer dependency so package managers warn when a
+zod 4 install is hoisted over the zod 3 these packages build against.
+
+Both packages depend on `zod@^3` but declared no peer range, so
+`npm install @hypequery/serve zod` silently resolved zod 4 at the top level with
+no warning. The first `query({ input: z.object(...) })` then failed to compile
+with `Type 'ZodObject<...>' is missing the following properties from type
+'ZodType<any, any, any>': _type, _parse, _getType, _getOrReturnCtx, and 7 more`,
+which gives no hint that a version mismatch is the cause.
+
+The peer is marked optional, so nothing breaks for consumers who never install
+zod directly. Quick Start now pins `zod@^3` in its install commands.

--- a/packages/datasets/package.json
+++ b/packages/datasets/package.json
@@ -57,6 +57,14 @@
     "@noble/hashes": "^1.8.0",
     "zod": "^3.22.4"
   },
+  "peerDependencies": {
+    "zod": "^3.22.4"
+  },
+  "peerDependenciesMeta": {
+    "zod": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@hypequery/protocol-conformance": "workspace:^",
     "@types/node": "^18.19.80",

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -51,10 +51,14 @@
     "@hypequery/datasets": "^0.13.4"
   },
   "peerDependencies": {
-    "tsx": "^4.0.0"
+    "tsx": "^4.0.0",
+    "zod": "^3.23.8"
   },
   "peerDependenciesMeta": {
     "tsx": {
+      "optional": true
+    },
+    "zod": {
       "optional": true
     }
   },

--- a/website-next/docs/quick-start.mdx
+++ b/website-next/docs/quick-start.mdx
@@ -328,7 +328,7 @@ Both routes stay in-process until you need an HTTP boundary. Add `@hypequery/ser
   <Tab value="npm" label="npm">
     <CodeBlock>
       ```bash
-      npm install @hypequery/serve zod
+      npm install @hypequery/serve zod@^3
       npm install @hypequery/react @tanstack/react-query
       ```
     </CodeBlock>
@@ -337,7 +337,7 @@ Both routes stay in-process until you need an HTTP boundary. Add `@hypequery/ser
   <Tab value="pnpm" label="pnpm">
     <CodeBlock>
       ```bash
-      pnpm add @hypequery/serve zod
+      pnpm add @hypequery/serve zod@^3
       pnpm add @hypequery/react @tanstack/react-query
       ```
     </CodeBlock>
@@ -346,7 +346,7 @@ Both routes stay in-process until you need an HTTP boundary. Add `@hypequery/ser
   <Tab value="yarn" label="yarn">
     <CodeBlock>
       ```bash
-      yarn add @hypequery/serve zod
+      yarn add @hypequery/serve zod@^3
       yarn add @hypequery/react @tanstack/react-query
       ```
     </CodeBlock>
@@ -355,12 +355,19 @@ Both routes stay in-process until you need an HTTP boundary. Add `@hypequery/ser
   <Tab value="bun" label="bun">
     <CodeBlock>
       ```bash
-      bun add @hypequery/serve zod
+      bun add @hypequery/serve zod@^3
       bun add @hypequery/react @tanstack/react-query
       ```
     </CodeBlock>
   </Tab>
 </Tabs>
+
+<Callout type="warn" title="zod 3 is required">
+  `@hypequery/serve` and `@hypequery/datasets` build their validation types against zod 3. Installing
+  a bare `zod` today resolves zod 4, whose schema types are structurally incompatible — your first
+  `query({ input: z.object(...) })` will fail to compile with `Type 'ZodObject<...>' is missing the
+  following properties from type 'ZodType<any, any, any>'`. Pin `zod@^3`.
+</Callout>
 
 ### From Route 1: serve a named query
 


### PR DESCRIPTION
Found while building a Next.js app against ClickHouse Cloud from the published docs, installing only from npm. First of three PRs from that audit.

## The problem

Quick Start says:

```bash
npm install @hypequery/serve zod
```

That resolves **zod 4.4.3**. But `@hypequery/serve` and `@hypequery/datasets` both depend on `zod@^3` (3.25.76, nested), and neither declares a `peerDependencies.zod` — so npm installs both copies and prints **no warning**.

The user's very first endpoint then fails to compile:

```
error TS2740: Type 'ZodObject<{ year: ZodNumber; ... }, $strip>' is missing the
following properties from type 'ZodType<any, any, any>': _type, _parse,
_getType, _getOrReturnCtx, and 7 more.
```

Nothing in that message mentions zod, or versions. I lost real time to it before diffing the two installed copies, and I already knew the codebase.

## The change

- Declare `zod` as an **optional** peer on both packages, so package managers surface the mismatch at install time. Optional means nothing breaks for consumers who never install zod directly — the existing `dependencies` entry still satisfies them.
- Pin `zod@^3` in Quick Start's four install tabs.
- Add a callout naming the exact compile error, so anyone who hits it can search for it.

## Notes for review

- `pnpm install --lockfile-only` produced no lockfile change — the optional peer is already satisfied by the existing dependency.
- `@hypequery/datasets` and `@hypequery/serve` both build clean.
- **Open question:** this makes the mismatch *visible* but doesn't make zod 4 work. If supporting zod 4 is on the roadmap, that's a separate and much larger change, and this PR is the stopgap. If it isn't, we may want the peer to be non-optional so the warning is louder.

Reported as finding #1 in the audit; the friction report also covers a `_input` vs `_output` typing bug in serve that I have not fixed here.