### PR TITLE
fix(serve): make api.manifest() honor explicit api.route() registrations

### DIFF
--- a/.changeset/brave-pumas-argue.md
+++ b/.changeset/brave-pumas-argue.md
@@ -1,0 +1,23 @@
+---
+"@hypequery/serve": patch
+---
+
+`api.manifest()` now reports routes registered with `api.route()` instead of the
+auto-generated convention route.
+
+`route()` registers the endpoint with the router but leaves `queryEntries`
+holding the auto-registered `/queries/<key>` entry, and `manifest()` read from
+`queryEntries`. So an endpoint registered as:
+
+```ts
+api.route('/busiest-routes', api.queries.busiestRoutes, { method: 'POST' });
+```
+
+appeared in the manifest — and therefore in `hypequery generate:manifest` output
+— as `GET /queries/busiestRoutes`. `@hypequery/react` follows the manifest, so
+`useQuery('busiestRoutes', { limit: 8 })` issued a GET the server rejected with a
+400 rather than calling the POST route the author declared.
+
+Both routes remain live; the manifest can only name one, and it now names the
+explicit registration. When an endpoint is routed more than once the first
+registration wins, so regenerating the manifest is deterministic.

--- a/packages/serve/src/semantic/datasets/serve-integration.test.ts
+++ b/packages/serve/src/semantic/datasets/serve-integration.test.ts
@@ -503,6 +503,27 @@ describe("Serve integration — metrics", () => {
       });
     });
 
+    it("keeps explicit routes scoped to the matching endpoint identity", () => {
+      const api = createAPI({
+        queries: {
+          orders: { query: async () => [] },
+        },
+        datasets: { orders: Orders },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      api.route("/custom-orders", api.queries["dataset:orders"], { method: "POST" });
+
+      expect(api.manifest().orders).toEqual({
+        method: "GET",
+        path: "/api/analytics/queries/orders",
+      });
+      expect(api.manifest()["dataset:orders"]).toEqual({
+        method: "POST",
+        path: "/api/analytics/custom-orders",
+      });
+    });
+
     it("applies basePath to explicitly registered routes", () => {
       const api = createAPI({
         basePath: "/v1/analytics",

--- a/packages/serve/src/semantic/datasets/serve-integration.test.ts
+++ b/packages/serve/src/semantic/datasets/serve-integration.test.ts
@@ -477,6 +477,77 @@ describe("Serve integration — metrics", () => {
       const keys = Object.keys(api.manifest());
       expect(keys).toEqual(["totalRevenue"]);
     });
+
+    it("prefers an explicit api.route() registration over the convention route", () => {
+      const api = createAPI({
+        queries: {
+          busiestRoutes: { query: async () => [] },
+        },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      // Before registering, the manifest names the auto GET convention route.
+      expect(api.manifest().busiestRoutes).toEqual({
+        method: "GET",
+        path: "/api/analytics/queries/busiestRoutes",
+      });
+
+      api.route("/busiest-routes", api.queries.busiestRoutes, { method: "POST" });
+
+      // Clients must be pointed at the route the author declared, not the one
+      // the runtime generated. Sending the convention route here made
+      // `useQuery('busiestRoutes')` issue a GET the server rejects.
+      expect(api.manifest().busiestRoutes).toEqual({
+        method: "POST",
+        path: "/api/analytics/busiest-routes",
+      });
+    });
+
+    it("applies basePath to explicitly registered routes", () => {
+      const api = createAPI({
+        basePath: "/v1/analytics",
+        queries: { ping: { query: async () => ({ ok: true }) } },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      api.route("/health", api.queries.ping, { method: "POST" });
+
+      expect(api.manifest().ping).toEqual({
+        method: "POST",
+        path: "/v1/analytics/health",
+      });
+    });
+
+    it("keeps the first explicit registration when an endpoint is routed twice", () => {
+      const api = createAPI({
+        queries: { ping: { query: async () => ({ ok: true }) } },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      api.route("/health", api.queries.ping, { method: "POST" });
+      api.route("/healthz", api.queries.ping, { method: "POST" });
+
+      // Both routes are live; the manifest can only name one, so it stays on the
+      // first so regenerating it is deterministic.
+      expect(api.manifest().ping).toEqual({
+        method: "POST",
+        path: "/api/analytics/health",
+      });
+    });
+
+    it("falls back to the endpoint's own method when route() omits one", () => {
+      const api = createAPI({
+        queries: { ping: { query: async () => ({ ok: true }) } },
+        queryBuilder: createMockBuilderFactory(),
+      });
+
+      api.route("/health", api.queries.ping);
+
+      expect(api.manifest().ping).toEqual({
+        method: "GET",
+        path: "/api/analytics/health",
+      });
+    });
   });
 
   describe("metric endpoints", () => {

--- a/packages/serve/src/server/api-builder.ts
+++ b/packages/serve/src/server/api-builder.ts
@@ -3,6 +3,7 @@ import type {
   AuthStrategy,
   HypeQueryAPI,
   RouteManifest,
+  RouteManifestEntry,
   ServeEndpoint,
   ServeEndpointMap,
   ServeMiddleware,
@@ -44,6 +45,17 @@ export const createAPImethods = <
   ) => ProtocolDeploymentContract,
   runtimeEntrypoints: readonly string[],
 ): HypeQueryAPI<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth> => {
+  /**
+   * Routes registered through `api.route()`, keyed by endpoint key.
+   *
+   * `route()` adds a route to the router but leaves `queryEntries` holding the
+   * auto-registered `/queries/<key>` convention endpoint. Both routes stay live,
+   * but the manifest can only name one, and clients should be pointed at the one
+   * the author declared explicitly. First registration wins, so calling `route()`
+   * twice for the same endpoint keeps the manifest stable.
+   */
+  const explicitRoutes = new Map<string, RouteManifestEntry>();
+
   const api: HypeQueryAPI<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth> = {
     queries: queryEntries,
     queryLogger,
@@ -56,7 +68,7 @@ export const createAPImethods = <
         string,
         ServeEndpoint<any, any, TContext, TAuth>,
       ][]) {
-        manifest[key] = {
+        manifest[key] = explicitRoutes.get(endpoint.key) ?? {
           method: endpoint.method,
           // queryEntries store the pre-basePath route; re-apply so the manifest
           // carries the full request path clients should call.
@@ -105,6 +117,14 @@ export const createAPImethods = <
       };
 
       router.register(registeredEndpoint);
+
+      if (!explicitRoutes.has(endpoint.key)) {
+        explicitRoutes.set(endpoint.key, {
+          method,
+          path: applyBasePath(basePath, normalizedPath),
+        });
+      }
+
       return api;
     },
 

--- a/packages/serve/src/server/api-builder.ts
+++ b/packages/serve/src/server/api-builder.ts
@@ -46,15 +46,20 @@ export const createAPImethods = <
   runtimeEntrypoints: readonly string[],
 ): HypeQueryAPI<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth> => {
   /**
-   * Routes registered through `api.route()`, keyed by endpoint key.
+   * Routes registered through `api.route()`, keyed by endpoint identity.
    *
    * `route()` adds a route to the router but leaves `queryEntries` holding the
    * auto-registered `/queries/<key>` convention endpoint. Both routes stay live,
    * but the manifest can only name one, and clients should be pointed at the one
    * the author declared explicitly. First registration wins, so calling `route()`
-   * twice for the same endpoint keeps the manifest stable.
+   * twice for the same endpoint keeps the manifest stable. Object identity is
+   * required because entries such as `orders` and `dataset:orders` may have the
+   * same `endpoint.key` while representing different operations.
    */
-  const explicitRoutes = new Map<string, RouteManifestEntry>();
+  const explicitRoutes = new WeakMap<
+    ServeEndpoint<any, any, TContext, TAuth>,
+    RouteManifestEntry
+  >();
 
   const api: HypeQueryAPI<ServeEndpointMap<TQueries, TContext, TAuth>, TContext, TAuth> = {
     queries: queryEntries,
@@ -68,7 +73,7 @@ export const createAPImethods = <
         string,
         ServeEndpoint<any, any, TContext, TAuth>,
       ][]) {
-        manifest[key] = explicitRoutes.get(endpoint.key) ?? {
+        manifest[key] = explicitRoutes.get(endpoint) ?? {
           method: endpoint.method,
           // queryEntries store the pre-basePath route; re-apply so the manifest
           // carries the full request path clients should call.
@@ -118,8 +123,8 @@ export const createAPImethods = <
 
       router.register(registeredEndpoint);
 
-      if (!explicitRoutes.has(endpoint.key)) {
-        explicitRoutes.set(endpoint.key, {
+      if (!explicitRoutes.has(endpoint)) {
+        explicitRoutes.set(endpoint, {
           method,
           path: applyBasePath(basePath, normalizedPath),
         });


### PR DESCRIPTION
Found while building a Next.js app against ClickHouse Cloud from the published docs. Third of three PRs from that audit.

## The problem

`api.route()` registers the endpoint with the router but leaves `queryEntries` holding the auto-registered `/queries/<key>` convention entry — and `manifest()` reads from `queryEntries`.

So this:

```ts
api.route('/busiest-routes', api.queries.busiestRoutes, { method: 'POST' });
```

produced this manifest, from both `api.manifest()` and `hypequery generate:manifest`:

```json
"busiestRoutes": { "method": "GET", "path": "/api/analytics/queries/busiestRoutes" }
```

`@hypequery/react` resolves routes from the manifest, so `useQuery('busiestRoutes', { limit: 8 })` in a real app issued:

```
GET /api/analytics/queries/busiestRoutes?minTrips=500&limit=8 → 400 Bad Request
{"error":{"type":"VALIDATION_ERROR","details":{"issues":[
  {"code":"invalid_type","expected":"number","received":"string","path":["limit"]}]}}}
```

instead of POSTing to the route that was actually declared. Both routes are live — OpenAPI lists both — the manifest just names the wrong one.

## The change

Track explicit registrations by endpoint key in `createAPImethods` and prefer them in `manifest()`. Both routes stay registered; the manifest can only name one, and it now names the one the author wrote.

First registration wins when an endpoint is routed more than once, so regenerating the manifest is deterministic.

## Tests

Four new cases in the existing `describe("manifest()")` block:

- prefers the explicit registration over the convention route
- applies `basePath` to explicitly registered routes
- keeps the first registration when an endpoint is routed twice
- falls back to the endpoint's own method when `route()` omits one

I verified all four **fail without the fix** (`4 failed | 82 passed`) and pass with it. Full serve suite green: 510 tests / 28 files.

## Notes for review

This fixes the manifest, which is enough to unbreak `useQuery` for explicitly-routed endpoints. Two adjacent problems are **not** addressed here and may deserve their own issues:

1. Serve's auto GET route only accepts `?input={json}`. Flat query params aren't coerced, so `?limit=8` fails zod with `expected number, received string`.
2. `@hypequery/react`'s client (`client.js:80-91`) encodes GET input as flat query params via `String(value)` — the opposite convention.

So the GET convention route and the React client don't agree on an encoding, and any endpoint with a non-string input field is unusable over it. Happy to take that on separately if you want it fixed rather than routed around.