### PR TITLE
fix(clickhouse): keep the CLI out of browser bundles from the package root

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,32 @@
+---
+"@hypequery/clickhouse": minor
+---
+
+Stop leaking the CLI into browser bundles from the package root.
+
+`dist/index.js` re-exported `generateTypes` from `./cli/index.js`, which imports
+`fs/promises`, `path`, and `dotenv`. Any client-reachable import of
+`@hypequery/clickhouse` therefore pulled Node builtins into the browser graph and
+failed the build outright:
+
+```
+./node_modules/@hypequery/clickhouse/dist/cli/generate-types.js:2:1
+Error: Module not found: Can't resolve 'fs/promises'
+```
+
+The package root is now resolved by condition: `browser` (and the fallback
+`default`) get the browser-safe entry, while `node` gets a new `index.node.js`
+that re-exports everything plus `generateTypes`. No export is removed — Node
+consumers importing `generateTypes` from the package root keep working.
+
+One behaviour change worth noting: projects on `moduleResolution: "bundler"`
+resolve the `default` condition, so `generateTypes` no longer appears on the root
+*type* surface there. Import it from `@hypequery/clickhouse/cli`, which is
+condition-independent and has always been the intended home for build-time
+helpers.
+
+`verify-build.js` already asserted "dist/index.js should not export CLI modules",
+but only matched the literal `./cli/generate-types.js`, so a re-export via
+`./cli/index.js` slipped past it. The check now matches any import or export
+statement targeting `./cli/`, and unit tests cover both entry points and the
+exports map.

--- a/packages/clickhouse/package.json
+++ b/packages/clickhouse/package.json
@@ -22,9 +22,19 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "browser": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "node": {
+        "types": "./dist/index.node.d.ts",
+        "import": "./dist/index.node.js",
+        "require": "./dist/index.node.js"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     },
     "./datasets": {
       "types": "./dist/datasets.d.ts",

--- a/packages/clickhouse/scripts/verify-build.js
+++ b/packages/clickhouse/scripts/verify-build.js
@@ -9,6 +9,8 @@ const distDir = path.join(rootDir, 'dist');
 const requiredFiles = [
   'index.js',
   'index.d.ts',
+  'index.node.js',
+  'index.node.d.ts',
   'core/connection.js',
   'core/query-builder.js',
   'cli/bin.js',
@@ -40,7 +42,29 @@ if (fs.existsSync(indexPath)) {
   for (const marker of requiredIndexMarkers) {
     check(indexContent.includes(marker), `dist/index.js is missing ${marker}`);
   }
-  check(!indexContent.includes('./cli/generate-types.js'), 'dist/index.js should not export CLI modules');
+  // The browser-safe root entry must not reach the CLI by ANY path. The previous
+  // check only looked for the literal './cli/generate-types.js', so a re-export
+  // one level up ('./cli/index.js') slipped through and dragged fs/promises into
+  // client bundles. Match any import/export statement targeting ./cli/ instead.
+  check(
+    !/(?:from|import)\s*\(?\s*['"]\.\/cli\//.test(indexContent),
+    'dist/index.js should not export CLI modules',
+  );
+}
+
+// The node entry is the one that may reach the CLI, and must, so root imports keep
+// resolving `generateTypes` under Node.
+const nodeIndexPath = path.join(distDir, 'index.node.js');
+if (fs.existsSync(nodeIndexPath)) {
+  const nodeIndexContent = fs.readFileSync(nodeIndexPath, 'utf8');
+  check(
+    nodeIndexContent.includes('./cli/index.js'),
+    'dist/index.node.js should re-export the CLI helpers',
+  );
+  check(
+    nodeIndexContent.includes('./index.js'),
+    'dist/index.node.js should re-export the browser-safe root entry',
+  );
 }
 
 const binPath = path.join(distDir, 'cli', 'bin.js');

--- a/packages/clickhouse/src/entry-points.test.ts
+++ b/packages/clickhouse/src/entry-points.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const readSource = (relative: string) =>
+  readFileSync(path.join(packageRoot, 'src', relative), 'utf8');
+const packageJson = JSON.parse(
+  readFileSync(path.join(packageRoot, 'package.json'), 'utf8'),
+) as {
+  exports: Record<string, Record<string, unknown>>;
+};
+
+/** Matches `from './cli/…'` and `import('./cli/…')`, ignoring prose in comments. */
+const CLI_IMPORT = /(?:from|import)\s*\(?\s*['"]\.\/cli\//;
+
+describe('package entry points', () => {
+  it('keeps the browser-safe root entry free of CLI imports', () => {
+    // The CLI reaches for fs/promises, path, and dotenv. Anything imported here
+    // ends up in client bundles, where those fail to resolve and break the build.
+    expect(CLI_IMPORT.test(readSource('index.ts'))).toBe(false);
+  });
+
+  it('exposes generateTypes from the node entry', () => {
+    const nodeEntry = readSource('index.node.ts');
+    expect(nodeEntry).toContain("export * from './index.js'");
+    expect(CLI_IMPORT.test(nodeEntry)).toBe(true);
+    expect(nodeEntry).toContain('generateTypes');
+  });
+
+  it('maps the package root to the node entry only under the node condition', () => {
+    const root = packageJson.exports['.'];
+
+    expect(root.browser).toEqual({
+      types: './dist/index.d.ts',
+      default: './dist/index.js',
+    });
+    expect(root.node).toEqual({
+      types: './dist/index.node.d.ts',
+      import: './dist/index.node.js',
+      require: './dist/index.node.js',
+    });
+    expect(root.default).toEqual({
+      types: './dist/index.d.ts',
+      default: './dist/index.js',
+    });
+  });
+
+  it('keeps the dedicated cli subpath available', () => {
+    expect(packageJson.exports['./cli']).toEqual({
+      types: './dist/cli/index.d.ts',
+      import: './dist/cli/index.js',
+      require: './dist/cli/index.js',
+    });
+  });
+});

--- a/packages/clickhouse/src/index.node.ts
+++ b/packages/clickhouse/src/index.node.ts
@@ -1,0 +1,20 @@
+/**
+ * Node entry point for `@hypequery/clickhouse`.
+ *
+ * Identical to the browser-safe `./index.js`, plus the Node-only CLI helpers.
+ * `package.json` maps the package root to this file under the `node` condition
+ * and to `./index.js` under `browser`, so bundlers never pull `fs/promises`,
+ * `path`, or `dotenv` into a client graph while Node consumers keep every export
+ * the root has always had.
+ */
+
+export * from './index.js';
+
+/**
+ * Introspect a ClickHouse schema and emit TypeScript definitions.
+ *
+ * Node-only: this reaches the filesystem. Prefer importing it from
+ * `@hypequery/clickhouse/cli` in build scripts — that subpath works regardless
+ * of which condition the resolver picks.
+ */
+export { generateTypes } from './cli/index.js';

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -109,8 +109,12 @@ export type {
   PredicateArg
 } from './core/utils/predicate-builder.js';
 
-// CLI utilities
-export { generateTypes } from './cli/index.js';
+// CLI utilities are intentionally NOT re-exported from this entry point. The CLI
+// module pulls in `fs/promises`, `path`, and `dotenv`, which breaks any bundler
+// that resolves this module for the browser. Node consumers still get
+// `generateTypes` from the package root via the `node` condition in package.json,
+// which resolves to `index.node.ts`. Build scripts should prefer the dedicated
+// `@hypequery/clickhouse/cli` subpath.
 
 // =============================================================================
 // DATASET API (Phase 1)


### PR DESCRIPTION
Found while building a Next.js app against ClickHouse Cloud from the published docs. Second of three PRs from that audit, and the one I'd most like eyes on — it touches resolution.

## The problem

`dist/index.js:26` re-exports the CLI from the package root:

```js
export { generateTypes } from './cli/index.js';
```

`cli/index.js` → `generate-types.js` → `fs/promises`, `path`, `dotenv`. So any client-reachable import of `@hypequery/clickhouse` drags Node builtins into the browser graph and **fails the build outright**:

```
./node_modules/@hypequery/clickhouse/dist/cli/generate-types.js:2:1
Error: Module not found: Can't resolve 'fs/promises'
  1 | import { ClickHouseConnection } from '../core/connection.js';
> 2 | import fs from 'fs/promises';
```

This is reachable by following `docs/react/getting-started.mdx` **as written** — it value-imports the serve API into the module that client components import for hooks. Next.js 16 / Turbopack, but any bundler resolving for the browser hits it.

`scripts/verify-build.js:43` already asserted this shouldn't happen:

```js
check(!indexContent.includes('./cli/generate-types.js'), 'dist/index.js should not export CLI modules');
```

The intent was right; the check only matched the literal leaf path, so a re-export one level up via `./cli/index.js` sailed past it.

## The change

Resolve the package root by condition rather than removing anything:

| Condition | Entry | `generateTypes`? |
|---|---|---|
| `browser` | `dist/index.js` | no |
| `node` | `dist/index.node.js` | yes |
| `default` | `dist/index.js` | no |

`index.node.ts` is `export * from './index.js'` plus the CLI re-export. **No export is removed** — Node consumers importing `generateTypes` from the package root keep working, per the repo's don't-delete-shipped-exports policy.

Also:
- `verify-build.js` now matches any import/export statement targeting `./cli/`, and asserts the node entry *does* re-export it.
- New `src/entry-points.test.ts` covers both entries and the exports map.

## Verified against the reproduction

Same Next.js 16 app, same React-guide pattern that previously failed:

| | Before | After |
|---|---|---|
| `next build` | ❌ `Can't resolve 'fs/promises'` | ✅ compiles |
| Client chunks | n/a | 1.1M |

For contrast, Quick Start's static-manifest + type-only-import pattern builds to **660K with zero references to `clickhouse`/`serve`**. So this PR removes the *hard failure*; the remaining 440K leak is a docs problem (the React guide should lead with the static manifest), which I'd rather fix in a separate PR.

## Notes for review

- **Behaviour change worth a decision:** projects on `moduleResolution: "bundler"` resolve `default`, so `generateTypes` no longer appears on the root *type* surface there. `@hypequery/clickhouse/cli` is condition-independent and already exists — that's the recommended import for build scripts. Changeset is marked `minor` for this reason. If that's too subtle, the alternative is removing the root export outright and taking a major.
- No in-repo consumer imports `generateTypes` from the clickhouse root — `@hypequery/cli` has its own implementation in `src/typegen/`.
- Full suite green: 626 tests / 33 files.
- The package already had a `browser` field for `auto-client.js`, so the condition is not new to this package.