### PR TITLE
feat(python): implement portable identifiers (PYA-04)

### DIFF
--- a/.changeset/python-portable-identifiers.md
+++ b/.changeset/python-portable-identifiers.md
@@ -1,0 +1,5 @@
+---
+'@hypequery/protocol-conformance': patch
+---
+
+Add deterministic portable-identifier fuzz seeds to the shared conformance corpus.

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -71,7 +71,7 @@ jobs:
   conformance:
     # RFC 0012 gate: once Python announces a fixture family, that family must
     # remain byte- and error-code-identical to the shared protocol corpus.
-    name: conformance (tagged-values-v1)
+    name: conformance (tagged-values-v1, identifiers-v1)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -91,9 +91,9 @@ jobs:
       - run: uv sync --project python/hypequery --dev
       - run: pnpm --filter @hypequery/protocol build
       - run: pnpm --filter @hypequery/protocol-conformance build
-      - name: Run Python against the shared tagged-value fixtures
+      - name: Run Python against the declared shared fixture families
         run: >-
           node packages/protocol-conformance/dist/bin/conformance.js run
           --fixtures specs/security-protocol/fixtures
-          --families tagged-values-v1
+          --families tagged-values-v1,identifiers-v1
           -- uv run --project python/hypequery python -m hypequery.protocol.adapter

--- a/python/hypequery/README.md
+++ b/python/hypequery/README.md
@@ -37,6 +37,24 @@ Python-native `int`, `Decimal`, `date`, timezone-aware `datetime`, `UUID`, and
 artifact is hashed. Validation never calls custom serializers or conversion
 hooks.
 
+## Portable identifiers
+
+RFC 0002 simple and qualified logical identifiers are ASCII-only, preserve
+their exact spelling, and carry distinct static types after validation:
+
+```python
+from hypequery.protocol import (
+    parse_protocol_qualified_identifier,
+    split_protocol_qualified_identifier,
+)
+
+name = parse_protocol_qualified_identifier("orders.customer.country")
+segments = split_protocol_qualified_identifier(name)
+```
+
+These names are safe protocol nodes, not SQL identifiers, filenames, or URLs;
+adapters must still quote or sanitize them for their destination domain.
+
 ## Development
 
 ```bash
@@ -52,7 +70,7 @@ From the repository root, run the shared cross-language gate with:
 ```bash
 node packages/protocol-conformance/dist/bin/conformance.js run \
   --fixtures specs/security-protocol/fixtures \
-  --families tagged-values-v1 \
+  --families tagged-values-v1,identifiers-v1 \
   -- uv run --project python/hypequery python -m hypequery.protocol.adapter
 ```
 

--- a/python/hypequery/src/hypequery/protocol/__init__.py
+++ b/python/hypequery/src/hypequery/protocol/__init__.py
@@ -1,8 +1,4 @@
-"""Language-neutral Hypequery security-protocol primitives.
-
-RFC 0001 tagged values and exact RFC 8785 canonical JSON are available now.
-Portable identifiers are added by PYA-04.
-"""
+"""Language-neutral Hypequery security-protocol primitives."""
 
 from __future__ import annotations
 
@@ -19,7 +15,23 @@ from .constructors import (
     tuple_value,
     uuid_value,
 )
-from .errors import ProtocolValueError, ProtocolValueErrorCode
+from .errors import (
+    ProtocolIdentifierError,
+    ProtocolIdentifierErrorCode,
+    ProtocolValueError,
+    ProtocolValueErrorCode,
+)
+from .identifiers import (
+    PROTOCOL_IDENTIFIER_LIMITS,
+    ProtocolIdentifier,
+    ProtocolQualifiedIdentifier,
+    is_protocol_identifier,
+    is_protocol_qualified_identifier,
+    join_protocol_qualified_identifier,
+    parse_protocol_identifier,
+    parse_protocol_qualified_identifier,
+    split_protocol_qualified_identifier,
+)
 from .limits import DEFAULT_CANONICAL_VALUE_LIMITS, CanonicalValueLimits
 from .values import (
     CanonicalValue,
@@ -32,8 +44,13 @@ from .values import (
 
 __all__ = [
     "DEFAULT_CANONICAL_VALUE_LIMITS",
+    "PROTOCOL_IDENTIFIER_LIMITS",
     "CanonicalValue",
     "CanonicalValueLimits",
+    "ProtocolIdentifier",
+    "ProtocolIdentifierError",
+    "ProtocolIdentifierErrorCode",
+    "ProtocolQualifiedIdentifier",
     "ProtocolValueError",
     "ProtocolValueErrorCode",
     "TaggedValue",
@@ -48,7 +65,13 @@ __all__ = [
     "enum_value",
     "hash_canonical_value",
     "integer_value",
+    "is_protocol_identifier",
+    "is_protocol_qualified_identifier",
+    "join_protocol_qualified_identifier",
     "map_value",
+    "parse_protocol_identifier",
+    "parse_protocol_qualified_identifier",
+    "split_protocol_qualified_identifier",
     "tuple_value",
     "uuid_value",
     "validate_canonical_value",

--- a/python/hypequery/src/hypequery/protocol/adapter.py
+++ b/python/hypequery/src/hypequery/protocol/adapter.py
@@ -9,7 +9,12 @@ from collections.abc import Iterator, Mapping
 
 from hypequery import __version__
 
-from .errors import ProtocolValueError
+from .errors import ProtocolIdentifierError, ProtocolValueError
+from .identifiers import (
+    parse_protocol_identifier,
+    parse_protocol_qualified_identifier,
+    split_protocol_qualified_identifier,
+)
 from .values import (
     decode_canonical_value,
     encode_canonical_value,
@@ -17,7 +22,7 @@ from .values import (
     validate_canonical_value,
 )
 
-FAMILIES = ("tagged-values-v1",)
+FAMILIES = ("tagged-values-v1", "identifiers-v1")
 HOSTILE_OBJECT_SUITE = {
     "count": 7,
     "mechanisms": [
@@ -54,7 +59,7 @@ def _integer(generator: dict[str, object], key: str) -> int:
     return value
 
 
-def _materialize(generator: dict[str, object]) -> object:
+def _materialize_tagged_value(generator: dict[str, object]) -> object:
     kind = generator.get("type")
     if kind == "nested-array":
         value = generator.get("leaf")
@@ -79,7 +84,22 @@ def _materialize(generator: dict[str, object]) -> object:
     raise RuntimeError(f"unknown tagged-value generator: {kind!r}")
 
 
-def _handle(role: str, case: dict[str, object]) -> dict[str, object]:
+def _materialize_identifier(generator: dict[str, object]) -> str:
+    kind = generator.get("type")
+    if kind == "repeat-string":
+        value = generator.get("value")
+        if type(value) is not str:
+            raise RuntimeError("generator field 'value' must be a string")
+        return value * _integer(generator, "count")
+    if kind == "qualified-segments":
+        segment = generator.get("segment")
+        if type(segment) is not str:
+            raise RuntimeError("generator field 'segment' must be a string")
+        return ".".join([segment] * _integer(generator, "count"))
+    raise RuntimeError(f"unknown identifier generator: {kind!r}")
+
+
+def _handle_tagged_value(role: str, case: dict[str, object]) -> dict[str, object]:
     try:
         if role == "success":
             # The runner's wire JSON has already erased JavaScript's distinction
@@ -107,7 +127,7 @@ def _handle(role: str, case: dict[str, object]) -> dict[str, object]:
             declared_type = declared if type(declared) is str else None
             if type(generator) is dict:
                 validate_canonical_value(
-                    _materialize(generator),
+                    _materialize_tagged_value(generator),
                     declared_clickhouse_type=declared_type,
                 )
             else:
@@ -118,6 +138,41 @@ def _handle(role: str, case: dict[str, object]) -> dict[str, object]:
         return {"ok": True}
     except ProtocolValueError as error:
         return {"ok": False, "code": error.code}
+
+
+def _handle_identifier(role: str, case: dict[str, object]) -> dict[str, object]:
+    mode = case.get("mode")
+    if mode not in ("simple", "qualified"):
+        raise RuntimeError("identifier case mode must be 'simple' or 'qualified'")
+    simple = mode == "simple"
+
+    try:
+        if role == "success":
+            value = case.get("value")
+            if simple:
+                segments = [parse_protocol_identifier(value)]
+            else:
+                parsed = parse_protocol_qualified_identifier(value)
+                segments = list(split_protocol_qualified_identifier(parsed))
+            return {"ok": True, "output": {"segments": segments}}
+
+        generator = case.get("generator")
+        value = _materialize_identifier(generator) if type(generator) is dict else case.get("value")
+        if simple:
+            parse_protocol_identifier(value)
+        else:
+            parse_protocol_qualified_identifier(value)
+        return {"ok": True}
+    except ProtocolIdentifierError as error:
+        return {"ok": False, "code": error.code}
+
+
+def _handle(family: str, role: str, case: dict[str, object]) -> dict[str, object]:
+    if family == "tagged-values-v1":
+        return _handle_tagged_value(role, case)
+    if family == "identifiers-v1":
+        return _handle_identifier(role, case)
+    raise RuntimeError(f"unsupported fixture family: {family!r}")
 
 
 def main() -> int:
@@ -159,7 +214,7 @@ def main() -> int:
             response = {
                 "type": "result",
                 "seq": message.get("seq"),
-                **_handle(str(message.get("role")), fixture_case),
+                **_handle(family, str(message.get("role")), fixture_case),
             }
         elif message_type == "end":
             return 0

--- a/python/hypequery/src/hypequery/protocol/errors.py
+++ b/python/hypequery/src/hypequery/protocol/errors.py
@@ -1,4 +1,4 @@
-"""Stable public errors for the Hypequery value protocol."""
+"""Stable public errors for the Hypequery security protocol."""
 
 from __future__ import annotations
 
@@ -26,6 +26,15 @@ ProtocolValueErrorCode: TypeAlias = Literal[
     "HQ_VALUE_UNSAFE_OBJECT",
 ]
 
+ProtocolIdentifierErrorCode: TypeAlias = Literal[
+    "HQ_IDENTIFIER_TYPE",
+    "HQ_IDENTIFIER_EMPTY",
+    "HQ_IDENTIFIER_TOO_LONG",
+    "HQ_IDENTIFIER_INVALID_FORMAT",
+    "HQ_IDENTIFIER_RESERVED",
+    "HQ_IDENTIFIER_TOO_MANY_SEGMENTS",
+]
+
 
 class ProtocolValueError(TypeError):
     """A safe, stable RFC 0001 validation failure."""
@@ -43,3 +52,19 @@ def value_error(code: ProtocolValueErrorCode, path: str = "$") -> NoReturn:
     """Raise a protocol error without attaching input data to its message."""
 
     raise ProtocolValueError(code, path)
+
+
+class ProtocolIdentifierError(TypeError):
+    """A safe, stable RFC 0002 validation failure."""
+
+    code: ProtocolIdentifierErrorCode
+
+    def __init__(self, code: ProtocolIdentifierErrorCode) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+def identifier_error(code: ProtocolIdentifierErrorCode) -> NoReturn:
+    """Raise an identifier error without attaching the rejected input."""
+
+    raise ProtocolIdentifierError(code)

--- a/python/hypequery/src/hypequery/protocol/identifiers.py
+++ b/python/hypequery/src/hypequery/protocol/identifiers.py
@@ -1,0 +1,171 @@
+"""RFC 0002 portable logical identifiers.
+
+Parsed values are immutable built-in strings with distinct static brands.
+Validation intentionally avoids coercion, normalization, and user-defined
+hooks so every accepted value has the same meaning in Python and TypeScript.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import NewType
+
+from .errors import ProtocolIdentifierError, ProtocolIdentifierErrorCode, identifier_error
+
+ProtocolIdentifier = NewType("ProtocolIdentifier", str)
+ProtocolQualifiedIdentifier = NewType("ProtocolQualifiedIdentifier", str)
+
+
+@dataclass(frozen=True, slots=True)
+class _ProtocolIdentifierLimits:
+    """Frozen limits for identifier extension version 1."""
+
+    max_segment_bytes: int = 128
+    max_qualified_bytes: int = 512
+    max_segments: int = 8
+
+
+PROTOCOL_IDENTIFIER_LIMITS = _ProtocolIdentifierLimits()
+
+_IDENTIFIER_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*", re.ASCII)
+_RESERVED_PREFIX = "__hypequery"
+
+
+def _exceeds_utf8_byte_limit(value: str, maximum: int) -> bool:
+    """Check a UTF-8 limit using the USV-string semantics of TextEncoder.
+
+    Python can hold unpaired UTF-16 surrogates even though JSON and UTF-8
+    cannot. Treating each unpaired surrogate as U+FFFD matches the JavaScript
+    reference implementation and keeps validation precedence deterministic.
+    The scan stops as soon as the limit is exceeded, bounding work on hostile
+    in-memory inputs.
+    """
+
+    length = 0
+    index = 0
+    while index < len(value):
+        code_point = ord(value[index])
+        if code_point <= 0x7F:
+            length += 1
+        elif code_point <= 0x7FF:
+            length += 2
+        elif 0xD800 <= code_point <= 0xDBFF:
+            if index + 1 < len(value) and 0xDC00 <= ord(value[index + 1]) <= 0xDFFF:
+                length += 4
+                index += 1
+            else:
+                length += 3
+        elif 0xDC00 <= code_point <= 0xDFFF:
+            length += 3
+        elif code_point <= 0xFFFF:
+            length += 3
+        else:
+            length += 4
+        if length > maximum:
+            return True
+        index += 1
+    return False
+
+
+def _parse_segment(
+    value: object,
+    *,
+    empty_code: ProtocolIdentifierErrorCode,
+) -> ProtocolIdentifier:
+    if type(value) is not str:
+        identifier_error("HQ_IDENTIFIER_TYPE")
+    text = value
+    if not text:
+        identifier_error(empty_code)
+    if _exceeds_utf8_byte_limit(text, PROTOCOL_IDENTIFIER_LIMITS.max_segment_bytes):
+        identifier_error("HQ_IDENTIFIER_TOO_LONG")
+    if _IDENTIFIER_PATTERN.fullmatch(text) is None:
+        identifier_error("HQ_IDENTIFIER_INVALID_FORMAT")
+    # The grammar gate above proves the input is ASCII, making this
+    # case-insensitive comparison language-neutral.
+    if text[: len(_RESERVED_PREFIX)].lower() == _RESERVED_PREFIX:
+        identifier_error("HQ_IDENTIFIER_RESERVED")
+    return ProtocolIdentifier(text)
+
+
+def parse_protocol_identifier(value: object) -> ProtocolIdentifier:
+    """Parse one portable, case-sensitive logical identifier segment."""
+
+    return _parse_segment(value, empty_code="HQ_IDENTIFIER_EMPTY")
+
+
+def parse_protocol_qualified_identifier(value: object) -> ProtocolQualifiedIdentifier:
+    """Parse a dot-qualified portable identifier without normalizing it."""
+
+    if type(value) is not str:
+        identifier_error("HQ_IDENTIFIER_TYPE")
+    text = value
+    if not text:
+        identifier_error("HQ_IDENTIFIER_EMPTY")
+    if _exceeds_utf8_byte_limit(text, PROTOCOL_IDENTIFIER_LIMITS.max_qualified_bytes):
+        identifier_error("HQ_IDENTIFIER_TOO_LONG")
+
+    # Count before splitting so an attacker cannot force an unbounded derived
+    # allocation. The qualified byte limit bounds the scan itself.
+    segment_count = text.count(".") + 1
+    if segment_count > PROTOCOL_IDENTIFIER_LIMITS.max_segments:
+        identifier_error("HQ_IDENTIFIER_TOO_MANY_SEGMENTS")
+
+    for segment in text.split("."):
+        _parse_segment(segment, empty_code="HQ_IDENTIFIER_INVALID_FORMAT")
+    return ProtocolQualifiedIdentifier(text)
+
+
+def split_protocol_qualified_identifier(
+    value: ProtocolQualifiedIdentifier,
+) -> tuple[ProtocolIdentifier, ...]:
+    """Return the validated segments of a qualified identifier."""
+
+    parsed = parse_protocol_qualified_identifier(value)
+    return tuple(ProtocolIdentifier(segment) for segment in parsed.split("."))
+
+
+def join_protocol_qualified_identifier(
+    segments: Sequence[object],
+) -> ProtocolQualifiedIdentifier:
+    """Validate and join one to eight identifier segments."""
+
+    # Exact built-in containers prevent custom iteration or indexing hooks
+    # from running inside this security boundary.
+    if type(segments) not in (list, tuple):
+        identifier_error("HQ_IDENTIFIER_TYPE")
+    if len(segments) == 0:
+        identifier_error("HQ_IDENTIFIER_EMPTY")
+    if len(segments) > PROTOCOL_IDENTIFIER_LIMITS.max_segments:
+        identifier_error("HQ_IDENTIFIER_TOO_MANY_SEGMENTS")
+
+    snapshot = tuple(segments)
+    parsed = tuple(
+        _parse_segment(segment, empty_code="HQ_IDENTIFIER_INVALID_FORMAT") for segment in snapshot
+    )
+    value = ".".join(parsed)
+    if _exceeds_utf8_byte_limit(value, PROTOCOL_IDENTIFIER_LIMITS.max_qualified_bytes):
+        identifier_error("HQ_IDENTIFIER_TOO_LONG")
+    return ProtocolQualifiedIdentifier(value)
+
+
+def is_protocol_identifier(value: object) -> bool:
+    """Return whether *value* is a valid simple protocol identifier."""
+
+    try:
+        parse_protocol_identifier(value)
+    except ProtocolIdentifierError:
+        return False
+    return True
+
+
+def is_protocol_qualified_identifier(value: object) -> bool:
+    """Return whether *value* is a valid qualified protocol identifier."""
+
+    try:
+        parse_protocol_qualified_identifier(value)
+    except ProtocolIdentifierError:
+        return False
+    return True

--- a/python/hypequery/tests/test_protocol_adapter.py
+++ b/python/hypequery/tests/test_protocol_adapter.py
@@ -6,7 +6,7 @@ import sys
 from typing import cast
 
 
-def test_adapter_announces_pinned_family_and_hostile_suite() -> None:
+def test_adapter_announces_pinned_families_and_hostile_suite() -> None:
     messages = "\n".join(
         (
             json.dumps({"type": "hello", "protocol": 1}),
@@ -22,7 +22,7 @@ def test_adapter_announces_pinned_family_and_hostile_suite() -> None:
         check=True,
     )
     hello = cast(dict[str, object], json.loads(completed.stdout.splitlines()[0]))
-    assert hello["families"] == ["tagged-values-v1"]
+    assert hello["families"] == ["tagged-values-v1", "identifiers-v1"]
     suite = cast(dict[str, object], hello["hostileObjectSuite"])
     assert suite["count"] == 7
     assert suite["mechanisms"] == [
@@ -34,3 +34,47 @@ def test_adapter_announces_pinned_family_and_hostile_suite() -> None:
         "__getattr__",
         "cycle",
     ]
+
+
+def test_adapter_handles_identifier_success_and_rejection() -> None:
+    messages = "\n".join(
+        (
+            json.dumps({"type": "hello", "protocol": 1}),
+            json.dumps(
+                {
+                    "type": "case",
+                    "seq": 1,
+                    "family": "identifiers-v1",
+                    "role": "success",
+                    "case": {
+                        "mode": "qualified",
+                        "value": "orders.customer.country",
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "case",
+                    "seq": 2,
+                    "family": "identifiers-v1",
+                    "role": "rejection",
+                    "case": {"mode": "simple", "value": "__HypequeryInternal"},
+                }
+            ),
+            json.dumps({"type": "end"}),
+            "",
+        )
+    )
+    completed = subprocess.run(
+        [sys.executable, "-m", "hypequery.protocol.adapter"],
+        input=messages,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    responses = [
+        cast(dict[str, object], json.loads(line)) for line in completed.stdout.splitlines()
+    ]
+    success = cast(dict[str, object], responses[1]["output"])
+    assert success["segments"] == ["orders", "customer", "country"]
+    assert responses[2]["code"] == "HQ_IDENTIFIER_RESERVED"

--- a/python/hypequery/tests/test_protocol_identifiers.py
+++ b/python/hypequery/tests/test_protocol_identifiers.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import json
+import string
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Literal, cast
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from hypequery.protocol import (
+    PROTOCOL_IDENTIFIER_LIMITS,
+    ProtocolIdentifier,
+    ProtocolIdentifierError,
+    ProtocolQualifiedIdentifier,
+    is_protocol_identifier,
+    is_protocol_qualified_identifier,
+    join_protocol_qualified_identifier,
+    parse_protocol_identifier,
+    parse_protocol_qualified_identifier,
+    split_protocol_qualified_identifier,
+)
+
+FIXTURES = (
+    Path(__file__).resolve().parents[3]
+    / "specs"
+    / "security-protocol"
+    / "fixtures"
+    / "identifiers-v1"
+)
+FAILURE_CODES = {
+    "HQ_IDENTIFIER_TYPE",
+    "HQ_IDENTIFIER_EMPTY",
+    "HQ_IDENTIFIER_TOO_LONG",
+    "HQ_IDENTIFIER_INVALID_FORMAT",
+    "HQ_IDENTIFIER_RESERVED",
+    "HQ_IDENTIFIER_TOO_MANY_SEGMENTS",
+}
+
+
+def _fixtures(name: str) -> list[dict[str, object]]:
+    return cast(list[dict[str, object]], json.loads((FIXTURES / name).read_text()))
+
+
+def _materialize(generator: dict[str, object]) -> str:
+    kind = generator.get("type")
+    count = cast(int, generator.get("count"))
+    if kind == "repeat-string":
+        return cast(str, generator.get("value")) * count
+    if kind == "qualified-segments":
+        return ".".join([cast(str, generator.get("segment"))] * count)
+    raise AssertionError(f"unknown generator {kind!r}")
+
+
+@pytest.mark.parametrize("fixture", _fixtures("success.json"), ids=lambda item: str(item["id"]))
+def test_shared_success_fixtures_preserve_spelling(fixture: dict[str, object]) -> None:
+    value = cast(str, fixture["value"])
+    expected = cast(list[str], fixture["segments"])
+    if fixture["mode"] == "simple":
+        parsed: ProtocolIdentifier = parse_protocol_identifier(value)
+        assert parsed == value
+        assert type(parsed) is str
+        assert expected == [parsed]
+        return
+
+    parsed_qualified: ProtocolQualifiedIdentifier = parse_protocol_qualified_identifier(value)
+    assert parsed_qualified == value
+    assert type(parsed_qualified) is str
+    assert list(split_protocol_qualified_identifier(parsed_qualified)) == expected
+    assert join_protocol_qualified_identifier(expected) == parsed_qualified
+
+
+@pytest.mark.parametrize("fixture", _fixtures("rejections.json"), ids=lambda item: str(item["id"]))
+def test_shared_rejections_use_stable_codes(fixture: dict[str, object]) -> None:
+    generator = fixture.get("generator")
+    value = _materialize(generator) if type(generator) is dict else fixture.get("value")
+    parser = (
+        parse_protocol_identifier
+        if fixture["mode"] == "simple"
+        else parse_protocol_qualified_identifier
+    )
+    with pytest.raises(ProtocolIdentifierError) as raised:
+        parser(value)
+    assert raised.value.code == fixture["error"]
+    assert str(raised.value) == fixture["error"]
+
+
+def test_fixture_corpus_covers_every_failure_code_and_unique_id() -> None:
+    fixtures = [*_fixtures("success.json"), *_fixtures("rejections.json")]
+    ids = [fixture["id"] for fixture in fixtures]
+    assert len(ids) == len(set(ids))
+    assert {fixture["error"] for fixture in _fixtures("rejections.json")} == FAILURE_CODES
+
+
+def test_exact_limits_and_validation_precedence() -> None:
+    assert PROTOCOL_IDENTIFIER_LIMITS.max_segment_bytes == 128
+    assert PROTOCOL_IDENTIFIER_LIMITS.max_qualified_bytes == 512
+    assert PROTOCOL_IDENTIFIER_LIMITS.max_segments == 8
+    assert parse_protocol_identifier("a" * 128) == "a" * 128
+    assert parse_protocol_qualified_identifier(".".join(["a"] * 8))
+
+    cases = [
+        ("__hypequery" * 12, "HQ_IDENTIFIER_TOO_LONG", False),
+        ("-" * 129, "HQ_IDENTIFIER_TOO_LONG", False),
+        ("__hypequery-internal", "HQ_IDENTIFIER_INVALID_FORMAT", False),
+        (".".join(["a" * 64] * 9), "HQ_IDENTIFIER_TOO_LONG", True),
+        (".".join(["a"] * 9), "HQ_IDENTIFIER_TOO_MANY_SEGMENTS", True),
+        (f"{'a' * 129}.b", "HQ_IDENTIFIER_TOO_LONG", True),
+        ("orders..country", "HQ_IDENTIFIER_INVALID_FORMAT", True),
+    ]
+    for value, code, qualified in cases:
+        parser = parse_protocol_qualified_identifier if qualified else parse_protocol_identifier
+        with pytest.raises(ProtocolIdentifierError) as raised:
+            parser(value)
+        assert raised.value.code == code
+
+
+def test_non_bmp_and_surrogate_inputs_have_deterministic_byte_limits() -> None:
+    invalid_at_limit = ["😀" * 32, "\ud800" * 42, "\ud800\udc00" * 32]
+    too_long = ["😀" * 33, "\ud800" * 43, "\ud800\udc00" * 33]
+    for value in invalid_at_limit:
+        with pytest.raises(ProtocolIdentifierError) as raised:
+            parse_protocol_identifier(value)
+        assert raised.value.code == "HQ_IDENTIFIER_INVALID_FORMAT"
+    for value in too_long:
+        with pytest.raises(ProtocolIdentifierError) as raised:
+            parse_protocol_identifier(value)
+        assert raised.value.code == "HQ_IDENTIFIER_TOO_LONG"
+
+
+def test_guards_and_join_are_strict() -> None:
+    assert is_protocol_identifier("RevenueByDay")
+    assert not is_protocol_identifier("orders.customer")
+    assert is_protocol_qualified_identifier("orders.customer")
+    assert not is_protocol_qualified_identifier("orders..customer")
+    assert join_protocol_qualified_identifier(("orders", "customer")) == "orders.customer"
+
+    cases: list[tuple[Sequence[object], str]] = [
+        ([], "HQ_IDENTIFIER_EMPTY"),
+        (["a"] * 9, "HQ_IDENTIFIER_TOO_MANY_SEGMENTS"),
+        (["a", ""], "HQ_IDENTIFIER_INVALID_FORMAT"),
+        (["a", 1], "HQ_IDENTIFIER_TYPE"),
+        (["a" * 128] * 5, "HQ_IDENTIFIER_TOO_LONG"),
+    ]
+    for segments, code in cases:
+        with pytest.raises(ProtocolIdentifierError) as raised:
+            join_protocol_qualified_identifier(segments)
+        assert raised.value.code == code
+
+
+def test_hostile_objects_are_rejected_without_running_hooks_or_leaking_input() -> None:
+    calls: list[str] = []
+
+    class StringSubclass(str):
+        def lower(self) -> str:
+            calls.append("lower")
+            return super().lower()
+
+    class CustomString:
+        def __str__(self) -> str:
+            calls.append("str")
+            return "unsafe"
+
+    class CustomSequence:
+        def __getitem__(self, index: int) -> object:
+            calls.append("getitem")
+            return "unsafe"
+
+        def __len__(self) -> int:
+            calls.append("len")
+            return 1
+
+    hostile_values: list[object] = [StringSubclass("orders"), CustomString()]
+    for value in hostile_values:
+        with pytest.raises(ProtocolIdentifierError) as raised:
+            parse_protocol_identifier(value)
+        assert raised.value.code == "HQ_IDENTIFIER_TYPE"
+        assert not is_protocol_qualified_identifier(value)
+
+    with pytest.raises(ProtocolIdentifierError) as raised:
+        join_protocol_qualified_identifier(cast(Sequence[object], CustomSequence()))
+    assert raised.value.code == "HQ_IDENTIFIER_TYPE"
+    assert calls == []
+
+    rejected = "customer-secret-value"
+    with pytest.raises(ProtocolIdentifierError) as raised:
+        parse_protocol_identifier(rejected)
+    assert str(raised.value) == "HQ_IDENTIFIER_INVALID_FORMAT"
+    assert rejected not in str(raised.value)
+
+
+_VALID_IDENTIFIER = st.from_regex(r"[A-Za-z_][A-Za-z0-9_]{0,31}", fullmatch=True).filter(
+    lambda value: not value.lower().startswith("__hypequery")
+)
+_SURROGATE_CATEGORIES: tuple[Literal["Cs"], ...] = ("Cs",)
+
+
+@given(st.lists(_VALID_IDENTIFIER, min_size=1, max_size=8))
+@settings(max_examples=500)
+def test_qualified_identifier_properties(segments: list[str]) -> None:
+    joined = join_protocol_qualified_identifier(segments)
+    assert parse_protocol_qualified_identifier(joined) == joined
+    assert list(split_protocol_qualified_identifier(joined)) == segments
+    assert all(is_protocol_identifier(segment) for segment in segments)
+
+
+@given(
+    prefix=st.text(alphabet=string.ascii_letters + string.digits + "_", max_size=16),
+    non_ascii=st.characters(
+        min_codepoint=128,
+        blacklist_categories=_SURROGATE_CATEGORIES,
+    ),
+)
+@settings(max_examples=300)
+def test_non_ascii_input_is_never_normalized(prefix: str, non_ascii: str) -> None:
+    value = f"a{prefix}{non_ascii}"
+    with pytest.raises(ProtocolIdentifierError) as raised:
+        parse_protocol_identifier(value)
+    assert raised.value.code == "HQ_IDENTIFIER_INVALID_FORMAT"

--- a/specs/security-protocol/fixtures/fuzz-seeds-v1/README.md
+++ b/specs/security-protocol/fixtures/fuzz-seeds-v1/README.md
@@ -3,6 +3,8 @@
 These adversarial inputs replay on every conformance run under RFC 0012. An implementation may accept a seed within documented limits or reject it with a stable `HQ_*` code; it must never crash, hang, partially execute input, or allocate without bounds.
 
 - `value-sources.json` targets duplicate-aware JSON decoding and tagged values.
+- `identifiers.json` targets Unicode ambiguity, reserved names, separators,
+  validation limits, and non-string identifier inputs.
 - `structured-values.json` targets selected structural validator families.
 - `sql-expressions.json` targets the SQL portability compiler.
 

--- a/specs/security-protocol/fixtures/fuzz-seeds-v1/identifiers.json
+++ b/specs/security-protocol/fixtures/fuzz-seeds-v1/identifiers.json
@@ -1,0 +1,17 @@
+[
+  { "id": "identifier-null", "mode": "simple", "value": null },
+  { "id": "identifier-control-character", "mode": "simple", "value": "order\u0000id" },
+  { "id": "identifier-sql-shaped", "mode": "simple", "value": "orders;DROP_TABLE_users" },
+  { "id": "identifier-cyrillic-confusable", "mode": "simple", "value": "аdmin" },
+  { "id": "identifier-combining-mark", "mode": "simple", "value": "café" },
+  { "id": "identifier-fullwidth-dot", "mode": "qualified", "value": "orders．customer" },
+  { "id": "identifier-lone-high-surrogate", "mode": "simple", "value": "\ud800" },
+  { "id": "identifier-lone-low-surrogate", "mode": "simple", "value": "\udc00" },
+  { "id": "identifier-surrogate-pair", "mode": "simple", "value": "\ud83d\ude00" },
+  { "id": "identifier-reserved-mixed-case", "mode": "simple", "value": "__HyPeQuErY_admin" },
+  { "id": "identifier-qualified-leading-dot", "mode": "qualified", "value": ".orders" },
+  { "id": "identifier-qualified-trailing-dot", "mode": "qualified", "value": "orders." },
+  { "id": "identifier-qualified-repeated-dot", "mode": "qualified", "value": "orders..customer" },
+  { "id": "identifier-long-segment", "mode": "simple", "generator": { "type": "repeat-string", "value": "a", "count": 10000 } },
+  { "id": "identifier-many-segments", "mode": "qualified", "generator": { "type": "qualified-segments", "segment": "a", "count": 1000 } }
+]

--- a/specs/security-protocol/fixtures/manifest.json
+++ b/specs/security-protocol/fixtures/manifest.json
@@ -229,6 +229,10 @@
       "family": "tagged-values-v1"
     },
     {
+      "path": "fuzz-seeds-v1/identifiers.json",
+      "family": "identifiers-v1"
+    },
+    {
       "path": "fuzz-seeds-v1/structured-values.json"
     },
     {


### PR DESCRIPTION
## Summary

- implement the accepted RFC 0002 simple and qualified identifier grammar with immutable Python type brands
- preserve exact spelling while rejecting non-ASCII, ambiguous Unicode, reserved protocol names, invalid separators, and limit violations in normative order
- extend the RFC 0012 Python adapter and permanent CI gate to `identifiers-v1`
- add fixture, Hypothesis, hostile-input, surrogate-boundary, and deterministic fuzz coverage

## Stack

This is PYA-04 from `plans/python-datasets-serve-pr-level-plan.md`. It is intentionally stacked on #414 (PYA-03), which supplies the Python package and conformance adapter foundation. Reviewers should see only the portable-identifier commit here; this PR can be retargeted to `main` after #414 merges.

## Security review

Security review is required by the plan. The implementation:

- accepts exact built-in strings only and never invokes coercion or custom string/sequence hooks
- checks whole qualified-name byte limits and segment count before allocating split structures
- applies the ASCII grammar gate before the case-insensitive `__hypequery` reservation check
- matches JavaScript `TextEncoder` byte counting for non-BMP and unpaired-surrogate inputs, with an early bounded exit
- returns stable codes without including rejected identifiers in messages
- adds replayable fuzz seeds for confusables, combining marks, alternate separators, lone surrogates, reserved names, and oversized inputs

## Verification

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy`
- `uv run lint-imports`
- `uv run pytest` — 136 passed
- wheel and sdist build + artifact audit
- Python shared conformance — 162 passed across `tagged-values-v1` and `identifiers-v1`
- TypeScript identifier conformance — 35 passed
- randomized Python/TypeScript differential — 10,004 outcomes matched
- `pnpm --filter @hypequery/protocol test` — 474 passed
- `pnpm --filter @hypequery/protocol-conformance test` — 28 passed
- full repository conformance — 403 protocol + 79 SQL cases passed
