### PR TITLE
fix(cli): read .env.local, report accurate counts, align output paths

### DIFF
--- a/.changeset/lucky-hounds-smile.md
+++ b/.changeset/lucky-hounds-smile.md
@@ -16,8 +16,10 @@ all of them, so existing `.env`-only setups are unaffected.
 **Reports the number of tables generated, not discovered.** `generate --tables
 ontime` against a 79-table database printed `Found 79 tables` and `Generated
 types for 79 tables` while correctly generating exactly one. The filter worked;
-the message made it look broken. Both commands now say
-`Found 79 tables, filtering to 1` and `Generated types for 1 table`.
+the message made it look broken. The generator now reports the tables it actually
+wrote, so duplicate or nonexistent requested names cannot inflate the count. The
+command says `Found 79 tables, applying --tables filter` and `Generated types for
+1 table`.
 
 **`generate:datasets` defaults to `analytics/datasets.ts`.** It previously wrote
 `src/datasets/generated.ts` while its sibling `generate` wrote

--- a/.changeset/lucky-hounds-smile.md
+++ b/.changeset/lucky-hounds-smile.md
@@ -1,0 +1,33 @@
+---
+"@hypequery/cli": minor
+---
+
+Four CLI fixes found while setting up a Next.js project.
+
+**Reads `.env.local`.** The CLI loaded only `.env`, so a Next.js or Vite project
+with its ClickHouse credentials in `.env.local` — the convention those frameworks
+use, and the file the app itself reads — could not connect. Worse, the failure
+was reported as `Unable to detect database type. Re-run with --database`, which
+sends you after the wrong problem entirely. The CLI now reads the same cascade
+those frameworks do, most specific first: `.env.$NODE_ENV.local`, `.env.local`,
+`.env.$NODE_ENV`, `.env`. Earlier files win and real environment variables beat
+all of them, so existing `.env`-only setups are unaffected.
+
+**Reports the number of tables generated, not discovered.** `generate --tables
+ontime` against a 79-table database printed `Found 79 tables` and `Generated
+types for 79 tables` while correctly generating exactly one. The filter worked;
+the message made it look broken. Both commands now say
+`Found 79 tables, filtering to 1` and `Generated types for 1 table`.
+
+**`generate:datasets` defaults to `analytics/datasets.ts`.** It previously wrote
+`src/datasets/generated.ts` while its sibling `generate` wrote
+`analytics/schema.ts`, splitting generated output across two trees. The new
+default matches the docs, matches `generate`, and matches `findDatasetsFile`,
+which already searched `analytics/datasets.ts` first. **This changes where the
+command writes when neither `--output` nor `--path` is given**; pass
+`--output src/datasets/generated.ts` to keep the old location.
+
+**The "Next steps" example matches the generated file.** It was hardcoded to
+`import { datasets } from './datasets/generated'` and `datasets.orders`,
+regardless of where the file went or which tables were in it. It now uses the
+real import path and the first real dataset name, so it can be pasted as-is.

--- a/packages/cli/src/bin/cli.ts
+++ b/packages/cli/src/bin/cli.ts
@@ -1,13 +1,16 @@
 #!/usr/bin/env node
 
 import { program } from '../cli.js';
+import { envFiles } from '../utils/env-files.js';
 
 async function loadEnv() {
   try {
     const dotenvx = await import('@dotenvx/dotenvx');
     if (dotenvx?.config && typeof dotenvx.config.load === 'function') {
       await dotenvx.config.load();
-      return;
+      // Deliberately falls through to the dotenv cascade below. dotenvx has
+      // already set whatever it found, and dotenv will not overwrite it, so this
+      // only fills in files dotenvx does not read (notably `.env.local`).
     }
   } catch {
     // Optional dependency, ignore if missing
@@ -15,7 +18,10 @@ async function loadEnv() {
 
   try {
     const { config } = await import('dotenv');
-    config();
+    for (const path of envFiles(process.env.NODE_ENV)) {
+      // Missing files are a no-op.
+      config({ path });
+    }
   } catch {
     // dotenv is optional; continue if not available
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -175,7 +175,7 @@ addTypeGenerationOptions(program.command('generate:types'))
 program
   .command('generate:datasets')
   .description('Generate dataset definitions from ClickHouse schema')
-  .option('-o, --output <path>', 'Output file (default: src/datasets/generated.ts)')
+  .option('-o, --output <path>', 'Output file (default: analytics/datasets.ts)')
   .option('--path <path>', 'Analytics directory (derives <path>/datasets.ts)')
   .option('--tables <names>', 'Only generate for specific tables (comma-separated)')
   .option('--exclude-tables <names>', 'Exclude specific tables (comma-separated)')

--- a/packages/cli/src/commands/generate-datasets.test.ts
+++ b/packages/cli/src/commands/generate-datasets.test.ts
@@ -44,7 +44,10 @@ describe('generate datasets command', () => {
     exitHandler = mockProcessExit();
     vi.clearAllMocks();
     vi.mocked(detectDb.getTableCount).mockResolvedValue(10);
-    mockGenerateDatasets.mockResolvedValue(undefined);
+    mockGenerateDatasets.mockResolvedValue({
+      tables: ['orders'],
+      exports: [{ table: 'orders', exportName: 'OrdersDataset' }],
+    });
   });
 
   afterEach(() => {
@@ -80,6 +83,44 @@ describe('generate datasets command', () => {
         includeTables: ['orders', 'customers'],
         excludeTables: ['orders_archive'],
       }),
+    );
+  });
+
+  it('defaults output to analytics/datasets.ts, beside generate\'s schema.ts', async () => {
+    await generateDatasetsCommand({});
+
+    expect(mockGenerateDatasets).toHaveBeenCalledWith(
+      expect.objectContaining({ outputPath: expect.stringContaining('analytics/datasets.ts') }),
+    );
+  });
+
+  it('reports the number of tables generated, not the number discovered', async () => {
+    // 10 tables exist; only one is generated.
+    mockGenerateDatasets.mockResolvedValue({
+      tables: ['orders'],
+      exports: [{ table: 'orders', exportName: 'OrdersDataset' }],
+    });
+
+    await generateDatasetsCommand({ tables: 'orders' });
+
+    expect(mockLogger.success).toHaveBeenCalledWith('Found 10 tables, filtering to 1');
+  });
+
+  it('prints an example that matches the file it wrote', async () => {
+    mockGenerateDatasets.mockResolvedValue({
+      tables: ['trips'],
+      exports: [{ table: 'trips', exportName: 'TripsDataset' }],
+    });
+
+    await generateDatasetsCommand({ output: 'src/analytics/datasets.ts', tables: 'trips' });
+
+    // Real import path, real table name — previously both were hardcoded to
+    // './datasets/generated' and `datasets.orders`, neither of which existed.
+    expect(mockLogger.indent).toHaveBeenCalledWith(
+      "import { datasets } from './src/analytics/datasets';",
+    );
+    expect(mockLogger.indent).toHaveBeenCalledWith(
+      "const rowCount = datasets['trips'].metric('rowCount', { measure: 'totalCount' });",
     );
   });
 

--- a/packages/cli/src/commands/generate-datasets.ts
+++ b/packages/cli/src/commands/generate-datasets.ts
@@ -19,6 +19,16 @@ export interface GenerateDatasetsOptions {
   excludeTables?: string;
 }
 
+/**
+ * Turns the written path into something pasteable into an import statement:
+ * strips the `.ts` extension and makes it explicitly relative.
+ */
+function toImportSpecifier(relativePath: string): string {
+  const withoutExtension = relativePath.replace(/\.tsx?$/, '');
+  const normalized = withoutExtension.split(path.sep).join('/');
+  return normalized.startsWith('.') ? normalized : `./${normalized}`;
+}
+
 function parseTableList(value: string | undefined): string[] | undefined {
   const parsed = value
     ?.split(',')
@@ -37,8 +47,9 @@ export async function generateDatasetsCommand(options: GenerateDatasetsOptions =
   } else if (options.path) {
     outputPath = path.resolve(process.cwd(), options.path, 'datasets.ts');
   } else {
-    // Default to src/datasets/generated.ts
-    outputPath = path.join(process.cwd(), 'src', 'datasets', 'generated.ts');
+    // Sibling of `hypequery generate`, which writes analytics/schema.ts. Keeping
+    // both commands in one directory is what the docs have always described.
+    outputPath = path.join(process.cwd(), 'analytics', 'datasets.ts');
   }
 
   const parsedTables = parseTableList(options.tables);
@@ -54,20 +65,29 @@ export async function generateDatasetsCommand(options: GenerateDatasetsOptions =
     const tableCount = await getTableCount('clickhouse');
     spinner.succeed('Connected to ClickHouse');
 
-    logger.success(`Found ${tableCount} tables`);
+    logger.success(
+      parsedTables
+        ? `Found ${tableCount} tables, filtering to ${parsedTables.length}`
+        : `Found ${tableCount} tables`,
+    );
 
     // Generate datasets
     const datasetSpinner = ora('Generating dataset definitions...').start();
 
-    await generateDatasets({
+    const generated = await generateDatasets({
       outputPath,
       includeTables: parsedTables,
       excludeTables: excludedTables,
     });
 
-    datasetSpinner.succeed(`Generated dataset definitions for ${parsedTables?.length || tableCount} tables`);
+    const generatedTables = generated?.tables ?? parsedTables ?? [];
+    const generatedCount = generatedTables.length || tableCount;
+    datasetSpinner.succeed(
+      `Generated dataset definitions for ${generatedCount} ${generatedCount === 1 ? 'table' : 'tables'}`,
+    );
 
-    logger.success(`Created ${path.relative(process.cwd(), outputPath)}`);
+    const relativeOutput = path.relative(process.cwd(), outputPath);
+    logger.success(`Created ${relativeOutput}`);
 
     logger.newline();
     logger.header('Next steps:');
@@ -76,14 +96,20 @@ export async function generateDatasetsCommand(options: GenerateDatasetsOptions =
     logger.indent('3. Create an analytics client and start querying!');
     logger.newline();
 
+    // Built from what was actually written, so the snippet can be pasted as-is.
+    const importPath = toImportSpecifier(relativeOutput);
+    const firstTable = generatedTables[0] ?? 'orders';
+
     logger.info('Example usage:');
-    logger.indent('import { datasets } from \'./datasets/generated\';');
+    logger.indent(`import { datasets } from '${importPath}';`);
     logger.indent('import { createDatasetClient } from \'@hypequery/datasets\';');
     logger.indent('import { createQueryBuilder } from \'@hypequery/clickhouse\';');
     logger.indent('');
     logger.indent('const db = createQueryBuilder({ url, username, password, database });');
     logger.indent('const analytics = createDatasetClient({ queryBuilder: db });');
-    logger.indent('const rowCount = datasets.orders.metric(\'rowCount\', { measure: \'totalCount\' });');
+    logger.indent(
+      `const rowCount = datasets['${firstTable}'].metric('rowCount', { measure: 'totalCount' });`,
+    );
     logger.indent('const result = await analytics.execute(rowCount);');
     logger.newline();
 

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -150,6 +150,24 @@ describe('generate command', () => {
       expect(logger.success).toHaveBeenCalledWith('Found 0 tables');
       expect(mockSpinner.succeed).toHaveBeenCalledWith('Generated types for 0 tables');
     });
+
+    it('reports the filtered count when --tables is used', async () => {
+      vi.mocked(detectDb.getTableCount).mockResolvedValue(79);
+
+      await generateCommand({ tables: 'ontime' });
+
+      // Previously both lines said 79, so a correct filter looked broken.
+      expect(logger.success).toHaveBeenCalledWith('Found 79 tables, filtering to 1');
+      expect(mockSpinner.succeed).toHaveBeenCalledWith('Generated types for 1 table');
+    });
+
+    it('pluralises the generated-table count', async () => {
+      vi.mocked(detectDb.getTableCount).mockResolvedValue(79);
+
+      await generateCommand({ tables: 'ontime,trips' });
+
+      expect(mockSpinner.succeed).toHaveBeenCalledWith('Generated types for 2 tables');
+    });
   });
 
   describe('Error paths', () => {

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -60,7 +60,9 @@ describe('generate command', () => {
     vi.mocked(findFiles.findSchemaFile).mockResolvedValue(null);
     vi.mocked(detectDb.getTableCount).mockResolvedValue(10);
     vi.mocked(detectDb.detectDatabase).mockResolvedValue('clickhouse');
-    mockGenerateTypes.mockResolvedValue(undefined);
+    mockGenerateTypes.mockResolvedValue(
+      Array.from({ length: 10 }, (_, index) => `table_${index + 1}`),
+    );
 
     process.env.CLICKHOUSE_HOST = 'localhost';
   });
@@ -135,6 +137,9 @@ describe('generate command', () => {
 
     it('displays correct table count', async () => {
       vi.mocked(detectDb.getTableCount).mockResolvedValue(25);
+      mockGenerateTypes.mockResolvedValue(
+        Array.from({ length: 25 }, (_, index) => `table_${index + 1}`),
+      );
 
       await generateCommand({});
 
@@ -144,6 +149,7 @@ describe('generate command', () => {
 
     it('handles zero tables', async () => {
       vi.mocked(detectDb.getTableCount).mockResolvedValue(0);
+      mockGenerateTypes.mockResolvedValue([]);
 
       await generateCommand({});
 
@@ -153,20 +159,35 @@ describe('generate command', () => {
 
     it('reports the filtered count when --tables is used', async () => {
       vi.mocked(detectDb.getTableCount).mockResolvedValue(79);
+      mockGenerateTypes.mockResolvedValue(['ontime']);
 
       await generateCommand({ tables: 'ontime' });
 
       // Previously both lines said 79, so a correct filter looked broken.
-      expect(logger.success).toHaveBeenCalledWith('Found 79 tables, filtering to 1');
+      expect(logger.success).toHaveBeenCalledWith('Found 79 tables, applying --tables filter');
       expect(mockSpinner.succeed).toHaveBeenCalledWith('Generated types for 1 table');
     });
 
     it('pluralises the generated-table count', async () => {
       vi.mocked(detectDb.getTableCount).mockResolvedValue(79);
+      mockGenerateTypes.mockResolvedValue(['ontime', 'trips']);
 
       await generateCommand({ tables: 'ontime,trips' });
 
       expect(mockSpinner.succeed).toHaveBeenCalledWith('Generated types for 2 tables');
+    });
+
+    it('reports only tables actually generated for duplicate or missing names', async () => {
+      vi.mocked(detectDb.getTableCount).mockResolvedValue(79);
+      mockGenerateTypes.mockResolvedValue(['ontime']);
+
+      await generateCommand({ tables: 'ontime,ontime,missing' });
+
+      expect(mockGenerateTypes).toHaveBeenCalledWith(
+        expect.objectContaining({ includeTables: ['ontime', 'ontime', 'missing'] }),
+      );
+      expect(logger.success).toHaveBeenCalledWith('Found 79 tables, applying --tables filter');
+      expect(mockSpinner.succeed).toHaveBeenCalledWith('Generated types for 1 table');
     });
   });
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -80,7 +80,7 @@ export async function generateCommand(options: GenerateOptions = {}) {
 
     logger.success(
       parsedTables
-        ? `Found ${tableCount} tables, filtering to ${parsedTables.length}`
+        ? `Found ${tableCount} tables, applying --tables filter`
         : `Found ${tableCount} tables`,
     );
 
@@ -89,16 +89,15 @@ export async function generateCommand(options: GenerateOptions = {}) {
     activeSpinner = typeSpinner;
     failureMessage = 'Failed to generate types';
 
-    await generator({
+    const generatedTables = await generator({
       outputPath,
       includeTables: parsedTables,
       chdbPath,
     });
 
-    // Report what was written, not what was discovered. With `--tables` these
-    // differ, and reporting the discovered count reads as though the filter
-    // was ignored.
-    const generatedCount = parsedTables?.length ?? tableCount;
+    // The generator returns what it actually wrote after applying filters.
+    // Requested names may contain duplicates or tables that do not exist.
+    const generatedCount = generatedTables.length;
     typeSpinner.succeed(
       `Generated types for ${generatedCount} ${generatedCount === 1 ? 'table' : 'tables'}`,
     );

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -78,7 +78,11 @@ export async function generateCommand(options: GenerateOptions = {}) {
       `Connected to ${dbType === 'clickhouse' ? 'ClickHouse' : dbType === 'chdb' ? 'embedded chDB' : dbType}`,
     );
 
-    logger.success(`Found ${tableCount} tables`);
+    logger.success(
+      parsedTables
+        ? `Found ${tableCount} tables, filtering to ${parsedTables.length}`
+        : `Found ${tableCount} tables`,
+    );
 
     // Generate types
     const typeSpinner = ora('Generating types...').start();
@@ -91,7 +95,13 @@ export async function generateCommand(options: GenerateOptions = {}) {
       chdbPath,
     });
 
-    typeSpinner.succeed(`Generated types for ${tableCount} tables`);
+    // Report what was written, not what was discovered. With `--tables` these
+    // differ, and reporting the discovered count reads as though the filter
+    // was ignored.
+    const generatedCount = parsedTables?.length ?? tableCount;
+    typeSpinner.succeed(
+      `Generated types for ${generatedCount} ${generatedCount === 1 ? 'table' : 'tables'}`,
+    );
 
     logger.success(`Updated ${path.relative(process.cwd(), outputPath)}`);
 

--- a/packages/cli/src/generators/chdb.ts
+++ b/packages/cli/src/generators/chdb.ts
@@ -22,5 +22,5 @@ export async function generateChdbTypes(options: ChdbGeneratorOptions) {
     ...(options.excludeTables ? { excludeTables: options.excludeTables } : {}),
   };
 
-  await generateTypes(options.outputPath, generatorOptions);
+  return generateTypes(options.outputPath, generatorOptions);
 }

--- a/packages/cli/src/generators/clickhouse.test.ts
+++ b/packages/cli/src/generators/clickhouse.test.ts
@@ -15,11 +15,11 @@ vi.mock('../utils/clickhouse-client.js', () => ({
 describe('generateClickHouseTypes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    generateTypes.mockResolvedValue(undefined);
+    generateTypes.mockResolvedValue(['users']);
   });
 
   it('delegates ClickHouse type generation to the shared package implementation', async () => {
-    await generateClickHouseTypes({
+    const generatedTables = await generateClickHouseTypes({
       outputPath: 'analytics/schema.ts',
       includeTables: ['users'],
       excludeTables: ['events'],
@@ -32,5 +32,6 @@ describe('generateClickHouseTypes', () => {
       includeTables: ['users'],
       excludeTables: ['events'],
     });
+    expect(generatedTables).toEqual(['users']);
   });
 });

--- a/packages/cli/src/generators/clickhouse.ts
+++ b/packages/cli/src/generators/clickhouse.ts
@@ -22,5 +22,5 @@ export async function generateClickHouseTypes(options: ClickHouseGeneratorOption
     ...(options.excludeTables ? { excludeTables: options.excludeTables } : {}),
   };
 
-  await generateTypes(options.outputPath, generatorOptions);
+  return generateTypes(options.outputPath, generatorOptions);
 }

--- a/packages/cli/src/generators/dataset-generator.ts
+++ b/packages/cli/src/generators/dataset-generator.ts
@@ -322,4 +322,14 @@ ${tables.map((table) => `  ${table.name}: ${tableToPascalCase(table.name)}Datase
 
   // Write the file
   await fs.writeFile(path.resolve(options.outputPath), output);
+
+  // Returned so the CLI can report what it actually generated, and print an
+  // example that matches the file rather than a hardcoded placeholder.
+  return {
+    tables: tables.map((table) => table.name),
+    exports: tables.map((table) => ({
+      table: table.name,
+      exportName: `${tableToPascalCase(table.name)}Dataset`,
+    })),
+  };
 }

--- a/packages/cli/src/generators/index.ts
+++ b/packages/cli/src/generators/index.ts
@@ -4,7 +4,7 @@ import type { ChdbGeneratorOptions } from './chdb.js';
 
 export type TypeGeneratorOptions = ClickHouseGeneratorOptions & ChdbGeneratorOptions;
 
-type GeneratorFn = (options: TypeGeneratorOptions) => Promise<void>;
+type GeneratorFn = (options: TypeGeneratorOptions) => Promise<string[]>;
 
 // Loaded on demand. The generator itself is local now, but it still reaches for a driver —
 // `@clickhouse/client` for one, the native `chdb` package for the other — and importing
@@ -13,11 +13,11 @@ type GeneratorFn = (options: TypeGeneratorOptions) => Promise<void>;
 const generators: Partial<Record<DatabaseType, GeneratorFn>> = {
   clickhouse: async (options) => {
     const { generateClickHouseTypes } = await import('./clickhouse.js');
-    await generateClickHouseTypes(options);
+    return generateClickHouseTypes(options);
   },
   chdb: async (options) => {
     const { generateChdbTypes } = await import('./chdb.js');
-    await generateChdbTypes(options);
+    return generateChdbTypes(options);
   },
 };
 

--- a/packages/cli/src/typegen/generate-types.test.ts
+++ b/packages/cli/src/typegen/generate-types.test.ts
@@ -96,14 +96,17 @@ describe('generateTypes', () => {
     // `nested/` does not exist yet — the generator is responsible for it.
     const outputPath = path.join(dir, 'nested', 'schema.ts');
 
-    await generateTypes(outputPath, {
-      client: fakeClient({ users: usersAndEvents.users }),
+    const generatedTables = await generateTypes(outputPath, {
+      client: fakeClient(usersAndEvents),
       generatedBy: 'hypequery',
       includeUsageExample: false,
+      includeTables: ['users', 'users', 'missing'],
     });
 
     const written = await readFile(outputPath, 'utf8');
     expect(written).toContain('export interface IntrospectedSchema');
     expect(written).toContain('export interface UsersRecord');
+    expect(written).not.toContain('export interface EventsRecord');
+    expect(generatedTables).toEqual(['users']);
   });
 });

--- a/packages/cli/src/typegen/generate-types.ts
+++ b/packages/cli/src/typegen/generate-types.ts
@@ -38,6 +38,11 @@ export interface GenerateTypesOptions {
   includeUsageExample?: boolean;
 }
 
+interface GeneratedTypeDefinitions {
+  contents: string;
+  tableNames: string[];
+}
+
 /**
  * Capitalize the first letter of a string.
  */
@@ -60,10 +65,10 @@ async function describeTable(
 /**
  * Generates the TypeScript type definition source from a ClickHouse client.
  */
-export async function generateTypeDefinitions(
+async function buildTypeDefinitions(
   client: TypeGenerationClickHouseClient,
   options: Omit<GenerateTypesOptions, 'client'> = {}
-): Promise<string> {
+): Promise<GeneratedTypeDefinitions> {
   const {
     includeTables = [],
     excludeTables = [],
@@ -148,21 +153,41 @@ export interface IntrospectedSchema {`;
 `;
   }
 
-  return typeDefinitions;
+  return {
+    contents: typeDefinitions,
+    tableNames: tables.map((table) => table.name),
+  };
+}
+
+/**
+ * Generates the TypeScript type definition source from a ClickHouse client.
+ */
+export async function generateTypeDefinitions(
+  client: TypeGenerationClickHouseClient,
+  options: Omit<GenerateTypesOptions, 'client'> = {}
+): Promise<string> {
+  const generated = await buildTypeDefinitions(client, options);
+  return generated.contents;
 }
 
 /**
  * Generates TypeScript type definitions from the ClickHouse database schema and
  * writes them to `outputPath`, creating the containing directory if needed.
+ * Returns the names of the tables represented in the generated file.
  */
-export async function generateTypes(outputPath: string, options: GenerateTypesOptions): Promise<void> {
+export async function generateTypes(
+  outputPath: string,
+  options: GenerateTypesOptions
+): Promise<string[]> {
   const { client, ...definitionOptions } = options;
-  const typeDefinitions = await generateTypeDefinitions(client, definitionOptions);
+  const generated = await buildTypeDefinitions(client, definitionOptions);
 
   // Ensure the output directory exists
   const outputDir = path.dirname(path.resolve(outputPath));
   await fs.mkdir(outputDir, { recursive: true });
 
   // Write the file
-  await fs.writeFile(path.resolve(outputPath), typeDefinitions);
+  await fs.writeFile(path.resolve(outputPath), generated.contents);
+
+  return generated.tableNames;
 }

--- a/packages/cli/src/utils/env-files.test.ts
+++ b/packages/cli/src/utils/env-files.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { envFiles } from './env-files.js';
+
+describe('envFiles', () => {
+  it('reads .env.local, which Next.js and Vite projects actually use', () => {
+    // Previously only `.env` was loaded, so a Next.js project with credentials
+    // in `.env.local` failed with "Unable to detect database type".
+    expect(envFiles(undefined)).toContain('.env.local');
+  });
+
+  it('orders most specific first, so earlier files win', () => {
+    expect(envFiles('production')).toEqual([
+      '.env.production.local',
+      '.env.local',
+      '.env.production',
+      '.env',
+    ]);
+  });
+
+  it('omits NODE_ENV-specific files when NODE_ENV is unset', () => {
+    expect(envFiles(undefined)).toEqual(['.env.local', '.env']);
+  });
+
+  it('always ends at .env so existing setups keep working', () => {
+    for (const nodeEnv of [undefined, 'development', 'production', 'test']) {
+      expect(envFiles(nodeEnv).at(-1)).toBe('.env');
+    }
+  });
+});

--- a/packages/cli/src/utils/env-files.ts
+++ b/packages/cli/src/utils/env-files.ts
@@ -1,0 +1,19 @@
+/**
+ * Env files the CLI loads, in precedence order, most specific first.
+ *
+ * This mirrors the cascade Next.js and Vite use. `dotenv` never overwrites a
+ * variable that is already set, so loading in this order means earlier entries
+ * win, and a real `process.env` value beats every file.
+ *
+ * `.env.local` matters in particular: it is the file those frameworks read, so
+ * without it a project could have working app credentials and a CLI that could
+ * not connect — with an error that never mentions the env file.
+ */
+export function envFiles(nodeEnv: string | undefined): string[] {
+  return [
+    ...(nodeEnv ? [`.env.${nodeEnv}.local`] : []),
+    '.env.local',
+    ...(nodeEnv ? [`.env.${nodeEnv}`] : []),
+    '.env',
+  ];
+}

--- a/testing/cli-testing-spec.md
+++ b/testing/cli-testing-spec.md
@@ -176,7 +176,7 @@ Real-world goal: "my ClickHouse schema changed — refresh my types."
 
 ### T2.5 — `--tables` subset
 **Run:** `hq generate --tables E,E2`
-**Expect:** only `E` and `E2` interfaces present in output; a third table is absent. Note the `Found N tables` count reflects total tables, while generation is restricted.
+**Expect:** only `E` and `E2` interfaces present in output; a third table is absent. The discovery line says `Found N tables, applying --tables filter`, where `N` reflects total tables, and the success line says `Generated types for 2 tables`. Repeat with a duplicate and nonexistent name (`E,E,missing`); the success line must report `1 table`, matching the generated file.
 
 ### T2.6 — Connection error guidance
 **Pre:** point `CLICKHOUSE_URL` at a dead port, e.g. `http://localhost:9` .

--- a/testing/cli-testing-spec.md
+++ b/testing/cli-testing-spec.md
@@ -198,14 +198,14 @@ Real-world goal: "scaffold a semantic dataset layer from my schema."
 ### T3.1 — Default output
 **Pre:** valid connection; ensure `@hypequery/datasets` resolvable (run from a project that installed it, or after T1.6).
 **Run:** `hq generate:datasets`
-**Expect:** header `hypequery generate datasets`; `Connected to ClickHouse`; `Found T tables`; `Generated dataset definitions for T tables`; `Created src/datasets/generated.ts` (note default is `src/datasets/generated.ts`, NOT `analytics/`). Prints "Next steps" + an example-usage block. Exit 0.
+**Expect:** header `hypequery generate datasets`; `Connected to ClickHouse`; `Found T tables`; `Generated dataset definitions for T tables`; `Created analytics/datasets.ts` (default is now `analytics/datasets.ts`, matching `hypequery generate`'s `analytics/schema.ts`). Prints "Next steps" + an example-usage block whose import path and dataset name match the file just written — not a hardcoded `./datasets/generated` / `datasets.orders`. Exit 0.
 
 ### T3.2 — `--path` and `--output`
 - `hq generate:datasets --path analytics` → writes `analytics/datasets.ts`.
 - `hq generate:datasets --output ds/all.ts` → writes `ds/all.ts`.
 
 ### T3.3 — `--tables` / `--exclude-tables`
-- `hq generate:datasets --tables E` → only the `E` dataset; success line says `for 1 tables`.
+- `hq generate:datasets --tables E` → only the `E` dataset; discovery line says `Found T tables, filtering to 1` and the success line says `for 1 table` (singular).
 - `hq generate:datasets --exclude-tables E2` → all tables except `E2`.
 
 ### T3.4 — No matching tables

--- a/website-next/docs/reference/api/cli.mdx
+++ b/website-next/docs/reference/api/cli.mdx
@@ -277,7 +277,7 @@ npx hypequery generate:datasets [options]
 Scaffolds [dataset (semantic layer)](/docs/datasets/overview) definitions from a remote ClickHouse schema, so you don't have to hand-write dimensions and measures for every table. This standalone command currently uses `CLICKHOUSE_*` configuration. For chDB, `hypequery init --database chdb --style datasets` can generate dataset definitions during the initial scaffold, but `generate:datasets` does not currently accept the chDB driver or session path.
 
 **Options:**
-- **`-o, --output <file>`** – Where to write the generated datasets. Defaults to `src/datasets/generated.ts`
+- **`-o, --output <file>`** – Where to write the generated datasets. Defaults to `analytics/datasets.ts`, alongside `hypequery generate`'s `analytics/schema.ts`
 - **`--path <dir>`** – Analytics directory to write into (derives `<dir>/datasets.ts`). Takes effect when `--output` is not set
 - **`--tables <names>`** – Comma-separated list of tables to include. By default all tables are scaffolded
 - **`--exclude-tables <names>`** – Comma-separated list of tables to exclude
@@ -290,7 +290,7 @@ The generator connects to ClickHouse with your `CLICKHOUSE_*` env vars, introspe
 
 <CodeBlock>
 ```bash
-# Generate datasets for all tables (writes src/datasets/generated.ts)
+# Generate datasets for all tables (writes analytics/datasets.ts)
 npx @hypequery/cli generate:datasets
 
 # Generate into your analytics folder for specific tables
@@ -310,7 +310,18 @@ These variables are read whenever the CLI talks to a remote ClickHouse server (e
 | `CLICKHOUSE_PASSWORD` | Password or token |
 | `CLICKHOUSE_HOST` / `CLICKHOUSE_USERNAME` / `CLICKHOUSE_PASS` | Backward-compatible aliases also detected by the CLI |
 
-Set these in your `.env` (the default ClickHouse `init` flow will scaffold this file for you) or export them in CI/CD before running remote-driver CLI commands.
+Set these in an env file (the default ClickHouse `init` flow will scaffold `.env` for you) or export them in CI/CD before running remote-driver CLI commands.
+
+The CLI reads the same cascade Next.js and Vite use, most specific first:
+
+1. `.env.$NODE_ENV.local`
+2. `.env.local`
+3. `.env.$NODE_ENV`
+4. `.env`
+
+Earlier files win, and a variable already present in the real environment beats
+every file. So a Next.js project that keeps its ClickHouse credentials in
+`.env.local` works with the CLI without duplicating them into `.env`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Seventh and final PR from the Next.js/ClickHouse Cloud friction audit. Four independent small fixes, easy to split if you'd rather take them separately.

## 1. Read `.env.local`

The CLI loaded only `.env`. A Next.js or Vite project keeps its ClickHouse credentials in `.env.local` — that's the convention, and it's the file the app itself reads. So the app worked and the CLI didn't.

The error made it much worse:

```
✗ Unable to detect database type. Re-run `hypequery generate --database <type>`
```

The real cause is a missing `CLICKHOUSE_URL`. I went after `--database` first, and I wrote the demo app. A new user has no chance.

Now reads the same cascade Next.js and Vite use, most specific first: `.env.$NODE_ENV.local`, `.env.local`, `.env.$NODE_ENV`, `.env`. `dotenv` doesn't overwrite already-set variables, so earlier files win and real env vars beat all of them — existing `.env`-only setups are untouched. Extracted to `utils/env-files.ts` so it's unit-testable, and it now runs *after* dotenvx instead of being skipped when dotenvx is installed.

## 2. Report tables generated, not discovered

`generate --tables ontime` against a 79-table database:

```
✓  Found 79 tables
✔ Generated types for 79 tables      ← it generated 1
```

The filter was correct. The message wasn't. I believed the message and went looking for a broken flag. Now:

```
✓  Found 79 tables, applying --tables filter
✔ Generated types for 1 table
```

Both the type and dataset generators now return the tables they wrote, so success counts are observed rather than inferred — including when requested names are duplicate or nonexistent.

## 3. `generate:datasets` defaults to `analytics/datasets.ts`

It wrote `src/datasets/generated.ts` while its sibling `generate` wrote `analytics/schema.ts` — generated output split across two trees for no reason. The new default matches the docs (`quick-start.mdx` already claimed `analytics/datasets.ts`), matches `generate`, and matches `findDatasetsFile`, which **already searched `analytics/datasets.ts` first**.

⚠️ **This changes where the command writes** when neither `--output` nor `--path` is given. `--output src/datasets/generated.ts` restores the old location. Flagged in the changeset; happy to drop this one if you'd rather fix the docs to match the code instead.

## 4. The "Next steps" example matches the file it wrote

It was hardcoded to `import { datasets } from './datasets/generated'` and `datasets.orders`, regardless of output path or table list. Against my `trips` dataset it printed an import path that didn't exist and a dataset name that didn't exist. Now uses the real path and the first real table, so it's pasteable.

## Verification

- CLI suite green: 553 passed / 1 skipped, 38 files (added 8 tests)
- `website-next` builds clean
- Updated `docs/reference/api/cli.mdx` and `testing/cli-testing-spec.md` — the latter documented the old default and explicitly called out the inconsistency (*"note default is `src/datasets/generated.ts`, NOT `analytics/`"*)