### PR TITLE
fix(protocol): add default export condition

### DIFF
--- a/.changeset/calm-pandas-resolve.md
+++ b/.changeset/calm-pandas-resolve.md
@@ -1,0 +1,5 @@
+---
+'@hypequery/protocol': patch
+---
+
+Add a default export condition so CommonJS-targeting transforms can resolve the package entry point.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -18,7 +18,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/protocol/src/package-exports.test.ts
+++ b/packages/protocol/src/package-exports.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+interface PackageJson {
+  exports?: {
+    '.'?: Record<string, string>;
+  };
+}
+
+const packageJson = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+) as PackageJson;
+
+describe('package exports', () => {
+  it('provides a fallback for resolvers without the import condition', () => {
+    const rootExport = packageJson.exports?.['.'];
+
+    expect(rootExport?.default).toBe('./dist/index.js');
+    expect(Object.keys(rootExport ?? {})).toEqual(['types', 'import', 'default']);
+  });
+});

--- a/packages/protocol/src/package-exports.test.ts
+++ b/packages/protocol/src/package-exports.test.ts
@@ -1,21 +1,15 @@
-import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-interface PackageJson {
-  exports?: {
-    '.'?: Record<string, string>;
-  };
-}
-
-const packageJson = JSON.parse(
-  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
-) as PackageJson;
+const require = createRequire(import.meta.url);
 
 describe('package exports', () => {
-  it('provides a fallback for resolvers without the import condition', () => {
-    const rootExport = packageJson.exports?.['.'];
+  it('resolves and loads the package under require conditions', () => {
+    const entryPath = require.resolve('@hypequery/protocol');
+    const protocol = require('@hypequery/protocol') as Record<string, unknown>;
 
-    expect(rootExport?.default).toBe('./dist/index.js');
-    expect(Object.keys(rootExport ?? {})).toEqual(['types', 'import', 'default']);
+    expect(entryPath).toBe(fileURLToPath(new URL('../dist/index.js', import.meta.url)));
+    expect(protocol.validateCanonicalValue).toBeTypeOf('function');
   });
 });

--- a/packages/protocol/src/package-exports.test.ts
+++ b/packages/protocol/src/package-exports.test.ts
@@ -1,15 +1,47 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { createRequire } from 'node:module';
-import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
-
-const require = createRequire(import.meta.url);
 
 describe('package exports', () => {
   it('resolves and loads the package under require conditions', () => {
-    const entryPath = require.resolve('@hypequery/protocol');
-    const protocol = require('@hypequery/protocol') as Record<string, unknown>;
+    const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'hypequery-protocol-exports-'));
 
-    expect(entryPath).toBe(fileURLToPath(new URL('../dist/index.js', import.meta.url)));
-    expect(protocol.validateCanonicalValue).toBeTypeOf('function');
+    try {
+      const packageRoot = path.join(
+        fixtureRoot,
+        'node_modules',
+        '@hypequery',
+        'protocol',
+      );
+      const distRoot = path.join(packageRoot, 'dist');
+      const entryPath = path.join(distRoot, 'index.js');
+      mkdirSync(distRoot, { recursive: true });
+      writeFileSync(
+        path.join(packageRoot, 'package.json'),
+        readFileSync(new URL('../package.json', import.meta.url)),
+      );
+      writeFileSync(entryPath, 'export const exportConditionProbe = true;\n');
+
+      const require = createRequire(
+        pathToFileURL(path.join(fixtureRoot, 'consumer.cjs')),
+      );
+      const resolvedPath = require.resolve('@hypequery/protocol');
+      const protocol = require('@hypequery/protocol') as Record<string, unknown>;
+
+      expect(resolvedPath).toBe(realpathSync(entryPath));
+      expect(protocol.exportConditionProbe).toBe(true);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- add a `default` condition for the `@hypequery/protocol` root export
- preserve the existing ESM import path while allowing require-condition resolvers and CJS transforms to locate the entry point
- add a regression test for the export map and a patch changeset

## Verification

- `pnpm --filter @hypequery/protocol build`
- `pnpm --filter @hypequery/protocol test` — 475 tests passed
- `pnpm --filter @hypequery/protocol lint`
- `pnpm --filter @hypequery/protocol types`
- `pnpm check:package-metadata`
- `pnpm turbo run build --filter=@hypequery/clickhouse`
- verified `require()` and `import()` resolution for Protocol and native `require()` loading for ClickHouse

Fixes #438