### PR TITLE
fix(serve): type resolvers with zod's output type, not its input type

### DIFF
--- a/.changeset/olive-donkeys-tap.md
+++ b/.changeset/olive-donkeys-tap.md
@@ -1,5 +1,5 @@
 ---
-"@hypequery/serve": minor
+"@hypequery/serve": patch
 ---
 
 Type query resolvers with zod's **output** type instead of its input type.
@@ -29,7 +29,7 @@ Caller-facing types are unchanged and still use `SchemaInput`: `InferApiType`,
 Over the wire a defaulted field really is optional, so `@hypequery/react` and
 anything driving `api.execute()` keep the types they had.
 
-Marked minor rather than patch: resolvers are now typed more precisely, so code
-written against the previous (incorrect) type may surface new errors — most
-often a now-redundant `?? fallback`, which is safe to delete. Code that already
-handled the value correctly keeps compiling.
+Resolvers are now typed more precisely, so code written against the previous
+(incorrect) type may surface new errors — most often a now-redundant
+`?? fallback`, which is safe to delete. Code that already handled the value
+correctly keeps compiling, and no runtime behaviour changes.

--- a/.changeset/olive-donkeys-tap.md
+++ b/.changeset/olive-donkeys-tap.md
@@ -1,5 +1,5 @@
 ---
-"@hypequery/serve": patch
+"@hypequery/serve": minor
 ---
 
 Type query resolvers with zod's **output** type instead of its input type.

--- a/.changeset/olive-donkeys-tap.md
+++ b/.changeset/olive-donkeys-tap.md
@@ -1,0 +1,35 @@
+---
+"@hypequery/serve": minor
+---
+
+Type query resolvers with zod's **output** type instead of its input type.
+
+`SchemaInput<T>` (`T["_input"]`) was used for the resolver, its middlewares, and
+the endpoint handler. All three run *after* validation — `pipeline.ts` assigns
+`context.input = validationResult.data` before composing middlewares — so they
+receive zod's parsed output.
+
+The visible symptom was `.default()`:
+
+```ts
+const q = query({
+  input: z.object({ limit: z.number().default(10) }),
+  query: async ({ input }) => {
+    input.limit          // was: number | undefined
+    db.limit(input.limit ?? 10)   // default restated, because TS demanded it
+  },
+});
+```
+
+`.transform()`, `.coerce`, `.catch()`, and `.pipe()` were wrong in the same way —
+the resolver saw the pre-parse type for all of them.
+
+Caller-facing types are unchanged and still use `SchemaInput`: `InferApiType`,
+`InferQueryInput`, `api.execute()`, and `StandaloneQueryDefinition.execute()`.
+Over the wire a defaulted field really is optional, so `@hypequery/react` and
+anything driving `api.execute()` keep the types they had.
+
+Marked minor rather than patch: resolvers are now typed more precisely, so code
+written against the previous (incorrect) type may surface new errors — most
+often a now-redundant `?? fallback`, which is safe to delete. Code that already
+handled the value correctly keeps compiling.

--- a/packages/serve/src/type-tests/resolver-input.test-d.ts
+++ b/packages/serve/src/type-tests/resolver-input.test-d.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+import type { Equal, Expect } from '@type-challenges/utils';
+import { initServe, type InferApiType } from '../index.js';
+
+/**
+ * Resolvers run after validation — `pipeline.ts` assigns
+ * `context.input = validationResult.data` before invoking middlewares or the
+ * handler. So the resolver sees zod's *output* type, while callers send its
+ * *input* type. These tests pin both sides of that split.
+ */
+
+const serve = initServe({ context: () => ({ db: {} }) });
+const { query } = serve;
+
+// ---------------------------------------------------------------------------
+// .default() — the common case
+// ---------------------------------------------------------------------------
+
+const withDefault = query({
+  input: z.object({
+    limit: z.number().int().default(10),
+    name: z.string(),
+  }),
+  query: async ({ input }) => {
+    // Required in the resolver: zod has already filled the default in.
+    // Before this was fixed, `limit` was `number | undefined` and every caller
+    // had to write `input.limit ?? 10`, restating a default the schema owns.
+    type _LimitIsRequiredNumber = Expect<Equal<typeof input.limit, number>>;
+    type _NameIsString = Expect<Equal<typeof input.name, string>>;
+
+    const doubled: number = input.limit * 2;
+    return [{ doubled }];
+  },
+});
+
+// ---------------------------------------------------------------------------
+// .transform() — resolver sees the transformed type
+// ---------------------------------------------------------------------------
+
+const withTransform = query({
+  input: z.object({
+    csv: z.string().transform((value) => value.split(',')),
+  }),
+  query: async ({ input }) => {
+    type _CsvIsArray = Expect<Equal<typeof input.csv, string[]>>;
+    return [{ count: input.csv.length }];
+  },
+});
+
+// ---------------------------------------------------------------------------
+// .coerce — resolver sees the coerced type
+// ---------------------------------------------------------------------------
+
+const withCoerce = query({
+  input: z.object({
+    since: z.coerce.date(),
+  }),
+  query: async ({ input }) => {
+    type _SinceIsDate = Expect<Equal<typeof input.since, Date>>;
+    return [{ iso: input.since.toISOString() }];
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Callers still send the *input* type: a defaulted field stays optional there
+// ---------------------------------------------------------------------------
+
+export const api = serve.serve({
+  queries: { withDefault, withTransform, withCoerce },
+});
+
+// This is the shape `@hypequery/react` consumes, so it must stay on the *input*
+// side: over the wire a defaulted field is genuinely optional.
+type Api = InferApiType<typeof api>;
+type DefaultCallerInput = Api['withDefault']['input'];
+
+// Omitting the defaulted field is valid over the wire.
+const _callerMayOmitDefault: DefaultCallerInput = { name: 'a' };
+// Supplying it is valid too.
+const _callerMaySupplyDefault: DefaultCallerInput = { name: 'a', limit: 5 };
+// The non-defaulted field is still required.
+// @ts-expect-error `name` has no default, so callers must send it
+const _callerMustSendName: DefaultCallerInput = { limit: 5 };
+
+type TransformCallerInput = Api['withTransform']['input'];
+// Callers send the pre-transform type.
+const _callerSendsRawCsv: TransformCallerInput = { csv: 'a,b,c' };
+// @ts-expect-error callers send the input side of the transform, not the output
+const _callerCannotSendArray: TransformCallerInput = { csv: ['a', 'b'] };

--- a/packages/serve/src/types.ts
+++ b/packages/serve/src/types.ts
@@ -229,9 +229,23 @@ export type ServeMiddleware<
   next: () => Promise<TResult>
 ) => Promise<TResult>;
 
+/**
+ * What a *caller* sends. Use for anything crossing the wire or handed to
+ * `api.execute()` — a field with `.default()` is genuinely optional there.
+ */
 export type SchemaInput<T extends ZodTypeAny | undefined> = T extends ZodTypeAny
   ? T["_input"]
   : unknown;
+
+/**
+ * What zod produced after parsing. Use for anything running *after* validation —
+ * resolvers, handlers, and middlewares. `pipeline.ts` assigns
+ * `context.input = validationResult.data` before composing middlewares, so by
+ * then `.default()` is filled in, `.transform()` has run, and `.coerce` has
+ * converted. Typing those positions as {@link SchemaInput} makes defaulted
+ * fields look `| undefined` and forces callers to re-supply a default the
+ * schema already guarantees.
+ */
 export type SchemaOutput<T extends ZodTypeAny | undefined> = T extends ZodTypeAny
   ? T["_output"]
   : unknown;
@@ -419,14 +433,14 @@ export interface ServeEndpoint<
   inputSchema?: TInputSchema;
   outputSchema: TOutputSchema;
   handler: EndpointHandler<
-    SchemaInput<TInputSchema>,
+    SchemaOutput<TInputSchema>,
     TResult,
     TContext,
     TAuth
   >;
-  query?: ExecutableQuery<SchemaInput<TInputSchema>, TResult, TContext, TAuth>;
+  query?: ExecutableQuery<SchemaOutput<TInputSchema>, TResult, TContext, TAuth>;
   middlewares: ServeMiddleware<
-    SchemaInput<TInputSchema>,
+    SchemaOutput<TInputSchema>,
     SchemaOutput<TOutputSchema>,
     TContext,
     TAuth
@@ -455,7 +469,7 @@ export interface ServeQueryConfig<
   TResult = SchemaOutput<TOutputSchema>
 > {
   key?: string;
-  query: ExecutableQuery<SchemaInput<TInputSchema>, TResult, TContext, TAuth>;
+  query: ExecutableQuery<SchemaOutput<TInputSchema>, TResult, TContext, TAuth>;
   method?: HttpMethod;
   name?: string;
   summary?: string;
@@ -464,7 +478,7 @@ export interface ServeQueryConfig<
   inputSchema?: TInputSchema;
   outputSchema?: TOutputSchema;
   middlewares?: ServeMiddleware<
-    SchemaInput<TInputSchema>,
+    SchemaOutput<TInputSchema>,
     SchemaOutput<TOutputSchema>,
     TContext,
     TAuth
@@ -489,7 +503,9 @@ export interface StandaloneQueryDefinition<
   TAuth extends AuthContext = AuthContext,
   TResult = SchemaOutput<TOutputSchema>
 > extends ServeQueryConfig<TInputSchema, TOutputSchema, TContext, TAuth, TResult> {
-  run: QueryResolver<SchemaInput<TInputSchema>, TResult, TContext, TAuth>;
+  // `run` executes post-validation, so it sees parsed output. `execute` is the
+  // caller-facing entry point and takes the raw input the schema accepts.
+  run: QueryResolver<SchemaOutput<TInputSchema>, TResult, TContext, TAuth>;
   execute(options?: DirectQueryExecuteOptions<SchemaInput<TInputSchema>, TContext>): Promise<TResult>;
 }
 
@@ -515,7 +531,7 @@ export interface QueryObjectConfig<
   requiredRoles?: string[];
   requiredScopes?: string[];
   custom?: Record<string, unknown>;
-  query: QueryResolver<SchemaInput<TInputSchema>, TResult, TContext, TAuth>;
+  query: QueryResolver<SchemaOutput<TInputSchema>, TResult, TContext, TAuth>;
 }
 
 export type ServeQueriesMap<
@@ -1271,9 +1287,9 @@ export interface QueryProcedureBuilder<
   require(): QueryProcedureBuilder<TContext, TAuth, TInputSchema, TOutputSchema>;
   custom(custom: Record<string, unknown>): QueryProcedureBuilder<TContext, TAuth, TInputSchema, TOutputSchema>;
   use(
-    ...middlewares: ServeMiddleware<SchemaInput<TInputSchema>, SchemaOutput<TOutputSchema>, TContext, TAuth>[]
+    ...middlewares: ServeMiddleware<SchemaOutput<TInputSchema>, SchemaOutput<TOutputSchema>, TContext, TAuth>[]
   ): QueryProcedureBuilder<TContext, TAuth, TInputSchema, TOutputSchema>;
-  query<TExecutable extends ExecutableQuery<SchemaInput<TInputSchema>, any, TContext, TAuth>>(
+  query<TExecutable extends ExecutableQuery<SchemaOutput<TInputSchema>, any, TContext, TAuth>>(
     executable: TExecutable
   ): ServeQueryConfig<
     TInputSchema,


### PR DESCRIPTION
Fifth PR from the Next.js/ClickHouse Cloud friction audit.

## The problem

`types.ts` used `SchemaInput<T>` — that is, `T["_input"]` — for the resolver, its middlewares, and the endpoint handler. All three run **after** validation. `pipeline.ts:512-531`:

```ts
const validationResult = validateInput(endpoint.inputSchema, context.input);
if (!validationResult.success) { /* 400 */ }
context.input = validationResult.data;   // ← parsed OUTPUT
// ...then middlewares are composed, then the handler runs
```

So every post-validation position was typed with the pre-validation type. The visible symptom is `.default()`:

```ts
const busiestRoutes = query({
  input: z.object({ minTrips: z.number().int().default(500) }),
  query: async ({ ctx, input }) =>
    ctx.db.having('count(trip_id) > ?', [input.minTrips]),
    //                                    ^^^^^^^^^^^^^^
    // Argument of type 'number | undefined' is not assignable to 'number'
});
```

The fix in application code is `input.minTrips ?? 500` — restating a default the schema already owns, in every resolver, forever. That's what I ended up writing in the demo app.

`.transform()`, `.coerce`, `.catch()`, and `.pipe()` were wrong in the same way: a resolver behind `z.coerce.date()` was typed as the raw input rather than `Date`.

## The change

Switch the post-validation positions to `SchemaOutput`:

- `ServeEndpoint.handler`, `.query`, `.middlewares`
- `ServeQueryConfig.query`, `.middlewares`
- `StandaloneQueryDefinition.run`
- `QueryObjectConfig.query`
- `QueryProcedureBuilder.use()` / `.query()`

Caller-facing positions **deliberately keep `SchemaInput`** — over the wire a defaulted field really is optional:

- `InferApiType` / `InferApiEntry.input` (what `@hypequery/react` consumes)
- `InferQueryInput`
- `api.execute()` / `ApiExecuteOptions`
- `StandaloneQueryDefinition.execute()`

Both aliases now carry doc comments stating which side of validation they belong on, so the next person doesn't have to re-derive it.

## Tests

New `src/type-tests/resolver-input.test-d.ts` covers `.default()`, `.transform()`, and `.coerce` on the resolver side, plus caller-side assertions that defaulted fields stay optional and that callers send the pre-transform type.

Verified it fails without the change:

```
resolver-input.test-d.ts(28,42): error TS2344: Type 'false' does not satisfy the constraint 'true'.
resolver-input.test-d.ts(31,29): error TS18048: 'input.limit' is possibly 'undefined'.
resolver-input.test-d.ts(45,31): error TS2344: Type 'false' does not satisfy the constraint 'true'.
```

Unit suite green: 506 tests / 28 files. `test:types` green.

## Notes for review

Marked **minor**, not patch. Resolvers are now typed more precisely, so consumer code written against the old type can surface new errors. In practice that's a now-redundant `?? fallback` (safe to delete) or a `.transform()` resolver that was mis-typed and probably already had a latent runtime bug. Nothing that was correct before stops compiling.

`InferQueryInput` turns out not to be exercised by any test and resolved to `unknown` in my first draft of the type test, so I asserted against `InferApiType` instead — that's the type consumers actually receive. Might be worth a separate look at whether `InferQueryInput` is doing its job.