### PR TITLE
feat(mcp): add transport-neutral executor

### DIFF
--- a/.changeset/calm-servers-travel.md
+++ b/.changeset/calm-servers-travel.md
@@ -1,0 +1,7 @@
+---
+"@hypequery/mcp": minor
+---
+
+Add a public transport-neutral MCP executor and protocol server with injected
+transport support. Isolate stdio behind an explicit adapter while preserving
+the existing server, startup APIs, tool names, prompts, and behavior.

--- a/packages/cli/src/generators/dataset-generator.test.ts
+++ b/packages/cli/src/generators/dataset-generator.test.ts
@@ -9,6 +9,7 @@ import { generateDatasets } from './dataset-generator.js';
 
 const execFileAsync = promisify(execFile);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TSC_TIMEOUT_MS = 30_000;
 
 const mockQuery = vi.fn();
 
@@ -105,7 +106,7 @@ describe('generateDatasets', () => {
       ['--project', tsconfigPath],
       { cwd: repoRoot },
     );
-  }, 15_000);
+  }, TSC_TIMEOUT_MS);
 
   it('uses an injected introspection client', async () => {
     const injectedQuery = vi.fn(async ({ query }: { query: string }) => {

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -98,6 +98,39 @@ client to the backing ClickHouse request. Budget failures use the stable
 `MCP_REQUEST_CANCELLED`, `MCP_QUERY_TIMEOUT`, and `MCP_RESULT_TOO_LARGE`
 classifications.
 
+## Embed in another MCP transport
+
+The semantic executor is independent of stdio and network lifecycle. A hosted
+gateway can inject its own MCP transport without reimplementing Hypequery's
+tools, prompts, catalog schemas, or validation:
+
+```ts
+import {
+  createMCPExecutor,
+  createMCPProtocolServer,
+} from '@hypequery/mcp';
+
+const executor = createMCPExecutor({
+  datasets,
+  analytics,
+  tenantId: trustedPrincipal.tenantId,
+});
+
+const server = createMCPProtocolServer({
+  executor,
+  name: 'acme-hosted-analytics',
+  version: '1.0.0',
+});
+
+await server.connect(hostTransport);
+```
+
+`hostTransport` can be an MCP SDK in-memory, stdio, or hosted transport. This
+package does not create an HTTP endpoint; authentication, routing, and network
+lifecycle remain responsibilities of the host. For an explicit local adapter,
+use `startStdioMCPServer(config)`. The existing `createMCPServer(config)` and
+`HypequeryMCPServer.start()` APIs remain available for compatibility.
+
 ## Learn more
 
 - [ClickHouse MCP overview](https://hypequery.com/clickhouse-mcp)

--- a/packages/mcp-server/src/api.type-test.ts
+++ b/packages/mcp-server/src/api.type-test.ts
@@ -1,0 +1,26 @@
+import { expectTypeOf, it } from 'vitest';
+import {
+  HypequeryMCPExecutor,
+  HypequeryMCPProtocolServer,
+  HypequeryMCPServer,
+  connectMCPServerStdio,
+  createMCPExecutor,
+  createMCPProtocolServer,
+  createMCPServer,
+  startStdioMCPServer,
+  type MCPExecutorConfig,
+  type MCPProtocolServerOptions,
+  type MCPServerConfig,
+  type MCPToolExecutor,
+} from './index.js';
+
+it('exports the transport-neutral and backwards-compatible MCP APIs', () => {
+  expectTypeOf(HypequeryMCPExecutor).toBeConstructibleWith({} as MCPExecutorConfig);
+  expectTypeOf(HypequeryMCPProtocolServer).toBeConstructibleWith({} as MCPProtocolServerOptions);
+  expectTypeOf(HypequeryMCPServer).toBeConstructibleWith({} as MCPServerConfig);
+  expectTypeOf(createMCPExecutor).returns.toMatchTypeOf<MCPToolExecutor>();
+  expectTypeOf(createMCPProtocolServer).returns.toMatchTypeOf<HypequeryMCPProtocolServer>();
+  expectTypeOf(connectMCPServerStdio).returns.toMatchTypeOf<Promise<void>>();
+  expectTypeOf(startStdioMCPServer).returns.toMatchTypeOf<Promise<HypequeryMCPServer>>();
+  expectTypeOf(createMCPServer).returns.toMatchTypeOf<Promise<HypequeryMCPServer>>();
+});

--- a/packages/mcp-server/src/executor.test.ts
+++ b/packages/mcp-server/src/executor.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { DatasetClient } from '@hypequery/datasets';
+import { HypequeryMCPExecutor } from './executor.js';
+
+describe('HypequeryMCPExecutor', () => {
+  const analytics = {
+    execute: vi.fn(),
+  } as unknown as DatasetClient;
+
+  const datasets = {
+    orders: {
+      description: 'Orders',
+      dimensions: { region: {} },
+      measures: { revenue: {} },
+      metrics: { totalRevenue: {} },
+    },
+  };
+
+  it('exposes tools and prompts without constructing a transport', async () => {
+    const executor = new HypequeryMCPExecutor({ datasets, analytics });
+
+    await expect(executor.listTools()).resolves.toMatchObject({
+      tools: [
+        { name: 'list_datasets' },
+        { name: 'get_dataset_schema' },
+        { name: 'query_metric' },
+        { name: 'query_dataset' },
+      ],
+    });
+    await expect(executor.listPrompts()).resolves.toMatchObject({
+      prompts: [{ name: 'dataset_guide' }],
+    });
+    expect(executor.getManifestHash()).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('executes tools and prompts directly', async () => {
+    const executor = new HypequeryMCPExecutor({ datasets, analytics });
+
+    const toolResult = await executor.callTool('list_datasets');
+    expect(JSON.parse(toolResult.content[0].type === 'text' ? toolResult.content[0].text : '')).toMatchObject({
+      total: 1,
+      datasets: [{ name: 'orders' }],
+    });
+
+    await expect(executor.getPrompt('dataset_guide', { dataset: 'orders' })).resolves.toMatchObject({
+      messages: [{ role: 'user' }],
+    });
+  });
+
+  it('returns tool errors as MCP results', async () => {
+    const executor = new HypequeryMCPExecutor({ datasets, analytics });
+
+    await expect(executor.callTool('unknown')).resolves.toMatchObject({
+      isError: true,
+      content: [{ type: 'text', text: 'Error: Unknown tool: unknown' }],
+    });
+  });
+});

--- a/packages/mcp-server/src/executor.ts
+++ b/packages/mcp-server/src/executor.ts
@@ -1,0 +1,215 @@
+import type {
+  CallToolResult,
+  GetPromptResult,
+  ListPromptsResult,
+  ListToolsResult,
+} from '@modelcontextprotocol/sdk/types.js';
+import type {
+  CanonicalSemanticQuerySchemas,
+  DatasetClient,
+} from '@hypequery/datasets';
+import { formatMCPToolError } from './errors.js';
+import { datasetGuidePrompt } from './prompts/dataset-guide.js';
+import { getDatasetSchemaTool } from './tools/introspect.js';
+import { listDatasetsTool } from './tools/list-datasets.js';
+import { queryDatasetTool } from './tools/query-dataset.js';
+import { queryMetricTool } from './tools/query-metric.js';
+import { buildMCPQuerySchemas } from './tools/utils/canonical-query-schemas.js';
+import { resolveExecutionBudget } from './tools/utils/execution-budget.js';
+import { resolveQueryLimits } from './tools/utils/query-limits.js';
+import type { DatasetRegistry, MCPExecutionBudget, MCPQueryLimits } from './types.js';
+import { validateMCPServerTenantConfig } from './utils/tenant-config.js';
+
+export interface MCPExecutorConfig {
+  /** Dataset registry - map of dataset names to instances. */
+  datasets: DatasetRegistry;
+  /** Semantic analytics client for running metric and dataset queries. */
+  analytics: DatasetClient;
+  /** Trusted tenant id used to scope tenant-keyed datasets. */
+  tenantId?: string;
+  /** Include generated SQL in trusted-debug responses. Defaults to false. */
+  includeSql?: boolean;
+  /** Server-side query ceilings applied in addition to Dataset limits. */
+  queryLimits?: MCPQueryLimits;
+  /** Query deadline and serialized-result byte ceilings. */
+  executionBudget?: MCPExecutionBudget;
+}
+
+export interface MCPServerConfig extends MCPExecutorConfig {
+  /** Server name shown to MCP clients. */
+  name?: string;
+  /** Server version shown to MCP clients. */
+  version?: string;
+}
+
+export interface MCPToolExecutor {
+  listTools(): Promise<ListToolsResult>;
+  callTool(
+    name: string,
+    args?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<CallToolResult>;
+  listPrompts(): Promise<ListPromptsResult>;
+  getPrompt(name: string, args?: Record<string, string>): Promise<GetPromptResult>;
+  getManifestHash(): string;
+}
+
+/**
+ * Transport-neutral Hypequery MCP tool and prompt executor.
+ *
+ * This class owns semantic discovery and execution, but has no network or stdio
+ * lifecycle. It can be called directly or injected into any MCP transport
+ * adapter.
+ */
+export class HypequeryMCPExecutor implements MCPToolExecutor {
+  private readonly querySchemas: CanonicalSemanticQuerySchemas;
+
+  constructor(private readonly config: MCPExecutorConfig) {
+    validateMCPServerTenantConfig(config);
+    resolveQueryLimits(undefined, config.queryLimits);
+    resolveExecutionBudget(config.executionBudget);
+    this.querySchemas = buildMCPQuerySchemas(config.datasets ?? {}, config.queryLimits);
+  }
+
+  getManifestHash(): string {
+    return this.querySchemas.manifestHash;
+  }
+
+  async listTools(): Promise<ListToolsResult> {
+    return {
+      tools: [
+        {
+          name: 'list_datasets',
+          description: 'List all available datasets in the semantic layer',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+          },
+        },
+        {
+          name: 'get_dataset_schema',
+          description: 'Get the schema (dimensions, measures, named metrics, filters, relationships) for a specific dataset',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              dataset: {
+                type: 'string',
+                description: 'Name of the dataset to introspect',
+              },
+            },
+            required: ['dataset'],
+          },
+        },
+        {
+          name: 'query_metric',
+          description: 'Execute a metric query with optional dimensions, filters, time grain, and sorting',
+          inputSchema: this.querySchemas.queryMetricJsonSchema as {
+            type: 'object';
+            [key: string]: unknown;
+          },
+        },
+        {
+          name: 'query_dataset',
+          description: 'Execute an ad-hoc dataset query with custom dimensions and measures',
+          inputSchema: this.querySchemas.queryDatasetJsonSchema as {
+            type: 'object';
+            [key: string]: unknown;
+          },
+        },
+      ],
+    };
+  }
+
+  async callTool(
+    name: string,
+    args?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<CallToolResult> {
+    try {
+      switch (name) {
+        case 'list_datasets':
+          return await listDatasetsTool(this.config.datasets);
+
+        case 'get_dataset_schema':
+          return await getDatasetSchemaTool(
+            this.config.datasets,
+            args,
+            { includeSql: this.config.includeSql },
+          );
+
+        case 'query_metric':
+          return await queryMetricTool(
+            this.config.datasets,
+            this.config.analytics,
+            args,
+            {
+              tenantId: this.config.tenantId,
+              includeSql: this.config.includeSql,
+              limits: this.config.queryLimits,
+              executionBudget: this.config.executionBudget,
+              signal,
+              inputSchema: this.querySchemas.queryMetric,
+            },
+          );
+
+        case 'query_dataset':
+          return await queryDatasetTool(
+            this.config.datasets,
+            this.config.analytics,
+            args,
+            {
+              tenantId: this.config.tenantId,
+              includeSql: this.config.includeSql,
+              limits: this.config.queryLimits,
+              executionBudget: this.config.executionBudget,
+              signal,
+              inputSchema: this.querySchemas.queryDataset,
+            },
+          );
+
+        default:
+          throw new Error(`Unknown tool: ${name}`);
+      }
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: formatMCPToolError(error),
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  async listPrompts(): Promise<ListPromptsResult> {
+    return {
+      prompts: [
+        {
+          name: 'dataset_guide',
+          description: 'Guide for querying datasets with natural language',
+          arguments: [
+            {
+              name: 'dataset',
+              description: 'Name of the dataset to get guidance for',
+              required: false,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  async getPrompt(name: string, args?: Record<string, string>): Promise<GetPromptResult> {
+    if (name === 'dataset_guide') {
+      return datasetGuidePrompt(this.config.datasets, args?.dataset);
+    }
+
+    throw new Error(`Unknown prompt: ${name}`);
+  }
+}
+
+export function createMCPExecutor(config: MCPExecutorConfig): HypequeryMCPExecutor {
+  return new HypequeryMCPExecutor(config);
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -6,6 +6,18 @@
  */
 
 export { HypequeryMCPServer, createMCPServer, type MCPServerConfig } from './server.js';
+export {
+  HypequeryMCPExecutor,
+  createMCPExecutor,
+  type MCPExecutorConfig,
+  type MCPToolExecutor,
+} from './executor.js';
+export {
+  HypequeryMCPProtocolServer,
+  createMCPProtocolServer,
+  type MCPProtocolServerOptions,
+} from './protocol-server.js';
+export { connectMCPServerStdio, startStdioMCPServer } from './stdio.js';
 export { listDatasetsTool } from './tools/list-datasets.js';
 export { getDatasetSchemaTool } from './tools/introspect.js';
 export { queryMetricTool } from './tools/query-metric.js';

--- a/packages/mcp-server/src/protocol-server.test.ts
+++ b/packages/mcp-server/src/protocol-server.test.ts
@@ -1,0 +1,80 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { describe, expect, it, vi } from 'vitest';
+import type { MCPToolExecutor } from './executor.js';
+import { HypequeryMCPProtocolServer } from './protocol-server.js';
+
+describe('HypequeryMCPProtocolServer', () => {
+  it('serves an injected executor over an injected in-memory transport', async () => {
+    const executor: MCPToolExecutor = {
+      listTools: vi.fn(async () => ({
+        tools: [{
+          name: 'fixture_tool',
+          description: 'Fixture tool',
+          inputSchema: { type: 'object', properties: {} },
+        }],
+      })),
+      callTool: vi.fn(async (name, args) => ({
+        content: [{ type: 'text', text: JSON.stringify({ name, args }) }],
+      })),
+      listPrompts: vi.fn(async () => ({
+        prompts: [{ name: 'fixture_prompt' }],
+      })),
+      getPrompt: vi.fn(async (name, args) => ({
+        messages: [{
+          role: 'user',
+          content: { type: 'text', text: JSON.stringify({ name, args }) },
+        }],
+      })),
+      getManifestHash: vi.fn(() => 'fixture-hash'),
+    };
+    const server = new HypequeryMCPProtocolServer({
+      executor,
+      name: 'in-memory-hypequery',
+      version: '1.0.0',
+    });
+    const client = new Client(
+      { name: 'test-client', version: '1.0.0' },
+      { capabilities: {} },
+    );
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    try {
+      expect(server.getManifestHash()).toBe('fixture-hash');
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      await expect(client.listTools()).resolves.toMatchObject({
+        tools: [{ name: 'fixture_tool' }],
+      });
+      await expect(client.callTool({
+        name: 'fixture_tool',
+        arguments: { value: 42 },
+      })).resolves.toMatchObject({
+        content: [{ type: 'text', text: JSON.stringify({
+          name: 'fixture_tool',
+          args: { value: 42 },
+        }) }],
+      });
+      await expect(client.listPrompts()).resolves.toMatchObject({
+        prompts: [{ name: 'fixture_prompt' }],
+      });
+      await expect(client.getPrompt({
+        name: 'fixture_prompt',
+        arguments: { dataset: 'orders' },
+      })).resolves.toMatchObject({
+        messages: [{ role: 'user' }],
+      });
+
+      expect(executor.callTool).toHaveBeenCalledWith(
+        'fixture_tool',
+        { value: 42 },
+        expect.any(AbortSignal),
+      );
+      expect(executor.getPrompt).toHaveBeenCalledWith('fixture_prompt', { dataset: 'orders' });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/packages/mcp-server/src/protocol-server.ts
+++ b/packages/mcp-server/src/protocol-server.ts
@@ -1,0 +1,86 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import {
+  CallToolRequestSchema,
+  GetPromptRequestSchema,
+  ListPromptsRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { MCPToolExecutor } from './executor.js';
+import { MCP_PACKAGE_VERSION } from './version.js';
+
+export interface MCPProtocolServerOptions {
+  executor: MCPToolExecutor;
+  name?: string;
+  version?: string;
+}
+
+/**
+ * MCP protocol adapter for a transport-neutral Hypequery executor.
+ *
+ * The caller owns the transport. The same server can therefore be connected to
+ * stdio, an in-memory pair, or a hosted transport without changing tool logic.
+ */
+export class HypequeryMCPProtocolServer {
+  private readonly server: Server;
+  protected readonly executor: MCPToolExecutor;
+
+  constructor(options: MCPProtocolServerOptions) {
+    this.executor = options.executor;
+    this.server = new Server(
+      {
+        name: options.name ?? 'hypequery-mcp-server',
+        version: options.version ?? MCP_PACKAGE_VERSION,
+      },
+      {
+        capabilities: {
+          tools: {},
+          prompts: {},
+        },
+      },
+    );
+
+    this.setupHandlers();
+  }
+
+  private setupHandlers(): void {
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => (
+      this.executor.listTools()
+    ));
+
+    this.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => (
+      this.executor.callTool(request.params.name, request.params.arguments, extra?.signal)
+    ));
+
+    this.server.setRequestHandler(ListPromptsRequestSchema, async () => (
+      this.executor.listPrompts()
+    ));
+
+    this.server.setRequestHandler(GetPromptRequestSchema, async (request) => (
+      this.executor.getPrompt(request.params.name, request.params.arguments)
+    ));
+  }
+
+  getManifestHash(): string {
+    return this.executor.getManifestHash();
+  }
+
+  async connect(transport: Transport): Promise<void> {
+    await this.server.connect(transport);
+  }
+
+  async close(): Promise<void> {
+    await this.server.close();
+  }
+
+  /** Alias retained for the existing Hypequery MCP server lifecycle. */
+  async stop(): Promise<void> {
+    await this.close();
+  }
+}
+
+export function createMCPProtocolServer(
+  options: MCPProtocolServerOptions,
+): HypequeryMCPProtocolServer {
+  return new HypequeryMCPProtocolServer(options);
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,290 +1,42 @@
 /**
- * MCP Server for Hypequery Semantic Layer
+ * Backwards-compatible Hypequery MCP server facade.
  *
- * Exposes datasets and metrics via Model Context Protocol (MCP)
- * for use with Claude Desktop, Cursor, and other MCP-compatible tools.
+ * New integrations can compose HypequeryMCPExecutor with
+ * HypequeryMCPProtocolServer and supply their own transport. Existing callers
+ * can continue to construct this class and call start() for stdio.
  */
 
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-  ListPromptsRequestSchema,
-  GetPromptRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
-import {
-  type CanonicalSemanticQuerySchemas,
-  type DatasetClient,
-} from '@hypequery/datasets';
-import { listDatasetsTool } from './tools/list-datasets.js';
-import { getDatasetSchemaTool } from './tools/introspect.js';
-import { queryMetricTool } from './tools/query-metric.js';
-import { queryDatasetTool } from './tools/query-dataset.js';
-import { datasetGuidePrompt } from './prompts/dataset-guide.js';
-import type { DatasetRegistry, MCPExecutionBudget, MCPQueryLimits } from './types.js';
-import { MCP_PACKAGE_VERSION } from './version.js';
-import { buildMCPQuerySchemas } from './tools/utils/canonical-query-schemas.js';
-import { resolveQueryLimits } from './tools/utils/query-limits.js';
-import { resolveExecutionBudget } from './tools/utils/execution-budget.js';
-import { formatMCPToolError } from './errors.js';
+import { HypequeryMCPExecutor, type MCPServerConfig } from './executor.js';
+import { HypequeryMCPProtocolServer } from './protocol-server.js';
 
-export interface MCPServerConfig {
-  /**
-   * Dataset registry - map of dataset names to instances
-   */
-  datasets: DatasetRegistry;
+export type { MCPServerConfig } from './executor.js';
 
-  /**
-   * Semantic analytics for running metric and dataset queries
-   */
-  analytics: DatasetClient;
-
-  /**
-   * Server name (shown in MCP client)
-   */
-  name?: string;
-
-  /**
-   * Server version
-   */
-  version?: string;
-
-  /**
-   * Trusted tenant id used to scope tenant-keyed datasets.
-   */
-  tenantId?: string;
-
-  /**
-   * Include generated SQL in query tool responses.
-   *
-   * Defaults to false so agent-facing responses do not expose SQL text unless
-   * explicitly enabled for trusted debugging.
-   */
-  includeSql?: boolean;
-
-  /** Server-side query ceilings applied in addition to Dataset limits. */
-  queryLimits?: MCPQueryLimits;
-
-  /** Query deadline and serialized-result byte ceilings. */
-  executionBudget?: MCPExecutionBudget;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === 'object';
-}
-
-function getTenantKey(dataset: unknown): string | undefined {
-  if (!isRecord(dataset)) {
-    return undefined;
-  }
-
-  const config = dataset.config;
-  const configTenantKey = isRecord(config) ? config.tenantKey : undefined;
-  const tenantKey = dataset.tenantKey ?? configTenantKey;
-  return typeof tenantKey === 'string' && tenantKey.length > 0 ? tenantKey : undefined;
-}
-
-function validateTenantConfig(config: MCPServerConfig) {
-  if (config.tenantId) {
-    return;
-  }
-
-  const tenantScopedDatasets = Object.entries(config.datasets ?? {})
-    .filter(([, ds]) => getTenantKey(ds))
-    .map(([name]) => name);
-
-  if (tenantScopedDatasets.length > 0) {
-    throw new Error(
-      `MCP server tenantId is required for tenant-scoped datasets: ${tenantScopedDatasets.join(', ')}`,
-    );
-  }
-}
-
-export class HypequeryMCPServer {
-  private server: Server;
-  private config: MCPServerConfig;
-  private querySchemas: CanonicalSemanticQuerySchemas;
-
+export class HypequeryMCPServer extends HypequeryMCPProtocolServer {
   constructor(config: MCPServerConfig) {
-    validateTenantConfig(config);
-    resolveQueryLimits(undefined, config.queryLimits);
-    resolveExecutionBudget(config.executionBudget);
-    this.config = config;
-    this.querySchemas = buildMCPQuerySchemas(config.datasets ?? {}, config.queryLimits);
-
-    this.server = new Server(
-      {
-        name: config.name ?? 'hypequery-mcp-server',
-        version: config.version ?? MCP_PACKAGE_VERSION,
-      },
-      {
-        capabilities: {
-          tools: {},
-          prompts: {},
-        },
-      }
-    );
-
-    this.setupHandlers();
-  }
-
-  /** Stable hash of the catalog-derived query tool input manifest. */
-  getManifestHash(): string {
-    return this.querySchemas.manifestHash;
-  }
-
-  private setupHandlers() {
-    // List available tools
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
-      tools: [
-        {
-          name: 'list_datasets',
-          description: 'List all available datasets in the semantic layer',
-          inputSchema: {
-            type: 'object',
-            properties: {},
-          },
-        },
-        {
-          name: 'get_dataset_schema',
-          description: 'Get the schema (dimensions, measures, named metrics, filters, relationships) for a specific dataset',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              dataset: {
-                type: 'string',
-                description: 'Name of the dataset to introspect',
-              },
-            },
-            required: ['dataset'],
-          },
-        },
-        {
-          name: 'query_metric',
-          description: 'Execute a metric query with optional dimensions, filters, time grain, and sorting',
-          inputSchema: this.querySchemas.queryMetricJsonSchema,
-        },
-        {
-          name: 'query_dataset',
-          description: 'Execute an ad-hoc dataset query with custom dimensions and measures',
-          inputSchema: this.querySchemas.queryDatasetJsonSchema,
-        },
-      ],
-    }));
-
-    // Handle tool calls
-    this.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
-      const { name, arguments: args } = request.params;
-
-      try {
-        switch (name) {
-          case 'list_datasets':
-            return await listDatasetsTool(this.config.datasets);
-
-          case 'get_dataset_schema':
-            return await getDatasetSchemaTool(
-              this.config.datasets,
-              args,
-              { includeSql: this.config.includeSql },
-            );
-
-          case 'query_metric':
-            return await queryMetricTool(
-              this.config.datasets,
-              this.config.analytics,
-              args,
-              {
-                tenantId: this.config.tenantId,
-                includeSql: this.config.includeSql,
-                limits: this.config.queryLimits,
-                executionBudget: this.config.executionBudget,
-                signal: extra?.signal,
-                inputSchema: this.querySchemas.queryMetric,
-              },
-            );
-
-          case 'query_dataset':
-            return await queryDatasetTool(
-              this.config.datasets,
-              this.config.analytics,
-              args,
-              {
-                tenantId: this.config.tenantId,
-                includeSql: this.config.includeSql,
-                limits: this.config.queryLimits,
-                executionBudget: this.config.executionBudget,
-                signal: extra?.signal,
-                inputSchema: this.querySchemas.queryDataset,
-              },
-            );
-
-          default:
-            throw new Error(`Unknown tool: ${name}`);
-        }
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: formatMCPToolError(error),
-            },
-          ],
-          isError: true,
-        };
-      }
-    });
-
-    // List available prompts
-    this.server.setRequestHandler(ListPromptsRequestSchema, async () => ({
-      prompts: [
-        {
-          name: 'dataset_guide',
-          description: 'Guide for querying datasets with natural language',
-          arguments: [
-            {
-              name: 'dataset',
-              description: 'Name of the dataset to get guidance for',
-              required: false,
-            },
-          ],
-        },
-      ],
-    }));
-
-    // Get prompt content
-    this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
-      const { name, arguments: args } = request.params;
-
-      if (name === 'dataset_guide') {
-        return datasetGuidePrompt(this.config.datasets, args?.dataset);
-      }
-
-      throw new Error(`Unknown prompt: ${name}`);
+    const executor = new HypequeryMCPExecutor(config);
+    super({
+      executor,
+      name: config.name,
+      version: config.version,
     });
   }
 
   /**
-   * Start the MCP server with stdio transport
+   * Start with the legacy stdio transport.
+   *
+   * @deprecated Prefer connect(transport) or startStdioMCPServer(config).
    */
-  async start() {
-    const transport = new StdioServerTransport();
-    await this.server.connect(transport);
-
-    // Log to stderr (stdout is used for MCP protocol)
-    console.error('Hypequery MCP Server started');
-  }
-
-  /**
-   * Stop the MCP server
-   */
-  async stop() {
-    await this.server.close();
+  async start(): Promise<void> {
+    const { connectMCPServerStdio } = await import('./stdio.js');
+    await connectMCPServerStdio(this);
   }
 }
 
 /**
- * Create and start an MCP server
+ * Create and start a backwards-compatible stdio MCP server.
+ *
+ * @deprecated Prefer createMCPExecutor with createMCPProtocolServer, or
+ * startStdioMCPServer for an explicit stdio lifecycle.
  */
 export async function createMCPServer(config: MCPServerConfig): Promise<HypequeryMCPServer> {
   const server = new HypequeryMCPServer(config);

--- a/packages/mcp-server/src/stdio.ts
+++ b/packages/mcp-server/src/stdio.ts
@@ -1,0 +1,23 @@
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { MCPServerConfig } from './executor.js';
+import type { HypequeryMCPProtocolServer } from './protocol-server.js';
+import { HypequeryMCPServer } from './server.js';
+
+/** Connect an existing Hypequery MCP server to the stdio transport. */
+export async function connectMCPServerStdio(
+  server: HypequeryMCPProtocolServer,
+): Promise<void> {
+  await server.connect(new StdioServerTransport());
+
+  // MCP stdio owns stdout, so lifecycle logging must use stderr.
+  console.error('Hypequery MCP Server started');
+}
+
+/** Create and start the backwards-compatible stdio MCP server. */
+export async function startStdioMCPServer(
+  config: MCPServerConfig,
+): Promise<HypequeryMCPServer> {
+  const server = new HypequeryMCPServer(config);
+  await connectMCPServerStdio(server);
+  return server;
+}

--- a/packages/mcp-server/src/utils/tenant-config.ts
+++ b/packages/mcp-server/src/utils/tenant-config.ts
@@ -1,0 +1,32 @@
+import type { MCPExecutorConfig } from '../executor.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object';
+}
+
+function getTenantKey(dataset: unknown): string | undefined {
+  if (!isRecord(dataset)) {
+    return undefined;
+  }
+
+  const config = dataset.config;
+  const configTenantKey = isRecord(config) ? config.tenantKey : undefined;
+  const tenantKey = dataset.tenantKey ?? configTenantKey;
+  return typeof tenantKey === 'string' && tenantKey.length > 0 ? tenantKey : undefined;
+}
+
+export function validateMCPServerTenantConfig(config: MCPExecutorConfig): void {
+  if (config.tenantId) {
+    return;
+  }
+
+  const tenantScopedDatasets = Object.entries(config.datasets ?? {})
+    .filter(([, dataset]) => getTenantKey(dataset))
+    .map(([name]) => name);
+
+  if (tenantScopedDatasets.length > 0) {
+    throw new Error(
+      `MCP server tenantId is required for tenant-scoped datasets: ${tenantScopedDatasets.join(', ')}`,
+    );
+  }
+}

--- a/plans/mcp-cloud-agent-platform-plan.md
+++ b/plans/mcp-cloud-agent-platform-plan.md
@@ -436,6 +436,15 @@ Schemas, with exact enums, bounds, closed objects, selection validation, and a
 deterministic manifest hash. Legacy metadata-only MCP registries retain a
 generic compatibility validator until `CORE-08` replaces that input shape.
 
+**CORE-04 implementation status:** Implemented on top of `CORE-03`.
+`HypequeryMCPExecutor` now owns transport-independent tool and prompt behavior;
+`HypequeryMCPProtocolServer` binds an injected executor to any MCP SDK transport;
+and stdio is isolated in a thin adapter. Existing server names, tool names,
+stdio startup, tenant behavior, and query validation remain compatible. A real
+MCP client protocol test covers initialization, discovery, tool calls, and
+prompts through an injected in-memory transport and executor. No HTTP behavior
+is included.
+
 ### Deployment bridge PRs
 
 | PR | Depends on | Deliverable and merge gate |
@@ -537,7 +546,7 @@ identifiers above are the actual PR boundaries.
 - [ ] **MCP-102:** Add hard budgets for timeout, cancellation, response bytes,
   offset, dimensions, measures, filters, order fields, tool count, and catalog
   description bytes.
-- [ ] **MCP-103:** Refactor the MCP package around a public transport-neutral
+- [x] **MCP-103:** Refactor the MCP package around a public transport-neutral
   server/tool executor; keep stdio as an adapter.
 - [ ] **MCP-104:** Replace hand-written query schemas with catalog-derived schemas
   from `@hypequery/datasets`.


### PR DESCRIPTION
## Summary

- move Hypequery tool and prompt behavior into a public transport-neutral HypequeryMCPExecutor
- add HypequeryMCPProtocolServer with an injected executor and caller-owned MCP SDK transport
- isolate stdio startup in a thin explicit adapter while retaining HypequeryMCPServer, start(), stop(), and createMCPServer compatibility
- preserve the existing tool names, prompt names, tenant enforcement, canonical query schemas, manifest hash, and SQL redaction behavior
- document how a hosted gateway can bind the shared executor without adding HTTP behavior to Core

## Stack

Depends on CORE-03 PR #447 and should merge after it.

- ARCH-01: #443
- CORE-03: #447
- CORE-04: this PR

This PR unblocks CLOUD-01, where Cloud can supply a Streamable HTTP transport around the same protocol server and executor.

## Validation

- @hypequery/mcp lint
- @hypequery/mcp type tests
- @hypequery/mcp build
- 90 MCP tests across 10 files
- real MCP SDK client initialization, tool discovery/call, and prompt discovery/get over an injected linked in-memory transport
- legacy stdio lifecycle and handler compatibility tests
- git diff --check