### PR TITLE
feat(datasets): validate dataset definitions at definition time

### DIFF
--- a/.changeset/definition-time-dataset-validation.md
+++ b/.changeset/definition-time-dataset-validation.md
@@ -8,4 +8,6 @@ Validate dataset definitions structurally when `dataset()` is called, instead of
 
 Raw `sql` expressions on dimensions and measures are rejected when they carry a statement terminator or comment opener (`;`, `--`, `/*`), because the value is spliced into a larger expression. A declared `dependencies` entry the expression never references is also rejected — the definition would otherwise claim to read a column it does not read.
 
+Dimension and measure names are checked as identifiers too, since they appear in query inputs, generated tool schemas, and protocol artifacts. Previously a name was only checked indirectly, via the column it defaulted to, so the same bad name passed or failed depending on whether an explicit `column` was set.
+
 `limits` values must be positive integers.

--- a/.changeset/definition-time-dataset-validation.md
+++ b/.changeset/definition-time-dataset-validation.md
@@ -1,0 +1,11 @@
+---
+"@hypequery/datasets": minor
+---
+
+Validate dataset definitions structurally when `dataset()` is called, instead of letting a malformed model fail on the first query that reaches the broken part of it. Datasets are normally defined at module scope, so an invalid one now fails at import — in the build, in CI, and in the first test that touches the module.
+
+`source`, `tenantKey`, `timeKey`, dimension columns and measure fields are checked as SQL identifiers, since each is interpolated into generated SQL. `tenantKey` matters most: it becomes a predicate on every query against a tenant-scoped dataset, and a typo previously constructed cleanly.
+
+Raw `sql` expressions on dimensions and measures are rejected when they carry a statement terminator or comment opener (`;`, `--`, `/*`), because the value is spliced into a larger expression. A declared `dependencies` entry the expression never references is also rejected — the definition would otherwise claim to read a column it does not read.
+
+`limits` values must be positive integers.

--- a/packages/datasets/src/dataset.ts
+++ b/packages/datasets/src/dataset.ts
@@ -57,6 +57,7 @@ import {
   validateBaseMetric,
   validateDerivedMetric,
 } from './utils/dataset-validation.js';
+import { validateDatasetDefinition } from './utils/dataset-definition-validation.js';
 
 export function dataset<
   TDatasetName extends string,
@@ -67,6 +68,11 @@ export function dataset<
   name: TDatasetName,
   config: DatasetConfig<TDimensions, TMeasures, TRelationships>,
 ): DatasetInstance<TDimensions, TMeasures, TRelationships, TDatasetName> {
+  // Structural validation runs before anything is normalized, so an invalid
+  // model fails at definition time rather than on the first query that reaches
+  // the broken part of it.
+  validateDatasetDefinition(name, config);
+
   const dimensions = normalizeDimensions(config);
   const measures = normalizeMeasures(config.measures);
   const filters = normalizeFilters(dimensions, config.filters);

--- a/packages/datasets/src/sql-utils.test.ts
+++ b/packages/datasets/src/sql-utils.test.ts
@@ -6,8 +6,10 @@ import { divide, nullIfZero } from './formulas.js';
 import { measure } from './measure.js';
 import { eq, like } from './query-helpers.js';
 import {
+  escapeRegExp,
   isSafeSQLIdentifier,
   quoteSQLIdentifier,
+  stripSqlLiterals,
   validateSQLIdentifier,
 } from './sql-utils.js';
 
@@ -133,5 +135,47 @@ describe('metric validation through dataset()', () => {
       uses: { revenue, customers },
       formula: ({ revenue: revenueInput, customers: customersInput }) => divide(revenueInput, nullIfZero(customersInput)),
     })).toThrow('referenced metric "customers" belongs to dataset "customers", expected "orders"');
+  });
+});
+
+describe('stripSqlLiterals', () => {
+  it('blanks a single-quoted literal but keeps surrounding code', () => {
+    // The 4-character literal `'; '` becomes 4 spaces; everything else survives.
+    expect(stripSqlLiterals("concat(name, '; ')")).toBe('concat(name,     )');
+  });
+
+  it('preserves length so offsets survive', () => {
+    const sql = "replaceAll(note, '--', '')";
+    expect(stripSqlLiterals(sql)).toHaveLength(sql.length);
+  });
+
+  it('treats a doubled quote as an escape, not a close', () => {
+    expect(stripSqlLiterals("a || 'it''s' || b")).toBe('a ||         || b');
+  });
+
+  it('treats a backslash as escaping the next character', () => {
+    expect(stripSqlLiterals("'it\\'s'")).toBe('       ');
+  });
+
+  it('blanks double-quoted and backtick-quoted identifiers', () => {
+    expect(stripSqlLiterals('"col" + `other`')).toBe('      +        ');
+  });
+
+  it('leaves an expression with no literals untouched', () => {
+    expect(stripSqlLiterals('amount - discount')).toBe('amount - discount');
+  });
+
+  it('throws on an unterminated literal', () => {
+    expect(() => stripSqlLiterals("name' ; DROP")).toThrow(/Unterminated ' literal/);
+  });
+});
+
+describe('escapeRegExp', () => {
+  it('escapes regex metacharacters', () => {
+    expect(new RegExp(escapeRegExp('amount(')).test('amount(')).toBe(true);
+  });
+
+  it('stops a metacharacter from matching something else', () => {
+    expect(new RegExp(`^${escapeRegExp('a+')}$`).test('aaa')).toBe(false);
   });
 });

--- a/packages/datasets/src/sql-utils.test.ts
+++ b/packages/datasets/src/sql-utils.test.ts
@@ -165,6 +165,25 @@ describe('stripSqlLiterals', () => {
     expect(stripSqlLiterals('amount - discount')).toBe('amount - discount');
   });
 
+  it('keeps quoted-identifier text when asked, blanking only the delimiters', () => {
+    expect(stripSqlLiterals('`amount` - discount', { keepQuotedIdentifiers: true })).toBe(
+      ' amount  - discount',
+    );
+  });
+
+  it('still blanks string literals when keeping quoted identifiers', () => {
+    // `'a;b'` is 5 characters, so 5 spaces; `` `col` `` keeps its text as ` col `.
+    expect(stripSqlLiterals("concat('a;b', `col`)", { keepQuotedIdentifiers: true })).toBe(
+      'concat(     ,  col )',
+    );
+  });
+
+  it('preserves length in both modes', () => {
+    const sql = '`amount` - "other"';
+    expect(stripSqlLiterals(sql, { keepQuotedIdentifiers: true })).toHaveLength(sql.length);
+    expect(stripSqlLiterals(sql)).toHaveLength(sql.length);
+  });
+
   it('throws on an unterminated literal', () => {
     expect(() => stripSqlLiterals("name' ; DROP")).toThrow(/Unterminated ' literal/);
   });

--- a/packages/datasets/src/sql-utils.ts
+++ b/packages/datasets/src/sql-utils.ts
@@ -45,6 +45,23 @@ export function quoteSQLIdentifier(identifier: string): string {
 /** Quote characters that open a literal or a quoted identifier in ClickHouse. */
 const SQL_QUOTES = new Set(["'", '"', '`']);
 
+/** Quotes that delimit an identifier rather than a string literal. */
+const IDENTIFIER_QUOTES = new Set(['"', '`']);
+
+export interface StripSqlLiteralsOptions {
+  /**
+   * Keep the text inside quoted identifiers (`` `col` ``, `"col"`), blanking only
+   * the delimiters. String literals are blanked either way.
+   *
+   * The two callers need different views of the same expression. Finding a
+   * statement terminator means finding one that is *syntax*, and a `;` inside
+   * `` `odd;name` `` is not — so that check blanks quoted identifiers too.
+   * Deciding whether an expression references a column is the opposite: a quoted
+   * identifier is exactly such a reference, so that check needs its text.
+   */
+  readonly keepQuotedIdentifiers?: boolean;
+}
+
 /**
  * Blanks out quoted spans in a SQL expression, preserving length and structure.
  *
@@ -60,7 +77,7 @@ const SQL_QUOTES = new Set(["'", '"', '`']);
  * malformed on its own, and treating the remainder as data would let an open
  * quote hide anything after it.
  */
-export function stripSqlLiterals(sql: string): string {
+export function stripSqlLiterals(sql: string, options?: StripSqlLiteralsOptions): string {
   let output = '';
   let index = 0;
 
@@ -100,8 +117,14 @@ export function stripSqlLiterals(sql: string): string {
       throw new Error(`Unterminated ${quote} literal in SQL expression.`);
     }
 
-    // Replace the whole span, quotes included, with spaces so offsets survive.
-    output += ' '.repeat(cursor - index);
+    if (options?.keepQuotedIdentifiers && IDENTIFIER_QUOTES.has(quote)) {
+      // Blank only the delimiters, so the identifier stays readable as the
+      // column reference it is. Length is preserved either way.
+      output += ` ${sql.slice(index + 1, cursor - 1)} `;
+    } else {
+      // Replace the whole span, quotes included, with spaces so offsets survive.
+      output += ' '.repeat(cursor - index);
+    }
     index = cursor;
   }
 

--- a/packages/datasets/src/sql-utils.ts
+++ b/packages/datasets/src/sql-utils.ts
@@ -41,3 +41,79 @@ export function quoteSQLIdentifier(identifier: string): string {
   const escaped = identifier.replace(/`/g, '``');
   return `\`${escaped}\``;
 }
+
+/** Quote characters that open a literal or a quoted identifier in ClickHouse. */
+const SQL_QUOTES = new Set(["'", '"', '`']);
+
+/**
+ * Blanks out quoted spans in a SQL expression, preserving length and structure.
+ *
+ * Lexical checks that look for statement terminators or comment openers have to
+ * run on code rather than on data: `concat(name, '; ')` and
+ * `replaceAll(note, '--', '')` are ordinary expressions whose literals happen to
+ * contain those characters. Scanning the raw source text rejects them.
+ *
+ * Both ClickHouse escape forms are handled: a doubled quote (`'it''s'`) and a
+ * backslash escape (`'it\'s'`).
+ *
+ * @throws Error when a quote is never closed — an unterminated literal is
+ * malformed on its own, and treating the remainder as data would let an open
+ * quote hide anything after it.
+ */
+export function stripSqlLiterals(sql: string): string {
+  let output = '';
+  let index = 0;
+
+  while (index < sql.length) {
+    const char = sql[index] as string;
+    if (!SQL_QUOTES.has(char)) {
+      output += char;
+      index += 1;
+      continue;
+    }
+
+    const quote = char;
+    let cursor = index + 1;
+    let closed = false;
+
+    while (cursor < sql.length) {
+      const current = sql[cursor];
+      if (current === '\\') {
+        // Backslash escapes the next character, whatever it is.
+        cursor += 2;
+        continue;
+      }
+      if (current === quote) {
+        if (sql[cursor + 1] === quote) {
+          // A doubled quote is an escaped quote, not the end of the span.
+          cursor += 2;
+          continue;
+        }
+        closed = true;
+        cursor += 1;
+        break;
+      }
+      cursor += 1;
+    }
+
+    if (!closed) {
+      throw new Error(`Unterminated ${quote} literal in SQL expression.`);
+    }
+
+    // Replace the whole span, quotes included, with spaces so offsets survive.
+    output += ' '.repeat(cursor - index);
+    index = cursor;
+  }
+
+  return output;
+}
+
+/**
+ * Escapes a string for literal use inside a regular expression.
+ *
+ * Without this, a value carrying regex syntax either throws at `RegExp`
+ * construction or silently matches something other than itself.
+ */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/datasets/src/utils/dataset-definition-validation.test.ts
+++ b/packages/datasets/src/utils/dataset-definition-validation.test.ts
@@ -186,6 +186,75 @@ describe('dataset definition validation', () => {
       ).toThrow(/never references it/);
     });
 
+    it('accepts a terminator inside a quoted literal', () => {
+      expect(
+        defineWith({
+          dimensions: { ...baseDimensions, tag: dimension.string({ sql: "concat(name, '; ')" }) },
+        }),
+      ).not.toThrow();
+    });
+
+    it('accepts a comment opener inside a quoted literal', () => {
+      expect(
+        defineWith({
+          dimensions: {
+            ...baseDimensions,
+            clean: dimension.string({ sql: "replaceAll(note, '--', '')" }),
+          },
+        }),
+      ).not.toThrow();
+    });
+
+    it('handles a doubled-quote escape inside a literal', () => {
+      expect(
+        defineWith({
+          dimensions: { ...baseDimensions, tag: dimension.string({ sql: "concat(a, 'it''s;')" }) },
+        }),
+      ).not.toThrow();
+    });
+
+    it('rejects an unterminated literal rather than treating the rest as data', () => {
+      expect(
+        defineWith({
+          dimensions: { ...baseDimensions, evil: dimension.string({ sql: "name' ; DROP TABLE t" }) },
+        }),
+      ).toThrow(/unterminated quoted literal/);
+    });
+
+    it('does not count a dependency that appears only inside a literal', () => {
+      expect(
+        defineWith({
+          dimensions: {
+            ...baseDimensions,
+            label: dimension.string({ sql: "'amount'", dependencies: ['orders.amount'] }),
+          },
+        }),
+      ).toThrow(/never references it/);
+    });
+
+    it('reports a dependency carrying regex syntax instead of throwing a SyntaxError', () => {
+      expect(
+        defineWith({
+          dimensions: {
+            ...baseDimensions,
+            net: dimension.number({ sql: 'amount', dependencies: ['orders.amount('] }),
+          },
+        }),
+      ).toThrow(/declares dependency "orders\.amount\(", but its sql expression never references it/);
+    });
+
+    it('does not let regex metacharacters in a dependency match something else', () => {
+      // "a+" would match "aaa" if the value reached the pattern unescaped.
+      expect(
+        defineWith({
+          dimensions: {
+            ...baseDimensions,
+            net: dimension.number({ sql: 'aaa', dependencies: ['orders.a+'] }),
+          },
+        }),
+      ).toThrow(/never references it/);
+    });
+
     it('applies the same checks to measures', () => {
       expect(
         defineWith({
@@ -206,6 +275,28 @@ describe('dataset definition validation', () => {
       expect(
         defineWith({ measures: { latest: measure.argMax('amount', 'created_at)') } }),
       ).toThrow(/measure "latest" argField "created_at\)" is not a safe column identifier/);
+    });
+  });
+
+  describe('semantic names', () => {
+    it('rejects a dimension name that is not a safe identifier', () => {
+      expect(
+        defineWith({ dimensions: { ...baseDimensions, 'bad-name': dimension.string() } }),
+      ).toThrow(/dimension name "bad-name" must contain only letters/);
+    });
+
+    it('rejects a bad dimension name even when an explicit column stands in for it', () => {
+      expect(
+        defineWith({
+          dimensions: { ...baseDimensions, 'bad-name': dimension.string({ column: 'good_col' }) },
+        }),
+      ).toThrow(/dimension name "bad-name" must contain only letters/);
+    });
+
+    it('rejects a measure name that is not a safe identifier', () => {
+      expect(defineWith({ measures: { 'bad-name': measure.sum('amount') } })).toThrow(
+        /measure name "bad-name" must contain only letters/,
+      );
     });
   });
 

--- a/packages/datasets/src/utils/dataset-definition-validation.test.ts
+++ b/packages/datasets/src/utils/dataset-definition-validation.test.ts
@@ -255,6 +255,39 @@ describe('dataset definition validation', () => {
       ).toThrow(/never references it/);
     });
 
+    it('counts a dependency referenced through a backtick-quoted identifier', () => {
+      expect(
+        defineWith({
+          dimensions: {
+            ...baseDimensions,
+            net: dimension.number({
+              sql: '`amount` - discount',
+              dependencies: ['orders.amount', 'orders.discount'],
+            }),
+          },
+        }),
+      ).not.toThrow();
+    });
+
+    it('counts a dependency referenced through a double-quoted identifier', () => {
+      expect(
+        defineWith({
+          dimensions: {
+            ...baseDimensions,
+            doubled: dimension.number({ sql: '"amount" * 2', dependencies: ['orders.amount'] }),
+          },
+        }),
+      ).not.toThrow();
+    });
+
+    it('treats a terminator inside a quoted identifier as non-syntax', () => {
+      expect(
+        defineWith({
+          dimensions: { ...baseDimensions, odd: dimension.string({ sql: '`odd;name`' }) },
+        }),
+      ).not.toThrow();
+    });
+
     it('applies the same checks to measures', () => {
       expect(
         defineWith({

--- a/packages/datasets/src/utils/dataset-definition-validation.test.ts
+++ b/packages/datasets/src/utils/dataset-definition-validation.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import { dataset } from '../dataset.js';
+import { dimension } from '../field.js';
+import { measure } from '../measure.js';
+
+const baseDimensions = {
+  id: dimension.string(),
+  amount: dimension.number(),
+};
+
+/** A definition that differs from a valid one only in the field under test. */
+function defineWith(overrides: Record<string, unknown>) {
+  return () =>
+    dataset('orders', {
+      source: 'orders',
+      dimensions: baseDimensions,
+      ...overrides,
+    } as never);
+}
+
+describe('dataset definition validation', () => {
+  describe('accepts valid definitions', () => {
+    it('builds a minimal dataset', () => {
+      expect(defineWith({})).not.toThrow();
+    });
+
+    it('accepts a database-qualified source', () => {
+      expect(defineWith({ source: 'analytics.orders' })).not.toThrow();
+    });
+
+    it('accepts a tenantKey that is not exposed as a dimension', () => {
+      expect(defineWith({ tenantKey: 'tenant_id' })).not.toThrow();
+    });
+
+    it('accepts a timeKey naming a physical column', () => {
+      expect(defineWith({ timeKey: 'created_at' })).not.toThrow();
+    });
+
+    it('accepts a timeKey naming a declared dimension', () => {
+      expect(
+        defineWith({
+          dimensions: { ...baseDimensions, createdAt: dimension.timestamp({ column: 'created_at' }) },
+          timeKey: 'createdAt',
+        }),
+      ).not.toThrow();
+    });
+
+    it('accepts a measure over a hidden physical column', () => {
+      expect(
+        defineWith({ measures: { hiddenTotal: measure.sum('internal_amount') } }),
+      ).not.toThrow();
+    });
+
+    it('accepts a raw sql expression whose dependencies it references', () => {
+      expect(
+        defineWith({
+          dimensions: {
+            ...baseDimensions,
+            net: dimension.number({
+              sql: 'amount - discount',
+              dependencies: ['orders.amount', 'orders.discount'],
+            }),
+          },
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('dataset name and source', () => {
+    it('rejects an empty name', () => {
+      expect(() => dataset('', { source: 'orders', dimensions: baseDimensions })).toThrow(
+        /non-empty dataset name/,
+      );
+    });
+
+    it('rejects a name that is not a safe identifier', () => {
+      expect(() => dataset('orders-v2', { source: 'orders', dimensions: baseDimensions })).toThrow(
+        /dataset names must contain only letters/,
+      );
+    });
+
+    it('rejects an empty source', () => {
+      expect(defineWith({ source: '' })).toThrow(/non-empty source table/);
+    });
+
+    it('rejects a source carrying injected SQL', () => {
+      expect(defineWith({ source: 'orders; DROP TABLE users' })).toThrow(
+        /not a safe table identifier/,
+      );
+    });
+
+    it('rejects a source qualified more deeply than database.table', () => {
+      expect(defineWith({ source: 'cluster.analytics.orders' })).toThrow(
+        /not a safe table identifier/,
+      );
+    });
+  });
+
+  describe('tenant and time keys', () => {
+    it('rejects an empty tenantKey rather than treating it as absent', () => {
+      expect(defineWith({ tenantKey: '' })).toThrow(/tenantKey cannot be empty/);
+    });
+
+    it('rejects a tenantKey that is not a safe column identifier', () => {
+      expect(defineWith({ tenantKey: 'tenant_id OR 1=1' })).toThrow(
+        /tenantKey "tenant_id OR 1=1" is not a safe column identifier/,
+      );
+    });
+
+    it('rejects an empty timeKey', () => {
+      expect(defineWith({ timeKey: '' })).toThrow(/timeKey cannot be empty/);
+    });
+
+    it('rejects an unsafe timeKey', () => {
+      expect(defineWith({ timeKey: 'created_at)' })).toThrow(/not a safe column identifier/);
+    });
+  });
+
+  describe('dimensions', () => {
+    it('rejects a dimension name containing a dot', () => {
+      expect(
+        defineWith({ dimensions: { ...baseDimensions, 'customer.name': dimension.string() } }),
+      ).toThrow(/cannot contain "\."/);
+    });
+
+    it('rejects an unsafe backing column', () => {
+      expect(
+        defineWith({ dimensions: { ...baseDimensions, region: dimension.string({ column: 'a b' }) } }),
+      ).toThrow(/dimension "region" column "a b" is not a safe column identifier/);
+    });
+  });
+
+  describe('raw sql expressions', () => {
+    it('rejects a statement terminator', () => {
+      expect(
+        defineWith({
+          dimensions: { ...baseDimensions, evil: dimension.string({ sql: 'name; DROP TABLE users' }) },
+        }),
+      ).toThrow(/must be a single expression without statement terminators/);
+    });
+
+    it('rejects a line comment', () => {
+      expect(
+        defineWith({
+          dimensions: { ...baseDimensions, evil: dimension.string({ sql: 'name -- rest' }) },
+        }),
+      ).toThrow(/must be a single expression without statement terminators/);
+    });
+
+    it('rejects a block comment', () => {
+      expect(
+        defineWith({
+          dimensions: { ...baseDimensions, evil: dimension.string({ sql: 'name /* rest' }) },
+        }),
+      ).toThrow(/must be a single expression without statement terminators/);
+    });
+
+    it('rejects an empty sql expression', () => {
+      expect(
+        defineWith({ dimensions: { ...baseDimensions, blank: dimension.string({ sql: '   ' }) } }),
+      ).toThrow(/declares an empty sql expression/);
+    });
+
+    it('rejects a declared dependency the expression never references', () => {
+      expect(
+        defineWith({
+          dimensions: {
+            ...baseDimensions,
+            net: dimension.number({
+              sql: 'amount - discount',
+              dependencies: ['orders.amount', 'orders.tax'],
+            }),
+          },
+        }),
+      ).toThrow(/declares dependency "orders\.tax", but its sql expression never references it/);
+    });
+
+    it('does not treat a substring as a reference', () => {
+      expect(
+        defineWith({
+          dimensions: {
+            ...baseDimensions,
+            net: dimension.number({ sql: 'amount_net', dependencies: ['orders.amount'] }),
+          },
+        }),
+      ).toThrow(/never references it/);
+    });
+
+    it('applies the same checks to measures', () => {
+      expect(
+        defineWith({
+          measures: { evil: measure.sum('amount', { sql: 'sum(amount); DROP TABLE users' }) },
+        }),
+      ).toThrow(/measure "evil" sql must be a single expression/);
+    });
+  });
+
+  describe('measures', () => {
+    it('rejects an unsafe field', () => {
+      expect(defineWith({ measures: { total: measure.sum('amount)') } })).toThrow(
+        /measure "total" field "amount\)" is not a safe column identifier/,
+      );
+    });
+
+    it('rejects an unsafe argField', () => {
+      expect(
+        defineWith({ measures: { latest: measure.argMax('amount', 'created_at)') } }),
+      ).toThrow(/measure "latest" argField "created_at\)" is not a safe column identifier/);
+    });
+  });
+
+  describe('limits', () => {
+    it('rejects a non-positive limit', () => {
+      expect(defineWith({ limits: { maxResultSize: 0 } })).toThrow(
+        /limits\.maxResultSize must be a positive integer/,
+      );
+    });
+
+    it('rejects a fractional limit', () => {
+      expect(defineWith({ limits: { maxDimensions: 2.5 } })).toThrow(
+        /limits\.maxDimensions must be a positive integer/,
+      );
+    });
+  });
+});

--- a/packages/datasets/src/utils/dataset-definition-validation.ts
+++ b/packages/datasets/src/utils/dataset-definition-validation.ts
@@ -1,0 +1,250 @@
+/**
+ * Definition-time structural validation for `dataset()`.
+ *
+ * Every check here runs when the dataset is *constructed*, not when it is
+ * queried. A dataset is normally defined at module scope, so a malformed model
+ * fails at import — in the build, in CI, and in the first test that touches the
+ * module — instead of on the first request that happens to exercise the broken
+ * part. The alternative is a typo in `tenantKey` that constructs cleanly, passes
+ * review, and is discovered by a query that quietly returns another tenant's
+ * rows.
+ *
+ * Two categories of check live here:
+ *
+ * - **Identifier safety.** `source`, `tenantKey`, `timeKey`, dimension columns
+ *   and measure fields are all interpolated into SQL as identifiers. They are
+ *   validated once here rather than trusted at every call site that builds a
+ *   predicate from them.
+ * - **Raw SQL shape.** The `sql` escape hatch on dimensions and measures is an
+ *   expression, never a statement. A value carrying a statement terminator or a
+ *   comment is rejected structurally, so it cannot become a second statement or
+ *   comment out the rest of a clause.
+ */
+
+import type {
+  DatasetConfig,
+  DimensionDefinition,
+  MeasureDefinition,
+  RelationshipDefinition,
+} from '../types.js';
+import { isSafeSQLIdentifier } from '../sql-utils.js';
+
+type AnyDimensions = Record<string, DimensionDefinition>;
+type AnyMeasures = Record<string, MeasureDefinition>;
+type AnyRelationships = Record<string, RelationshipDefinition>;
+
+/**
+ * Statement terminators and comment openers.
+ *
+ * A raw `sql` value is spliced into a larger expression, so any of these turns
+ * one expression into something else: `;` starts a second statement, `--` and
+ * `/*` comment out whatever the builder appends after it.
+ */
+const STATEMENT_BREAKERS = /;|--|\/\*/;
+
+/** Dataset, dimension and measure names address fields as `<relationship>.<dimension>`. */
+const QUALIFIED_SEPARATOR = '.';
+
+function fail(datasetName: string, message: string): never {
+  throw new Error(`Invalid dataset "${datasetName}": ${message}`);
+}
+
+/**
+ * Validates a possibly-qualified physical name such as `orders` or
+ * `analytics.orders`. Each segment must stand alone as a safe identifier, so a
+ * qualified name cannot smuggle anything past the per-segment check.
+ */
+function isSafeQualifiedName(value: string, maxSegments: number): boolean {
+  const segments = value.split(QUALIFIED_SEPARATOR);
+  if (segments.length > maxSegments) {
+    return false;
+  }
+  return segments.every(isSafeSQLIdentifier);
+}
+
+function assertSafeColumn(
+  datasetName: string,
+  value: string,
+  context: string,
+): void {
+  if (!isSafeSQLIdentifier(value)) {
+    fail(
+      datasetName,
+      `${context} "${value}" is not a safe column identifier. It is interpolated into SQL, so it ` +
+      'must contain only letters, numbers and underscores, and start with a letter or underscore.',
+    );
+  }
+}
+
+/**
+ * Checks a raw `sql` expression and the dependencies declared alongside it.
+ *
+ * The dependency check runs in the direction that fails silently: a declared
+ * dependency the expression never references means the definition believes it
+ * reads a column it does not read. The opposite direction — an identifier used
+ * but not declared — would need a SQL parser, and is caught by the protocol
+ * adapter when the artifact is produced.
+ */
+function validateRawSql(
+  datasetName: string,
+  kind: 'dimension' | 'measure',
+  name: string,
+  sql: string,
+  dependencies: readonly string[] | undefined,
+): void {
+  if (sql.trim().length === 0) {
+    fail(datasetName, `${kind} "${name}" declares an empty sql expression.`);
+  }
+
+  if (STATEMENT_BREAKERS.test(sql)) {
+    fail(
+      datasetName,
+      `${kind} "${name}" sql must be a single expression without statement terminators or ` +
+      'comments (";", "--", "/*").',
+    );
+  }
+
+  for (const dependency of dependencies ?? []) {
+    // Dependencies are qualified identifiers (`analytics.orders.amount`); the
+    // expression references the column itself, so the final segment is what has
+    // to appear in it.
+    const segments = dependency.split(QUALIFIED_SEPARATOR);
+    const column = segments[segments.length - 1] ?? '';
+    if (column.length === 0 || !new RegExp(`\\b${column}\\b`).test(sql)) {
+      fail(
+        datasetName,
+        `${kind} "${name}" declares dependency "${dependency}", but its sql expression never ` +
+        'references it. A dependency the expression does not read makes the definition claim ' +
+        'a column it never touches.',
+      );
+    }
+  }
+}
+
+function validateDimensions(datasetName: string, dimensions: AnyDimensions): void {
+  for (const [name, definition] of Object.entries(dimensions)) {
+    if (name.includes(QUALIFIED_SEPARATOR)) {
+      fail(
+        datasetName,
+        `dimension "${name}" cannot contain "." because qualified fields are addressed as ` +
+        '"<relationship>.<dimension>".',
+      );
+    }
+
+    if (definition.sql !== undefined) {
+      validateRawSql(datasetName, 'dimension', name, definition.sql, definition.dependencies);
+      continue;
+    }
+
+    // A dimension with no explicit column is backed by a column of the same name.
+    assertSafeColumn(datasetName, definition.column ?? name, `dimension "${name}" column`);
+  }
+}
+
+function validateMeasures(
+  datasetName: string,
+  measures: AnyMeasures,
+  dimensions: AnyDimensions,
+): void {
+  for (const [name, definition] of Object.entries(measures)) {
+    if (definition.sql !== undefined) {
+      validateRawSql(datasetName, 'measure', name, definition.sql, definition.dependencies);
+    }
+
+    // `field` and `argField` name either a declared dimension or a physical
+    // column that the model deliberately does not expose (the `allowHiddenField`
+    // case in metric validation). Either way the value reaches SQL, so a name
+    // that is not a declared dimension must at least be a safe identifier.
+    for (const [label, value] of [
+      ['field', definition.field],
+      ['argField', definition.argField],
+    ] as const) {
+      if (value === undefined || value in dimensions) {
+        continue;
+      }
+      assertSafeColumn(datasetName, value, `measure "${name}" ${label}`);
+    }
+  }
+}
+
+function validateLimits(datasetName: string, limits: DatasetConfig['limits']): void {
+  if (!limits) {
+    return;
+  }
+
+  for (const [name, value] of Object.entries(limits)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (!Number.isInteger(value) || value <= 0) {
+      fail(
+        datasetName,
+        `limits.${name} must be a positive integer, received ${String(value)}.`,
+      );
+    }
+  }
+}
+
+/**
+ * Validates a dataset definition. Throws on the first problem found.
+ *
+ * Called by `dataset()` before the instance is built, so an invalid model never
+ * becomes a queryable object.
+ */
+export function validateDatasetDefinition(
+  name: string,
+  config: DatasetConfig<AnyDimensions, AnyMeasures, AnyRelationships>,
+): void {
+  if (typeof name !== 'string' || name.trim().length === 0) {
+    throw new Error('Invalid dataset: a non-empty dataset name is required.');
+  }
+
+  if (!isSafeSQLIdentifier(name)) {
+    fail(
+      name,
+      'dataset names must contain only letters, numbers and underscores, and start with a letter ' +
+      'or underscore, so they remain valid identifiers in generated artifacts.',
+    );
+  }
+
+  if (typeof config.source !== 'string' || config.source.trim().length === 0) {
+    fail(name, 'a non-empty source table is required.');
+  }
+
+  // `database.table` is the deepest qualification ClickHouse addresses.
+  if (!isSafeQualifiedName(config.source, 2)) {
+    fail(
+      name,
+      `source "${config.source}" is not a safe table identifier. Expected "table" or ` +
+      '"database.table", each segment containing only letters, numbers and underscores.',
+    );
+  }
+
+  // The tenant key is the isolation boundary: it becomes a WHERE predicate on
+  // every query against a tenant-scoped dataset, so it is checked here rather
+  // than trusted wherever that predicate is assembled.
+  if (config.tenantKey !== undefined) {
+    if (config.tenantKey.trim().length === 0) {
+      fail(name, 'tenantKey cannot be empty. Omit it entirely for a dataset without tenancy.');
+    }
+    assertSafeColumn(name, config.tenantKey, 'tenantKey');
+  }
+
+  if (config.timeKey !== undefined) {
+    if (config.timeKey.trim().length === 0) {
+      fail(name, 'timeKey cannot be empty. Omit it entirely for a dataset without a time key.');
+    }
+    if (!(config.timeKey in (config.dimensions ?? {}))) {
+      assertSafeColumn(name, config.timeKey, 'timeKey');
+    }
+  }
+
+  // A dataset with no dimensions is not rejected here: the query layer already
+  // refuses an empty dataset query, which is the honest place for it — a
+  // measure-only model is a legitimate thing to define.
+  const dimensions = config.dimensions ?? {};
+
+  validateDimensions(name, dimensions);
+  validateMeasures(name, config.measures ?? {}, dimensions);
+  validateLimits(name, config.limits);
+}

--- a/packages/datasets/src/utils/dataset-definition-validation.ts
+++ b/packages/datasets/src/utils/dataset-definition-validation.ts
@@ -122,8 +122,12 @@ function validateRawSql(
   // string literal is data rather than syntax. An unterminated quote is itself a
   // rejection: left as data, an open quote would hide everything after it.
   let code: string;
+  let referenceable: string;
   try {
     code = stripSqlLiterals(sql);
+    // A quoted identifier is a column reference, so the dependency check below
+    // needs its text even though the terminator check above must not see it.
+    referenceable = stripSqlLiterals(sql, { keepQuotedIdentifiers: true });
   } catch {
     fail(datasetName, `${kind} "${name}" sql has an unterminated quoted literal.`);
   }
@@ -143,7 +147,7 @@ function validateRawSql(
     // regex syntax would either throw at construction or match something else.
     const segments = dependency.split(QUALIFIED_SEPARATOR);
     const column = segments[segments.length - 1] ?? '';
-    if (column.length === 0 || !new RegExp(`\\b${escapeRegExp(column)}\\b`).test(code)) {
+    if (column.length === 0 || !new RegExp(`\\b${escapeRegExp(column)}\\b`).test(referenceable)) {
       fail(
         datasetName,
         `${kind} "${name}" declares dependency "${dependency}", but its sql expression never ` +

--- a/packages/datasets/src/utils/dataset-definition-validation.ts
+++ b/packages/datasets/src/utils/dataset-definition-validation.ts
@@ -27,7 +27,7 @@ import type {
   MeasureDefinition,
   RelationshipDefinition,
 } from '../types.js';
-import { isSafeSQLIdentifier } from '../sql-utils.js';
+import { escapeRegExp, isSafeSQLIdentifier, stripSqlLiterals } from '../sql-utils.js';
 
 type AnyDimensions = Record<string, DimensionDefinition>;
 type AnyMeasures = Record<string, MeasureDefinition>;
@@ -77,6 +77,28 @@ function assertSafeColumn(
 }
 
 /**
+ * Validates a semantic name — a dimension or measure key.
+ *
+ * These are not physical columns, but they are identifiers: they appear in query
+ * inputs, generated tool schemas, and protocol artifacts, where the strict
+ * identifier grammar applies. Rejecting here beats failing later during artifact
+ * production, which is far from the definition that caused it.
+ */
+function assertSafeName(
+  datasetName: string,
+  kind: 'dimension' | 'measure',
+  name: string,
+): void {
+  if (!isSafeSQLIdentifier(name)) {
+    fail(
+      datasetName,
+      `${kind} name "${name}" must contain only letters, numbers and underscores, and start ` +
+      'with a letter or underscore, so it stays a valid identifier in generated artifacts.',
+    );
+  }
+}
+
+/**
  * Checks a raw `sql` expression and the dependencies declared alongside it.
  *
  * The dependency check runs in the direction that fails silently: a declared
@@ -96,21 +118,32 @@ function validateRawSql(
     fail(datasetName, `${kind} "${name}" declares an empty sql expression.`);
   }
 
-  if (STATEMENT_BREAKERS.test(sql)) {
+  // Quoted spans are blanked first, so a terminator or comment opener *inside* a
+  // string literal is data rather than syntax. An unterminated quote is itself a
+  // rejection: left as data, an open quote would hide everything after it.
+  let code: string;
+  try {
+    code = stripSqlLiterals(sql);
+  } catch {
+    fail(datasetName, `${kind} "${name}" sql has an unterminated quoted literal.`);
+  }
+
+  if (STATEMENT_BREAKERS.test(code)) {
     fail(
       datasetName,
       `${kind} "${name}" sql must be a single expression without statement terminators or ` +
-      'comments (";", "--", "/*").',
+      'comments (";", "--", "/*") outside a quoted literal.',
     );
   }
 
   for (const dependency of dependencies ?? []) {
     // Dependencies are qualified identifiers (`analytics.orders.amount`); the
     // expression references the column itself, so the final segment is what has
-    // to appear in it.
+    // to appear in it. Escaped before it becomes a pattern: a raw value carrying
+    // regex syntax would either throw at construction or match something else.
     const segments = dependency.split(QUALIFIED_SEPARATOR);
     const column = segments[segments.length - 1] ?? '';
-    if (column.length === 0 || !new RegExp(`\\b${column}\\b`).test(sql)) {
+    if (column.length === 0 || !new RegExp(`\\b${escapeRegExp(column)}\\b`).test(code)) {
       fail(
         datasetName,
         `${kind} "${name}" declares dependency "${dependency}", but its sql expression never ` +
@@ -131,6 +164,12 @@ function validateDimensions(datasetName: string, dimensions: AnyDimensions): voi
       );
     }
 
+    // The name is a semantic identifier in its own right — it appears in
+    // protocol artifacts and query inputs — so it is checked whether or not an
+    // explicit column stands in for it below. Without this, the check silently
+    // depended on the column being omitted.
+    assertSafeName(datasetName, 'dimension', name);
+
     if (definition.sql !== undefined) {
       validateRawSql(datasetName, 'dimension', name, definition.sql, definition.dependencies);
       continue;
@@ -147,6 +186,8 @@ function validateMeasures(
   dimensions: AnyDimensions,
 ): void {
   for (const [name, definition] of Object.entries(measures)) {
+    assertSafeName(datasetName, 'measure', name);
+
     if (definition.sql !== undefined) {
       validateRawSql(datasetName, 'measure', name, definition.sql, definition.dependencies);
     }


### PR DESCRIPTION
## Why

`dataset()` validated almost nothing. A malformed model constructed cleanly and failed on the first query that happened to reach the broken part of it — in production, under a tenant, often as a plausible-looking number rather than an error.

The sharpest case is `tenantKey`. It was copied verbatim (`dataset.ts:117`), never checked against anything, and becomes a `WHERE` predicate on every query against a tenant-scoped dataset. `tenantKey: 'tenant_i'` was a clean construction, a passing review, and a discovery made by a query.

Datasets are normally defined at module scope, so validating in `dataset()` moves these failures to import time: the build, CI, and the first test that touches the module.

The design is borrowed from the allowlisted-operation registry in [OpenLabs-so/openanalytics](https://github.com/OpenLabs-so/openanalytics)' query gateway, which runs its structural assertions at module load for the same reason — *"a future edit that points an operation at events_raw fails at load, not in review."*

## What changed

New `packages/datasets/src/utils/dataset-definition-validation.ts`, called from `dataset()` before normalization.

**Identifier safety** — `source`, `tenantKey`, `timeKey`, dimension columns and measure `field`/`argField` are all interpolated into generated SQL. They are validated once here rather than trusted at every call site that assembles a predicate from them. `source` accepts `table` or `database.table`, each segment checked independently. `tenantKey` and `timeKey` may name physical columns the model deliberately does not expose, so they are checked as identifiers rather than required to be declared dimensions. Dimension and measure *names* are checked directly too — previously a bad name was caught only indirectly through the column it defaulted to, so the same name passed or failed depending on whether an explicit `column` was set.

**Raw SQL shape** — the `sql` escape hatch is an expression spliced into a larger one, never a statement. A value carrying `;`, `--` or `/*` **outside a quoted literal** is rejected structurally. Quoted spans are blanked first via `stripSqlLiterals` (new, in `sql-utils.ts`), so `concat(name, '; ')` is accepted as the ordinary expression it is. An unterminated quote is rejected outright — left as data, an open quote would hide everything after it.

**Dependency direction** — a declared `dependencies` entry the expression never references means the definition claims to read a column it does not read. This is the direction that fails silently; the opposite direction needs a SQL parser and is already caught by the protocol adapter. The check runs against a view of the expression that keeps quoted identifiers (`` `amount` `` is a column reference) but still blanks string literals (a name inside a string is not).

**Limits** — `limits` values must be positive integers.

## Review rounds

Greptile raised four findings across three rounds. All four were real, each was reproduced before fixing, and all are addressed:

| Finding | Fix |
|---|---|
| Quoted SQL literals rejected as statement terminators | ad4b88e |
| Dependency values reached `RegExp` unescaped | ad4b88e |
| Semantic names bypassed validation | ad4b88e |
| Quoted identifiers lost dependency references (a regression from ad4b88e) | 9f1fb33 |

One finding is **open by design**: enforcing the protocol's reserved `__hypequery` prefix and 128-byte limit on semantic names. The facts are correct, but that is the protocol-artifact contract rather than this PR's SQL-safety one, and enforcing it in `dataset()` would reject definitions at import for users who never generate an artifact. [Left for a maintainer decision with a proposed patch](https://github.com/hypequery/hypequery/pull/433#discussion_r3892264646); the reviewer agreed it belongs as a follow-up.

## Deliberately not included

A dataset with no dimensions is still allowed. The query layer already refuses an empty dataset query and has a test asserting exactly that — duplicating the check at definition time broke that test and would have been a behavior change for measure-only models, which are legitimate.

`validateBaseMetric` is still only run for measures promoted to metrics. Running it over every declared measure would apply metric-level filter validation to unpromoted measures, a larger behavior change than this PR should make.

## Testing

- 40 tests in `dataset-definition-validation.test.ts`, covering each rule, the valid definitions that must keep working (qualified sources, hidden tenant columns, hidden measure columns, dimension-name vs. column-name time keys, quoted-identifier dependency references), and a regression test per review finding.
- 12 tests for `stripSqlLiterals` / `escapeRegExp` in `sql-utils.test.ts`, including both escape forms, both stripping modes, and length preservation.
- `@hypequery/datasets` — 359 passing.
- Downstream suites that construct datasets, re-run against the built package: `serve` 533, `cli` 566, `mcp` 84, `react` 51, `clickhouse` 669, `protocol` 474 — all passing.
- `lint` and `test:types` clean.

One pre-existing failure in `@hypequery/deployment` (`intake.test.ts > does not turn a successful persist into a failure when cleanup fails`) is unrelated — verified failing on a stashed working tree at the same base commit.

## Release

Changeset included: `@hypequery/datasets` minor. New validation errors are user-facing, and a definition that violates the new rules will now throw where it previously did not.