### PR TITLE
fix(serve): coerce GET query-string values against the input schema

### DIFF
--- a/.changeset/khaki-pots-play.md
+++ b/.changeset/khaki-pots-play.md
@@ -28,5 +28,8 @@ passes through unchanged so validation still reports the genuine error —
 `?limit=abc` continues to fail with `expected number, received string`, and
 `?limit=5000` is coerced and then correctly rejected by `.max(100)`.
 
+Explicit `z.preprocess(...)` callbacks receive the raw query value and own
+coercion for the schema subtree they wrap.
+
 POST bodies are unaffected; JSON already carries types, so a body value of `"5"`
 stays a string.

--- a/.changeset/khaki-pots-play.md
+++ b/.changeset/khaki-pots-play.md
@@ -1,0 +1,32 @@
+---
+"@hypequery/serve": patch
+---
+
+Coerce GET query-string values against the endpoint's input schema before
+validating.
+
+Query strings carry no types, so every value arrives as a string. A field
+declared `z.number()` therefore always failed:
+
+```
+GET /api/analytics/queries/busiestRoutes?minTrips=500&limit=8
+→ 400 { "code": "invalid_type", "expected": "number",
+        "received": "string", "path": ["limit"] }
+```
+
+That made GET endpoints unusable for any input that was not itself a string —
+including through `@hypequery/react`, whose client serialises GET input as flat
+query params.
+
+Values are now converted toward what the schema declares: numbers, booleans,
+bigints, and dates. Strings and enums are untouched. A repeated key becomes an
+array, and a single occurrence of a key typed as `z.array(...)` is wrapped into
+one.
+
+Coercion is conservative and never invents a value. Anything it cannot convert
+passes through unchanged so validation still reports the genuine error —
+`?limit=abc` continues to fail with `expected number, received string`, and
+`?limit=5000` is coerced and then correctly rejected by `.max(100)`.
+
+POST bodies are unaffected; JSON already carries types, so a body value of `"5"`
+stays a string.

--- a/packages/serve/src/create-api.test.ts
+++ b/packages/serve/src/create-api.test.ts
@@ -370,3 +370,89 @@ describe("toFetchHandler", () => {
     expect(body).toEqual({ ok: true });
   });
 });
+
+describe("GET query-param coercion", () => {
+  const busiestRoutes = {
+    inputSchema: z.object({
+      minTrips: z.number().int().default(500),
+      limit: z.number().int().max(100).default(10),
+      verbose: z.boolean().optional(),
+    }),
+    query: async ({ input }: { input: Record<string, unknown> }) => input,
+  };
+
+  it("accepts typed values from a query string", async () => {
+    const api = createAPI({ queries: { busiestRoutes } });
+
+    // Previously: 400 VALIDATION_ERROR, "expected number, received string".
+    const response = await api.handler(
+      createRequest({
+        path: "/queries/busiestRoutes",
+        query: { minTrips: "500", limit: "8", verbose: "true" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ minTrips: 500, limit: 8, verbose: true });
+  });
+
+  it("still applies schema defaults for omitted params", async () => {
+    const api = createAPI({ queries: { busiestRoutes } });
+
+    const response = await api.handler(
+      createRequest({ path: "/queries/busiestRoutes", query: { limit: "3" } }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ minTrips: 500, limit: 3 });
+  });
+
+  it("still rejects values that violate the schema", async () => {
+    const api = createAPI({ queries: { busiestRoutes } });
+
+    // Coercion succeeds; `.max(100)` is what rejects it. The caller gets the
+    // real constraint error, not a type error about strings.
+    const response = await api.handler(
+      createRequest({ path: "/queries/busiestRoutes", query: { limit: "5000" } }),
+    );
+
+    expect(response.status).toBe(400);
+    expect((response.body as { error: { type: string } }).error.type).toBe(
+      "VALIDATION_ERROR",
+    );
+  });
+
+  it("reports a genuine type error when a value cannot be coerced", async () => {
+    const api = createAPI({ queries: { busiestRoutes } });
+
+    const response = await api.handler(
+      createRequest({ path: "/queries/busiestRoutes", query: { limit: "abc" } }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(
+      (response.body as { error: { details: { issues: Array<{ path: string[] }> } } })
+        .error.details.issues[0],
+    ).toMatchObject({ expected: "number", path: ["limit"] });
+  });
+
+  it("leaves JSON bodies untouched", async () => {
+    const api = createAPI({
+      queries: {
+        echo: {
+          inputSchema: z.object({ value: z.union([z.string(), z.number()]) }),
+          query: async ({ input }: { input: { value: string | number } }) => input,
+        },
+      },
+    });
+    api.route("/echo", api.queries.echo, { method: "POST" });
+
+    // A body already carries types: "5" must stay a string, not become 5.
+    const response = await api.handler(
+      createRequest({ method: "POST", path: "/echo", body: { value: "5" } }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ value: "5" });
+  });
+});

--- a/packages/serve/src/pipeline.ts
+++ b/packages/serve/src/pipeline.ts
@@ -34,6 +34,7 @@ import {
 } from './auth.js';
 import { type ResolvedCorsConfig, handleCorsRequest } from './cors.js';
 import { resolveLocalAuthRequirement } from './auth-requirement.js';
+import { coerceQueryInput } from './query-coercion.js';
 
 const safeInvokeHook = async <T>(
   name: string,
@@ -59,6 +60,15 @@ const createErrorResponse = (
   headers: headers ?? {},
   body: { error: { type, message, ...(details ? { details } : {}) } },
 });
+
+/**
+ * True when {@link buildContextInput} sourced the input from the query string
+ * rather than a body. Query values are always strings, so they need coercing
+ * against the schema before validation; JSON bodies already carry types.
+ */
+const inputCameFromQuery = (request: ServeRequest) =>
+  (request.body === undefined || request.body === null) &&
+  Boolean(request.query && Object.keys(request.query).length > 0);
 
 const buildContextInput = (request: ServeRequest) => {
   if (request.body !== undefined && request.body !== null) {
@@ -507,6 +517,10 @@ export const executeEndpoint = async <
           mode: activeTenantConfig.mode,
         });
       }
+    }
+
+    if (inputCameFromQuery(request)) {
+      context.input = coerceQueryInput(endpoint.inputSchema, context.input);
     }
 
     const validationResult = validateInput(endpoint.inputSchema, context.input);

--- a/packages/serve/src/query-coercion.test.ts
+++ b/packages/serve/src/query-coercion.test.ts
@@ -77,6 +77,56 @@ describe("coerceQueryInput", () => {
     );
   });
 
+  it("preserves raw query values for preprocessors", () => {
+    const schema = z.object({
+      tags: z.preprocess(
+        (value) => typeof value === "string" ? value.split(",") : value,
+        z.array(z.string()),
+      ),
+    });
+
+    expect(parse(schema, { tags: "a,b" })).toMatchObject({
+      success: true,
+      data: { tags: ["a", "b"] },
+    });
+  });
+
+  it("does not invent a zero bigint for an empty query value", () => {
+    const schema = z.object({ id: z.bigint() });
+
+    for (const id of ["", "  "]) {
+      const result = parse(schema, { id });
+      expect(result.success).toBe(false);
+      expect((result as { error: z.ZodError }).error.issues[0]).toMatchObject({
+        code: "invalid_type",
+        expected: "bigint",
+        received: "string",
+        path: ["id"],
+      });
+    }
+  });
+
+  it("coerces through branded and readonly wrappers", () => {
+    const schema = z.object({
+      id: z.number().brand<"UserId">(),
+      page: z.number().readonly(),
+    });
+
+    expect(parse(schema, { id: "5", page: "2" })).toMatchObject({
+      success: true,
+      data: { id: 5, page: 2 },
+    });
+  });
+
+  it("coerces values declared by an object catchall schema", () => {
+    const schema = z.object({}).catchall(z.number());
+
+    expect(parse(schema, { first: "1", second: "2" })).toMatchObject({
+      success: true,
+      data: { first: 1, second: 2 },
+    });
+  });
+
   it("leaves strings and enums alone", () => {
     const schema = z.object({ name: z.string(), status: z.enum(["a", "b"]) });
 

--- a/packages/serve/src/query-coercion.test.ts
+++ b/packages/serve/src/query-coercion.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { coerceQueryInput } from "./query-coercion.js";
+
+/** Coercion is only useful if the schema then accepts the result. */
+const parse = (schema: z.ZodTypeAny, raw: unknown) =>
+  schema.safeParse(coerceQueryInput(schema, raw));
+
+describe("coerceQueryInput", () => {
+  it("coerces the numeric case that made GET endpoints unusable", () => {
+    const schema = z.object({ limit: z.number().int() });
+
+    // Before: `expected number, received string`.
+    expect(parse(schema, { limit: "8" })).toMatchObject({
+      success: true,
+      data: { limit: 8 },
+    });
+  });
+
+  it("coerces through optional, default, and nullable wrappers", () => {
+    const schema = z.object({
+      a: z.number().optional(),
+      b: z.number().default(10),
+      c: z.number().nullable(),
+    });
+
+    expect(parse(schema, { a: "1", b: "2", c: "3" })).toMatchObject({
+      success: true,
+      data: { a: 1, b: 2, c: 3 },
+    });
+  });
+
+  it("applies defaults when the key is absent", () => {
+    const schema = z.object({ limit: z.number().default(10) });
+
+    expect(parse(schema, {})).toMatchObject({ success: true, data: { limit: 10 } });
+  });
+
+  it("coerces booleans from the forms a query string can carry", () => {
+    const schema = z.object({ flag: z.boolean() });
+
+    for (const [raw, expected] of [
+      ["true", true],
+      ["TRUE", true],
+      ["1", true],
+      ["false", false],
+      ["0", false],
+    ] as const) {
+      expect(parse(schema, { flag: raw })).toMatchObject({
+        success: true,
+        data: { flag: expected },
+      });
+    }
+  });
+
+  it("wraps a single repeated-key value into an array", () => {
+    const schema = z.object({ ids: z.array(z.number()) });
+
+    // One `?ids=1` arrives as a scalar; the schema wants a list.
+    expect(parse(schema, { ids: "1" })).toMatchObject({
+      success: true,
+      data: { ids: [1] },
+    });
+    expect(parse(schema, { ids: ["1", "2"] })).toMatchObject({
+      success: true,
+      data: { ids: [1, 2] },
+    });
+  });
+
+  it("coerces dates", () => {
+    const schema = z.object({ since: z.date() });
+    const result = parse(schema, { since: "2026-01-01T00:00:00.000Z" });
+
+    expect(result.success).toBe(true);
+    expect((result as { data: { since: Date } }).data.since.toISOString()).toBe(
+      "2026-01-01T00:00:00.000Z",
+    );
+  });
+
+  it("leaves strings and enums alone", () => {
+    const schema = z.object({ name: z.string(), status: z.enum(["a", "b"]) });
+
+    expect(coerceQueryInput(schema, { name: "1", status: "a" })).toEqual({
+      name: "1",
+      status: "a",
+    });
+  });
+
+  it("passes unconvertible values through so zod reports the real error", () => {
+    const schema = z.object({ limit: z.number() });
+    const result = parse(schema, { limit: "abc" });
+
+    expect(result.success).toBe(false);
+    expect((result as { error: z.ZodError }).error.issues[0]).toMatchObject({
+      code: "invalid_type",
+      expected: "number",
+      received: "string",
+      path: ["limit"],
+    });
+  });
+
+  it("leaves unknown keys for the schema to handle", () => {
+    const schema = z.object({ limit: z.number() });
+
+    expect(coerceQueryInput(schema, { limit: "5", stray: "x" })).toEqual({
+      limit: 5,
+      stray: "x",
+    });
+  });
+
+  it("returns the payload untouched when there is no schema", () => {
+    expect(coerceQueryInput(undefined, { limit: "5" })).toEqual({ limit: "5" });
+  });
+
+  it("returns the payload untouched for non-object schemas and payloads", () => {
+    expect(coerceQueryInput(z.string(), { limit: "5" })).toEqual({ limit: "5" });
+    expect(coerceQueryInput(z.object({ a: z.number() }), "nope")).toBe("nope");
+    expect(coerceQueryInput(z.object({ a: z.number() }), null)).toBe(null);
+  });
+
+  it("does not mutate the input object", () => {
+    const raw = { limit: "5" };
+    coerceQueryInput(z.object({ limit: z.number() }), raw);
+
+    expect(raw).toEqual({ limit: "5" });
+  });
+});

--- a/packages/serve/src/query-coercion.test.ts
+++ b/packages/serve/src/query-coercion.test.ts
@@ -91,6 +91,27 @@ describe("coerceQueryInput", () => {
     });
   });
 
+  it("lets a root preprocessor own coercion for its subtree", () => {
+    let received: unknown;
+    const schema = z.preprocess((value) => {
+      received = value;
+      if (value === null || typeof value !== "object" || Array.isArray(value)) {
+        return value;
+      }
+      const input = value as Record<string, unknown>;
+      return {
+        ...input,
+        limit: typeof input.limit === "string" ? Number(input.limit) : input.limit,
+      };
+    }, z.object({ limit: z.number() }));
+
+    expect(parse(schema, { limit: "8" })).toMatchObject({
+      success: true,
+      data: { limit: 8 },
+    });
+    expect(received).toEqual({ limit: "8" });
+  });
+
   it("does not invent a zero bigint for an empty query value", () => {
     const schema = z.object({ id: z.bigint() });
 

--- a/packages/serve/src/query-coercion.ts
+++ b/packages/serve/src/query-coercion.ts
@@ -1,0 +1,130 @@
+import type { ZodTypeAny } from "zod";
+
+/**
+ * Query strings carry no types — every value arrives as a string, or an array of
+ * strings when a key repeats. A schema field declared `z.number()` therefore
+ * always failed validation with `expected number, received string`, which made
+ * GET endpoints unusable for any input that was not itself a string.
+ *
+ * This coerces query values toward what the schema declares, before validation.
+ * It is deliberately conservative: anything it cannot confidently convert is
+ * passed through untouched so zod still produces the real error message rather
+ * than a misleading one about a value this module invented.
+ *
+ * Only applied to query-sourced input. JSON bodies already carry types and are
+ * left alone.
+ */
+
+type ZodDefLike = { typeName?: string; [key: string]: unknown };
+
+const defOf = (schema: unknown): ZodDefLike | undefined =>
+  (schema as { _def?: ZodDefLike } | undefined)?._def;
+
+const typeNameOf = (schema: unknown): string | undefined => defOf(schema)?.typeName;
+
+/**
+ * Strips the wrappers that do not change what a query value should be coerced
+ * to. `ZodPipeline` unwraps to its input side, since that is what validation
+ * receives.
+ */
+function unwrap(schema: unknown, depth = 0): unknown {
+  if (!schema || depth > 10) return schema;
+
+  const def = defOf(schema);
+  switch (def?.typeName) {
+    case "ZodOptional":
+    case "ZodNullable":
+    case "ZodDefault":
+    case "ZodCatch":
+      return unwrap(def.innerType, depth + 1);
+    case "ZodEffects":
+      return unwrap(def.schema, depth + 1);
+    case "ZodPipeline":
+      return unwrap(def.in, depth + 1);
+    default:
+      return schema;
+  }
+}
+
+function coerceScalar(target: unknown, value: string): unknown {
+  switch (typeNameOf(target)) {
+    case "ZodNumber": {
+      if (value.trim() === "") return value;
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : value;
+    }
+    case "ZodBigInt": {
+      try {
+        return BigInt(value);
+      } catch {
+        return value;
+      }
+    }
+    case "ZodBoolean": {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === "true" || normalized === "1") return true;
+      if (normalized === "false" || normalized === "0") return false;
+      return value;
+    }
+    case "ZodDate": {
+      const parsed = new Date(value);
+      return Number.isNaN(parsed.getTime()) ? value : parsed;
+    }
+    default:
+      // Strings, enums, literals, unions, and anything unrecognised are already
+      // in their wire form or too ambiguous to guess at.
+      return value;
+  }
+}
+
+function coerceValue(target: unknown, value: unknown): unknown {
+  const unwrapped = unwrap(target);
+
+  if (typeNameOf(unwrapped) === "ZodArray") {
+    const element = (defOf(unwrapped)?.type ?? undefined) as ZodTypeAny | undefined;
+    // A key that appears once arrives as a scalar, but the schema wants a list.
+    const items = Array.isArray(value) ? value : [value];
+    return items.map((item) => coerceValue(element, item));
+  }
+
+  // A repeated key produced an array the schema does not want. Leave it so zod
+  // reports the real mismatch.
+  if (Array.isArray(value)) return value;
+  if (typeof value !== "string") return value;
+
+  return coerceScalar(unwrapped, value);
+}
+
+/**
+ * Returns a copy of `raw` with values coerced toward `schema`. Returns `raw`
+ * untouched when the schema is absent, is not an object schema, or when the
+ * payload is not a plain object.
+ */
+export function coerceQueryInput(schema: ZodTypeAny | undefined, raw: unknown): unknown {
+  if (!schema || raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return raw;
+  }
+
+  try {
+    const objectSchema = unwrap(schema);
+    if (typeNameOf(objectSchema) !== "ZodObject") return raw;
+
+    const shapeFactory = defOf(objectSchema)?.shape;
+    const shape = (typeof shapeFactory === "function" ? shapeFactory() : shapeFactory) as
+      | Record<string, ZodTypeAny>
+      | undefined;
+    if (!shape) return raw;
+
+    const coerced: Record<string, unknown> = { ...(raw as Record<string, unknown>) };
+    for (const [key, value] of Object.entries(coerced)) {
+      // Unknown keys are left for the schema to strip or reject.
+      if (!(key in shape)) continue;
+      coerced[key] = coerceValue(shape[key], value);
+    }
+    return coerced;
+  } catch {
+    // Coercion is a convenience, never a failure mode. Fall back to the raw
+    // payload so validation reports the genuine problem.
+    return raw;
+  }
+}

--- a/packages/serve/src/query-coercion.ts
+++ b/packages/serve/src/query-coercion.ts
@@ -23,9 +23,10 @@ const defOf = (schema: unknown): ZodDefLike | undefined =>
 const typeNameOf = (schema: unknown): string | undefined => defOf(schema)?.typeName;
 
 /**
- * Strips the wrappers that do not change what a query value should be coerced
- * to. `ZodPipeline` unwraps to its input side, since that is what validation
- * receives.
+ * Strips wrappers that do not change what a query value should be coerced to.
+ * `ZodPipeline` unwraps to its input side, since that is what validation
+ * receives. Preprocess effects stay wrapped so their callback sees the raw wire
+ * value as declared by the schema.
  */
 function unwrap(schema: unknown, depth = 0): unknown {
   if (!schema || depth > 10) return schema;
@@ -36,9 +37,15 @@ function unwrap(schema: unknown, depth = 0): unknown {
     case "ZodNullable":
     case "ZodDefault":
     case "ZodCatch":
+    case "ZodReadonly":
       return unwrap(def.innerType, depth + 1);
-    case "ZodEffects":
+    case "ZodBranded":
+      return unwrap(def.type, depth + 1);
+    case "ZodEffects": {
+      const effect = def.effect as { type?: unknown } | undefined;
+      if (effect?.type === "preprocess") return schema;
       return unwrap(def.schema, depth + 1);
+    }
     case "ZodPipeline":
       return unwrap(def.in, depth + 1);
     default:
@@ -54,6 +61,7 @@ function coerceScalar(target: unknown, value: string): unknown {
       return Number.isFinite(parsed) ? parsed : value;
     }
     case "ZodBigInt": {
+      if (value.trim() === "") return value;
       try {
         return BigInt(value);
       } catch {
@@ -109,17 +117,24 @@ export function coerceQueryInput(schema: ZodTypeAny | undefined, raw: unknown): 
     const objectSchema = unwrap(schema);
     if (typeNameOf(objectSchema) !== "ZodObject") return raw;
 
-    const shapeFactory = defOf(objectSchema)?.shape;
+    const objectDef = defOf(objectSchema);
+    const shapeFactory = objectDef?.shape;
     const shape = (typeof shapeFactory === "function" ? shapeFactory() : shapeFactory) as
       | Record<string, ZodTypeAny>
       | undefined;
     if (!shape) return raw;
+    const catchall = typeNameOf(objectDef?.catchall) === "ZodNever"
+      ? undefined
+      : objectDef?.catchall as ZodTypeAny | undefined;
 
     const coerced: Record<string, unknown> = { ...(raw as Record<string, unknown>) };
     for (const [key, value] of Object.entries(coerced)) {
-      // Unknown keys are left for the schema to strip or reject.
-      if (!(key in shape)) continue;
-      coerced[key] = coerceValue(shape[key], value);
+      const target = Object.prototype.hasOwnProperty.call(shape, key)
+        ? shape[key]
+        : catchall;
+      // Untyped unknown keys are left for the schema to strip or reject.
+      if (!target) continue;
+      coerced[key] = coerceValue(target, value);
     }
     return coerced;
   } catch {

--- a/website-next/docs/http-openapi.mdx
+++ b/website-next/docs/http-openapi.mdx
@@ -418,5 +418,10 @@ so validation reports the real problem. `?limit=abc` still fails with
 the runtime invented. Constraints apply as normal — `?limit=5000` is coerced to
 `5000` and then rejected by `.max(100)`.
 
+An explicit `z.preprocess(...)` is a coercion boundary. Its callback receives the
+raw query value and owns conversion for the schema subtree it wraps. This keeps
+existing preprocessors predictable; use `z.coerce.*` inside that subtree or
+return the converted value from the callback when conversion is required.
+
 `POST` bodies are untouched. JSON already carries types, so a body value of
 `"5"` stays the string `"5"`.

--- a/website-next/docs/http-openapi.mdx
+++ b/website-next/docs/http-openapi.mdx
@@ -377,3 +377,46 @@ api.route('/weekly', api.queries.weeklyRevenue);
 ```
 </Pre>
 </CodeBlock>
+
+### Input on GET routes
+
+`GET` endpoints read their input from the query string. Query strings carry no
+types — every value arrives as a string — so hypequery coerces each value toward
+what your schema declares before validating it.
+
+<CodeBlock>
+<Pre>
+```typescript
+const busiestRoutes = query({
+  input: z.object({
+    minTrips: z.number().int().default(500),
+    limit: z.number().int().max(100).default(10),
+    verbose: z.boolean().optional(),
+  }),
+  query: async ({ input }) => { /* ... */ },
+});
+```
+</Pre>
+</CodeBlock>
+
+<CodeBlock>
+<Pre>
+```bash
+curl '/api/analytics/queries/busiestRoutes?minTrips=500&limit=8&verbose=true'
+# input === { minTrips: 500, limit: 8, verbose: true }
+```
+</Pre>
+</CodeBlock>
+
+Numbers, booleans, bigints, and dates are converted; strings and enums are left
+alone. A repeated key (`?ids=1&ids=2`) becomes an array, and a single occurrence
+of a key typed as `z.array(...)` is wrapped into one.
+
+Coercion is conservative: anything it cannot convert is passed through unchanged
+so validation reports the real problem. `?limit=abc` still fails with
+`expected number, received string` rather than a misleading error about a value
+the runtime invented. Constraints apply as normal — `?limit=5000` is coerced to
+`5000` and then rejected by `.max(100)`.
+
+`POST` bodies are untouched. JSON already carries types, so a body value of
+`"5"` stays the string `"5"`.


### PR DESCRIPTION
Option A from the decision list on #400. Eighth PR from the Next.js/ClickHouse Cloud friction audit.

## The problem

Query strings carry no types — every value arrives as a string. A field declared `z.number()` therefore always failed:

```
GET /api/analytics/queries/busiestRoutes?minTrips=500&limit=8
→ 400 { "code": "invalid_type", "expected": "number",
        "received": "string", "path": ["limit"] }
```

So GET endpoints were unusable for any input that wasn't itself a string. That includes every call through `@hypequery/react`, whose client serialises GET input as flat query params via `String(value)` (`client.js:80-91`).

**Correction to what I said on #400.** I claimed serve's GET route "only accepts `?input={json}`". That was wrong — there's no such convention anywhere in the code. What actually happened in my test is worse: my endpoint's fields all had `.default()`, so `?input={...}` parsed as an object with one unknown key, zod stripped it, applied every default, and returned **200 with the caller's input silently discarded**. A GET endpoint whose fields are all defaulted would quietly ignore everything you sent. This PR fixes that too, since the values now coerce and validate properly.

## The change

`coerceQueryInput(schema, raw)` runs on query-sourced input only, before validation:

- **Converted:** numbers, booleans (`true`/`1`/`false`/`0`), bigints, dates
- **Left alone:** strings, enums, literals, unions, anything unrecognised
- **Arrays:** a repeated key becomes an array; a single occurrence of a key typed `z.array(...)` is wrapped into one
- **Wrappers unwrapped** to find the target type: `optional`, `default`, `nullable`, `catch`, `effects`, `pipeline` (input side)

Conservative by construction — it never invents a value:

| Request | Result |
|---|---|
| `?limit=8` | `8` ✅ |
| `?limit=abc` | passed through → `expected number, received string` |
| `?limit=5000` | coerced to `5000`, then rejected by `.max(100)` |
| unknown key | untouched, left for the schema to strip or reject |

The whole path is wrapped in a `try`/`catch` that falls back to the raw payload, so a schema shape it doesn't understand can never turn a validation error into a crash.

**POST bodies are untouched.** JSON already carries types, so a body value of `"5"` stays the string `"5"` — there's an explicit test for that.

## Tests

- 12 unit tests on the coercion itself (`query-coercion.test.ts`)
- 5 end-to-end through `api.handler` (`create-api.test.ts`), covering the success path, defaults still applying, constraint violations still rejected, uncoercible values still producing the real type error, and bodies being left alone
- Verified 2 of the end-to-end tests fail without the change
- Full serve suite green: 523 tests / 29 files

Docs: new "Input on GET routes" section in `http-openapi.mdx`.

## Notes for review

- Reads `_def.typeName` to identify zod types, which is the conventional way to introspect a zod 3 schema but is technically internal. If zod 4 support lands (#398), this needs revisiting — worth a comment there.
- Deliberately does **not** coerce empty strings to `0` or `false`. `?limit=` passes through as `""` and fails validation, which seemed safer than guessing the caller meant zero.