### PR TITLE
docs(react): lead with the static manifest instead of importing the serve API

### DIFF
--- a/website-next/docs/nextjs.mdx
+++ b/website-next/docs/nextjs.mdx
@@ -1,5 +1,4 @@
 ---
-layout: ../../../layouts/DocsLayout.astro
 title: Next.js
 description: Mount hypequery in a Next.js App Router project.
 ---
@@ -68,6 +67,43 @@ export default async function Page() {
 </CodeBlock>
 
 Use `force-dynamic` on Server Components or pages that query ClickHouse during render. Without it, Next.js may try to prerender the page at build time and fail or time out when the database is unavailable.
+
+</Step>
+
+<Step>
+
+### Call the API from client components
+
+Client components cannot import the serve API as a value — doing so bundles `initServe` and
+`@hypequery/clickhouse` for the browser and fails the build with `Can't resolve 'fs/promises'`.
+Generate the route manifest as static JSON instead:
+
+<CodeBlock>
+```bash
+npx hypequery generate:manifest analytics/queries.ts --output analytics/hypequery-manifest.json
+```
+</CodeBlock>
+
+<CodeBlock>
+```typescript
+// lib/analytics.ts
+import { createAnalyticsHooks } from '@hypequery/react';
+import type { InferApiType } from '@hypequery/serve';
+import type { api } from '@/analytics/queries';
+import manifest from '@/analytics/hypequery-manifest.json';
+
+type Api = InferApiType<typeof api>;
+
+export const { useQuery, useMetric, useDataset } = createAnalyticsHooks<Api>({
+  baseUrl: '/api/analytics',
+  manifest,
+});
+```
+</CodeBlock>
+
+Both `api` and `InferApiType` are imported with `import type`, so they are erased at build time and
+only the manifest JSON survives into the client bundle. See the [React guide](/docs/react/getting-started)
+for provider setup.
 
 </Step>
 

--- a/website-next/docs/react/advanced-patterns.mdx
+++ b/website-next/docs/react/advanced-patterns.mdx
@@ -18,7 +18,7 @@ By default, `useQuery` and `useMutation` issue `GET` requests. Override HTTP met
 <Pre>
 ```ts
 import { createHooks } from '@hypequery/react';
-import { InferApiType } from '@hypequery/serve';
+import type { InferApiType } from '@hypequery/serve';
 import type { api } from '@/analytics/queries';
 
 type Api = InferApiType<typeof api>;
@@ -47,32 +47,55 @@ export const { useQuery, useMutation } = createHooks<Api>({
 
 Instead of manually maintaining HTTP method configuration, let the server tell the client which methods to use.
 
-### Option A: Shared Server Module (Next.js / Remix)
+### Option A: Static Manifest (Next.js / Remix / any bundler)
 
-When your React code can import the server bundle (e.g., Next.js App Router), pass the `api` directly:
+Generate the route manifest as JSON at build time and import it:
+
+<CodeBlock>
+<Pre>
+```bash
+npx hypequery generate:manifest analytics/api.ts --output analytics/hypequery-manifest.json
+```
+</Pre>
+</CodeBlock>
 
 <CodeBlock>
 <Pre>
 ```ts
 // lib/analytics.ts
 import { createHooks } from '@hypequery/react';
-import { InferApiType } from '@hypequery/serve';
-import { api } from '@/analytics/queries';
+import type { InferApiType } from '@hypequery/serve';
+import type { api } from '@/analytics/api';
+import manifest from '@/analytics/hypequery-manifest.json';
 
 type Api = InferApiType<typeof api>;
 
 export const { useQuery, useMutation } = createHooks<Api>({
   baseUrl: '/api/hypequery',
-  api, // ✅ Method metadata extracted automatically
+  manifest, // ✅ Method metadata, no server code in the bundle
 });
 ```
 </Pre>
 </CodeBlock>
 
-The `api` object contains method metadata from your route definitions. This keeps client and server configuration in sync automatically.
+The manifest carries the method and full path for every query, metric, and dataset key, so client and
+server stay in sync without the client importing anything from the server.
+
+<Callout type="warn" title="Passing `api` directly does not work in a client module">
+  An earlier version of this page suggested `createHooks({ api })` with a value import of `api`.
+  That only holds if the module is server-only. `lib/analytics.ts` is imported by client components,
+  so a value import of `api` bundles `initServe` and `@hypequery/clickhouse` for the browser — and
+  in Next.js App Router it fails the build with `Can't resolve 'fs/promises'`.
+
+  Use the static manifest above, or the config endpoint in Option B. Reserve `api` and
+  `api.manifest()` for server-side code.
+</Callout>
 
 <Callout type="info">
-  Passing `api` (or `manifest: api.manifest()`) is **required** when you use semantic `metrics`/`datasets` endpoints with `useMetric`/`useDataset`. Their POST paths differ from their map keys, so the hooks need the resolved routes. `extractClientConfig(api)` in Option B includes these routes too.
+  A `manifest` (or an explicit `config` entry) is **required** when you use semantic
+  `metrics`/`datasets` endpoints with `useMetric`/`useDataset`. Their POST paths differ from their map
+  keys, so the hooks need the resolved routes. `extractClientConfig(api)` in Option B includes these
+  routes too.
 </Callout>
 
 ### Option B: Config Endpoint (SPAs / Vite)
@@ -100,7 +123,7 @@ export function GET() {
 ```ts
 // lib/analytics.ts
 import { createHooks } from '@hypequery/react';
-import { InferApiType } from '@hypequery/serve';
+import type { InferApiType } from '@hypequery/serve';
 import type { api } from '@/analytics/queries';
 
 type Api = InferApiType<typeof api>;

--- a/website-next/docs/react/getting-started.mdx
+++ b/website-next/docs/react/getting-started.mdx
@@ -35,8 +35,8 @@ Use `InferApiType` to automatically extract types from your API definition:
 ```ts
 // lib/analytics.ts
 import { createHooks } from '@hypequery/react';
-import { InferApiType } from '@hypequery/serve';
-import type { api } from '@/analytics/queries';
+import type { InferApiType } from '@hypequery/serve';
+import type { api } from '@/analytics/api';
 
 // Automatic type inference - no manual type definition needed!
 type Api = InferApiType<typeof api>;
@@ -49,6 +49,10 @@ export const { useQuery, useMutation } = createHooks<Api>({
 </CodeBlock>
 
 This eliminates the need to manually define and maintain a separate type for your API.
+
+Both `@hypequery/serve` imports here are `import type`, so they are erased at build time and no
+server code reaches the client bundle. Keep it that way — this module is imported by client
+components.
 
 ### Option 2: Manual Type Definition
 
@@ -79,16 +83,29 @@ export const { useQuery, useMutation } = createHooks<Api>({
 
 When your API registers `metrics` or `datasets`, use `createAnalyticsHooks` instead of `createHooks`. It returns everything `createHooks` does, plus `useMetric`, `useDataset`, `useInfiniteMetric`, and `useInfiniteDataset`.
 
-Semantic endpoints are POST routes whose paths differ from their map keys (e.g. the `orders` dataset lives at `POST /datasets/orders/query`). Pass a `manifest` from the serve API's `api.manifest()` so the hooks can resolve those routes:
+Semantic endpoints are POST routes whose paths differ from their map keys (e.g. the `orders` dataset lives at `POST /datasets/orders/query`), so the hooks need a `manifest` to resolve them.
+
+Generate the manifest as static JSON and import **the type** of your API, never its value:
+
+<CodeBlock>
+<Pre>
+```bash
+npx hypequery generate:manifest analytics/api.ts --output analytics/hypequery-manifest.json
+```
+</Pre>
+</CodeBlock>
 
 <CodeBlock>
 <Pre>
 ```ts
 // lib/analytics.ts
 import { createAnalyticsHooks } from '@hypequery/react';
-import { InferApiType } from '@hypequery/serve';
-import { api } from '@/analytics/queries';
+import type { InferApiType } from '@hypequery/serve';
+import type { api } from '@/analytics/api';
+import manifest from '@/analytics/hypequery-manifest.json';
 
+// `import type` is erased at build time, so the server module — and the
+// ClickHouse client it constructs — never reaches the browser bundle.
 type Api = InferApiType<typeof api>;
 
 export const {
@@ -100,15 +117,36 @@ export const {
   useInfiniteDataset,
 } = createAnalyticsHooks<Api>({
   baseUrl: '/api',
-  // Required for metric/dataset endpoints — resolves each key's method + path.
-  manifest: api.manifest(),
+  manifest,
 });
 ```
 </Pre>
 </CodeBlock>
 
+Re-run `generate:manifest` whenever you add or re-route an endpoint. Wire it into your build (`"prebuild": "hypequery generate:manifest …"`) so it cannot drift.
+
+<Callout type="warn" title="Do not import the serve API as a value here">
+  This module is imported by client components, so anything it imports as a *value* is bundled for
+  the browser. Calling `manifest: api.manifest()` requires a value import of `api`, which pulls
+  `initServe` and `@hypequery/clickhouse` into the client graph. In a Next.js App Router project that
+  fails the build outright:
+
+  <CodeBlock>
+  <Pre>
+  ```text
+  ./node_modules/@hypequery/clickhouse/dist/cli/generate-types.js:2:1
+  Error: Module not found: Can't resolve 'fs/promises'
+  ```
+  </Pre>
+  </CodeBlock>
+
+  `api.manifest()` is a **server-side** API. Use it in your build step, in a config endpoint, or
+  anywhere else that only runs on the server — not in the module that exports your hooks.
+</Callout>
+
 <Callout type="info">
-  `api.manifest()` is safe to JSON-serialize, so you can also fetch it from a small endpoint at runtime when your client can't import the server module — see <a href="/docs/react/advanced-patterns#auto-config-from-server">Auto-config from server</a>. Without a manifest (or an explicit <code>config</code> entry), `useMetric`/`useDataset` throw a clear error rather than calling the wrong URL.
+  `api.manifest()` output is plain JSON, so you can also serve it from a small endpoint and fetch it
+  at runtime when a static file does not suit your setup — see <a href="/docs/react/advanced-patterns#auto-config-from-server">Auto-config from server</a>. Without a manifest (or an explicit <code>config</code> entry), `useMetric`/`useDataset` throw a clear error rather than calling the wrong URL.
 </Callout>
 
 ## Provider Setup


### PR DESCRIPTION
Fourth PR from the Next.js/ClickHouse Cloud friction audit. Pairs with #399 — that one removes the crash, this one removes the cause.

## The problem

`docs/react/getting-started.mdx` told readers to build their hooks module like this:

```ts
// lib/analytics.ts
import { api } from '@/analytics/queries';   // ← value import
export const { useMetric, useDataset } = createAnalyticsHooks<Api>({
  manifest: api.manifest(),
});
```

`lib/analytics.ts` is imported by client components, so that value import pulls `initServe` and `@hypequery/clickhouse` into the client graph. On Next.js App Router it fails the build:

```
./node_modules/@hypequery/clickhouse/dist/cli/generate-types.js:2:1
Error: Module not found: Can't resolve 'fs/promises'
```

Quick Start already documented the working pattern — `generate:manifest` to static JSON plus `import type { api }` — but the two pages never referenced each other. Which page a reader opened first decided whether their build worked. I followed Quick Start and shipped; following the React guide first would have left me staring at an `fs/promises` error with no obvious connection to what I'd written.

`docs/react/advanced-patterns.mdx` made it worse: **"Option A: Shared Server Module (Next.js / Remix)"** recommends `createHooks({ api })` and names App Router as the case it suits — the exact case where it breaks.

## Changes

**getting-started.mdx**
- Lead with `generate:manifest` + `import type`, with a `prebuild` suggestion so the manifest cannot drift
- Add a callout quoting the exact error and stating plainly that `api.manifest()` is a server-side API
- `import { InferApiType }` → `import type`

**advanced-patterns.mdx**
- Retitle Option A to "Static Manifest (Next.js / Remix / any bundler)" and rewrite it
- Add a callout explaining the change, for anyone who already followed the old advice
- `import type { InferApiType }` in both snippets
- Left the value import of `api` in the config-endpoint example alone — that's a server route handler and correct

**nextjs.mdx**
- Add a step covering client-component setup, which the guide never mentioned at all
- Drop the stale `layout: ../../../layouts/DocsLayout.astro` frontmatter from the removed Starlight site

## Verification

- `website-next` builds clean with the new MDX
- Measured on a real Next.js 16 app: static-manifest pattern → **660K client chunks, zero references to `clickhouse`, `@hypequery/serve`, or `initServe`**. The `api.manifest()` pattern → **1.1M and still contains `createQueryBuilder`/`initServe`**, even after #399 makes it compile.

So #399 stops the build failing; this stops the 440K leak.