### PR TITLE
Add content engine dispatch workflow

### DIFF
--- a/.github/workflows/notify-content-engine.yml
+++ b/.github/workflows/notify-content-engine.yml
@@ -27,7 +27,8 @@ jobs:
           BEFORE_SHA: ${{ github.event.before }}
           AFTER_SHA: ${{ github.sha }}
         run: |
-          FILES=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- 'website-next/content/blog/**' | grep -E '\.mdx?$' || true)
+          CHANGED_FILES=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- 'website-next/content/blog/**')
+          FILES=$(printf '%s\n' "$CHANGED_FILES" | grep -E '\.mdx?$' || true)
           echo "files<<EOF" >> "$GITHUB_OUTPUT"
           echo "$FILES" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/notify-content-engine.yml
+++ b/.github/workflows/notify-content-engine.yml
@@ -1,0 +1,69 @@
+# Sends blog and release events to the private content-engine repository.
+# CONTENT_ENGINE_DISPATCH_TOKEN must be a fine-grained PAT with Contents: write
+# on hypequery/hypequery-content-engine (required by repository_dispatch).
+
+name: Notify content engine
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "website-next/content/blog/**"
+  release:
+    types: [published]
+
+jobs:
+  notify-blog:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Find the changed post(s)
+        id: changed
+        run: |
+          FILES=$(git diff --name-only HEAD^ HEAD -- 'website-next/content/blog/**' | grep -E '\.mdx?$' || true)
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$FILES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch one event per changed post
+        if: steps.changed.outputs.files != ''
+        env:
+          TOKEN: ${{ secrets.CONTENT_ENGINE_DISPATCH_TOKEN }}
+          FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            echo "Dispatching: $f"
+            curl -sS --fail-with-body -X POST \
+              -H "Authorization: Bearer $TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/hypequery/hypequery-content-engine/dispatches \
+              -d "$(jq -nc --arg path "$f" '{event_type: "blog-post-merged", client_payload: {path: $path}}')"
+          done <<< "$FILES"
+
+  notify-release:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch the published release
+        env:
+          TOKEN: ${{ secrets.CONTENT_ENGINE_DISPATCH_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          curl -sS --fail-with-body -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/hypequery/hypequery-content-engine/dispatches \
+            -d "$(jq -nc \
+              --arg tag_name "$RELEASE_TAG" \
+              --arg name "$RELEASE_NAME" \
+              --arg body "$RELEASE_BODY" \
+              --arg html_url "$RELEASE_URL" \
+              '{event_type: "product-release-published", client_payload: {tag_name: $tag_name, name: $name, body: $body, html_url: $html_url}}')"

--- a/.github/workflows/notify-content-engine.yml
+++ b/.github/workflows/notify-content-engine.yml
@@ -17,14 +17,17 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Find the changed post(s)
         id: changed
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
         run: |
-          FILES=$(git diff --name-only HEAD^ HEAD -- 'website-next/content/blog/**' | grep -E '\.mdx?$' || true)
+          FILES=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- 'website-next/content/blog/**' | grep -E '\.mdx?$' || true)
           echo "files<<EOF" >> "$GITHUB_OUTPUT"
           echo "$FILES" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- dispatch changed blog posts to `hypequery-content-engine`
- dispatch published release metadata to the content engine
- fail visibly when the repository-dispatch request is rejected

## Setup dependency
Requires the `CONTENT_ENGINE_DISPATCH_TOKEN` repository secret. The fine-grained token needs **Contents: write** on `hypequery/hypequery-content-engine`.

Merge the companion content-engine PR first: https://github.com/hypequery/hypequery-content-engine/pull/2

## Verification
- parsed the workflow as YAML
- `git diff --check`