### PR TITLE
feat(clickhouse): add close() for graceful shutdown

### DIFF
--- a/.changeset/hip-mugs-close.md
+++ b/.changeset/hip-mugs-close.md
@@ -1,0 +1,16 @@
+---
+"@hypequery/clickhouse": minor
+---
+
+Add `close()` for graceful shutdown.
+
+`createQueryBuilder(...)` now returns a `close()` method that releases the underlying ClickHouse connection pool, so processes can drain and exit without dangling keep-alive sockets. `DatabaseAdapter` gained an optional `close()` that custom adapters can implement; adapters without it resolve as a no-op.
+
+```ts
+process.on('SIGTERM', async () => {
+  await server.stop();
+  await db.close();
+});
+```
+
+A client supplied through `createQueryBuilder({ client })` is closed as well, so only call `close()` when the builder owns the process lifetime of that client.

--- a/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
+++ b/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
@@ -104,6 +104,10 @@ export class ClickHouseAdapter implements DatabaseAdapter {
     };
   }
 
+  async close(): Promise<void> {
+    await this.client.close();
+  }
+
   render(sql: string, params: unknown[] = []): string {
     return substituteParameters(sql, params);
   }

--- a/packages/clickhouse/src/core/adapters/database-adapter.ts
+++ b/packages/clickhouse/src/core/adapters/database-adapter.ts
@@ -24,6 +24,8 @@ export interface DatabaseAdapter {
   readonly name: string;
   readonly namespace?: string;
   query<T>(sql: string, params?: unknown[], options?: QueryExecutionOptions): Promise<T[]>;
+  /** Releases connections held by the adapter. Callers must not reuse it afterwards. */
+  close?(): Promise<void>;
   stream?<T>(sql: string, params?: unknown[], options?: QueryExecutionOptions): Promise<ReadableStream<T[]>>;
   /**
    * Inserts rows that have already been normalized for JSONEachRow-compatible

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -1219,6 +1219,14 @@ export function createQueryBuilder<Schema extends SchemaDefinition<Schema>>(
       return resolvedAdapter.query<TResult>(sql, params, options);
     },
     /**
+     * Closes the underlying connection pool for graceful shutdown. A client
+     * passed in through config is closed too, and the builder must not be used
+     * afterwards.
+     */
+    async close(): Promise<void> {
+      await resolvedAdapter.close?.();
+    },
+    /**
      * Starts a type-safe insert into the given table.
      *
      * Row shapes are derived from the schema: `Nullable(...)` columns are

--- a/packages/clickhouse/src/core/tests/clickhouse-adapter.test.ts
+++ b/packages/clickhouse/src/core/tests/clickhouse-adapter.test.ts
@@ -117,3 +117,37 @@ describe('ClickHouseAdapter', () => {
     expect(clientInsertMock).not.toHaveBeenCalled();
   });
 });
+
+describe('ClickHouseAdapter shutdown', () => {
+  it('closes the underlying ClickHouse client', async () => {
+    const clientCloseMock = vi.fn().mockResolvedValue(undefined);
+    const adapter = new ClickHouseAdapter({
+      client: { close: clientCloseMock } as any,
+    });
+
+    await adapter.close();
+
+    expect(clientCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the adapter through the query builder handle', async () => {
+    const clientCloseMock = vi.fn().mockResolvedValue(undefined);
+    const db = createQueryBuilder<{ events: { id: 'UInt32' } }>({
+      adapter: new ClickHouseAdapter({
+        client: { close: clientCloseMock } as any,
+      }),
+    });
+
+    await db.close();
+
+    expect(clientCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves when the adapter does not implement close', async () => {
+    const db = createQueryBuilder<{ events: { id: 'UInt32' } }>({
+      adapter: { name: 'no-close', query: async () => [] },
+    });
+
+    await expect(db.close()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

`createQueryBuilder(...)` opens a ClickHouse client but never exposes a way to close it. On `SIGTERM` a process can drain its HTTP server (`@hypequery/serve` already does) and still hang on keep-alive sockets held by the ClickHouse client, or exit before the pool is released.

## What this changes

- `createQueryBuilder(...)` returns `close()`, which releases the underlying connection pool.
- `ClickHouseAdapter.close()` delegates to `client.close()`.
- `DatabaseAdapter.close?()` is optional, so existing custom adapters keep compiling and `db.close()` is a no-op for them.

```ts
process.on('SIGTERM', async () => {
  await stop();        // drain in-flight HTTP requests
  await db.close();    // release ClickHouse connections
});
```

## Decision worth reviewing

A client passed in via `createQueryBuilder({ client })` is closed too. `close()` is an explicit call, so the caller is asking for the pool to go away; the alternative — silently skipping user-supplied clients — makes shutdown unreliable in exactly the config most production apps use. Documented on the method.

## Follow-ups (not in this PR)

`@hypequery/serve`'s `gracefulStop` drains the HTTP server but does not close the database handle; wiring that up is a `serve`-level change and needs its own decision about handle ownership.

## Tests

Adapter closes the client; `db.close()` reaches the adapter; adapters without `close()` resolve.

`pnpm test` and `pnpm lint` pass across the workspace. Changeset included (minor, `@hypequery/clickhouse`).
