### PR TITLE
fix(clickhouse): work against connections running under readonly = 1

### DIFF
--- a/.changeset/great-spoons-cheer.md
+++ b/.changeset/great-spoons-cheer.md
@@ -1,0 +1,28 @@
+---
+"@hypequery/clickhouse": patch
+---
+
+Work against ClickHouse connections running under `readonly = 1`.
+
+The adapter sent `output_format_json_quote_64bit_integers: 1` with every query.
+`readonly = 1` forbids *any* session-setting change, so every query failed:
+
+```
+Cannot modify 'output_format_json_quote_64bit_integers' setting in readonly mode.
+```
+
+Two changes:
+
+- **Best-effort setting.** When ClickHouse rejects the setting with error code
+  164 (`READONLY`), the adapter drops it, warns once, and retries. The flag stays
+  off for the life of the adapter, so a read-only connection pays one extra round
+  trip in total rather than failing outright. Unrelated errors are not retried.
+- **Connection settings now outrank the adapter's default.** Precedence is
+  adapter default < connection `clickhouse_settings` < per-query settings.
+  Previously the adapter applied its own value last for this flag, so a
+  connection-level `clickhouse_settings` could not turn it off. Setting it
+  explicitly also disables the retry path, since nothing unrequested is sent.
+
+Note that when the fallback engages, `Int64` and wider values come back as JSON
+numbers rather than quoted strings, and lose precision beyond 2^53. The warning
+says so and points at the setting to make the choice explicit.

--- a/.changeset/great-spoons-cheer.md
+++ b/.changeset/great-spoons-cheer.md
@@ -14,9 +14,11 @@ Cannot modify 'output_format_json_quote_64bit_integers' setting in readonly mode
 Two changes:
 
 - **Best-effort setting.** When ClickHouse rejects the setting with error code
-  164 (`READONLY`), the adapter drops it, warns once, and retries. The flag stays
-  off for the life of the adapter, so a read-only connection pays one extra round
-  trip in total rather than failing outright. Unrelated errors are not retried.
+  164 (`READONLY`) and names the adapter-owned setting, the adapter drops it,
+  warns once, and retries. The flag stays off for the life of the adapter, so
+  later queries do not pay another round trip. Queries already in flight during
+  discovery may each retry. Unrelated errors and caller-owned settings are not
+  retried.
 - **Connection settings now outrank the adapter's default.** Precedence is
   adapter default < connection `clickhouse_settings` < per-query settings.
   Previously the adapter applied its own value last for this flag, so a

--- a/.changeset/great-spoons-cheer.md
+++ b/.changeset/great-spoons-cheer.md
@@ -2,29 +2,27 @@
 "@hypequery/clickhouse": patch
 ---
 
-Work against ClickHouse connections running under `readonly = 1`.
+Add explicit support for ClickHouse connections running under `readonly = 1`.
 
 The adapter sent `output_format_json_quote_64bit_integers: 1` with every query.
-`readonly = 1` forbids *any* session-setting change, so every query failed:
+That preserves integers beyond JavaScript's safe range and matches HypeQuery's
+generated `string` types. However, `readonly = 1` rejects the setting when it
+differs from the user's profile, so queries can fail with:
 
 ```
 Cannot modify 'output_format_json_quote_64bit_integers' setting in readonly mode.
 ```
 
-Two changes:
+Two changes keep that tradeoff explicit:
 
-- **Best-effort setting.** When ClickHouse rejects the setting with error code
-  164 (`READONLY`) and names the adapter-owned setting, the adapter drops it,
-  warns once, and retries. The flag stays off for the life of the adapter, so
-  later queries do not pay another round trip. Queries already in flight during
-  discovery may each retry. Unrelated errors and caller-owned settings are not
-  retried.
+- **Strict read-only mode.** Set `integerJsonEncoding: 'server-default'` on
+  `createQueryBuilder` or `ClickHouseAdapter` to omit the adapter-owned setting.
+  This performs no capability probe or retry. The default remains `'quoted'`
+  because server-default JSON numbers can lose precision beyond 2^53 and may not
+  match generated `Int64`/`UInt64` string types. If the default is rejected, the
+  adapter now returns an actionable error describing this option.
 - **Connection settings now outrank the adapter's default.** Precedence is
   adapter default < connection `clickhouse_settings` < per-query settings.
   Previously the adapter applied its own value last for this flag, so a
-  connection-level `clickhouse_settings` could not turn it off. Setting it
-  explicitly also disables the retry path, since nothing unrequested is sent.
-
-Note that when the fallback engages, `Int64` and wider values come back as JSON
-numbers rather than quoted strings, and lose precision beyond 2^53. The warning
-says so and points at the setting to make the choice explicit.
+  connection-level value could not override it. Caller-owned values are never
+  replaced or reinterpreted by the adapter.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Codex repository instructions
+
+Follow the repository layout, commands, API policies, and release guidance in
+`CLAUDE.md`.
+
+## Code organization
+
+- Keep reusable or independently testable pure helpers in focused files under
+  the nearest `utils/` directory, or in a focused domain helper module.
+- Do not define utility functions as top-level implementation details inside
+  adapters, controllers, builders, or other feature files.
+- Keep behavior that depends on an owning class's state as class methods.
+- Do not accumulate unrelated helpers in a generic `utils.ts` file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ pnpm + Turbo monorepo. `pnpm-workspace.yaml` is the authoritative workspace list
 | `packages/protocol` / `packages/protocol-conformance` | Security protocol + cross-language conformance runner |
 | `packages/deployment` | Deployment contracts and tooling |
 | `packages/tsconfig` | Shared tsconfig presets — new packages extend this |
-| `website-next/` | Next.js + Fumadocs site. Docs live in `website-next/content/docs/` |
+| `website-next/` | Next.js + Fumadocs site. Docs live in `website-next/docs/` |
 | `testing/` | Manual, model-executable E2E test specs (see `testing/README.md`) |
 | `specs/` | RFCs, decisions, and conformance fixtures (`specs/security-protocol/`) |
 | `plans/` | Design docs / implementation plans |
@@ -43,11 +43,12 @@ pnpm smoke:consumers    # all consumer smoke tests (scripts/smoke-*.sh)
 
 ## Known-stale tooling
 
-- The TypeDoc docs pipeline (`pnpm docs:api` / `docs:mdx` / `fix:mdx`, scripts in `packages/clickhouse/scripts/`) still writes to the deleted `website/` directory. Don't run it expecting docs updates; docs are hand-maintained in `website-next/content/docs/` until the pipeline is repointed.
+- The TypeDoc docs pipeline (`pnpm docs:api` / `docs:mdx` / `fix:mdx`, scripts in `packages/clickhouse/scripts/`) still writes to the deleted `website/` directory. Don't run it expecting docs updates; docs are hand-maintained in `website-next/docs/` until the pipeline is repointed.
 
 ## API & architecture policies
 
 - **Never delete a shipped export.** If a released API is superseded, restore/keep it with a `@deprecated` JSDoc tag pointing at the replacement. Removal happens only in a planned major.
+- **Keep utility logic in focused files.** Reusable or independently testable pure helpers belong in the nearest `utils/` directory (or a focused domain helper module), not as top-level functions inside adapters, controllers, builders, or other feature files. Keep only behavior that depends on an owning class's state as class methods, and do not accumulate unrelated helpers in a generic `utils.ts` file.
 - **New builders must mirror QueryBuilder's architecture** (state + node + features design), not merely be immutable. Study `packages/clickhouse`'s query builder before adding a builder elsewhere.
 - **Dataset client docs and examples lead with `createDatasetClient({ queryBuilder })`.** `createBackend` is documented as advanced-only, never the primary path.
 

--- a/packages/clickhouse/README.md
+++ b/packages/clickhouse/README.md
@@ -57,31 +57,6 @@ const topProducts = await db
 
 See [what hypequery supports today](https://hypequery.com/docs/capabilities) for the exact public surface.
 
-## Strict read-only connections
-
-By default, the adapter asks ClickHouse to return `Int64` and wider values as
-JSON strings. This prevents precision loss beyond JavaScript's safe integer
-range and matches the generated schema types.
-
-If the ClickHouse user has `readonly = 1` and its profile does not already
-enable quoted integers, tell the adapter to leave the server's encoding
-unchanged:
-
-```ts
-const db = createQueryBuilder<IntrospectedSchema>({
-  url: process.env.CLICKHOUSE_URL!,
-  username: process.env.CLICKHOUSE_USERNAME!,
-  password: process.env.CLICKHOUSE_PASSWORD ?? '',
-  integerJsonEncoding: 'server-default',
-});
-```
-
-This omits the adapter-owned `output_format_json_quote_64bit_integers` rather
-than sending `0`, so there is no capability probe, retry, or added query
-latency. Explicit `clickhouse_settings` are still sent unchanged. Depending on
-the server profile, wide integers may then arrive as JavaScript numbers and
-lose precision beyond `2^53` instead of matching the generated `string` types.
-
 ## Grow beyond one query
 
 When analytics meaning needs to be shared, add `@hypequery/datasets` for a code-first semantic layer, `@hypequery/serve` for validated APIs, `@hypequery/react` for typed hooks, and `@hypequery/mcp` for governed AI-agent access. They all build on this query layer.

--- a/packages/clickhouse/README.md
+++ b/packages/clickhouse/README.md
@@ -57,6 +57,31 @@ const topProducts = await db
 
 See [what hypequery supports today](https://hypequery.com/docs/capabilities) for the exact public surface.
 
+## Strict read-only connections
+
+By default, the adapter asks ClickHouse to return `Int64` and wider values as
+JSON strings. This prevents precision loss beyond JavaScript's safe integer
+range and matches the generated schema types.
+
+If the ClickHouse user has `readonly = 1` and its profile does not already
+enable quoted integers, tell the adapter to leave the server's encoding
+unchanged:
+
+```ts
+const db = createQueryBuilder<IntrospectedSchema>({
+  url: process.env.CLICKHOUSE_URL!,
+  username: process.env.CLICKHOUSE_USERNAME!,
+  password: process.env.CLICKHOUSE_PASSWORD ?? '',
+  integerJsonEncoding: 'server-default',
+});
+```
+
+This omits the adapter-owned `output_format_json_quote_64bit_integers` rather
+than sending `0`, so there is no capability probe, retry, or added query
+latency. Explicit `clickhouse_settings` are still sent unchanged. Depending on
+the server profile, wide integers may then arrive as JavaScript numbers and
+lose precision beyond `2^53` instead of matching the generated `string` types.
+
 ## Grow beyond one query
 
 When analytics meaning needs to be shared, add `@hypequery/datasets` for a code-first semantic layer, `@hypequery/serve` for validated APIs, `@hypequery/react` for typed hooks, and `@hypequery/mcp` for governed AI-agent access. They all build on this query layer.

--- a/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
+++ b/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
@@ -6,7 +6,10 @@ import type {
 } from './database-adapter.js';
 import type { ClickHouseClient as NodeClickHouseClient } from '@clickhouse/client';
 import type { ClickHouseClient as WebClickHouseClient } from '@clickhouse/client-web';
-import type { ClickHouseConfig } from '../query-builder.js';
+import type {
+  ClickHouseAdapterConfig,
+  IntegerJsonEncoding,
+} from '../query-builder.js';
 import { isClientConfig } from '../query-builder.js';
 import { substituteParameters } from '../utils.js';
 import { getConnectionEndpoint } from '../utils/connection-endpoint.js';
@@ -16,7 +19,6 @@ import type { AutoClientModule } from '../env/auto-client.js';
 import { assertSafeInsertIdentifiers } from '../utils/insert-identifiers.js';
 import { consumeResultWithAbort } from '../utils/abortable-result.js';
 import { throwIfAborted } from '../utils/abort.js';
-import { logger } from '../utils/logger.js';
 import type { ClickHouseSettings } from '@clickhouse/client-common';
 
 type ClickHouseClient = NodeClickHouseClient | WebClickHouseClient;
@@ -24,22 +26,23 @@ type ClickHouseClient = NodeClickHouseClient | WebClickHouseClient;
 /**
  * The node and web clients return structurally different `ResultSet`s (the web
  * one lacks `log_error` and `Symbol.dispose`). Naming the union keeps it intact
- * through the readonly-retry wrapper, which would otherwise infer only the first
- * member and reject the other.
+ * through the readonly-guidance wrapper, which would otherwise infer only the
+ * first member and reject the other.
  */
 type QueryResultSet =
   | Awaited<ReturnType<NodeClickHouseClient['query']>>
   | Awaited<ReturnType<WebClickHouseClient['query']>>;
 
-function createClickHouseClient(config: ClickHouseConfig): ClickHouseClient {
+function createClickHouseClient(config: ClickHouseAdapterConfig): ClickHouseClient {
   if (isClientConfig(config)) {
     return config.client;
   }
   const clientModule: AutoClientModule = getAutoClientModule();
-  return clientModule.createClient(config);
+  const { integerJsonEncoding: _adapterOption, ...clientConfig } = config;
+  return clientModule.createClient(clientConfig);
 }
 
-function deriveNamespace(config: ClickHouseConfig): string {
+function deriveNamespace(config: ClickHouseAdapterConfig): string {
   if ('client' in config && config.client) {
     return 'client';
   }
@@ -83,13 +86,13 @@ export class ClickHouseAdapter implements DatabaseAdapter {
   private client: ClickHouseClient;
   /** Connection-level settings, so they can outrank the adapter's own defaults. */
   private readonly configSettings?: ClickHouseSettings;
-  /** Cleared when the server rejects the adapter-owned default. */
-  private quote64BitDefaultEnabled = true;
+  private readonly integerJsonEncoding: IntegerJsonEncoding;
 
-  constructor(private config: ClickHouseConfig) {
+  constructor(config: ClickHouseAdapterConfig) {
     this.namespace = deriveNamespace(config);
     this.client = createClickHouseClient(config);
     this.configSettings = config.clickhouse_settings;
+    this.integerJsonEncoding = config.integerJsonEncoding ?? 'quoted';
   }
 
   /**
@@ -98,7 +101,7 @@ export class ClickHouseAdapter implements DatabaseAdapter {
    * 64-bit-quoting flag, so a connection-level value could not override it.
    */
   private querySettings(optionSettings?: ClickHouseSettings): QuerySettingsAttempt {
-    const adapterDefaultApplied = this.quote64BitDefaultEnabled
+    const adapterDefaultApplied = this.integerJsonEncoding === 'quoted'
       && !hasQuote64BitSetting(this.configSettings)
       && !hasQuote64BitSetting(optionSettings);
 
@@ -114,14 +117,12 @@ export class ClickHouseAdapter implements DatabaseAdapter {
   }
 
   /**
-   * Retries only when this request included the adapter-owned default and the
-   * server specifically rejected it. Eligibility is captured before sending so
-   * overlapping initial requests can each retry after the shared default is
-   * disabled for future requests.
+   * Converts only rejections of the adapter-owned precision setting into an
+   * actionable configuration error. Caller-owned settings and unrelated
+   * readonly failures retain their original error identity.
    */
-  private async withReadonlyFallback<T>(
+  private async withReadonlyGuidance<T>(
     optionSettings: ClickHouseSettings | undefined,
-    abortSignal: AbortSignal | undefined,
     send: (settings: ClickHouseSettings) => Promise<T>,
   ): Promise<T> {
     const attempt = this.querySettings(optionSettings);
@@ -131,23 +132,14 @@ export class ClickHouseAdapter implements DatabaseAdapter {
     } catch (error) {
       if (!attempt.adapterDefaultApplied || !isReadonlyQuote64BitError(error)) throw error;
 
-      // The ClickHouse clients do not check an already-aborted signal. The
-      // caller may have cancelled while the first request was being rejected.
-      throwIfAborted(abortSignal);
-
-      const shouldWarn = this.quote64BitDefaultEnabled;
-      this.quote64BitDefaultEnabled = false;
-      if (shouldWarn) {
-        logger.warn(
-          `ClickHouse rejected '${QUOTE_64BIT}' under readonly mode; retrying without it. ` +
-          `Int64 and larger values will be returned as JSON numbers, which loses precision ` +
-          `beyond 2^53. Set '${QUOTE_64BIT}' explicitly in clickhouse_settings to silence this.`,
-        );
-      }
-
-      const retrySettings = { ...attempt.settings };
-      delete retrySettings[QUOTE_64BIT];
-      return await send(retrySettings);
+      throw new Error(
+        `ClickHouse rejected HypeQuery's precision-safe setting (${QUOTE_64BIT}=1) ` +
+        `because this connection uses readonly = 1. Set ` +
+        `integerJsonEncoding: 'server-default' in the HypeQuery adapter or query-builder ` +
+        `configuration to omit it. The server may then return Int64 and wider values as ` +
+        `JSON numbers, which lose precision beyond 2^53.`,
+        { cause: error },
+      );
     }
   }
 
@@ -155,9 +147,8 @@ export class ClickHouseAdapter implements DatabaseAdapter {
     // The ClickHouse clients never check an already-aborted signal, so fail before sending anything.
     throwIfAborted(options?.abortSignal);
     const finalSQL = substituteParameters(sql, params);
-    const result = await this.withReadonlyFallback<QueryResultSet>(
+    const result = await this.withReadonlyGuidance<QueryResultSet>(
       options?.clickhouseSettings,
-      options?.abortSignal,
       clickhouseSettings =>
         this.client.query({
           query: finalSQL,
@@ -179,11 +170,8 @@ export class ClickHouseAdapter implements DatabaseAdapter {
   async stream<T>(sql: string, params: unknown[] = [], options?: QueryExecutionOptions): Promise<ReadableStream<T[]>> {
     throwIfAborted(options?.abortSignal);
     const finalSQL = substituteParameters(sql, params);
-    // The settings error surfaces from client.query(), before any row is read,
-    // so retrying here cannot replay a partially consumed stream.
-    const result = await this.withReadonlyFallback<QueryResultSet>(
+    const result = await this.withReadonlyGuidance<QueryResultSet>(
       options?.clickhouseSettings,
-      options?.abortSignal,
       clickhouseSettings =>
         this.client.query({
           query: finalSQL,
@@ -235,6 +223,6 @@ export class ClickHouseAdapter implements DatabaseAdapter {
   }
 }
 
-export function createClickHouseAdapter(config: ClickHouseConfig): DatabaseAdapter {
+export function createClickHouseAdapter(config: ClickHouseAdapterConfig): DatabaseAdapter {
   return new ClickHouseAdapter(config);
 }

--- a/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
+++ b/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
@@ -16,9 +16,20 @@ import type { AutoClientModule } from '../env/auto-client.js';
 import { assertSafeInsertIdentifiers } from '../utils/insert-identifiers.js';
 import { consumeResultWithAbort } from '../utils/abortable-result.js';
 import { throwIfAborted } from '../utils/abort.js';
+import { logger } from '../utils/logger.js';
 import type { ClickHouseSettings } from '@clickhouse/client-common';
 
 type ClickHouseClient = NodeClickHouseClient | WebClickHouseClient;
+
+/**
+ * The node and web clients return structurally different `ResultSet`s (the web
+ * one lacks `log_error` and `Symbol.dispose`). Naming the union keeps it intact
+ * through the readonly-retry wrapper, which would otherwise infer only the first
+ * member and reject the other.
+ */
+type QueryResultSet =
+  | Awaited<ReturnType<NodeClickHouseClient['query']>>
+  | Awaited<ReturnType<WebClickHouseClient['query']>>;
 
 function createClickHouseClient(config: ClickHouseConfig): ClickHouseClient {
   if (isClientConfig(config)) {
@@ -38,48 +49,114 @@ function deriveNamespace(config: ClickHouseConfig): string {
   return `${endpoint || 'unknown-host'}|${database || 'default'}|${username || 'default'}`;
 }
 
-function jsonOutputSettings(settings?: ClickHouseSettings): ClickHouseSettings {
-  return {
-    // Matches generated Int64+ result types and prevents JSON.parse precision loss.
-    output_format_json_quote_64bit_integers: 1,
-    ...settings,
-  };
+const QUOTE_64BIT = 'output_format_json_quote_64bit_integers';
+
+/**
+ * ClickHouse rejects *any* session-setting change under `readonly = 1` with
+ * error code 164. Detect that so the adapter can drop the settings it injects
+ * itself and retry, rather than failing every query on a read-only connection.
+ */
+function isReadonlySettingsError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const { code, type } = error as { code?: unknown; type?: unknown };
+  if (code === '164' || code === 164 || type === 'READONLY') return true;
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' && /in readonly mode/i.test(message);
 }
 
 export class ClickHouseAdapter implements DatabaseAdapter {
   readonly name = 'clickhouse';
   readonly namespace?: string;
   private client: ClickHouseClient;
+  /** Connection-level settings, so they can outrank the adapter's own defaults. */
+  private readonly configSettings?: ClickHouseSettings;
+  /** Cleared the first time the server rejects it, so we retry at most once. */
+  private quote64BitIntegers = true;
 
   constructor(private config: ClickHouseConfig) {
     this.namespace = deriveNamespace(config);
     this.client = createClickHouseClient(config);
+    this.configSettings = config.clickhouse_settings;
+
+    // An explicit connection-level value is authoritative; never override or
+    // second-guess it.
+    if (this.configSettings && QUOTE_64BIT in this.configSettings) {
+      this.quote64BitIntegers = false;
+    }
+  }
+
+  /**
+   * Precedence: adapter default < connection `clickhouse_settings` < per-query
+   * settings. Previously the adapter's default was applied last for the
+   * 64-bit-quoting flag, so a connection-level value could not override it.
+   */
+  private querySettings(optionSettings?: ClickHouseSettings): ClickHouseSettings {
+    return {
+      // Matches generated Int64+ result types and prevents JSON.parse precision loss.
+      ...(this.quote64BitIntegers ? { [QUOTE_64BIT]: 1 } : {}),
+      ...this.configSettings,
+      ...optionSettings,
+    };
+  }
+
+  /**
+   * Runs `send`, and if the server rejects it purely because we asked to change
+   * a setting on a `readonly = 1` connection, drops our own default and retries
+   * once. The flag stays off for the life of the adapter, so a read-only
+   * connection pays this at most one round trip.
+   */
+  private async withReadonlyFallback<T>(send: () => Promise<T>): Promise<T> {
+    try {
+      return await send();
+    } catch (error) {
+      if (!this.quote64BitIntegers || !isReadonlySettingsError(error)) throw error;
+
+      this.quote64BitIntegers = false;
+      logger.warn(
+        `ClickHouse rejected '${QUOTE_64BIT}' under readonly mode; retrying without it. ` +
+        `Int64 and larger values will be returned as JSON numbers, which loses precision ` +
+        `beyond 2^53. Set '${QUOTE_64BIT}' explicitly in clickhouse_settings to silence this.`,
+      );
+      return await send();
+    }
   }
 
   async query<T>(sql: string, params: unknown[] = [], options?: QueryExecutionOptions): Promise<T[]> {
     // The ClickHouse clients never check an already-aborted signal, so fail before sending anything.
     throwIfAborted(options?.abortSignal);
     const finalSQL = substituteParameters(sql, params);
-    const result = await this.client.query({
-      query: finalSQL,
-      format: 'JSONEachRow',
-      clickhouse_settings: jsonOutputSettings(options?.clickhouseSettings),
-      query_id: options?.queryId,
-      abort_signal: options?.abortSignal,
-    });
-    return consumeResultWithAbort(options?.abortSignal, result, () => result.json<T>());
+    const result = await this.withReadonlyFallback<QueryResultSet>(() =>
+      this.client.query({
+        query: finalSQL,
+        format: 'JSONEachRow',
+        clickhouse_settings: this.querySettings(options?.clickhouseSettings),
+        query_id: options?.queryId,
+        abort_signal: options?.abortSignal,
+      }),
+    );
+    // The web client types `json()` as the union of every format's shape; with
+    // `format: 'JSONEachRow'` it is always a row array.
+    return consumeResultWithAbort(
+      options?.abortSignal,
+      result,
+      () => result.json<T>() as Promise<T[]>,
+    );
   }
 
   async stream<T>(sql: string, params: unknown[] = [], options?: QueryExecutionOptions): Promise<ReadableStream<T[]>> {
     throwIfAborted(options?.abortSignal);
     const finalSQL = substituteParameters(sql, params);
-    const result = await this.client.query({
-      query: finalSQL,
-      format: 'JSONEachRow',
-      clickhouse_settings: jsonOutputSettings(options?.clickhouseSettings),
-      query_id: options?.queryId,
-      abort_signal: options?.abortSignal,
-    });
+    // The settings error surfaces from client.query(), before any row is read,
+    // so retrying here cannot replay a partially consumed stream.
+    const result = await this.withReadonlyFallback<QueryResultSet>(() =>
+      this.client.query({
+        query: finalSQL,
+        format: 'JSONEachRow',
+        clickhouse_settings: this.querySettings(options?.clickhouseSettings),
+        query_id: options?.queryId,
+        abort_signal: options?.abortSignal,
+      }),
+    );
     const stream = result.stream();
     return createJsonEachRowStream<T>(stream as NodeJS.ReadableStream, options?.abortSignal);
   }

--- a/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
+++ b/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
@@ -10,18 +10,21 @@ import type {
   ClickHouseAdapterConfig,
   IntegerJsonEncoding,
 } from '../query-builder.js';
-import { isClientConfig } from '../query-builder.js';
 import { substituteParameters } from '../utils.js';
-import { getConnectionEndpoint } from '../utils/connection-endpoint.js';
 import { createJsonEachRowStream } from '../utils/streaming-helpers.js';
-import { getAutoClientModule } from '../env/auto-client.js';
-import type { AutoClientModule } from '../env/auto-client.js';
 import { assertSafeInsertIdentifiers } from '../utils/insert-identifiers.js';
 import { consumeResultWithAbort } from '../utils/abortable-result.js';
 import { throwIfAborted } from '../utils/abort.js';
+import {
+  createClickHouseClient,
+  deriveClickHouseNamespace,
+  type ClickHouseClient,
+} from '../utils/clickhouse-adapter-config.js';
+import {
+  buildIntegerJsonSettings,
+  createReadonlyIntegerJsonError,
+} from '../utils/integer-json-encoding.js';
 import type { ClickHouseSettings } from '@clickhouse/client-common';
-
-type ClickHouseClient = NodeClickHouseClient | WebClickHouseClient;
 
 /**
  * The node and web clients return structurally different `ResultSet`s (the web
@@ -33,53 +36,6 @@ type QueryResultSet =
   | Awaited<ReturnType<NodeClickHouseClient['query']>>
   | Awaited<ReturnType<WebClickHouseClient['query']>>;
 
-function createClickHouseClient(config: ClickHouseAdapterConfig): ClickHouseClient {
-  if (isClientConfig(config)) {
-    return config.client;
-  }
-  const clientModule: AutoClientModule = getAutoClientModule();
-  const { integerJsonEncoding: _adapterOption, ...clientConfig } = config;
-  return clientModule.createClient(clientConfig);
-}
-
-function deriveNamespace(config: ClickHouseAdapterConfig): string {
-  if ('client' in config && config.client) {
-    return 'client';
-  }
-  const endpoint = getConnectionEndpoint(config);
-  const database = 'database' in config ? config.database : 'default';
-  const username = 'username' in config ? config.username : 'default';
-  return `${endpoint || 'unknown-host'}|${database || 'default'}|${username || 'default'}`;
-}
-
-const QUOTE_64BIT = 'output_format_json_quote_64bit_integers';
-
-/**
- * Only attribute a readonly failure to the adapter default when ClickHouse
- * names that exact setting. Code 164 can also come from caller-owned settings
- * and forbidden operations, which must not disable precision-safe results.
- */
-function isReadonlyQuote64BitError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') return false;
-  const { code, type } = error as { code?: unknown; type?: unknown };
-  const message = (error as { message?: unknown }).message;
-  if (typeof message !== 'string' || !message.includes(QUOTE_64BIT)) return false;
-
-  return code === '164'
-    || code === 164
-    || type === 'READONLY'
-    || /in readonly mode/i.test(message);
-}
-
-function hasQuote64BitSetting(settings?: ClickHouseSettings): boolean {
-  return settings !== undefined && Object.prototype.hasOwnProperty.call(settings, QUOTE_64BIT);
-}
-
-interface QuerySettingsAttempt {
-  settings: ClickHouseSettings;
-  adapterDefaultApplied: boolean;
-}
-
 export class ClickHouseAdapter implements DatabaseAdapter {
   readonly name = 'clickhouse';
   readonly namespace?: string;
@@ -89,31 +45,10 @@ export class ClickHouseAdapter implements DatabaseAdapter {
   private readonly integerJsonEncoding: IntegerJsonEncoding;
 
   constructor(config: ClickHouseAdapterConfig) {
-    this.namespace = deriveNamespace(config);
+    this.namespace = deriveClickHouseNamespace(config);
     this.client = createClickHouseClient(config);
     this.configSettings = config.clickhouse_settings;
     this.integerJsonEncoding = config.integerJsonEncoding ?? 'quoted';
-  }
-
-  /**
-   * Precedence: adapter default < connection `clickhouse_settings` < per-query
-   * settings. Previously the adapter's default was applied last for the
-   * 64-bit-quoting flag, so a connection-level value could not override it.
-   */
-  private querySettings(optionSettings?: ClickHouseSettings): QuerySettingsAttempt {
-    const adapterDefaultApplied = this.integerJsonEncoding === 'quoted'
-      && !hasQuote64BitSetting(this.configSettings)
-      && !hasQuote64BitSetting(optionSettings);
-
-    return {
-      adapterDefaultApplied,
-      settings: {
-        // Matches generated Int64+ result types and prevents JSON.parse precision loss.
-        ...(adapterDefaultApplied ? { [QUOTE_64BIT]: 1 } : {}),
-        ...this.configSettings,
-        ...optionSettings,
-      },
-    };
   }
 
   /**
@@ -125,21 +60,20 @@ export class ClickHouseAdapter implements DatabaseAdapter {
     optionSettings: ClickHouseSettings | undefined,
     send: (settings: ClickHouseSettings) => Promise<T>,
   ): Promise<T> {
-    const attempt = this.querySettings(optionSettings);
+    const attempt = buildIntegerJsonSettings(
+      this.integerJsonEncoding,
+      this.configSettings,
+      optionSettings,
+    );
 
     try {
       return await send(attempt.settings);
     } catch (error) {
-      if (!attempt.adapterDefaultApplied || !isReadonlyQuote64BitError(error)) throw error;
-
-      throw new Error(
-        `ClickHouse rejected HypeQuery's precision-safe setting (${QUOTE_64BIT}=1) ` +
-        `because this connection uses readonly = 1. Set ` +
-        `integerJsonEncoding: 'server-default' in the HypeQuery adapter or query-builder ` +
-        `configuration to omit it. The server may then return Int64 and wider values as ` +
-        `JSON numbers, which lose precision beyond 2^53.`,
-        { cause: error },
+      const guidanceError = createReadonlyIntegerJsonError(
+        error,
+        attempt.adapterDefaultApplied,
       );
+      throw guidanceError ?? error;
     }
   }
 

--- a/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
+++ b/packages/clickhouse/src/core/adapters/clickhouse-adapter.ts
@@ -52,16 +52,29 @@ function deriveNamespace(config: ClickHouseConfig): string {
 const QUOTE_64BIT = 'output_format_json_quote_64bit_integers';
 
 /**
- * ClickHouse rejects *any* session-setting change under `readonly = 1` with
- * error code 164. Detect that so the adapter can drop the settings it injects
- * itself and retry, rather than failing every query on a read-only connection.
+ * Only attribute a readonly failure to the adapter default when ClickHouse
+ * names that exact setting. Code 164 can also come from caller-owned settings
+ * and forbidden operations, which must not disable precision-safe results.
  */
-function isReadonlySettingsError(error: unknown): boolean {
+function isReadonlyQuote64BitError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
   const { code, type } = error as { code?: unknown; type?: unknown };
-  if (code === '164' || code === 164 || type === 'READONLY') return true;
   const message = (error as { message?: unknown }).message;
-  return typeof message === 'string' && /in readonly mode/i.test(message);
+  if (typeof message !== 'string' || !message.includes(QUOTE_64BIT)) return false;
+
+  return code === '164'
+    || code === 164
+    || type === 'READONLY'
+    || /in readonly mode/i.test(message);
+}
+
+function hasQuote64BitSetting(settings?: ClickHouseSettings): boolean {
+  return settings !== undefined && Object.prototype.hasOwnProperty.call(settings, QUOTE_64BIT);
+}
+
+interface QuerySettingsAttempt {
+  settings: ClickHouseSettings;
+  adapterDefaultApplied: boolean;
 }
 
 export class ClickHouseAdapter implements DatabaseAdapter {
@@ -70,19 +83,13 @@ export class ClickHouseAdapter implements DatabaseAdapter {
   private client: ClickHouseClient;
   /** Connection-level settings, so they can outrank the adapter's own defaults. */
   private readonly configSettings?: ClickHouseSettings;
-  /** Cleared the first time the server rejects it, so we retry at most once. */
-  private quote64BitIntegers = true;
+  /** Cleared when the server rejects the adapter-owned default. */
+  private quote64BitDefaultEnabled = true;
 
   constructor(private config: ClickHouseConfig) {
     this.namespace = deriveNamespace(config);
     this.client = createClickHouseClient(config);
     this.configSettings = config.clickhouse_settings;
-
-    // An explicit connection-level value is authoritative; never override or
-    // second-guess it.
-    if (this.configSettings && QUOTE_64BIT in this.configSettings) {
-      this.quote64BitIntegers = false;
-    }
   }
 
   /**
@@ -90,34 +97,57 @@ export class ClickHouseAdapter implements DatabaseAdapter {
    * settings. Previously the adapter's default was applied last for the
    * 64-bit-quoting flag, so a connection-level value could not override it.
    */
-  private querySettings(optionSettings?: ClickHouseSettings): ClickHouseSettings {
+  private querySettings(optionSettings?: ClickHouseSettings): QuerySettingsAttempt {
+    const adapterDefaultApplied = this.quote64BitDefaultEnabled
+      && !hasQuote64BitSetting(this.configSettings)
+      && !hasQuote64BitSetting(optionSettings);
+
     return {
-      // Matches generated Int64+ result types and prevents JSON.parse precision loss.
-      ...(this.quote64BitIntegers ? { [QUOTE_64BIT]: 1 } : {}),
-      ...this.configSettings,
-      ...optionSettings,
+      adapterDefaultApplied,
+      settings: {
+        // Matches generated Int64+ result types and prevents JSON.parse precision loss.
+        ...(adapterDefaultApplied ? { [QUOTE_64BIT]: 1 } : {}),
+        ...this.configSettings,
+        ...optionSettings,
+      },
     };
   }
 
   /**
-   * Runs `send`, and if the server rejects it purely because we asked to change
-   * a setting on a `readonly = 1` connection, drops our own default and retries
-   * once. The flag stays off for the life of the adapter, so a read-only
-   * connection pays this at most one round trip.
+   * Retries only when this request included the adapter-owned default and the
+   * server specifically rejected it. Eligibility is captured before sending so
+   * overlapping initial requests can each retry after the shared default is
+   * disabled for future requests.
    */
-  private async withReadonlyFallback<T>(send: () => Promise<T>): Promise<T> {
-    try {
-      return await send();
-    } catch (error) {
-      if (!this.quote64BitIntegers || !isReadonlySettingsError(error)) throw error;
+  private async withReadonlyFallback<T>(
+    optionSettings: ClickHouseSettings | undefined,
+    abortSignal: AbortSignal | undefined,
+    send: (settings: ClickHouseSettings) => Promise<T>,
+  ): Promise<T> {
+    const attempt = this.querySettings(optionSettings);
 
-      this.quote64BitIntegers = false;
-      logger.warn(
-        `ClickHouse rejected '${QUOTE_64BIT}' under readonly mode; retrying without it. ` +
-        `Int64 and larger values will be returned as JSON numbers, which loses precision ` +
-        `beyond 2^53. Set '${QUOTE_64BIT}' explicitly in clickhouse_settings to silence this.`,
-      );
-      return await send();
+    try {
+      return await send(attempt.settings);
+    } catch (error) {
+      if (!attempt.adapterDefaultApplied || !isReadonlyQuote64BitError(error)) throw error;
+
+      // The ClickHouse clients do not check an already-aborted signal. The
+      // caller may have cancelled while the first request was being rejected.
+      throwIfAborted(abortSignal);
+
+      const shouldWarn = this.quote64BitDefaultEnabled;
+      this.quote64BitDefaultEnabled = false;
+      if (shouldWarn) {
+        logger.warn(
+          `ClickHouse rejected '${QUOTE_64BIT}' under readonly mode; retrying without it. ` +
+          `Int64 and larger values will be returned as JSON numbers, which loses precision ` +
+          `beyond 2^53. Set '${QUOTE_64BIT}' explicitly in clickhouse_settings to silence this.`,
+        );
+      }
+
+      const retrySettings = { ...attempt.settings };
+      delete retrySettings[QUOTE_64BIT];
+      return await send(retrySettings);
     }
   }
 
@@ -125,14 +155,17 @@ export class ClickHouseAdapter implements DatabaseAdapter {
     // The ClickHouse clients never check an already-aborted signal, so fail before sending anything.
     throwIfAborted(options?.abortSignal);
     const finalSQL = substituteParameters(sql, params);
-    const result = await this.withReadonlyFallback<QueryResultSet>(() =>
-      this.client.query({
-        query: finalSQL,
-        format: 'JSONEachRow',
-        clickhouse_settings: this.querySettings(options?.clickhouseSettings),
-        query_id: options?.queryId,
-        abort_signal: options?.abortSignal,
-      }),
+    const result = await this.withReadonlyFallback<QueryResultSet>(
+      options?.clickhouseSettings,
+      options?.abortSignal,
+      clickhouseSettings =>
+        this.client.query({
+          query: finalSQL,
+          format: 'JSONEachRow',
+          clickhouse_settings: clickhouseSettings,
+          query_id: options?.queryId,
+          abort_signal: options?.abortSignal,
+        }),
     );
     // The web client types `json()` as the union of every format's shape; with
     // `format: 'JSONEachRow'` it is always a row array.
@@ -148,14 +181,17 @@ export class ClickHouseAdapter implements DatabaseAdapter {
     const finalSQL = substituteParameters(sql, params);
     // The settings error surfaces from client.query(), before any row is read,
     // so retrying here cannot replay a partially consumed stream.
-    const result = await this.withReadonlyFallback<QueryResultSet>(() =>
-      this.client.query({
-        query: finalSQL,
-        format: 'JSONEachRow',
-        clickhouse_settings: this.querySettings(options?.clickhouseSettings),
-        query_id: options?.queryId,
-        abort_signal: options?.abortSignal,
-      }),
+    const result = await this.withReadonlyFallback<QueryResultSet>(
+      options?.clickhouseSettings,
+      options?.abortSignal,
+      clickhouseSettings =>
+        this.client.query({
+          query: finalSQL,
+          format: 'JSONEachRow',
+          clickhouse_settings: clickhouseSettings,
+          query_id: options?.queryId,
+          abort_signal: options?.abortSignal,
+        }),
     );
     const stream = result.stream();
     return createJsonEachRowStream<T>(stream as NodeJS.ReadableStream, options?.abortSignal);

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -158,6 +158,28 @@ export interface ClickHouseClientConfig extends ClickHouseConnectionOptions {
  */
 export type ClickHouseConfig = ClickHouseConnectionOptions | ClickHouseClientConfig;
 
+export type IntegerJsonEncoding = 'quoted' | 'server-default';
+
+/** Options owned by HypeQuery's built-in ClickHouse adapter. */
+export interface ClickHouseAdapterOptions {
+  /**
+   * Controls whether the adapter requests precision-safe JSON strings for
+   * `Int64` and wider values.
+   *
+   * - `quoted` (default) sends `output_format_json_quote_64bit_integers: 1`.
+   * - `server-default` omits that adapter-owned setting, which is required for
+   *   strict `readonly = 1` connections whose profile does not already enable
+   *   it. Such servers may return wide integers as precision-losing numbers.
+   *
+   * Explicit connection-level and per-query ClickHouse settings remain
+   * authoritative in either mode.
+   */
+  integerJsonEncoding?: IntegerJsonEncoding;
+}
+
+/** Configuration accepted by HypeQuery's built-in ClickHouse adapter. */
+export type ClickHouseAdapterConfig = ClickHouseConfig & ClickHouseAdapterOptions;
+
 /**
  * Type guard to check if a config is a client-based configuration.
  */
@@ -1237,7 +1259,7 @@ export type SelectQB<
 > = QueryBuilder<Schema, BuilderState<Schema, Tables, Output, BaseTable, {}>>;
 
 export type CreateQueryBuilderConfig =
-  | (ClickHouseConfig & {
+  | (ClickHouseAdapterConfig & {
     cache?: CacheConfig;
     adapter?: DatabaseAdapter;
     dialect?: SqlDialect;
@@ -1256,7 +1278,7 @@ export function createQueryBuilder<Schema extends SchemaDefinition<Schema>>(
     adapter?: DatabaseAdapter;
     dialect?: SqlDialect;
   };
-  const resolvedAdapter = adapter ?? createClickHouseAdapter(config as ClickHouseConfig);
+  const resolvedAdapter = adapter ?? createClickHouseAdapter(config as ClickHouseAdapterConfig);
   const resolvedDialect = dialect ?? new ClickHouseDialect();
   const namespace = cacheConfig?.namespace || resolvedAdapter.namespace || resolvedAdapter.name;
   const { runtime, cacheController } = initializeCacheRuntime(cacheConfig, namespace);

--- a/packages/clickhouse/src/core/tests/clickhouse-adapter.test.ts
+++ b/packages/clickhouse/src/core/tests/clickhouse-adapter.test.ts
@@ -356,105 +356,84 @@ describe('ClickHouseAdapter abort signals', () => {
         { code: '164', type: 'READONLY' },
       );
 
-    it('retries without the quoting setting when the server rejects it', async () => {
-      const jsonMock = vi.fn().mockResolvedValue([{ id: 1 }]);
-      const clientQueryMock = vi
-        .fn()
-        .mockRejectedValueOnce(readonlyError())
-        .mockResolvedValue({ json: jsonMock });
-
-      const adapter = new ClickHouseAdapter({
-        client: { query: clientQueryMock } as any,
-      });
-
-      const result = await adapter.query<{ id: number }>('SELECT 1');
-
-      expect(result).toEqual([{ id: 1 }]);
-      expect(clientQueryMock).toHaveBeenCalledTimes(2);
-      expect(clientQueryMock.mock.calls[0][0].clickhouse_settings).toEqual({
-        [QUOTE_64BIT]: 1,
-      });
-      expect(clientQueryMock.mock.calls[1][0].clickhouse_settings).toEqual({});
-    });
-
-    it('retries every overlapping request that sent the adapter default', async () => {
-      const jsonMock = vi.fn().mockResolvedValue([]);
-      let initialRequestCount = 0;
-      let releaseInitialRequests!: () => void;
-      const initialRequestsStarted = new Promise<void>(resolve => {
-        releaseInitialRequests = resolve;
-      });
-      const clientQueryMock = vi.fn().mockImplementation(async (
-        { clickhouse_settings: settings }: { clickhouse_settings: Record<string, unknown> },
-      ) => {
-        if (QUOTE_64BIT in settings) {
-          initialRequestCount += 1;
-          if (initialRequestCount === 2) releaseInitialRequests();
-          await initialRequestsStarted;
-          throw readonlyError();
-        }
-        return { json: jsonMock };
+    it('omits the adapter-owned quoting setting in server-default mode', async () => {
+      const clientQueryMock = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue([]),
       });
 
       const adapter = new ClickHouseAdapter({
         client: { query: clientQueryMock } as any,
-      });
-
-      await expect(Promise.all([
-        adapter.query('SELECT 1'),
-        adapter.query('SELECT 2'),
-      ])).resolves.toEqual([[], []]);
-
-      expect(clientQueryMock).toHaveBeenCalledTimes(4);
-      expect(clientQueryMock.mock.calls.filter(
-        ([request]) => QUOTE_64BIT in request.clickhouse_settings,
-      )).toHaveLength(2);
-      expect(clientQueryMock.mock.calls.filter(
-        ([request]) => !(QUOTE_64BIT in request.clickhouse_settings),
-      )).toHaveLength(2);
-    });
-
-    it('remembers the fallback so later queries do not retry', async () => {
-      const jsonMock = vi.fn().mockResolvedValue([]);
-      const clientQueryMock = vi
-        .fn()
-        .mockRejectedValueOnce(readonlyError())
-        .mockResolvedValue({ json: jsonMock });
-
-      const adapter = new ClickHouseAdapter({
-        client: { query: clientQueryMock } as any,
+        integerJsonEncoding: 'server-default',
       });
 
       await adapter.query('SELECT 1');
-      clientQueryMock.mockClear();
-      await adapter.query('SELECT 2');
 
-      // One call, already without the setting — a read-only connection pays the
-      // extra round trip once, not on every query.
       expect(clientQueryMock).toHaveBeenCalledTimes(1);
       expect(clientQueryMock.mock.calls[0][0].clickhouse_settings).toEqual({});
     });
 
-    it('does not retry errors unrelated to readonly settings', async () => {
-      const clientQueryMock = vi.fn().mockRejectedValue(new Error('connection refused'));
+    it('supports server-default mode through createQueryBuilder', async () => {
+      const clientQueryMock = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue([]),
+      });
+      const db = createQueryBuilder<{ events: { id: 'UInt64' } }>({
+        client: { query: clientQueryMock } as any,
+        integerJsonEncoding: 'server-default',
+      });
+
+      await db.rawQuery('SELECT id FROM events');
+
+      expect(clientQueryMock.mock.calls[0][0].clickhouse_settings).toEqual({});
+    });
+
+    it('preserves explicit settings in server-default mode', async () => {
+      const clientQueryMock = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue([]),
+      });
+
+      const adapter = new ClickHouseAdapter({
+        client: { query: clientQueryMock } as any,
+        integerJsonEncoding: 'server-default',
+        clickhouse_settings: { max_execution_time: 30 },
+      });
+
+      await adapter.query('SELECT 1', [], {
+        clickhouseSettings: { final: 1 },
+      });
+
+      expect(clientQueryMock.mock.calls[0][0].clickhouse_settings).toEqual({
+        max_execution_time: 30,
+        final: 1,
+      });
+    });
+
+    it('returns actionable guidance instead of retrying the adapter setting', async () => {
+      const cause = readonlyError();
+      const clientQueryMock = vi.fn().mockRejectedValue(cause);
 
       const adapter = new ClickHouseAdapter({
         client: { query: clientQueryMock } as any,
       });
 
-      await expect(adapter.query('SELECT 1')).rejects.toThrow('connection refused');
+      let error: unknown;
+      try {
+        await adapter.query('SELECT 1');
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("integerJsonEncoding: 'server-default'");
+      expect((error as Error).cause).toBe(cause);
       expect(clientQueryMock).toHaveBeenCalledTimes(1);
     });
 
-    it('does not disable quoting for a readonly error caused by another setting', async () => {
+    it('preserves readonly errors caused by another setting', async () => {
       const error = Object.assign(
         new Error("Cannot modify 'max_execution_time' setting in readonly mode."),
         { code: '164', type: 'READONLY' },
       );
-      const clientQueryMock = vi
-        .fn()
-        .mockRejectedValueOnce(error)
-        .mockResolvedValue({ json: vi.fn().mockResolvedValue([]) });
+      const clientQueryMock = vi.fn().mockRejectedValue(error);
 
       const adapter = new ClickHouseAdapter({
         client: { query: clientQueryMock } as any,
@@ -462,20 +441,11 @@ describe('ClickHouseAdapter abort signals', () => {
 
       await expect(adapter.query('SELECT 1')).rejects.toBe(error);
       expect(clientQueryMock).toHaveBeenCalledTimes(1);
-
-      await adapter.query('SELECT 2');
-
-      expect(clientQueryMock.mock.calls[1][0].clickhouse_settings).toEqual({
-        [QUOTE_64BIT]: 1,
-      });
     });
 
-    it('does not retry or disable a caller-owned quoting setting', async () => {
+    it('preserves errors for a caller-owned quoting setting', async () => {
       const error = readonlyError();
-      const clientQueryMock = vi
-        .fn()
-        .mockRejectedValueOnce(error)
-        .mockResolvedValue({ json: vi.fn().mockResolvedValue([]) });
+      const clientQueryMock = vi.fn().mockRejectedValue(error);
 
       const adapter = new ClickHouseAdapter({
         client: { query: clientQueryMock } as any,
@@ -484,29 +454,6 @@ describe('ClickHouseAdapter abort signals', () => {
       await expect(adapter.query('SELECT 1', [], {
         clickhouseSettings: { [QUOTE_64BIT]: 0 },
       })).rejects.toBe(error);
-      expect(clientQueryMock).toHaveBeenCalledTimes(1);
-
-      await adapter.query('SELECT 2');
-
-      expect(clientQueryMock.mock.calls[1][0].clickhouse_settings).toEqual({
-        [QUOTE_64BIT]: 1,
-      });
-    });
-
-    it('does not retry after the caller aborts the failed request', async () => {
-      const controller = new AbortController();
-      const clientQueryMock = vi.fn().mockImplementationOnce(() => {
-        controller.abort(new Error('caller went away'));
-        return Promise.reject(readonlyError());
-      });
-
-      const adapter = new ClickHouseAdapter({
-        client: { query: clientQueryMock } as any,
-      });
-
-      await expect(adapter.query('SELECT 1', [], {
-        abortSignal: controller.signal,
-      })).rejects.toThrow('caller went away');
       expect(clientQueryMock).toHaveBeenCalledTimes(1);
     });
 
@@ -521,8 +468,7 @@ describe('ClickHouseAdapter abort signals', () => {
 
       await adapter.query('SELECT 1');
 
-      // Explicit config wins, and no retry is attempted because we never sent
-      // a value the caller did not ask for.
+      // Explicit config wins because the adapter default has lower precedence.
       expect(clientQueryMock).toHaveBeenCalledTimes(1);
       expect(clientQueryMock.mock.calls[0][0].clickhouse_settings).toEqual({
         [QUOTE_64BIT]: 0,

--- a/packages/clickhouse/src/core/tests/clickhouse-adapter.test.ts
+++ b/packages/clickhouse/src/core/tests/clickhouse-adapter.test.ts
@@ -377,6 +377,43 @@ describe('ClickHouseAdapter abort signals', () => {
       expect(clientQueryMock.mock.calls[1][0].clickhouse_settings).toEqual({});
     });
 
+    it('retries every overlapping request that sent the adapter default', async () => {
+      const jsonMock = vi.fn().mockResolvedValue([]);
+      let initialRequestCount = 0;
+      let releaseInitialRequests!: () => void;
+      const initialRequestsStarted = new Promise<void>(resolve => {
+        releaseInitialRequests = resolve;
+      });
+      const clientQueryMock = vi.fn().mockImplementation(async (
+        { clickhouse_settings: settings }: { clickhouse_settings: Record<string, unknown> },
+      ) => {
+        if (QUOTE_64BIT in settings) {
+          initialRequestCount += 1;
+          if (initialRequestCount === 2) releaseInitialRequests();
+          await initialRequestsStarted;
+          throw readonlyError();
+        }
+        return { json: jsonMock };
+      });
+
+      const adapter = new ClickHouseAdapter({
+        client: { query: clientQueryMock } as any,
+      });
+
+      await expect(Promise.all([
+        adapter.query('SELECT 1'),
+        adapter.query('SELECT 2'),
+      ])).resolves.toEqual([[], []]);
+
+      expect(clientQueryMock).toHaveBeenCalledTimes(4);
+      expect(clientQueryMock.mock.calls.filter(
+        ([request]) => QUOTE_64BIT in request.clickhouse_settings,
+      )).toHaveLength(2);
+      expect(clientQueryMock.mock.calls.filter(
+        ([request]) => !(QUOTE_64BIT in request.clickhouse_settings),
+      )).toHaveLength(2);
+    });
+
     it('remembers the fallback so later queries do not retry', async () => {
       const jsonMock = vi.fn().mockResolvedValue([]);
       const clientQueryMock = vi
@@ -406,6 +443,70 @@ describe('ClickHouseAdapter abort signals', () => {
       });
 
       await expect(adapter.query('SELECT 1')).rejects.toThrow('connection refused');
+      expect(clientQueryMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not disable quoting for a readonly error caused by another setting', async () => {
+      const error = Object.assign(
+        new Error("Cannot modify 'max_execution_time' setting in readonly mode."),
+        { code: '164', type: 'READONLY' },
+      );
+      const clientQueryMock = vi
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue({ json: vi.fn().mockResolvedValue([]) });
+
+      const adapter = new ClickHouseAdapter({
+        client: { query: clientQueryMock } as any,
+      });
+
+      await expect(adapter.query('SELECT 1')).rejects.toBe(error);
+      expect(clientQueryMock).toHaveBeenCalledTimes(1);
+
+      await adapter.query('SELECT 2');
+
+      expect(clientQueryMock.mock.calls[1][0].clickhouse_settings).toEqual({
+        [QUOTE_64BIT]: 1,
+      });
+    });
+
+    it('does not retry or disable a caller-owned quoting setting', async () => {
+      const error = readonlyError();
+      const clientQueryMock = vi
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValue({ json: vi.fn().mockResolvedValue([]) });
+
+      const adapter = new ClickHouseAdapter({
+        client: { query: clientQueryMock } as any,
+      });
+
+      await expect(adapter.query('SELECT 1', [], {
+        clickhouseSettings: { [QUOTE_64BIT]: 0 },
+      })).rejects.toBe(error);
+      expect(clientQueryMock).toHaveBeenCalledTimes(1);
+
+      await adapter.query('SELECT 2');
+
+      expect(clientQueryMock.mock.calls[1][0].clickhouse_settings).toEqual({
+        [QUOTE_64BIT]: 1,
+      });
+    });
+
+    it('does not retry after the caller aborts the failed request', async () => {
+      const controller = new AbortController();
+      const clientQueryMock = vi.fn().mockImplementationOnce(() => {
+        controller.abort(new Error('caller went away'));
+        return Promise.reject(readonlyError());
+      });
+
+      const adapter = new ClickHouseAdapter({
+        client: { query: clientQueryMock } as any,
+      });
+
+      await expect(adapter.query('SELECT 1', [], {
+        abortSignal: controller.signal,
+      })).rejects.toThrow('caller went away');
       expect(clientQueryMock).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/clickhouse/src/core/tests/clickhouse-adapter.test.ts
+++ b/packages/clickhouse/src/core/tests/clickhouse-adapter.test.ts
@@ -345,4 +345,107 @@ describe('ClickHouseAdapter abort signals', () => {
 
     await expect(pending).rejects.toThrow('The user aborted a request.');
   });
+
+  describe('readonly connections', () => {
+    const QUOTE_64BIT = 'output_format_json_quote_64bit_integers';
+
+    /** What @clickhouse/client throws under `readonly = 1`. */
+    const readonlyError = () =>
+      Object.assign(
+        new Error(`Cannot modify '${QUOTE_64BIT}' setting in readonly mode. `),
+        { code: '164', type: 'READONLY' },
+      );
+
+    it('retries without the quoting setting when the server rejects it', async () => {
+      const jsonMock = vi.fn().mockResolvedValue([{ id: 1 }]);
+      const clientQueryMock = vi
+        .fn()
+        .mockRejectedValueOnce(readonlyError())
+        .mockResolvedValue({ json: jsonMock });
+
+      const adapter = new ClickHouseAdapter({
+        client: { query: clientQueryMock } as any,
+      });
+
+      const result = await adapter.query<{ id: number }>('SELECT 1');
+
+      expect(result).toEqual([{ id: 1 }]);
+      expect(clientQueryMock).toHaveBeenCalledTimes(2);
+      expect(clientQueryMock.mock.calls[0][0].clickhouse_settings).toEqual({
+        [QUOTE_64BIT]: 1,
+      });
+      expect(clientQueryMock.mock.calls[1][0].clickhouse_settings).toEqual({});
+    });
+
+    it('remembers the fallback so later queries do not retry', async () => {
+      const jsonMock = vi.fn().mockResolvedValue([]);
+      const clientQueryMock = vi
+        .fn()
+        .mockRejectedValueOnce(readonlyError())
+        .mockResolvedValue({ json: jsonMock });
+
+      const adapter = new ClickHouseAdapter({
+        client: { query: clientQueryMock } as any,
+      });
+
+      await adapter.query('SELECT 1');
+      clientQueryMock.mockClear();
+      await adapter.query('SELECT 2');
+
+      // One call, already without the setting — a read-only connection pays the
+      // extra round trip once, not on every query.
+      expect(clientQueryMock).toHaveBeenCalledTimes(1);
+      expect(clientQueryMock.mock.calls[0][0].clickhouse_settings).toEqual({});
+    });
+
+    it('does not retry errors unrelated to readonly settings', async () => {
+      const clientQueryMock = vi.fn().mockRejectedValue(new Error('connection refused'));
+
+      const adapter = new ClickHouseAdapter({
+        client: { query: clientQueryMock } as any,
+      });
+
+      await expect(adapter.query('SELECT 1')).rejects.toThrow('connection refused');
+      expect(clientQueryMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets connection-level clickhouse_settings override the adapter default', async () => {
+      const jsonMock = vi.fn().mockResolvedValue([]);
+      const clientQueryMock = vi.fn().mockResolvedValue({ json: jsonMock });
+
+      const adapter = new ClickHouseAdapter({
+        client: { query: clientQueryMock } as any,
+        clickhouse_settings: { [QUOTE_64BIT]: 0, max_execution_time: 30 },
+      });
+
+      await adapter.query('SELECT 1');
+
+      // Explicit config wins, and no retry is attempted because we never sent
+      // a value the caller did not ask for.
+      expect(clientQueryMock).toHaveBeenCalledTimes(1);
+      expect(clientQueryMock.mock.calls[0][0].clickhouse_settings).toEqual({
+        [QUOTE_64BIT]: 0,
+        max_execution_time: 30,
+      });
+    });
+
+    it('keeps per-query settings ahead of connection-level ones', async () => {
+      const jsonMock = vi.fn().mockResolvedValue([]);
+      const clientQueryMock = vi.fn().mockResolvedValue({ json: jsonMock });
+
+      const adapter = new ClickHouseAdapter({
+        client: { query: clientQueryMock } as any,
+        clickhouse_settings: { max_execution_time: 30 },
+      });
+
+      await adapter.query('SELECT 1', [], {
+        clickhouseSettings: { max_execution_time: 5 },
+      });
+
+      expect(clientQueryMock.mock.calls[0][0].clickhouse_settings).toEqual({
+        [QUOTE_64BIT]: 1,
+        max_execution_time: 5,
+      });
+    });
+  });
 });

--- a/packages/clickhouse/src/core/utils/clickhouse-adapter-config.ts
+++ b/packages/clickhouse/src/core/utils/clickhouse-adapter-config.ts
@@ -1,0 +1,30 @@
+import type { ClickHouseClient as NodeClickHouseClient } from '@clickhouse/client';
+import type { ClickHouseClient as WebClickHouseClient } from '@clickhouse/client-web';
+import type { ClickHouseAdapterConfig } from '../query-builder.js';
+import { isClientConfig } from '../query-builder.js';
+import { getAutoClientModule } from '../env/auto-client.js';
+import type { AutoClientModule } from '../env/auto-client.js';
+import { getConnectionEndpoint } from './connection-endpoint.js';
+
+export type ClickHouseClient = NodeClickHouseClient | WebClickHouseClient;
+
+export function createClickHouseClient(config: ClickHouseAdapterConfig): ClickHouseClient {
+  if (isClientConfig(config)) {
+    return config.client;
+  }
+
+  const clientModule: AutoClientModule = getAutoClientModule();
+  const { integerJsonEncoding: _adapterOption, ...clientConfig } = config;
+  return clientModule.createClient(clientConfig);
+}
+
+export function deriveClickHouseNamespace(config: ClickHouseAdapterConfig): string {
+  if ('client' in config && config.client) {
+    return 'client';
+  }
+
+  const endpoint = getConnectionEndpoint(config);
+  const database = 'database' in config ? config.database : 'default';
+  const username = 'username' in config ? config.username : 'default';
+  return `${endpoint || 'unknown-host'}|${database || 'default'}|${username || 'default'}`;
+}

--- a/packages/clickhouse/src/core/utils/integer-json-encoding.ts
+++ b/packages/clickhouse/src/core/utils/integer-json-encoding.ts
@@ -1,0 +1,69 @@
+import type { ClickHouseSettings } from '@clickhouse/client-common';
+import type { IntegerJsonEncoding } from '../query-builder.js';
+
+const QUOTE_64BIT = 'output_format_json_quote_64bit_integers';
+
+export interface IntegerJsonSettingsAttempt {
+  settings: ClickHouseSettings;
+  adapterDefaultApplied: boolean;
+}
+
+function hasQuote64BitSetting(settings?: ClickHouseSettings): boolean {
+  return settings !== undefined && Object.prototype.hasOwnProperty.call(settings, QUOTE_64BIT);
+}
+
+/**
+ * Applies the adapter default without overriding connection-level or per-query
+ * settings, and records whether the final value belongs to the adapter.
+ */
+export function buildIntegerJsonSettings(
+  encoding: IntegerJsonEncoding,
+  configSettings?: ClickHouseSettings,
+  optionSettings?: ClickHouseSettings,
+): IntegerJsonSettingsAttempt {
+  const adapterDefaultApplied = encoding === 'quoted'
+    && !hasQuote64BitSetting(configSettings)
+    && !hasQuote64BitSetting(optionSettings);
+
+  return {
+    adapterDefaultApplied,
+    settings: {
+      ...(adapterDefaultApplied ? { [QUOTE_64BIT]: 1 } : {}),
+      ...configSettings,
+      ...optionSettings,
+    },
+  };
+}
+
+/**
+ * Returns guidance only when ClickHouse rejected the adapter-owned precision
+ * setting. Code 164 can also represent caller-owned settings and forbidden
+ * operations, whose original errors must be preserved.
+ */
+export function createReadonlyIntegerJsonError(
+  error: unknown,
+  adapterDefaultApplied: boolean,
+): Error | undefined {
+  if (!adapterDefaultApplied || !isReadonlyQuote64BitError(error)) return undefined;
+
+  return new Error(
+    `ClickHouse rejected HypeQuery's precision-safe setting (${QUOTE_64BIT}=1) ` +
+    `because this connection uses readonly = 1. Set ` +
+    `integerJsonEncoding: 'server-default' in the HypeQuery adapter or query-builder ` +
+    `configuration to omit it. The server may then return Int64 and wider values as ` +
+    `JSON numbers, which lose precision beyond 2^53.`,
+    { cause: error },
+  );
+}
+
+function isReadonlyQuote64BitError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const { code, type } = error as { code?: unknown; type?: unknown };
+  const message = (error as { message?: unknown }).message;
+  if (typeof message !== 'string' || !message.includes(QUOTE_64BIT)) return false;
+
+  return code === '164'
+    || code === 164
+    || type === 'READONLY'
+    || /in readonly mode/i.test(message);
+}

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -18,9 +18,12 @@ export type { SqlDialect } from './core/dialects/sql-dialect.js';
 // Re-export types for convenience
 export type {
   ClickHouseConfig,
+  ClickHouseAdapterConfig,
+  ClickHouseAdapterOptions,
   ClickHouseClientConfig,
   CreateQueryBuilderConfig,
   ExecuteOptions,
+  IntegerJsonEncoding,
   StreamOptions
 } from './core/query-builder.js';
 export { isClientConfig } from './core/query-builder.js';

--- a/website-next/docs/reference/clickhouse-behavior.mdx
+++ b/website-next/docs/reference/clickhouse-behavior.mdx
@@ -130,6 +130,35 @@ Common examples:
 
 One important caveat: JavaScript numbers can lose precision for larger decimal values even when ClickHouse stored them exactly.
 
+## 64-bit integer encoding and strict read-only users
+
+The built-in adapter requests quoted JSON values for `Int64` and wider integer
+types. This prevents precision loss beyond JavaScript's safe integer range and
+keeps runtime values aligned with the generated `string` types.
+
+A ClickHouse user with `readonly = 1` can reject that request when its effective
+profile does not already enable quoted integers. For such a connection, opt into
+the profile's existing behavior explicitly:
+
+```ts
+const db = createQueryBuilder<IntrospectedSchema>({
+  url: process.env.CLICKHOUSE_URL!,
+  username: process.env.CLICKHOUSE_USERNAME!,
+  password: process.env.CLICKHOUSE_PASSWORD ?? '',
+  integerJsonEncoding: 'server-default',
+});
+```
+
+`server-default` omits the adapter-owned
+`output_format_json_quote_64bit_integers` setting rather than sending `0`. It
+does not probe the server or retry the query, and explicit `clickhouse_settings`
+are still passed through unchanged.
+
+The tradeoff is that the server may return wide integers as JavaScript numbers.
+Values beyond `2^53` can then lose precision and may not match the generated
+`string` types. When possible, configuring the read-only user's ClickHouse
+profile to quote wide integers preserves the default precision-safe behavior.
+
 ## Practical guidance
 
 If you are deciding where something belongs, the usual rules are:


### PR DESCRIPTION
Sixth PR from the Next.js/ClickHouse Cloud friction audit.

## The problem

The built-in adapter requests `output_format_json_quote_64bit_integers: 1` with every query. That keeps `Int64` and wider values precise in JavaScript and matches HypeQuery's generated `string` types.

A ClickHouse user with `readonly = 1` rejects that request when the setting differs from the user's effective profile:

```
Cannot modify 'output_format_json_quote_64bit_integers' setting in readonly mode.
Code: 164, type: READONLY
```

This is common for ClickHouse Cloud, BI, and dashboard accounts. Previously, connection-level `clickhouse_settings` also could not override the adapter default because the adapter applied its value last.

## The change

**1. Explicit integer JSON encoding.** The new adapter option defaults to the existing precision-safe behavior:

```ts
integerJsonEncoding: 'quoted'
```

Strict read-only users can opt into:

```ts
integerJsonEncoding: 'server-default'
```

That omits the adapter-owned setting entirely. It does not send `0`, probe the server, retry a query, or keep mutable capability state.

**2. Actionable failure.** If ClickHouse specifically rejects the adapter-owned quoting setting, HypeQuery returns an error explaining the `server-default` option. Caller-owned settings and unrelated `READONLY` errors retain their original error identity.

**3. Correct precedence.** Adapter default < connection `clickhouse_settings` < per-query settings. Explicit caller values are never replaced or reinterpreted.

The adapter-only option is scoped to `createQueryBuilder` and `ClickHouseAdapter` and is stripped before constructing the underlying ClickHouse client.

## Tradeoff

`server-default` is deliberately explicit. Depending on the ClickHouse version and user profile, `Int64` and wider values may arrive as JavaScript numbers, lose precision beyond `2^53`, and no longer match generated string types. Administrators can instead enable quoted integers in the read-only user's profile and retain the default safe mode.

## Verification

- 664 unit tests across 33 files
- Type tests
- ESLint
- ClickHouse package build

Coverage includes the default safe mode, `server-default` through both `ClickHouseAdapter` and `createQueryBuilder`, connection/per-query precedence, actionable errors, and preservation of unrelated or caller-owned failures.
