### PR TITLE
feat(mcp): enforce execution budgets

### DIFF
--- a/.changeset/quiet-budgets-stop.md
+++ b/.changeset/quiet-budgets-stop.md
@@ -1,8 +1,9 @@
 ---
 "@hypequery/datasets": minor
 "@hypequery/mcp": minor
+"@hypequery/clickhouse": minor
 ---
 
-Propagate semantic query cancellation to backing query builders and enforce MCP
-query deadlines and serialized-response byte ceilings with stable budget error
-classifications.
+Propagate semantic query cancellation through the datasets client and ClickHouse
+semantic backend, and enforce MCP query deadlines and serialized-response byte
+ceilings with stable budget error classifications.

--- a/.changeset/quiet-budgets-stop.md
+++ b/.changeset/quiet-budgets-stop.md
@@ -1,0 +1,8 @@
+---
+"@hypequery/datasets": minor
+"@hypequery/mcp": minor
+---
+
+Propagate semantic query cancellation to backing query builders and enforce MCP
+query deadlines and serialized-response byte ceilings with stable budget error
+classifications.

--- a/packages/clickhouse/src/core/tests/datasets-backend.test.ts
+++ b/packages/clickhouse/src/core/tests/datasets-backend.test.ts
@@ -115,18 +115,21 @@ const Products = dataset('products', {
 
 function createTestBackend(mockData: any[] = []) {
   const queries: string[] = [];
+  const abortSignals: Array<AbortSignal | undefined> = [];
 
   return {
     backend: createBackend({
       adapter: {
         name: 'test',
-        query: async (sql: string) => {
+        query: async (sql: string, _params, options) => {
           queries.push(sql);
+          abortSignals.push(options?.abortSignal);
           return mockData;
         },
       },
     }),
     queries,
+    abortSignals,
   };
 }
 
@@ -135,6 +138,16 @@ function createTestBackend(mockData: any[] = []) {
 // =============================================================================
 
 describe('ClickHouse Backend - Base Aggregations', () => {
+  it('forwards cancellation to the backing ClickHouse query', async () => {
+    const { backend, abortSignals } = createTestBackend([]);
+    const analytics = createDatasetClient({ backend });
+    const abortSignal = new AbortController().signal;
+
+    await analytics.execute(Orders, { measures: ['revenue'] }, { abortSignal });
+
+    expect(abortSignals).toEqual([abortSignal]);
+  });
+
   it('generates SUM aggregation', async () => {
     const { backend, queries } = createTestBackend([{ country: 'US', revenue: 1000 }]);
     const analytics = createDatasetClient({ backend });

--- a/packages/clickhouse/src/datasets.ts
+++ b/packages/clickhouse/src/datasets.ts
@@ -535,14 +535,17 @@ export function createBackend<Schema extends SchemaDefinition<Schema>>(
     /**
      * Execute a semantic plan and return results
      */
-    async execute<T = Record<string, unknown>>(plan: PlanNode): Promise<SemanticBackendResult<T>> {
+    async execute<T = Record<string, unknown>>(
+      plan: PlanNode,
+      options?: { abortSignal?: AbortSignal },
+    ): Promise<SemanticBackendResult<T>> {
       const start = Date.now();
 
       if (plan.kind === 'aggregate') {
         // Base metrics: use query builder for full safety
         const query = buildAggregateQuery(queryBuilder, plan);
         const { sql } = query.toSQLWithParams();
-        const data = await query.execute() as T[];
+        const data = await query.execute({ abortSignal: options?.abortSignal }) as T[];
 
         return {
           data,
@@ -556,7 +559,9 @@ export function createBackend<Schema extends SchemaDefinition<Schema>>(
 
       // Derived metrics: CTE query with formulas
       const { sql, parameters } = buildDerivedSQL(queryBuilder, plan);
-      const data = await queryBuilder.rawQuery<T>(sql, parameters);
+      const data = await queryBuilder.rawQuery<T>(sql, parameters, {
+        abortSignal: options?.abortSignal,
+      });
       const tenant = plan.input.kind === 'aggregate' && plan.input.tenant?.operator === 'eq'
         ? plan.input.tenant.value
         : undefined;

--- a/packages/datasets/README.md
+++ b/packages/datasets/README.md
@@ -56,9 +56,13 @@ const result = await analytics.execute(
   },
   {
     runtime: { tenant: session.accountId },
+    abortSignal: request.signal,
   },
 );
 ```
+
+Passing an `AbortSignal` cancels the semantic query and forwards cancellation to
+the backing query builder/database request.
 
 The same definition can become:
 

--- a/packages/datasets/src/api.type-test.ts
+++ b/packages/datasets/src/api.type-test.ts
@@ -171,6 +171,11 @@ const runtimeContext: ExecutionContext = {
   },
 };
 
+const abortableContext: ExecutionContext = {
+  abortSignal: new AbortController().signal,
+};
+void abortableContext;
+
 const _legacyTenantRuntimeContext: ExecutionContext = {
   runtime: {
     tenant: { id: 'tenant-1' },

--- a/packages/datasets/src/cache/dataset-client-cache.test.ts
+++ b/packages/datasets/src/cache/dataset-client-cache.test.ts
@@ -162,6 +162,17 @@ describe('DatasetClient result caching', () => {
     expect(executions).toHaveBeenCalledTimes(2);
   });
 
+  it('an abortable call bypasses the result cache so cancellation reaches execution', async () => {
+    const { factory, executions } = createCountingFactory();
+    const analytics = createDatasetClient({ queryBuilder: factory, cache: { ttlMs: 60_000 } });
+    const context = { abortSignal: new AbortController().signal };
+
+    await analytics.execute(Orders, { measures: ['revenue'] }, context);
+    await analytics.execute(Orders, { measures: ['revenue'] }, context);
+
+    expect(executions).toHaveBeenCalledTimes(2);
+  });
+
   it('partitions cache entries per tenant scope', async () => {
     const { factory, executions } = createCountingFactory();
     const analytics = createDatasetClient({ queryBuilder: factory, cache: { ttlMs: 60_000 } });

--- a/packages/datasets/src/dataset-query.ts
+++ b/packages/datasets/src/dataset-query.ts
@@ -117,7 +117,7 @@ export async function runDatasetQuery(
     ...options,
     executionLimit: overfetchLimit(query.limit),
   });
-  const rows = await qb.execute();
+  const rows = await qb.execute({ abortSignal: options.context?.abortSignal });
   const { data, pagination } = applyPagination(rows, query.limit, query.offset);
   const serializedData = serializeSemanticMeasureValues(
     data,

--- a/packages/datasets/src/datasets.test.ts
+++ b/packages/datasets/src/datasets.test.ts
@@ -479,6 +479,20 @@ describe("dataset query helpers", () => {
     expect(result.meta?.sql).toContain('SUM(amount) AS revenue');
   });
 
+  it("forwards semantic cancellation to query-builder execution", async () => {
+    const baseFactory = createDatasetQueryBuilderFactory([{ revenue: 42 }]);
+    const builder = baseFactory.table('orders');
+    const execute = vi.spyOn(builder, 'execute');
+    const abortSignal = new AbortController().signal;
+
+    await runDatasetQuery(Orders, { measures: ['revenue'] }, {
+      builderFactory: { ...baseFactory, table: () => builder },
+      context: { ...TENANT_CONTEXT, abortSignal },
+    });
+
+    expect(execute).toHaveBeenCalledWith({ abortSignal });
+  });
+
   it("reports hasMore via over-fetch and trims the extra row", async () => {
     const result = await runDatasetQuery(Orders, {
       measures: ['revenue'],

--- a/packages/datasets/src/datasets.test.ts
+++ b/packages/datasets/src/datasets.test.ts
@@ -1079,6 +1079,32 @@ describe("MetricQueryEngine", () => {
   });
 
   describe("createDatasetClient()", () => {
+    it("forwards semantic cancellation to backend execution", async () => {
+      const execute = vi.fn().mockResolvedValue({ data: [] });
+      const analytics = createDatasetClient({ backend: { execute } });
+      const abortSignal = new AbortController().signal;
+
+      await analytics.execute(Orders, { measures: ["revenue"] }, {
+        ...TENANT_CONTEXT,
+        abortSignal,
+      });
+      await analytics.execute(avgOrderValue, {}, {
+        ...TENANT_CONTEXT,
+        abortSignal,
+      });
+
+      expect(execute).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        { abortSignal },
+      );
+      expect(execute).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        { abortSignal },
+      );
+    });
+
     it("executes all-tenant dataset queries across tenants", async () => {
       const analytics = createDatasetClient({
         backend: createInMemoryBackend({

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -461,7 +461,9 @@ export class MetricQueryEngine {
     if (spec.__type === 'derived_metric_spec') {
       // Derived metrics: build CTE via builder, outer query via string, execute via rawQuery
       const { sql, params } = this.buildDerivedSQLViaBuilder(ref, spec, buildQuery, grain, context);
-      const rows = await activeBuilderFactory.rawQuery<T>(sql, params);
+      const rows = await activeBuilderFactory.rawQuery<T>(sql, params, {
+        abortSignal: context?.abortSignal,
+      });
       const timingMs = Date.now() - start;
       const { data, pagination } = applyPagination(rows, query.limit, query.offset);
       const serializedData = serializeSemanticMeasureValues(data, [ref.name]);
@@ -480,7 +482,7 @@ export class MetricQueryEngine {
     // Base metrics: fully use the builder's execute()
     const builder = this.buildBaseQuery(ref, spec, ref.dataset, buildQuery, grain, context);
     const { sql } = builder.toSQLWithParams();
-    const rows = await builder.execute<T>();
+    const rows = await builder.execute<T>({ abortSignal: context?.abortSignal });
     const timingMs = Date.now() - start;
     const { data, pagination } = applyPagination(rows, query.limit, query.offset);
     const serializedData = serializeSemanticMeasureValues(data, [ref.name]);
@@ -711,7 +713,7 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
    * the common uncached path.
    */
   private isCacheable(context?: ExecutionContext): boolean {
-    if (context?.cache === false || context?.cache?.mode === 'bypass') {
+    if (context?.abortSignal || context?.cache === false || context?.cache?.mode === 'bypass') {
       return false;
     }
     const builderOverride = context?.runtime?.builderFactory;

--- a/packages/datasets/src/executor.ts
+++ b/packages/datasets/src/executor.ts
@@ -871,6 +871,7 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
         }
         return (this.backend.execute<TRow>(
           this.planMetric(metric, boundedQuery, context),
+          { abortSignal: context?.abortSignal },
         ) as Promise<MetricResult<TRow>>).then((result) => ({
           ...result,
           data: serializeSemanticMeasureValues(result.data, [getMetricRef(metric).name]),
@@ -924,6 +925,7 @@ export class DatasetClientImpl extends MetricQueryEngine implements DatasetClien
       if (this.backend) {
         return (this.backend.execute<TRow>(
           this.planDataset(ds, boundedQuery, context),
+          { abortSignal: context?.abortSignal },
         ) as Promise<DatasetQueryResult<TRow>>).then((result) => ({
           ...result,
           data: serializeSemanticMeasureValues(

--- a/packages/datasets/src/query-builder-protocol.ts
+++ b/packages/datasets/src/query-builder-protocol.ts
@@ -68,7 +68,7 @@ export interface QueryBuilderLike {
 
   // Terminal operations
   toSQLWithParams(): { sql: string; parameters: unknown[] };
-  execute<T = Record<string, unknown>>(): Promise<T[]>;
+  execute<T = Record<string, unknown>>(options?: { abortSignal?: AbortSignal }): Promise<T[]>;
 }
 
 export interface QueryBuilderJoinCondition {
@@ -80,7 +80,11 @@ export interface QueryBuilderJoinCondition {
 /** A query builder factory (what `createQueryBuilder(config)` returns). */
 export interface QueryBuilderFactoryLike {
   table(name: string): QueryBuilderLike;
-  rawQuery<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]>;
+  rawQuery<T = Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+    options?: { abortSignal?: AbortSignal },
+  ): Promise<T[]>;
 }
 
 /**

--- a/packages/datasets/src/semantic-plan.ts
+++ b/packages/datasets/src/semantic-plan.ts
@@ -127,6 +127,9 @@ export interface SemanticBackendResult<T = Record<string, unknown>> {
  * implementing a backend.
  */
 export interface SemanticBackend {
-  execute<T = Record<string, unknown>>(plan: PlanNode): Promise<SemanticBackendResult<T>>;
+  execute<T = Record<string, unknown>>(
+    plan: PlanNode,
+    options?: { abortSignal?: AbortSignal },
+  ): Promise<SemanticBackendResult<T>>;
   explain?(plan: PlanNode): Promise<{ sql?: string }>;
 }

--- a/packages/datasets/src/types.ts
+++ b/packages/datasets/src/types.ts
@@ -282,6 +282,8 @@ export interface SemanticExecutionRuntime {
 
 export interface ExecutionContext {
   runtime?: SemanticExecutionRuntime;
+  /** Cancels the in-flight semantic query and its backing database request. */
+  abortSignal?: AbortSignal;
   /**
    * Per-call result-cache controls. `false` bypasses the cache entirely;
    * `{ ttlMs }` opts this call into caching (or overrides the client default).

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -78,6 +78,10 @@ await createMCPServer({
     maxResultSize: 1_000,
     maxOffset: 10_000,
   },
+  executionBudget: {
+    timeoutMs: 30_000,
+    maxResponseBytes: 1_048_576,
+  },
 });
 ```
 
@@ -85,6 +89,12 @@ Every query receives a server-side limit even when the agent omits one. The
 effective ceiling is the lowest applicable server or Dataset limit. Dimensions,
 measures, filters, ordering, and pagination offsets also have hard package
 ceilings that server configuration may lower but cannot raise.
+
+Query calls also have a hard wall-clock deadline and UTF-8 response-byte
+ceiling. Client cancellation and local deadlines propagate through the semantic
+client to the backing ClickHouse request. Budget failures use the stable
+`MCP_REQUEST_CANCELLED`, `MCP_QUERY_TIMEOUT`, and `MCP_RESULT_TOO_LARGE`
+classifications.
 
 ## Learn more
 

--- a/packages/mcp-server/TEST_SUMMARY.md
+++ b/packages/mcp-server/TEST_SUMMARY.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-Comprehensive test suite for `@hypequery/mcp` with **101 passing tests** across 10 test files.
+Comprehensive test suite for `@hypequery/mcp` with **107 passing tests** across 11 test files.
 
 ## Test Coverage
 
-### 1. Tools (68 tests)
+### 1. Tools (73 tests)
 
 #### `list-datasets.test.ts` (8 tests)
 - ✅ Empty dataset list handling
@@ -61,6 +61,12 @@ Comprehensive test suite for `@hypequery/mcp` with **101 passing tests** across 
 - ✅ Per-dataset effective limit advertisement
 - ✅ Metric schemas omit measure limits
 
+#### `execution-budget.test.ts` (5 tests)
+- ✅ Safe deadline and response-byte defaults
+- ✅ Request cancellation propagation
+- ✅ Cooperative and non-cooperative query deadlines
+- ✅ UTF-8 serialized result byte ceilings
+
 #### `query-sql.integration.test.ts` (5 tests)
 - ✅ SQL redaction for dataset and metric results
 - ✅ Explicit trusted SQL debugging
@@ -106,7 +112,7 @@ Comprehensive test suite for `@hypequery/mcp` with **101 passing tests** across 
 ## Test Statistics
 
 - **Total Tests:** 101
-- **Test Files:** 10
+- **Test Files:** 11
 - **Pass Rate:** 100%
 
 ## Test Framework
@@ -155,7 +161,7 @@ pnpm dev
 
 - **Comprehensive:** Tests cover happy paths, error cases, and edge cases
 - **Isolated:** Each test uses mocks to avoid external dependencies
-- **Fast:** Entire suite runs in under 50ms
+- **Fast:** The isolated suite completes in seconds
 - **Maintainable:** Clear test names and organized by feature
 - **Documented:** Tests serve as usage examples
 

--- a/packages/mcp-server/TEST_SUMMARY.md
+++ b/packages/mcp-server/TEST_SUMMARY.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-Comprehensive test suite for `@hypequery/mcp` with **107 passing tests** across 11 test files.
+Comprehensive test suite for `@hypequery/mcp` with **109 passing tests** across 11 test files.
 
 ## Test Coverage
 
-### 1. Tools (73 tests)
+### 1. Tools (75 tests)
 
 #### `list-datasets.test.ts` (8 tests)
 - ✅ Empty dataset list handling
@@ -61,11 +61,13 @@ Comprehensive test suite for `@hypequery/mcp` with **107 passing tests** across 
 - ✅ Per-dataset effective limit advertisement
 - ✅ Metric schemas omit measure limits
 
-#### `execution-budget.test.ts` (5 tests)
+#### `execution-budget.test.ts` (7 tests)
 - ✅ Safe deadline and response-byte defaults
 - ✅ Request cancellation propagation
+- ✅ Pre-cancelled requests skip query invocation
 - ✅ Cooperative and non-cooperative query deadlines
 - ✅ UTF-8 serialized result byte ceilings
+- ✅ Stable classified error formatting
 
 #### `query-sql.integration.test.ts` (5 tests)
 - ✅ SQL redaction for dataset and metric results
@@ -111,7 +113,7 @@ Comprehensive test suite for `@hypequery/mcp` with **107 passing tests** across 
 
 ## Test Statistics
 
-- **Total Tests:** 101
+- **Total Tests:** 109
 - **Test Files:** 11
 - **Pass Rate:** 100%
 
@@ -195,7 +197,7 @@ it('should execute metric query with dimensions', async () => {
 
 ## Next Steps
 
-1. ✅ **Unit Tests** - Complete (101 tests)
+1. ✅ **Unit Tests** - Complete (109 tests)
 2. ⏭️ **Integration Tests** - Test with real MCP clients
 3. ⏭️ **E2E Tests** - Full workflow with ClickHouse
 4. ⏭️ **Performance Tests** - Load testing with large datasets

--- a/packages/mcp-server/src/errors.ts
+++ b/packages/mcp-server/src/errors.ts
@@ -1,0 +1,21 @@
+export type MCPExecutionErrorCode =
+  | 'MCP_REQUEST_CANCELLED'
+  | 'MCP_QUERY_TIMEOUT'
+  | 'MCP_RESULT_TOO_LARGE';
+
+export class MCPExecutionBudgetError extends Error {
+  readonly code: MCPExecutionErrorCode;
+
+  constructor(code: MCPExecutionErrorCode, message: string) {
+    super(message);
+    this.name = 'MCPExecutionBudgetError';
+    this.code = code;
+  }
+}
+
+export function formatMCPToolError(error: unknown): string {
+  if (error instanceof MCPExecutionBudgetError) {
+    return `Error [${error.code}]: ${error.message}`;
+  }
+  return `Error: ${error instanceof Error ? error.message : String(error)}`;
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -18,6 +18,7 @@ export type {
   QueryMetricArgs,
   QueryDatasetArgs,
   QueryToolOptions,
+  MCPExecutionBudget,
   MCPQueryLimits,
   SchemaToolOptions,
   GetDatasetSchemaArgs,
@@ -32,6 +33,11 @@ export type {
   QueryResultMeta,
 } from './types.js';
 export {
+  MCPExecutionBudgetError,
+  formatMCPToolError,
+  type MCPExecutionErrorCode,
+} from './errors.js';
+export {
   MAX_QUERY_LIMIT,
   DEFAULT_QUERY_LIMIT,
   MAX_QUERY_OFFSET,
@@ -39,5 +45,9 @@ export {
   MAX_QUERY_MEASURES,
   MAX_QUERY_FILTERS,
   MAX_QUERY_ORDER_BY,
+  DEFAULT_QUERY_TIMEOUT_MS,
+  MAX_QUERY_TIMEOUT_MS,
+  DEFAULT_RESPONSE_BYTES,
+  MAX_RESPONSE_BYTES,
 } from './types.js';
 export { MCP_PACKAGE_VERSION } from './version.js';

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -159,6 +159,14 @@ describe('HypequeryMCPServer', () => {
     expect(datasetProperties?.limit.maximum).toBe(6);
   });
 
+  it('should reject unsafe execution budget configuration', () => {
+    expect(() => new HypequeryMCPServer({
+      datasets: {},
+      analytics: mockAnalytics,
+      executionBudget: { timeoutMs: 120_001 },
+    })).toThrow('timeoutMs must be an integer between 1 and 120000');
+  });
+
   it('should start server successfully', async () => {
     const server = new HypequeryMCPServer({
       datasets: mockDatasets,
@@ -242,11 +250,13 @@ describe('HypequeryMCPServer', () => {
         dimensions: ['region'],
         measures: ['revenue'],
       }),
-      {
+      expect.objectContaining({
+        abortSignal: expect.any(AbortSignal),
+        cache: false,
         runtime: {
           tenant: { id: 'tenant-123' },
         },
-      },
+      }),
     );
   });
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -19,10 +19,19 @@ import { getDatasetSchemaTool } from './tools/introspect.js';
 import { queryMetricTool } from './tools/query-metric.js';
 import { queryDatasetTool } from './tools/query-dataset.js';
 import { datasetGuidePrompt } from './prompts/dataset-guide.js';
-import type { DatasetRegistry, MCPQueryLimits } from './types.js';
+import {
+  DEFAULT_QUERY_LIMIT,
+  MAX_QUERY_LIMIT,
+  MAX_QUERY_OFFSET,
+  type DatasetRegistry,
+  type MCPExecutionBudget,
+  type MCPQueryLimits,
+} from './types.js';
 import { MCP_PACKAGE_VERSION } from './version.js';
 import { advertiseDatasetQueryLimits } from './tools/utils/query-schema.js';
 import { resolveQueryLimits } from './tools/utils/query-limits.js';
+import { resolveExecutionBudget } from './tools/utils/execution-budget.js';
+import { formatMCPToolError } from './errors.js';
 
 export interface MCPServerConfig {
   /**
@@ -60,6 +69,9 @@ export interface MCPServerConfig {
 
   /** Server-side query ceilings applied in addition to Dataset limits. */
   queryLimits?: MCPQueryLimits;
+
+  /** Query deadline and serialized-result byte ceilings. */
+  executionBudget?: MCPExecutionBudget;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -100,6 +112,7 @@ export class HypequeryMCPServer {
   constructor(config: MCPServerConfig) {
     validateTenantConfig(config);
     resolveQueryLimits(undefined, config.queryLimits);
+    resolveExecutionBudget(config.executionBudget);
     this.config = config;
 
     this.server = new Server(
@@ -322,7 +335,7 @@ export class HypequeryMCPServer {
     });
 
     // Handle tool calls
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    this.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
       const { name, arguments: args } = request.params;
 
       try {
@@ -346,6 +359,8 @@ export class HypequeryMCPServer {
                 tenantId: this.config.tenantId,
                 includeSql: this.config.includeSql,
                 limits: this.config.queryLimits,
+                executionBudget: this.config.executionBudget,
+                signal: extra?.signal,
               },
             );
 
@@ -358,6 +373,8 @@ export class HypequeryMCPServer {
                 tenantId: this.config.tenantId,
                 includeSql: this.config.includeSql,
                 limits: this.config.queryLimits,
+                executionBudget: this.config.executionBudget,
+                signal: extra?.signal,
               },
             );
 
@@ -369,7 +386,7 @@ export class HypequeryMCPServer {
           content: [
             {
               type: 'text' as const,
-              text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+              text: formatMCPToolError(error),
             },
           ],
           isError: true,

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -20,9 +20,6 @@ import { queryMetricTool } from './tools/query-metric.js';
 import { queryDatasetTool } from './tools/query-dataset.js';
 import { datasetGuidePrompt } from './prompts/dataset-guide.js';
 import {
-  DEFAULT_QUERY_LIMIT,
-  MAX_QUERY_LIMIT,
-  MAX_QUERY_OFFSET,
   type DatasetRegistry,
   type MCPExecutionBudget,
   type MCPQueryLimits,

--- a/packages/mcp-server/src/tools/query-dataset.test.ts
+++ b/packages/mcp-server/src/tools/query-dataset.test.ts
@@ -74,11 +74,13 @@ describe('queryDatasetTool', () => {
         orderBy: [],
         limit: 100,
       },
-      {
+      expect.objectContaining({
+        abortSignal: expect.any(AbortSignal),
+        cache: false,
         runtime: {
           tenant: undefined,
         },
-      }
+      })
     );
   });
 

--- a/packages/mcp-server/src/tools/query-dataset.ts
+++ b/packages/mcp-server/src/tools/query-dataset.ts
@@ -8,6 +8,11 @@ import type { DatasetClient, DatasetQuery } from '@hypequery/datasets';
 import type { DatasetRegistry, MCPToolResponse, QueryResultResponse, QueryToolOptions } from '../types.js';
 import { parseToolArgs, queryDatasetArgsSchema, toMetricFilters } from './args.js';
 import { applyQueryLimits } from './utils/query-limits.js';
+import {
+  executeWithinBudget,
+  resolveExecutionBudget,
+  serializeWithinBudget,
+} from './utils/execution-budget.js';
 
 export async function queryDatasetTool(
   datasets: DatasetRegistry,
@@ -33,6 +38,7 @@ export async function queryDatasetTool(
   }
 
   const pagination = applyQueryLimits(dataset, validatedArgs, options.limits);
+  const executionBudget = resolveExecutionBudget(options.executionBudget);
 
   // Build the query with proper types
   const query: DatasetQuery = {
@@ -51,11 +57,17 @@ export async function queryDatasetTool(
     query.offset = pagination.offset;
   }
 
-  const result = await analytics.execute(dataset as any, query, {
-    runtime: {
-      tenant: options.tenantId ? { id: options.tenantId } : undefined,
-    },
-  });
+  const result = await executeWithinBudget(
+    signal => analytics.execute(dataset as any, query, {
+      runtime: {
+        tenant: options.tenantId ? { id: options.tenantId } : undefined,
+      },
+      abortSignal: signal,
+      cache: false,
+    }),
+    executionBudget,
+    options.signal,
+  );
 
   // Format the response with proper types
   const response: QueryResultResponse = {
@@ -72,7 +84,7 @@ export async function queryDatasetTool(
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(response, null, 2),
+        text: serializeWithinBudget(response, executionBudget),
       },
     ],
   };

--- a/packages/mcp-server/src/tools/query-metric.test.ts
+++ b/packages/mcp-server/src/tools/query-metric.test.ts
@@ -86,11 +86,13 @@ describe('queryMetricTool', () => {
         orderBy: [],
         limit: 100,
       },
-      {
+      expect.objectContaining({
+        abortSignal: expect.any(AbortSignal),
+        cache: false,
         runtime: {
           tenant: undefined,
         },
-      }
+      })
     );
   });
 

--- a/packages/mcp-server/src/tools/query-metric.ts
+++ b/packages/mcp-server/src/tools/query-metric.ts
@@ -8,6 +8,11 @@ import type { DatasetClient, MetricQuery } from '@hypequery/datasets';
 import type { DatasetRegistry, MCPToolResponse, QueryResultResponse, QueryToolOptions } from '../types.js';
 import { parseToolArgs, queryMetricArgsSchema, toMetricFilters } from './args.js';
 import { applyQueryLimits } from './utils/query-limits.js';
+import {
+  executeWithinBudget,
+  resolveExecutionBudget,
+  serializeWithinBudget,
+} from './utils/execution-budget.js';
 
 export async function queryMetricTool(
   datasets: DatasetRegistry,
@@ -40,6 +45,7 @@ export async function queryMetricTool(
   }
 
   const pagination = applyQueryLimits(dataset, validatedArgs, options.limits);
+  const executionBudget = resolveExecutionBudget(options.executionBudget);
 
   // Build the query with proper types
   const query: MetricQuery = {
@@ -58,11 +64,17 @@ export async function queryMetricTool(
   }
 
   // Execute the query
-  const result = await analytics.execute(metric, query, {
-    runtime: {
-      tenant: options.tenantId ? { id: options.tenantId } : undefined,
-    },
-  });
+  const result = await executeWithinBudget(
+    signal => analytics.execute(metric, query, {
+      runtime: {
+        tenant: options.tenantId ? { id: options.tenantId } : undefined,
+      },
+      abortSignal: signal,
+      cache: false,
+    }),
+    executionBudget,
+    options.signal,
+  );
 
   // Format the response with proper types
   const response: QueryResultResponse = {
@@ -79,7 +91,7 @@ export async function queryMetricTool(
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify(response, null, 2),
+        text: serializeWithinBudget(response, executionBudget),
       },
     ],
   };

--- a/packages/mcp-server/src/tools/utils/execution-budget.test.ts
+++ b/packages/mcp-server/src/tools/utils/execution-budget.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { formatMCPToolError, MCPExecutionBudgetError } from '../../errors.js';
 import {
   executeWithinBudget,
   resolveExecutionBudget,
@@ -38,6 +39,21 @@ describe('execution budgets', () => {
     });
   });
 
+  it('does not invoke an operation for a request that is already cancelled', async () => {
+    const request = new AbortController();
+    const operation = vi.fn(() => Promise.resolve('unexpected'));
+    request.abort();
+
+    await expect(executeWithinBudget(
+      operation,
+      resolveExecutionBudget({ timeoutMs: 1_000 }),
+      request.signal,
+    )).rejects.toMatchObject({
+      code: 'MCP_REQUEST_CANCELLED',
+    });
+    expect(operation).not.toHaveBeenCalled();
+  });
+
   it('aborts slow queries at the configured deadline', async () => {
     await expect(executeWithinBudget(
       waitForAbort,
@@ -64,5 +80,13 @@ describe('execution budgets', () => {
         code: 'MCP_RESULT_TOO_LARGE',
       }),
     );
+  });
+
+  it('formats classified and generic tool errors', () => {
+    expect(formatMCPToolError(new MCPExecutionBudgetError(
+      'MCP_QUERY_TIMEOUT',
+      'deadline exceeded',
+    ))).toBe('Error [MCP_QUERY_TIMEOUT]: deadline exceeded');
+    expect(formatMCPToolError(new Error('query failed'))).toBe('Error: query failed');
   });
 });

--- a/packages/mcp-server/src/tools/utils/execution-budget.test.ts
+++ b/packages/mcp-server/src/tools/utils/execution-budget.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  executeWithinBudget,
+  resolveExecutionBudget,
+  serializeWithinBudget,
+} from './execution-budget.js';
+
+function waitForAbort(signal: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+  });
+}
+
+describe('execution budgets', () => {
+  it('resolves bounded defaults and rejects unsafe configuration', () => {
+    expect(resolveExecutionBudget()).toEqual({
+      timeoutMs: 30_000,
+      maxResponseBytes: 1_048_576,
+    });
+    expect(() => resolveExecutionBudget({ timeoutMs: 0 }))
+      .toThrow('timeoutMs must be an integer between 1 and 120000');
+    expect(() => resolveExecutionBudget({ maxResponseBytes: 10_485_761 }))
+      .toThrow('maxResponseBytes must be an integer between 1 and 10485760');
+  });
+
+  it('propagates request cancellation with a stable classification', async () => {
+    const request = new AbortController();
+    const pending = executeWithinBudget(
+      waitForAbort,
+      resolveExecutionBudget({ timeoutMs: 1_000 }),
+      request.signal,
+    );
+
+    request.abort();
+
+    await expect(pending).rejects.toMatchObject({
+      code: 'MCP_REQUEST_CANCELLED',
+    });
+  });
+
+  it('aborts slow queries at the configured deadline', async () => {
+    await expect(executeWithinBudget(
+      waitForAbort,
+      resolveExecutionBudget({ timeoutMs: 1 }),
+    )).rejects.toMatchObject({
+      code: 'MCP_QUERY_TIMEOUT',
+    });
+  });
+
+  it('returns at the deadline when a custom executor ignores cancellation', async () => {
+    await expect(executeWithinBudget(
+      () => new Promise(() => {}),
+      resolveExecutionBudget({ timeoutMs: 1 }),
+    )).rejects.toMatchObject({
+      code: 'MCP_QUERY_TIMEOUT',
+    });
+  });
+
+  it('enforces the UTF-8 serialized response byte ceiling', () => {
+    const budget = resolveExecutionBudget({ maxResponseBytes: 3 });
+
+    expect(() => serializeWithinBudget('é', budget)).toThrowError(
+      expect.objectContaining({
+        code: 'MCP_RESULT_TOO_LARGE',
+      }),
+    );
+  });
+});

--- a/packages/mcp-server/src/tools/utils/execution-budget.ts
+++ b/packages/mcp-server/src/tools/utils/execution-budget.ts
@@ -61,10 +61,9 @@ export async function executeWithinBudget<T>(
   const cancel = () => controller.abort(cancellationError);
 
   if (requestSignal?.aborted) {
-    cancel();
-  } else {
-    requestSignal?.addEventListener('abort', cancel, { once: true });
+    throw cancellationError;
   }
+  requestSignal?.addEventListener('abort', cancel, { once: true });
   const timeout = setTimeout(() => controller.abort(timeoutError), budget.timeoutMs);
   let removeBudgetAbortListener = () => {};
   const budgetAbort = new Promise<never>((_, reject) => {

--- a/packages/mcp-server/src/tools/utils/execution-budget.ts
+++ b/packages/mcp-server/src/tools/utils/execution-budget.ts
@@ -1,0 +1,109 @@
+import { MCPExecutionBudgetError } from '../../errors.js';
+import {
+  DEFAULT_QUERY_TIMEOUT_MS,
+  DEFAULT_RESPONSE_BYTES,
+  MAX_QUERY_TIMEOUT_MS,
+  MAX_RESPONSE_BYTES,
+  type MCPExecutionBudget,
+} from '../../types.js';
+
+export interface EffectiveExecutionBudget {
+  readonly timeoutMs: number;
+  readonly maxResponseBytes: number;
+}
+
+function positiveInteger(
+  value: number | undefined,
+  fallback: number,
+  maximum: number,
+  name: string,
+): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved < 1 || resolved > maximum) {
+    throw new Error(`${name} must be an integer between 1 and ${maximum}`);
+  }
+  return resolved;
+}
+
+export function resolveExecutionBudget(
+  configured: MCPExecutionBudget = {},
+): EffectiveExecutionBudget {
+  return Object.freeze({
+    timeoutMs: positiveInteger(
+      configured.timeoutMs,
+      DEFAULT_QUERY_TIMEOUT_MS,
+      MAX_QUERY_TIMEOUT_MS,
+      'timeoutMs',
+    ),
+    maxResponseBytes: positiveInteger(
+      configured.maxResponseBytes,
+      DEFAULT_RESPONSE_BYTES,
+      MAX_RESPONSE_BYTES,
+      'maxResponseBytes',
+    ),
+  });
+}
+
+export async function executeWithinBudget<T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+  budget: EffectiveExecutionBudget,
+  requestSignal?: AbortSignal,
+): Promise<T> {
+  const controller = new AbortController();
+  const cancellationError = new MCPExecutionBudgetError(
+    'MCP_REQUEST_CANCELLED',
+    'The MCP request was cancelled',
+  );
+  const timeoutError = new MCPExecutionBudgetError(
+    'MCP_QUERY_TIMEOUT',
+    `The query exceeded its ${budget.timeoutMs}ms execution deadline`,
+  );
+  const cancel = () => controller.abort(cancellationError);
+
+  if (requestSignal?.aborted) {
+    cancel();
+  } else {
+    requestSignal?.addEventListener('abort', cancel, { once: true });
+  }
+  const timeout = setTimeout(() => controller.abort(timeoutError), budget.timeoutMs);
+  let removeBudgetAbortListener = () => {};
+  const budgetAbort = new Promise<never>((_, reject) => {
+    const rejectForAbort = () => reject(controller.signal.reason);
+    if (controller.signal.aborted) {
+      rejectForAbort();
+      return;
+    }
+    controller.signal.addEventListener('abort', rejectForAbort, { once: true });
+    removeBudgetAbortListener = () => {
+      controller.signal.removeEventListener('abort', rejectForAbort);
+    };
+  });
+
+  try {
+    const result = await Promise.race([operation(controller.signal), budgetAbort]);
+    if (controller.signal.aborted) throw controller.signal.reason;
+    return result;
+  } catch (error) {
+    if (controller.signal.aborted) throw controller.signal.reason;
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+    removeBudgetAbortListener();
+    requestSignal?.removeEventListener('abort', cancel);
+  }
+}
+
+export function serializeWithinBudget(
+  value: unknown,
+  budget: EffectiveExecutionBudget,
+): string {
+  const serialized = JSON.stringify(value, null, 2);
+  const size = Buffer.byteLength(serialized, 'utf8');
+  if (size > budget.maxResponseBytes) {
+    throw new MCPExecutionBudgetError(
+      'MCP_RESULT_TOO_LARGE',
+      `The serialized result is ${size} bytes; maximum is ${budget.maxResponseBytes} bytes`,
+    );
+  }
+  return serialized;
+}

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -46,6 +46,16 @@ export interface QueryToolOptions {
   tenantId?: string;
   includeSql?: boolean;
   limits?: MCPQueryLimits;
+  executionBudget?: MCPExecutionBudget;
+  signal?: AbortSignal;
+}
+
+/** Per-query wall-clock and serialized-response ceilings. */
+export interface MCPExecutionBudget {
+  /** Maximum query duration in milliseconds. Defaults to 30 seconds. */
+  timeoutMs?: number;
+  /** Maximum UTF-8 bytes in the serialized query response. Defaults to 1 MiB. */
+  maxResponseBytes?: number;
 }
 
 /** Server-side ceilings applied in addition to Dataset limits. */
@@ -226,3 +236,7 @@ export const MAX_QUERY_DIMENSIONS = 50;
 export const MAX_QUERY_MEASURES = 50;
 export const MAX_QUERY_FILTERS = 100;
 export const MAX_QUERY_ORDER_BY = 50;
+export const DEFAULT_QUERY_TIMEOUT_MS = 30_000;
+export const MAX_QUERY_TIMEOUT_MS = 120_000;
+export const DEFAULT_RESPONSE_BYTES = 1_048_576;
+export const MAX_RESPONSE_BYTES = 10_485_760;

--- a/plans/mcp-cloud-agent-platform-plan.md
+++ b/plans/mcp-cloud-agent-platform-plan.md
@@ -421,6 +421,13 @@ effective default/Dataset/server limits, bounded offsets and query collections,
 package-derived server version metadata, finite examples, focused tests, and a
 release changeset.
 
+**CORE-02 implementation status:** Implemented on top of `CORE-01`, including a
+shared deadline/response-byte budget, MCP cancellation propagation through the
+semantic client to ClickHouse, hard timeout settlement for non-cooperative
+executors, classified budget errors, focused tests, and release changesets.
+`MCP-102` remains open for the later tool-count and catalog-description byte
+ceilings; its query-execution and query-input portions are complete.
+
 ### Deployment bridge PRs
 
 | PR | Depends on | Deliverable and merge gate |


### PR DESCRIPTION
## Summary

- add shared MCP query deadlines and serialized UTF-8 response-byte ceilings
- propagate MCP request cancellation through `ExecutionContext` to ClickHouse query execution
- bypass semantic result caching for abortable calls so cancellation reaches live work
- classify cancellation, timeout, and oversized-result failures with stable codes
- settle hard deadlines even when a custom executor ignores cancellation

This is **CORE-02**, stacked on #445 (`CORE-01`), which is stacked on #443 (`ARCH-01`). Review and merge it after its base PR.

## Validation

- `pnpm --filter @hypequery/datasets lint`
- `pnpm --filter @hypequery/datasets test` (307 tests)
- `pnpm --filter @hypequery/datasets build`
- `pnpm --filter @hypequery/mcp lint`
- `pnpm --filter @hypequery/mcp test` (101 tests)
- `pnpm --filter @hypequery/mcp build`
- `git diff --check`
