### PR TITLE
feat(mcp): return structured tool results

### DIFF
--- a/.changeset/bright-tools-answer.md
+++ b/.changeset/bright-tools-answer.md
@@ -1,0 +1,8 @@
+---
+"@hypequery/mcp": minor
+---
+
+Add output schemas, structured content with compact text fallback, tool titles
+and read-only annotations, query result metadata, and stable structured errors.
+Backend failure details and SQL remain redacted from agent-facing responses by
+default.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -56,6 +56,29 @@ Now an agent can ask, “Show revenue by region for the last month,” using the
 - `query_metric` executes named KPIs;
 - `query_dataset` explores the fields you chose to publish.
 
+Every tool declares an output schema and returns the same result twice: MCP
+`structuredContent` for clients that support typed results, and compact JSON in
+the text content block for compatibility. Query metadata includes row count,
+timing when available, pagination state, and cache outcome. Tools also advertise
+human-readable titles and read-only, non-destructive, idempotent annotations.
+
+Tool failures use a stable structured envelope:
+
+```json
+{
+  "error": {
+    "code": "MCP_INVALID_ARGUMENTS",
+    "category": "correctable_input",
+    "message": "Invalid query_dataset arguments: ...",
+    "retryable": false,
+    "correctable": true
+  }
+}
+```
+
+Unclassified backend failures are redacted to `MCP_EXECUTION_FAILED`; database
+error details and physical SQL are not copied into agent-facing errors.
+
 ## Safer than raw SQL access
 
 - Tool schemas come from your TypeScript semantic layer.

--- a/packages/mcp-server/TEST_SUMMARY.md
+++ b/packages/mcp-server/TEST_SUMMARY.md
@@ -2,11 +2,12 @@
 
 ## Overview
 
-Comprehensive test suite for `@hypequery/mcp` with **115 passing tests** across 12 test files.
+Comprehensive test suite for `@hypequery/mcp` covering tools, prompts,
+transport-neutral execution, protocol integration, and public contracts.
 
 ## Test Coverage
 
-### 1. Tools (81 tests)
+### 1. Tools
 
 #### `list-datasets.test.ts` (8 tests)
 - ✅ Empty dataset list handling
@@ -61,7 +62,7 @@ Comprehensive test suite for `@hypequery/mcp` with **115 passing tests** across 
 - ✅ Per-dataset effective limit advertisement
 - ✅ Metric schemas omit measure limits
 
-#### `execution-budget.test.ts` (7 tests)
+#### `execution-budget.test.ts`
 - ✅ Safe deadline and response-byte defaults
 - ✅ Request cancellation propagation
 - ✅ Pre-cancelled requests skip query invocation
@@ -76,6 +77,7 @@ Comprehensive test suite for `@hypequery/mcp` with **115 passing tests** across 
 - ✅ Malformed Dataset entries fail closed
 - ✅ Deterministic manifest hashing
 - ✅ Canonical MCP and Dataset manifests have identical structure and identity
+- ✅ Complete structured and text-fallback response byte accounting
 
 #### `query-sql.integration.test.ts` (5 tests)
 - ✅ SQL redaction for dataset and metric results
@@ -98,7 +100,7 @@ Comprehensive test suite for `@hypequery/mcp` with **115 passing tests** across 
 - ✅ Example workflow
 - ✅ Message structure validation
 
-### 3. Server (20 tests)
+### 3. Core, protocol, and contracts
 
 #### `server.test.ts` (20 tests)
 - ✅ Server instantiation with default config
@@ -119,10 +121,12 @@ Comprehensive test suite for `@hypequery/mcp` with **115 passing tests** across 
 #### `examples.test.ts` (1 test)
 - ✅ Finite no-setup configuration loads as a valid Dataset
 
+Additional focused suites cover canonical manifests (2), the transport-neutral
+executor (4), real in-memory MCP protocol exchange (2), stable errors (4), and
+tool output schemas/annotations (1).
+
 ## Test Statistics
 
-- **Total Tests:** 115
-- **Test Files:** 12
 - **Pass Rate:** 100%
 
 ## Test Framework
@@ -141,12 +145,13 @@ Comprehensive test suite for `@hypequery/mcp` with **115 passing tests** across 
 - Edge cases (empty data, missing fields, defaults)
 
 ### 🔄 Mocked
-- MCP SDK components (Server, StdioServerTransport)
+- Stdio lifecycle components; protocol conformance uses the real MCP SDK client
+  and linked in-memory transport
 - Semantic runner (query execution)
 - BuilderFactory
 
 ### 📝 Not Tested
-- Integration tests with real MCP clients (Claude Desktop, Cursor)
+- Compatibility tests with external MCP clients (Claude Desktop, Cursor)
 - Integration tests with real ClickHouse databases
 - End-to-end workflow tests
 - Performance/load tests
@@ -206,6 +211,7 @@ it('should execute metric query with dimensions', async () => {
 ## Next Steps
 
 1. ✅ **Unit Tests** - Complete (115 tests)
-2. ⏭️ **Integration Tests** - Test with real MCP clients
-3. ⏭️ **E2E Tests** - Full workflow with ClickHouse
-4. ⏭️ **Performance Tests** - Load testing with large datasets
+2. ✅ **In-memory MCP protocol tests** - Real SDK client and server transport
+3. ⏭️ **Integration Tests** - Test with external MCP clients
+4. ⏭️ **E2E Tests** - Full workflow with ClickHouse
+5. ⏭️ **Performance Tests** - Load testing with large datasets

--- a/packages/mcp-server/TEST_SUMMARY.md
+++ b/packages/mcp-server/TEST_SUMMARY.md
@@ -210,7 +210,7 @@ it('should execute metric query with dimensions', async () => {
 
 ## Next Steps
 
-1. ✅ **Unit Tests** - Complete (115 tests)
+1. ✅ **Unit Tests** - Complete
 2. ✅ **In-memory MCP protocol tests** - Real SDK client and server transport
 3. ⏭️ **Integration Tests** - Test with external MCP clients
 4. ⏭️ **E2E Tests** - Full workflow with ClickHouse

--- a/packages/mcp-server/src/api.type-test.ts
+++ b/packages/mcp-server/src/api.type-test.ts
@@ -3,6 +3,7 @@ import {
   HypequeryMCPExecutor,
   HypequeryMCPProtocolServer,
   HypequeryMCPServer,
+  MCPToolError,
   connectMCPServerStdio,
   createMCPExecutor,
   createMCPProtocolServer,
@@ -12,6 +13,7 @@ import {
   type MCPProtocolServerOptions,
   type MCPServerConfig,
   type MCPToolExecutor,
+  type MCPToolErrorCode,
 } from './index.js';
 
 it('exports the transport-neutral and backwards-compatible MCP APIs', () => {
@@ -23,4 +25,6 @@ it('exports the transport-neutral and backwards-compatible MCP APIs', () => {
   expectTypeOf(connectMCPServerStdio).returns.toMatchTypeOf<Promise<void>>();
   expectTypeOf(startStdioMCPServer).returns.toMatchTypeOf<Promise<HypequeryMCPServer>>();
   expectTypeOf(createMCPServer).returns.toMatchTypeOf<Promise<HypequeryMCPServer>>();
+  expectTypeOf(new MCPToolError('MCP_UNAUTHORIZED', 'Forbidden').code)
+    .toMatchTypeOf<MCPToolErrorCode>();
 });

--- a/packages/mcp-server/src/errors.test.ts
+++ b/packages/mcp-server/src/errors.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MCPExecutionBudgetError,
+  MCPToolError,
+  classifyMCPToolError,
+  formatMCPToolError,
+} from './errors.js';
+
+describe('stable MCP tool errors', () => {
+  it('preserves budget classifications and retryability', () => {
+    expect(classifyMCPToolError(new MCPExecutionBudgetError(
+      'MCP_QUERY_TIMEOUT',
+      'deadline exceeded',
+    ))).toEqual({
+      code: 'MCP_QUERY_TIMEOUT',
+      category: 'budget',
+      message: 'deadline exceeded',
+      retryable: true,
+      correctable: false,
+    });
+  });
+
+  it('classifies validation and lookup failures', () => {
+    expect(classifyMCPToolError(new Error('Invalid query_dataset arguments: limit')))
+      .toMatchObject({
+        code: 'MCP_INVALID_ARGUMENTS',
+        category: 'correctable_input',
+        retryable: false,
+        correctable: true,
+      });
+    expect(classifyMCPToolError(new Error('Dataset not found: secret')))
+      .toMatchObject({ code: 'MCP_NOT_FOUND', retryable: false });
+  });
+
+  it('provides stable host-facing authorization and contract categories', () => {
+    expect(classifyMCPToolError(new MCPToolError('MCP_UNAUTHORIZED', 'Forbidden')))
+      .toMatchObject({ category: 'unauthorized', retryable: false });
+    expect(classifyMCPToolError(new MCPToolError('MCP_STALE_CONTRACT', 'Relist tools')))
+      .toMatchObject({ category: 'stale_contract', retryable: true });
+  });
+
+  it('redacts unclassified execution details', () => {
+    const classified = classifyMCPToolError(new Error(
+      'DB::Exception: SELECT password FROM private_table',
+    ));
+
+    expect(classified).toEqual({
+      code: 'MCP_EXECUTION_FAILED',
+      category: 'internal',
+      message: 'Query execution failed',
+      retryable: true,
+      correctable: false,
+    });
+    expect(formatMCPToolError(new Error('SELECT password')))
+      .toBe('Error [MCP_EXECUTION_FAILED]: Query execution failed');
+  });
+});

--- a/packages/mcp-server/src/errors.test.ts
+++ b/packages/mcp-server/src/errors.test.ts
@@ -21,14 +21,20 @@ describe('stable MCP tool errors', () => {
   });
 
   it('classifies validation and lookup failures', () => {
-    expect(classifyMCPToolError(new Error('Invalid query_dataset arguments: limit')))
+    expect(classifyMCPToolError(new MCPToolError(
+      'MCP_INVALID_ARGUMENTS',
+      'Invalid query_dataset arguments: limit',
+    )))
       .toMatchObject({
         code: 'MCP_INVALID_ARGUMENTS',
         category: 'correctable_input',
         retryable: false,
         correctable: true,
       });
-    expect(classifyMCPToolError(new Error('Dataset not found: secret')))
+    expect(classifyMCPToolError(new MCPToolError(
+      'MCP_NOT_FOUND',
+      'Dataset not found: secret',
+    )))
       .toMatchObject({ code: 'MCP_NOT_FOUND', retryable: false });
   });
 
@@ -53,5 +59,11 @@ describe('stable MCP tool errors', () => {
     });
     expect(formatMCPToolError(new Error('SELECT password')))
       .toBe('Error [MCP_EXECUTION_FAILED]: Query execution failed');
+    expect(classifyMCPToolError(new Error(
+      'Table not found: private_table; SELECT password FROM users',
+    ))).toMatchObject({
+      code: 'MCP_EXECUTION_FAILED',
+      message: 'Query execution failed',
+    });
   });
 });

--- a/packages/mcp-server/src/errors.ts
+++ b/packages/mcp-server/src/errors.ts
@@ -87,10 +87,6 @@ export class MCPExecutionBudgetError extends MCPToolError {
   }
 }
 
-function messageOf(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 export function classifyMCPToolError(error: unknown): MCPErrorDetails {
   if (error instanceof MCPToolError) {
     return {
@@ -99,39 +95,6 @@ export function classifyMCPToolError(error: unknown): MCPErrorDetails {
       message: error.message,
       retryable: error.retryable,
       correctable: error.correctable,
-    };
-  }
-
-  const message = messageOf(error);
-  if (message.startsWith('Unknown tool:')) {
-    return {
-      code: 'MCP_UNKNOWN_TOOL',
-      category: 'correctable_input',
-      message,
-      retryable: false,
-      correctable: true,
-    };
-  }
-  if (message.includes('not found:') || message.startsWith('Metric not found:')) {
-    return {
-      code: 'MCP_NOT_FOUND',
-      category: 'correctable_input',
-      message,
-      retryable: false,
-      correctable: true,
-    };
-  }
-  if (
-    message.startsWith('Invalid ')
-    || message.endsWith('parameter is required')
-    || message.startsWith('At least one ')
-  ) {
-    return {
-      code: 'MCP_INVALID_ARGUMENTS',
-      category: 'correctable_input',
-      message,
-      retryable: false,
-      correctable: true,
     };
   }
 

--- a/packages/mcp-server/src/errors.ts
+++ b/packages/mcp-server/src/errors.ts
@@ -1,21 +1,150 @@
-export type MCPExecutionErrorCode =
+export type MCPToolErrorCode =
+  | 'MCP_INVALID_ARGUMENTS'
+  | 'MCP_NOT_FOUND'
+  | 'MCP_UNKNOWN_TOOL'
+  | 'MCP_UNAUTHORIZED'
+  | 'MCP_STALE_CONTRACT'
   | 'MCP_REQUEST_CANCELLED'
   | 'MCP_QUERY_TIMEOUT'
-  | 'MCP_RESULT_TOO_LARGE';
+  | 'MCP_RESULT_TOO_LARGE'
+  | 'MCP_EXECUTION_FAILED';
 
-export class MCPExecutionBudgetError extends Error {
-  readonly code: MCPExecutionErrorCode;
+export type MCPToolErrorCategory =
+  | 'correctable_input'
+  | 'unauthorized'
+  | 'stale_contract'
+  | 'budget'
+  | 'internal';
 
-  constructor(code: MCPExecutionErrorCode, message: string) {
-    super(message);
-    this.name = 'MCPExecutionBudgetError';
-    this.code = code;
+/** @deprecated Use MCPToolErrorCode. */
+export type MCPExecutionErrorCode = Extract<
+  MCPToolErrorCode,
+  'MCP_REQUEST_CANCELLED' | 'MCP_QUERY_TIMEOUT' | 'MCP_RESULT_TOO_LARGE'
+>;
+
+export interface MCPErrorDetails {
+  code: MCPToolErrorCode;
+  category: MCPToolErrorCategory;
+  message: string;
+  retryable: boolean;
+  correctable: boolean;
+}
+
+function defaultErrorMetadata(code: MCPToolErrorCode): Omit<MCPErrorDetails, 'code' | 'message'> {
+  switch (code) {
+    case 'MCP_INVALID_ARGUMENTS':
+    case 'MCP_NOT_FOUND':
+    case 'MCP_UNKNOWN_TOOL':
+      return { category: 'correctable_input', retryable: false, correctable: true };
+    case 'MCP_UNAUTHORIZED':
+      return { category: 'unauthorized', retryable: false, correctable: false };
+    case 'MCP_STALE_CONTRACT':
+      return { category: 'stale_contract', retryable: true, correctable: false };
+    case 'MCP_REQUEST_CANCELLED':
+    case 'MCP_RESULT_TOO_LARGE':
+      return { category: 'budget', retryable: false, correctable: false };
+    case 'MCP_QUERY_TIMEOUT':
+      return { category: 'budget', retryable: true, correctable: false };
+    case 'MCP_EXECUTION_FAILED':
+      return { category: 'internal', retryable: true, correctable: false };
   }
 }
 
-export function formatMCPToolError(error: unknown): string {
-  if (error instanceof MCPExecutionBudgetError) {
-    return `Error [${error.code}]: ${error.message}`;
+export class MCPToolError extends Error {
+  readonly code: MCPToolErrorCode;
+  readonly category: MCPToolErrorCategory;
+  readonly retryable: boolean;
+  readonly correctable: boolean;
+
+  constructor(
+    code: MCPToolErrorCode,
+    message: string,
+    options: {
+      category?: MCPToolErrorCategory;
+      retryable?: boolean;
+      correctable?: boolean;
+    } = {},
+  ) {
+    super(message);
+    const defaults = defaultErrorMetadata(code);
+    this.name = 'MCPToolError';
+    this.code = code;
+    this.category = options.category ?? defaults.category;
+    this.retryable = options.retryable ?? defaults.retryable;
+    this.correctable = options.correctable ?? defaults.correctable;
   }
-  return `Error: ${error instanceof Error ? error.message : String(error)}`;
+}
+
+export class MCPExecutionBudgetError extends MCPToolError {
+  declare readonly code: MCPExecutionErrorCode;
+
+  constructor(code: MCPExecutionErrorCode, message: string) {
+    super(code, message, {
+      category: 'budget',
+      retryable: code === 'MCP_QUERY_TIMEOUT',
+    });
+    this.name = 'MCPExecutionBudgetError';
+  }
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function classifyMCPToolError(error: unknown): MCPErrorDetails {
+  if (error instanceof MCPToolError) {
+    return {
+      code: error.code,
+      category: error.category,
+      message: error.message,
+      retryable: error.retryable,
+      correctable: error.correctable,
+    };
+  }
+
+  const message = messageOf(error);
+  if (message.startsWith('Unknown tool:')) {
+    return {
+      code: 'MCP_UNKNOWN_TOOL',
+      category: 'correctable_input',
+      message,
+      retryable: false,
+      correctable: true,
+    };
+  }
+  if (message.includes('not found:') || message.startsWith('Metric not found:')) {
+    return {
+      code: 'MCP_NOT_FOUND',
+      category: 'correctable_input',
+      message,
+      retryable: false,
+      correctable: true,
+    };
+  }
+  if (
+    message.startsWith('Invalid ')
+    || message.endsWith('parameter is required')
+    || message.startsWith('At least one ')
+  ) {
+    return {
+      code: 'MCP_INVALID_ARGUMENTS',
+      category: 'correctable_input',
+      message,
+      retryable: false,
+      correctable: true,
+    };
+  }
+
+  return {
+    code: 'MCP_EXECUTION_FAILED',
+    category: 'internal',
+    message: 'Query execution failed',
+    retryable: true,
+    correctable: false,
+  };
+}
+
+export function formatMCPToolError(error: unknown): string {
+  const classified = classifyMCPToolError(error);
+  return `Error [${classified.code}]: ${classified.message}`;
 }

--- a/packages/mcp-server/src/executor.test.ts
+++ b/packages/mcp-server/src/executor.test.ts
@@ -52,7 +52,46 @@ describe('HypequeryMCPExecutor', () => {
 
     await expect(executor.callTool('unknown')).resolves.toMatchObject({
       isError: true,
-      content: [{ type: 'text', text: 'Error: Unknown tool: unknown' }],
+      content: [{
+        type: 'text',
+        text: 'Error [MCP_UNKNOWN_TOOL]: Unknown tool: unknown',
+      }],
+      structuredContent: {
+        error: {
+          code: 'MCP_UNKNOWN_TOOL',
+          category: 'correctable_input',
+          message: 'Unknown tool: unknown',
+          retryable: false,
+          correctable: true,
+        },
+      },
+    });
+  });
+
+  it('maps oversized dual-format results to a structured budget error', async () => {
+    const oversizedAnalytics = {
+      execute: vi.fn(async () => ({
+        data: [{ payload: 'x'.repeat(200) }],
+        meta: {},
+      })),
+    } as unknown as DatasetClient;
+    const executor = new HypequeryMCPExecutor({
+      datasets,
+      analytics: oversizedAnalytics,
+      executionBudget: { maxResponseBytes: 200 },
+    });
+
+    await expect(executor.callTool('query_dataset', {
+      dataset: 'orders',
+      dimensions: ['region'],
+    })).resolves.toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: {
+          code: 'MCP_RESULT_TOO_LARGE',
+          category: 'budget',
+        },
+      },
     });
   });
 });

--- a/packages/mcp-server/src/executor.test.ts
+++ b/packages/mcp-server/src/executor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { DatasetClient } from '@hypequery/datasets';
 import { HypequeryMCPExecutor } from './executor.js';
+import { MIN_RESPONSE_BYTES } from './tools/utils/execution-budget.js';
 
 describe('HypequeryMCPExecutor', () => {
   const analytics = {
@@ -78,7 +79,7 @@ describe('HypequeryMCPExecutor', () => {
     const executor = new HypequeryMCPExecutor({
       datasets,
       analytics: oversizedAnalytics,
-      executionBudget: { maxResponseBytes: 200 },
+      executionBudget: { maxResponseBytes: MIN_RESPONSE_BYTES },
     });
 
     await expect(executor.callTool('query_dataset', {
@@ -93,5 +94,11 @@ describe('HypequeryMCPExecutor', () => {
         },
       },
     });
+    const response = await executor.callTool('query_dataset', {
+      dataset: 'orders',
+      dimensions: ['region'],
+    });
+    expect(Buffer.byteLength(JSON.stringify(response), 'utf8'))
+      .toBeLessThanOrEqual(MIN_RESPONSE_BYTES);
   });
 });

--- a/packages/mcp-server/src/executor.ts
+++ b/packages/mcp-server/src/executor.ts
@@ -8,17 +8,18 @@ import type {
   CanonicalSemanticQuerySchemas,
   DatasetClient,
 } from '@hypequery/datasets';
-import { formatMCPToolError } from './errors.js';
 import { datasetGuidePrompt } from './prompts/dataset-guide.js';
 import { getDatasetSchemaTool } from './tools/introspect.js';
 import { listDatasetsTool } from './tools/list-datasets.js';
 import { queryDatasetTool } from './tools/query-dataset.js';
 import { queryMetricTool } from './tools/query-metric.js';
+import { buildMCPToolManifest } from './tools/tool-manifest.js';
 import { buildMCPQuerySchemas } from './tools/utils/canonical-query-schemas.js';
 import { resolveExecutionBudget } from './tools/utils/execution-budget.js';
 import { resolveQueryLimits } from './tools/utils/query-limits.js';
 import type { DatasetRegistry, MCPExecutionBudget, MCPQueryLimits } from './types.js';
 import { validateMCPServerTenantConfig } from './utils/tenant-config.js';
+import { createMCPErrorResponse } from './tools/utils/tool-response.js';
 
 export interface MCPExecutorConfig {
   /** Dataset registry - map of dataset names to instances. */
@@ -76,48 +77,7 @@ export class HypequeryMCPExecutor implements MCPToolExecutor {
   }
 
   async listTools(): Promise<ListToolsResult> {
-    return {
-      tools: [
-        {
-          name: 'list_datasets',
-          description: 'List all available datasets in the semantic layer',
-          inputSchema: {
-            type: 'object',
-            properties: {},
-          },
-        },
-        {
-          name: 'get_dataset_schema',
-          description: 'Get the schema (dimensions, measures, named metrics, filters, relationships) for a specific dataset',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              dataset: {
-                type: 'string',
-                description: 'Name of the dataset to introspect',
-              },
-            },
-            required: ['dataset'],
-          },
-        },
-        {
-          name: 'query_metric',
-          description: 'Execute a metric query with optional dimensions, filters, time grain, and sorting',
-          inputSchema: this.querySchemas.queryMetricJsonSchema as {
-            type: 'object';
-            [key: string]: unknown;
-          },
-        },
-        {
-          name: 'query_dataset',
-          description: 'Execute an ad-hoc dataset query with custom dimensions and measures',
-          inputSchema: this.querySchemas.queryDatasetJsonSchema as {
-            type: 'object';
-            [key: string]: unknown;
-          },
-        },
-      ],
-    };
+    return buildMCPToolManifest(this.querySchemas);
   }
 
   async callTool(
@@ -171,15 +131,7 @@ export class HypequeryMCPExecutor implements MCPToolExecutor {
           throw new Error(`Unknown tool: ${name}`);
       }
     } catch (error) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: formatMCPToolError(error),
-          },
-        ],
-        isError: true,
-      };
+      return createMCPErrorResponse(error);
     }
   }
 

--- a/packages/mcp-server/src/executor.ts
+++ b/packages/mcp-server/src/executor.ts
@@ -8,6 +8,7 @@ import type {
   CanonicalSemanticQuerySchemas,
   DatasetClient,
 } from '@hypequery/datasets';
+import { MCPToolError } from './errors.js';
 import { datasetGuidePrompt } from './prompts/dataset-guide.js';
 import { getDatasetSchemaTool } from './tools/introspect.js';
 import { listDatasetsTool } from './tools/list-datasets.js';
@@ -136,7 +137,7 @@ export class HypequeryMCPExecutor implements MCPToolExecutor {
           );
 
         default:
-          throw new Error(`Unknown tool: ${name}`);
+          throw new MCPToolError('MCP_UNKNOWN_TOOL', `Unknown tool: ${name}`);
       }
     } catch (error) {
       const response = createMCPErrorResponse(error);

--- a/packages/mcp-server/src/executor.ts
+++ b/packages/mcp-server/src/executor.ts
@@ -15,11 +15,18 @@ import { queryDatasetTool } from './tools/query-dataset.js';
 import { queryMetricTool } from './tools/query-metric.js';
 import { buildMCPToolManifest } from './tools/tool-manifest.js';
 import { buildMCPQuerySchemas } from './tools/utils/canonical-query-schemas.js';
-import { resolveExecutionBudget } from './tools/utils/execution-budget.js';
+import {
+  assertWithinBudget,
+  resolveExecutionBudget,
+  type EffectiveExecutionBudget,
+} from './tools/utils/execution-budget.js';
 import { resolveQueryLimits } from './tools/utils/query-limits.js';
 import type { DatasetRegistry, MCPExecutionBudget, MCPQueryLimits } from './types.js';
 import { validateMCPServerTenantConfig } from './utils/tenant-config.js';
-import { createMCPErrorResponse } from './tools/utils/tool-response.js';
+import {
+  createMCPErrorResponse,
+  createMCPResultTooLargeResponse,
+} from './tools/utils/tool-response.js';
 
 export interface MCPExecutorConfig {
   /** Dataset registry - map of dataset names to instances. */
@@ -64,11 +71,12 @@ export interface MCPToolExecutor {
  */
 export class HypequeryMCPExecutor implements MCPToolExecutor {
   private readonly querySchemas: CanonicalSemanticQuerySchemas;
+  private readonly executionBudget: EffectiveExecutionBudget;
 
   constructor(private readonly config: MCPExecutorConfig) {
     validateMCPServerTenantConfig(config);
     resolveQueryLimits(undefined, config.queryLimits);
-    resolveExecutionBudget(config.executionBudget);
+    this.executionBudget = resolveExecutionBudget(config.executionBudget);
     this.querySchemas = buildMCPQuerySchemas(config.datasets ?? {}, config.queryLimits);
   }
 
@@ -131,7 +139,13 @@ export class HypequeryMCPExecutor implements MCPToolExecutor {
           throw new Error(`Unknown tool: ${name}`);
       }
     } catch (error) {
-      return createMCPErrorResponse(error);
+      const response = createMCPErrorResponse(error);
+      try {
+        assertWithinBudget(response, this.executionBudget);
+        return response;
+      } catch {
+        return createMCPResultTooLargeResponse();
+      }
     }
   }
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -46,8 +46,13 @@ export type {
 } from './types.js';
 export {
   MCPExecutionBudgetError,
+  MCPToolError,
+  classifyMCPToolError,
   formatMCPToolError,
+  type MCPErrorDetails,
   type MCPExecutionErrorCode,
+  type MCPToolErrorCode,
+  type MCPToolErrorCategory,
 } from './errors.js';
 export {
   MAX_QUERY_LIMIT,

--- a/packages/mcp-server/src/protocol-server.test.ts
+++ b/packages/mcp-server/src/protocol-server.test.ts
@@ -1,7 +1,8 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { DatasetClient } from '@hypequery/datasets';
 import { describe, expect, it, vi } from 'vitest';
-import type { MCPToolExecutor } from './executor.js';
+import { HypequeryMCPExecutor, type MCPToolExecutor } from './executor.js';
 import { HypequeryMCPProtocolServer } from './protocol-server.js';
 
 describe('HypequeryMCPProtocolServer', () => {
@@ -72,6 +73,74 @@ describe('HypequeryMCPProtocolServer', () => {
         expect.any(AbortSignal),
       );
       expect(executor.getPrompt).toHaveBeenCalledWith('fixture_prompt', { dataset: 'orders' });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('returns schema-valid structured results with compatible text fallback', async () => {
+    const analytics = {
+      execute: vi.fn(async () => ({
+        data: [{ region: 'EU', revenue: 42 }],
+        meta: { timingMs: 5 },
+      })),
+    } as unknown as DatasetClient;
+    const executor = new HypequeryMCPExecutor({
+      datasets: {
+        orders: {
+          dimensions: { region: {} },
+          measures: { revenue: {} },
+          metrics: {},
+        },
+      },
+      analytics,
+    });
+    const server = new HypequeryMCPProtocolServer({ executor });
+    const client = new Client(
+      { name: 'structured-client', version: '1.0.0' },
+      { capabilities: {} },
+    );
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+      await client.listTools();
+
+      const result = await client.callTool({
+        name: 'query_dataset',
+        arguments: {
+          dataset: 'orders',
+          dimensions: ['region'],
+          measures: ['revenue'],
+        },
+      });
+
+      expect(result.structuredContent).toEqual({
+        data: [{ region: 'EU', revenue: 42 }],
+        meta: {
+          timingMs: 5,
+          rowCount: 1,
+          cache: { status: 'bypass' },
+        },
+      });
+      expect(JSON.parse(result.content[0].type === 'text' ? result.content[0].text : ''))
+        .toEqual(result.structuredContent);
+
+      const error = await client.callTool({
+        name: 'query_dataset',
+        arguments: { dimensions: ['region'] },
+      });
+      expect(error).toMatchObject({
+        isError: true,
+        structuredContent: {
+          error: {
+            code: 'MCP_INVALID_ARGUMENTS',
+            retryable: false,
+          },
+        },
+      });
     } finally {
       await client.close();
       await server.close();

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -290,6 +290,7 @@ describe('HypequeryMCPServer', () => {
 
     const redactedBody = JSON.parse((redactedResult as any).content[0].text);
     expect(redactedBody.meta.sql).toBeUndefined();
+    expect((redactedResult as any).structuredContent.meta.sql).toBeUndefined();
 
     requestHandlers.clear();
     new HypequeryMCPServer({
@@ -311,6 +312,8 @@ describe('HypequeryMCPServer', () => {
 
     const debugBody = JSON.parse((debugResult as any).content[0].text);
     expect(debugBody.meta.sql).toBe('SELECT SUM(amount) AS revenue FROM orders');
+    expect((debugResult as any).structuredContent.meta.sql)
+      .toBe('SELECT SUM(amount) AS revenue FROM orders');
   });
 });
 

--- a/packages/mcp-server/src/tools/args.ts
+++ b/packages/mcp-server/src/tools/args.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { SEMANTIC_FILTER_OPERATORS, type MetricFilter } from '@hypequery/datasets';
+import { MCPToolError } from '../errors.js';
 import {
   MAX_QUERY_DIMENSIONS,
   MAX_QUERY_FILTERS,
@@ -51,7 +52,10 @@ function formatZodError(error: z.ZodError): string {
 export function parseToolArgs<T>(schema: z.ZodType<T>, toolName: string, args: unknown): T {
   const result = schema.safeParse(args);
   if (!result.success) {
-    throw new Error(`Invalid ${toolName} arguments: ${formatZodError(result.error)}`);
+    throw new MCPToolError(
+      'MCP_INVALID_ARGUMENTS',
+      `Invalid ${toolName} arguments: ${formatZodError(result.error)}`,
+    );
   }
   return result.data;
 }

--- a/packages/mcp-server/src/tools/introspect.test.ts
+++ b/packages/mcp-server/src/tools/introspect.test.ts
@@ -11,6 +11,12 @@ describe('getDatasetSchemaTool', () => {
     await expect(getDatasetSchemaTool({}, {})).rejects.toThrow(
       'dataset parameter is required'
     );
+    await expect(getDatasetSchemaTool({}, undefined)).rejects.toMatchObject({
+      code: 'MCP_INVALID_ARGUMENTS',
+    });
+    await expect(getDatasetSchemaTool({}, { dataset: 42 })).rejects.toMatchObject({
+      code: 'MCP_INVALID_ARGUMENTS',
+    });
   });
 
   it('should throw error when dataset is not found', async () => {

--- a/packages/mcp-server/src/tools/introspect.test.ts
+++ b/packages/mcp-server/src/tools/introspect.test.ts
@@ -66,6 +66,7 @@ describe('getDatasetSchemaTool', () => {
 
     const result = await getDatasetSchemaTool(datasets, { dataset: 'orders' });
     const schema = JSON.parse(result.content[0].text);
+    expect(result.structuredContent).toEqual(schema);
 
     expect(schema.name).toBe('orders');
     expect(schema.description).toBe('Order data');

--- a/packages/mcp-server/src/tools/introspect.ts
+++ b/packages/mcp-server/src/tools/introspect.ts
@@ -6,6 +6,7 @@
  */
 
 import { getDatasetCatalog, listQueryableRelationshipFields } from '@hypequery/datasets';
+import { MCPToolError } from '../errors.js';
 import type {
   DatasetRegistry,
   GetDatasetSchemaArgs,
@@ -29,18 +30,18 @@ export async function getDatasetSchemaTool(
   args: unknown,
   options: SchemaToolOptions = {},
 ): Promise<MCPToolResponse> {
-  // Parse and validate args
-  const validatedArgs = args as GetDatasetSchemaArgs;
-  const datasetName = validatedArgs.dataset;
+  const datasetName = args && typeof args === 'object' && !Array.isArray(args)
+    ? (args as Partial<GetDatasetSchemaArgs>).dataset
+    : undefined;
 
-  if (!datasetName) {
-    throw new Error('dataset parameter is required');
+  if (typeof datasetName !== 'string' || datasetName.length === 0) {
+    throw new MCPToolError('MCP_INVALID_ARGUMENTS', 'dataset parameter is required');
   }
 
   const dataset = datasets[datasetName];
 
   if (!dataset) {
-    throw new Error(`Dataset not found: ${datasetName}`);
+    throw new MCPToolError('MCP_NOT_FOUND', `Dataset not found: ${datasetName}`);
   }
 
   const datasetAny = dataset as any;

--- a/packages/mcp-server/src/tools/introspect.ts
+++ b/packages/mcp-server/src/tools/introspect.ts
@@ -18,6 +18,7 @@ import type {
   RelationshipSchema,
   SchemaToolOptions,
 } from '../types.js';
+import { createMCPToolResponse } from './utils/tool-response.js';
 
 function isDatasetInstance(value: unknown): value is Parameters<typeof getDatasetCatalog>[0] {
   return !!value && typeof value === 'object' && (value as { __type?: unknown }).__type === 'dataset';
@@ -202,12 +203,5 @@ export async function getDatasetSchemaTool(
     }
   }
 
-  return {
-    content: [
-      {
-        type: 'text' as const,
-        text: JSON.stringify(schema, null, 2),
-      },
-    ],
-  };
+  return createMCPToolResponse(schema);
 }

--- a/packages/mcp-server/src/tools/list-datasets.test.ts
+++ b/packages/mcp-server/src/tools/list-datasets.test.ts
@@ -16,6 +16,7 @@ describe('listDatasetsTool', () => {
     const data = JSON.parse(result.content[0].text);
     expect(data.datasets).toEqual([]);
     expect(data.total).toBe(0);
+    expect(result.structuredContent).toEqual(data);
   });
 
   it('should list datasets with descriptions', async () => {

--- a/packages/mcp-server/src/tools/list-datasets.ts
+++ b/packages/mcp-server/src/tools/list-datasets.ts
@@ -6,6 +6,7 @@
 
 import { getDatasetCatalog } from '@hypequery/datasets';
 import type { DatasetRegistry, MCPToolResponse, DatasetsListResponse, DatasetListItem } from '../types.js';
+import { createMCPToolResponse } from './utils/tool-response.js';
 
 function isDatasetInstance(value: unknown): value is Parameters<typeof getDatasetCatalog>[0] {
   return !!value && typeof value === 'object' && (value as { __type?: unknown }).__type === 'dataset';
@@ -46,12 +47,5 @@ export async function listDatasetsTool(datasets: DatasetRegistry): Promise<MCPTo
     total: datasetList.length,
   };
 
-  return {
-    content: [
-      {
-        type: 'text' as const,
-        text: JSON.stringify(response, null, 2),
-      },
-    ],
-  };
+  return createMCPToolResponse(response);
 }

--- a/packages/mcp-server/src/tools/query-dataset.ts
+++ b/packages/mcp-server/src/tools/query-dataset.ts
@@ -5,6 +5,7 @@
  */
 
 import type { DatasetClient, DatasetQuery } from '@hypequery/datasets';
+import { MCPToolError } from '../errors.js';
 import type { DatasetRegistry, MCPToolResponse, QueryToolOptions } from '../types.js';
 import { parseToolArgs, toMetricFilters } from './args.js';
 import { buildMCPQuerySchemas } from './utils/canonical-query-schemas.js';
@@ -28,17 +29,20 @@ export async function queryDatasetTool(
   const { dataset: datasetName, dimensions, measures, filters, grain, orderBy } = validatedArgs;
 
   if (!datasetName) {
-    throw new Error('dataset parameter is required');
+    throw new MCPToolError('MCP_INVALID_ARGUMENTS', 'dataset parameter is required');
   }
 
   const dataset = datasets[datasetName];
 
   if (!dataset) {
-    throw new Error(`Dataset not found: ${datasetName}`);
+    throw new MCPToolError('MCP_NOT_FOUND', `Dataset not found: ${datasetName}`);
   }
 
   if (!dimensions?.length && !measures?.length) {
-    throw new Error('At least one dimension or measure must be specified');
+    throw new MCPToolError(
+      'MCP_INVALID_ARGUMENTS',
+      'At least one dimension or measure must be specified',
+    );
   }
 
   const pagination = applyQueryLimits(dataset, validatedArgs, options.limits);

--- a/packages/mcp-server/src/tools/query-dataset.ts
+++ b/packages/mcp-server/src/tools/query-dataset.ts
@@ -5,15 +5,17 @@
  */
 
 import type { DatasetClient, DatasetQuery } from '@hypequery/datasets';
-import type { DatasetRegistry, MCPToolResponse, QueryResultResponse, QueryToolOptions } from '../types.js';
+import type { DatasetRegistry, MCPToolResponse, QueryToolOptions } from '../types.js';
 import { parseToolArgs, toMetricFilters } from './args.js';
 import { buildMCPQuerySchemas } from './utils/canonical-query-schemas.js';
 import { applyQueryLimits } from './utils/query-limits.js';
 import {
+  assertWithinBudget,
   executeWithinBudget,
   resolveExecutionBudget,
-  serializeWithinBudget,
 } from './utils/execution-budget.js';
+import { buildMCPQueryResult } from './utils/query-result.js';
+import { createMCPToolResponse } from './utils/tool-response.js';
 
 export async function queryDatasetTool(
   datasets: DatasetRegistry,
@@ -72,22 +74,8 @@ export async function queryDatasetTool(
   );
 
   // Format the response with proper types
-  const response: QueryResultResponse = {
-    data: result.data,
-    meta: {
-      ...(options.includeSql ? { sql: result.meta?.sql } : {}),
-      timingMs: result.meta?.timingMs,
-      rowCount: result.data.length,
-      ...(result.meta?.pagination ? { pagination: result.meta.pagination } : {}),
-    },
-  };
-
-  return {
-    content: [
-      {
-        type: 'text' as const,
-        text: serializeWithinBudget(response, executionBudget),
-      },
-    ],
-  };
+  const response = buildMCPQueryResult(result, options.includeSql);
+  const toolResponse = createMCPToolResponse(response);
+  assertWithinBudget(toolResponse, executionBudget);
+  return toolResponse;
 }

--- a/packages/mcp-server/src/tools/query-metric.ts
+++ b/packages/mcp-server/src/tools/query-metric.ts
@@ -5,15 +5,17 @@
  */
 
 import type { DatasetClient, MetricQuery } from '@hypequery/datasets';
-import type { DatasetRegistry, MCPToolResponse, QueryResultResponse, QueryToolOptions } from '../types.js';
+import type { DatasetRegistry, MCPToolResponse, QueryToolOptions } from '../types.js';
 import { parseToolArgs, toMetricFilters } from './args.js';
 import { buildMCPQuerySchemas } from './utils/canonical-query-schemas.js';
 import { applyQueryLimits } from './utils/query-limits.js';
 import {
+  assertWithinBudget,
   executeWithinBudget,
   resolveExecutionBudget,
-  serializeWithinBudget,
 } from './utils/execution-budget.js';
+import { buildMCPQueryResult } from './utils/query-result.js';
+import { createMCPToolResponse } from './utils/tool-response.js';
 
 export async function queryMetricTool(
   datasets: DatasetRegistry,
@@ -79,22 +81,8 @@ export async function queryMetricTool(
   );
 
   // Format the response with proper types
-  const response: QueryResultResponse = {
-    data: result.data,
-    meta: {
-      ...(options.includeSql ? { sql: result.meta?.sql } : {}),
-      timingMs: result.meta?.timingMs,
-      rowCount: result.data.length,
-      ...(result.meta?.pagination ? { pagination: result.meta.pagination } : {}),
-    },
-  };
-
-  return {
-    content: [
-      {
-        type: 'text' as const,
-        text: serializeWithinBudget(response, executionBudget),
-      },
-    ],
-  };
+  const response = buildMCPQueryResult(result, options.includeSql);
+  const toolResponse = createMCPToolResponse(response);
+  assertWithinBudget(toolResponse, executionBudget);
+  return toolResponse;
 }

--- a/packages/mcp-server/src/tools/query-metric.ts
+++ b/packages/mcp-server/src/tools/query-metric.ts
@@ -5,6 +5,7 @@
  */
 
 import type { DatasetClient, MetricQuery } from '@hypequery/datasets';
+import { MCPToolError } from '../errors.js';
 import type { DatasetRegistry, MCPToolResponse, QueryToolOptions } from '../types.js';
 import { parseToolArgs, toMetricFilters } from './args.js';
 import { buildMCPQuerySchemas } from './utils/canonical-query-schemas.js';
@@ -28,24 +29,27 @@ export async function queryMetricTool(
   const { dataset: datasetName, metric: metricName, dimensions, filters, grain, orderBy } = validatedArgs;
 
   if (!datasetName) {
-    throw new Error('dataset parameter is required');
+    throw new MCPToolError('MCP_INVALID_ARGUMENTS', 'dataset parameter is required');
   }
 
   if (!metricName) {
-    throw new Error('metric parameter is required');
+    throw new MCPToolError('MCP_INVALID_ARGUMENTS', 'metric parameter is required');
   }
 
   const dataset = datasets[datasetName];
 
   if (!dataset) {
-    throw new Error(`Dataset not found: ${datasetName}`);
+    throw new MCPToolError('MCP_NOT_FOUND', `Dataset not found: ${datasetName}`);
   }
 
   // Get the metric from the dataset
   const metric = (dataset as any)[metricName] || (dataset as any).metrics?.[metricName];
 
   if (!metric) {
-    throw new Error(`Metric not found: ${metricName} in dataset ${datasetName}`);
+    throw new MCPToolError(
+      'MCP_NOT_FOUND',
+      `Metric not found: ${metricName} in dataset ${datasetName}`,
+    );
   }
 
   const pagination = applyQueryLimits(dataset, validatedArgs, options.limits);

--- a/packages/mcp-server/src/tools/tool-manifest.test.ts
+++ b/packages/mcp-server/src/tools/tool-manifest.test.ts
@@ -1,0 +1,24 @@
+import { ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it } from 'vitest';
+import { buildMCPQuerySchemas } from './utils/canonical-query-schemas.js';
+import { buildMCPToolManifest } from './tool-manifest.js';
+
+describe('MCP tool manifest', () => {
+  it('declares valid output schemas, titles, and read-only annotations', () => {
+    const manifest = buildMCPToolManifest(buildMCPQuerySchemas({}));
+
+    expect(() => ListToolsResultSchema.parse(manifest)).not.toThrow();
+    expect(manifest.tools).toHaveLength(4);
+    for (const tool of manifest.tools) {
+      expect(tool.title).toEqual(expect.any(String));
+      expect(tool.outputSchema).toMatchObject({ type: 'object' });
+      expect(tool.annotations).toMatchObject({
+        title: tool.title,
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      });
+    }
+  });
+});

--- a/packages/mcp-server/src/tools/tool-manifest.ts
+++ b/packages/mcp-server/src/tools/tool-manifest.ts
@@ -1,0 +1,209 @@
+import type { CanonicalSemanticQuerySchemas } from '@hypequery/datasets';
+import type { ListToolsResult, Tool } from '@modelcontextprotocol/sdk/types.js';
+
+type ObjectSchema = Tool['outputSchema'] & Record<string, unknown>;
+
+const errorEnvelopeSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    error: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        code: {
+          type: 'string',
+          enum: [
+            'MCP_INVALID_ARGUMENTS',
+            'MCP_NOT_FOUND',
+            'MCP_UNKNOWN_TOOL',
+            'MCP_UNAUTHORIZED',
+            'MCP_STALE_CONTRACT',
+            'MCP_REQUEST_CANCELLED',
+            'MCP_QUERY_TIMEOUT',
+            'MCP_RESULT_TOO_LARGE',
+            'MCP_EXECUTION_FAILED',
+          ],
+        },
+        message: { type: 'string' },
+        category: {
+          type: 'string',
+          enum: [
+            'correctable_input',
+            'unauthorized',
+            'stale_contract',
+            'budget',
+            'internal',
+          ],
+        },
+        retryable: { type: 'boolean' },
+        correctable: { type: 'boolean' },
+      },
+      required: ['code', 'category', 'message', 'retryable', 'correctable'],
+    },
+  },
+  required: ['error'],
+};
+
+function resultSchema(successSchema: Record<string, unknown>): ObjectSchema {
+  return {
+    type: 'object',
+    oneOf: [successSchema, errorEnvelopeSchema],
+  } as ObjectSchema;
+}
+
+export const DATASET_LIST_OUTPUT_SCHEMA = resultSchema({
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    datasets: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          name: { type: 'string' },
+          description: { type: 'string' },
+          dimensionCount: { type: 'integer', minimum: 0 },
+          measureCount: { type: 'integer', minimum: 0 },
+          metricCount: { type: 'integer', minimum: 0 },
+        },
+        required: ['name', 'description', 'dimensionCount', 'metricCount'],
+      },
+    },
+    total: { type: 'integer', minimum: 0 },
+  },
+  required: ['datasets', 'total'],
+});
+
+export const DATASET_SCHEMA_OUTPUT_SCHEMA = resultSchema({
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    name: { type: 'string' },
+    description: { type: 'string' },
+    source: { type: 'string' },
+    timeKey: { type: ['string', 'null'] },
+    tenantKey: { type: ['string', 'null'] },
+    dimensions: { type: 'object', additionalProperties: { type: 'object' } },
+    measures: { type: 'object', additionalProperties: { type: 'object' } },
+    metrics: { type: 'object', additionalProperties: { type: 'object' } },
+    filters: { type: 'object', additionalProperties: { type: 'object' } },
+    relationships: { type: 'object', additionalProperties: { type: 'object' } },
+    limits: { type: 'object' },
+  },
+  required: [
+    'name',
+    'description',
+    'source',
+    'timeKey',
+    'tenantKey',
+    'dimensions',
+    'measures',
+    'metrics',
+    'filters',
+    'relationships',
+  ],
+});
+
+export const QUERY_OUTPUT_SCHEMA = resultSchema({
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    data: {
+      type: 'array',
+      items: { type: 'object', additionalProperties: true },
+    },
+    meta: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        sql: { type: 'string' },
+        timingMs: { type: 'number', minimum: 0 },
+        rowCount: { type: 'integer', minimum: 0 },
+        pagination: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            limit: { type: 'integer', minimum: 1 },
+            offset: { type: 'integer', minimum: 0 },
+            hasMore: { type: 'boolean' },
+          },
+          required: ['limit', 'offset', 'hasMore'],
+        },
+        cache: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            status: { type: 'string', enum: ['hit', 'miss', 'bypass'] },
+            ageMs: { type: 'number', minimum: 0 },
+            stale: { type: 'boolean' },
+          },
+          required: ['status'],
+        },
+      },
+      required: ['rowCount', 'cache'],
+    },
+  },
+  required: ['data', 'meta'],
+});
+
+function annotations(title: string): Tool['annotations'] {
+  return {
+    title,
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  };
+}
+
+export function buildMCPToolManifest(
+  querySchemas: CanonicalSemanticQuerySchemas,
+): ListToolsResult {
+  return {
+    tools: [
+      {
+        name: 'list_datasets',
+        title: 'List datasets',
+        description: 'List all available datasets in the semantic layer',
+        inputSchema: { type: 'object', properties: {} },
+        outputSchema: DATASET_LIST_OUTPUT_SCHEMA,
+        annotations: annotations('List datasets'),
+      },
+      {
+        name: 'get_dataset_schema',
+        title: 'Inspect dataset schema',
+        description: 'Get the schema (dimensions, measures, named metrics, filters, relationships) for a specific dataset',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            dataset: {
+              type: 'string',
+              description: 'Name of the dataset to introspect',
+            },
+          },
+          required: ['dataset'],
+        },
+        outputSchema: DATASET_SCHEMA_OUTPUT_SCHEMA,
+        annotations: annotations('Inspect dataset schema'),
+      },
+      {
+        name: 'query_metric',
+        title: 'Query named metric',
+        description: 'Execute a metric query with optional dimensions, filters, time grain, and sorting',
+        inputSchema: querySchemas.queryMetricJsonSchema as Tool['inputSchema'],
+        outputSchema: QUERY_OUTPUT_SCHEMA,
+        annotations: annotations('Query named metric'),
+      },
+      {
+        name: 'query_dataset',
+        title: 'Query dataset',
+        description: 'Execute an ad-hoc dataset query with custom dimensions and measures',
+        inputSchema: querySchemas.queryDatasetJsonSchema as Tool['inputSchema'],
+        outputSchema: QUERY_OUTPUT_SCHEMA,
+        annotations: annotations('Query dataset'),
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/utils/execution-budget.test.ts
+++ b/packages/mcp-server/src/tools/utils/execution-budget.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { formatMCPToolError, MCPExecutionBudgetError } from '../../errors.js';
 import {
+  assertWithinBudget,
   executeWithinBudget,
   resolveExecutionBudget,
   serializeWithinBudget,
@@ -87,6 +88,19 @@ describe('execution budgets', () => {
       'MCP_QUERY_TIMEOUT',
       'deadline exceeded',
     ))).toBe('Error [MCP_QUERY_TIMEOUT]: deadline exceeded');
-    expect(formatMCPToolError(new Error('query failed'))).toBe('Error: query failed');
+    expect(formatMCPToolError(new Error('query failed')))
+      .toBe('Error [MCP_EXECUTION_FAILED]: Query execution failed');
+  });
+
+  it('accounts for the complete structured and fallback MCP response', () => {
+    const response = {
+      content: [{ type: 'text', text: '{"data":"value"}' }],
+      structuredContent: { data: 'value' },
+    };
+
+    expect(() => assertWithinBudget(
+      response,
+      resolveExecutionBudget({ maxResponseBytes: 20 }),
+    )).toThrowError(expect.objectContaining({ code: 'MCP_RESULT_TOO_LARGE' }));
   });
 });

--- a/packages/mcp-server/src/tools/utils/execution-budget.test.ts
+++ b/packages/mcp-server/src/tools/utils/execution-budget.test.ts
@@ -3,6 +3,7 @@ import { formatMCPToolError, MCPExecutionBudgetError } from '../../errors.js';
 import {
   assertWithinBudget,
   executeWithinBudget,
+  MIN_RESPONSE_BYTES,
   resolveExecutionBudget,
   serializeWithinBudget,
 } from './execution-budget.js';
@@ -22,7 +23,9 @@ describe('execution budgets', () => {
     expect(() => resolveExecutionBudget({ timeoutMs: 0 }))
       .toThrow('timeoutMs must be an integer between 1 and 120000');
     expect(() => resolveExecutionBudget({ maxResponseBytes: 10_485_761 }))
-      .toThrow('maxResponseBytes must be an integer between 1 and 10485760');
+      .toThrow(`maxResponseBytes must be an integer between ${MIN_RESPONSE_BYTES} and 10485760`);
+    expect(() => resolveExecutionBudget({ maxResponseBytes: MIN_RESPONSE_BYTES - 1 }))
+      .toThrow(`maxResponseBytes must be an integer between ${MIN_RESPONSE_BYTES} and 10485760`);
   });
 
   it('propagates request cancellation with a stable classification', async () => {
@@ -74,7 +77,7 @@ describe('execution budgets', () => {
   });
 
   it('enforces the UTF-8 serialized response byte ceiling', () => {
-    const budget = resolveExecutionBudget({ maxResponseBytes: 3 });
+    const budget = { timeoutMs: 30_000, maxResponseBytes: 3 };
 
     expect(() => serializeWithinBudget('é', budget)).toThrowError(
       expect.objectContaining({
@@ -100,7 +103,7 @@ describe('execution budgets', () => {
 
     expect(() => assertWithinBudget(
       response,
-      resolveExecutionBudget({ maxResponseBytes: 20 }),
+      { timeoutMs: 30_000, maxResponseBytes: 20 },
     )).toThrowError(expect.objectContaining({ code: 'MCP_RESULT_TOO_LARGE' }));
   });
 });

--- a/packages/mcp-server/src/tools/utils/execution-budget.ts
+++ b/packages/mcp-server/src/tools/utils/execution-budget.ts
@@ -6,6 +6,12 @@ import {
   MAX_RESPONSE_BYTES,
   type MCPExecutionBudget,
 } from '../../types.js';
+import { createMCPResultTooLargeResponse } from './tool-response.js';
+
+export const MIN_RESPONSE_BYTES = Buffer.byteLength(
+  JSON.stringify(createMCPResultTooLargeResponse()),
+  'utf8',
+);
 
 export interface EffectiveExecutionBudget {
   readonly timeoutMs: number;
@@ -19,8 +25,9 @@ function positiveInteger(
   name: string,
 ): number {
   const resolved = value ?? fallback;
-  if (!Number.isSafeInteger(resolved) || resolved < 1 || resolved > maximum) {
-    throw new Error(`${name} must be an integer between 1 and ${maximum}`);
+  const minimum = name === 'maxResponseBytes' ? MIN_RESPONSE_BYTES : 1;
+  if (!Number.isSafeInteger(resolved) || resolved < minimum || resolved > maximum) {
+    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
   }
   return resolved;
 }

--- a/packages/mcp-server/src/tools/utils/execution-budget.ts
+++ b/packages/mcp-server/src/tools/utils/execution-budget.ts
@@ -96,7 +96,22 @@ export function serializeWithinBudget(
   value: unknown,
   budget: EffectiveExecutionBudget,
 ): string {
-  const serialized = JSON.stringify(value, null, 2);
+  const serialized = JSON.stringify(value);
+  assertSerializedWithinBudget(serialized, budget);
+  return serialized;
+}
+
+export function assertWithinBudget(
+  value: unknown,
+  budget: EffectiveExecutionBudget,
+): void {
+  assertSerializedWithinBudget(JSON.stringify(value), budget);
+}
+
+function assertSerializedWithinBudget(
+  serialized: string,
+  budget: EffectiveExecutionBudget,
+): void {
   const size = Buffer.byteLength(serialized, 'utf8');
   if (size > budget.maxResponseBytes) {
     throw new MCPExecutionBudgetError(
@@ -104,5 +119,4 @@ export function serializeWithinBudget(
       `The serialized result is ${size} bytes; maximum is ${budget.maxResponseBytes} bytes`,
     );
   }
-  return serialized;
 }

--- a/packages/mcp-server/src/tools/utils/query-limits.ts
+++ b/packages/mcp-server/src/tools/utils/query-limits.ts
@@ -1,4 +1,5 @@
 import type { DatasetLimits } from '@hypequery/datasets';
+import { MCPToolError } from '../../errors.js';
 import {
   DEFAULT_QUERY_LIMIT,
   MAX_QUERY_DIMENSIONS,
@@ -110,7 +111,10 @@ function assertCollectionLimit(
   name: string,
 ): void {
   if ((values?.length ?? 0) > maximum) {
-    throw new Error(`Invalid ${name}: maximum ${maximum} items`);
+    throw new MCPToolError(
+      'MCP_INVALID_ARGUMENTS',
+      `Invalid ${name}: maximum ${maximum} items`,
+    );
   }
 }
 
@@ -127,10 +131,16 @@ export function applyQueryLimits(
 
   const limit = query.limit ?? limits.defaultResultSize;
   if (limit > limits.maxResultSize) {
-    throw new Error(`Invalid limit: ${limit}. Max: ${limits.maxResultSize}`);
+    throw new MCPToolError(
+      'MCP_INVALID_ARGUMENTS',
+      `Invalid limit: ${limit}. Max: ${limits.maxResultSize}`,
+    );
   }
   if (query.offset !== undefined && query.offset > limits.maxOffset) {
-    throw new Error(`Invalid offset: ${query.offset}. Max: ${limits.maxOffset}`);
+    throw new MCPToolError(
+      'MCP_INVALID_ARGUMENTS',
+      `Invalid offset: ${query.offset}. Max: ${limits.maxOffset}`,
+    );
   }
   return Object.freeze({ limit, ...(query.offset === undefined ? {} : { offset: query.offset }) });
 }

--- a/packages/mcp-server/src/tools/utils/query-result.ts
+++ b/packages/mcp-server/src/tools/utils/query-result.ts
@@ -1,0 +1,25 @@
+import type { DatasetQueryResult } from '@hypequery/datasets';
+import type { QueryResultResponse } from '../../types.js';
+
+export function buildMCPQueryResult(
+  result: DatasetQueryResult,
+  includeSql = false,
+): QueryResultResponse {
+  const cache = result.meta?.cache;
+  return {
+    data: result.data,
+    meta: {
+      ...(includeSql && result.meta?.sql ? { sql: result.meta.sql } : {}),
+      ...(result.meta?.timingMs === undefined ? {} : { timingMs: result.meta.timingMs }),
+      rowCount: result.data.length,
+      ...(result.meta?.pagination ? { pagination: result.meta.pagination } : {}),
+      cache: cache
+        ? {
+            status: cache.hit ? 'hit' : 'miss',
+            ...(cache.ageMs === undefined ? {} : { ageMs: cache.ageMs }),
+            ...(cache.stale === undefined ? {} : { stale: cache.stale }),
+          }
+        : { status: 'bypass' },
+    },
+  };
+}

--- a/packages/mcp-server/src/tools/utils/tool-response.ts
+++ b/packages/mcp-server/src/tools/utils/tool-response.ts
@@ -20,3 +20,22 @@ export function createMCPErrorResponse(error: unknown): MCPToolResponse {
     isError: true,
   };
 }
+
+/** Smallest schema-valid error used when even the original error exceeds its budget. */
+export function createMCPResultTooLargeResponse(): MCPToolResponse {
+  const details: MCPErrorDetails = {
+    code: 'MCP_RESULT_TOO_LARGE',
+    category: 'budget',
+    message: 'Result exceeds response byte limit',
+    retryable: false,
+    correctable: false,
+  };
+  return {
+    content: [{
+      type: 'text',
+      text: `Error [${details.code}]: ${details.message}`,
+    }],
+    structuredContent: { error: details },
+    isError: true,
+  };
+}

--- a/packages/mcp-server/src/tools/utils/tool-response.ts
+++ b/packages/mcp-server/src/tools/utils/tool-response.ts
@@ -1,0 +1,22 @@
+import type { MCPErrorDetails } from '../../errors.js';
+import { classifyMCPToolError, formatMCPToolError } from '../../errors.js';
+import type { MCPToolResponse } from '../../types.js';
+
+export function createMCPToolResponse<T extends object>(
+  value: T,
+  text = JSON.stringify(value),
+): MCPToolResponse {
+  return {
+    content: [{ type: 'text', text }],
+    structuredContent: value as Record<string, unknown>,
+  };
+}
+
+export function createMCPErrorResponse(error: unknown): MCPToolResponse {
+  const details: MCPErrorDetails = classifyMCPToolError(error);
+  return {
+    content: [{ type: 'text', text: formatMCPToolError(error) }],
+    structuredContent: { error: details },
+    isError: true,
+  };
+}

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -99,6 +99,7 @@ export interface MCPToolResponse {
     type: 'text';
     text: string;
   }>;
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
   [key: string]: unknown;  // Allow additional properties for MCP protocol
 }
@@ -218,6 +219,12 @@ export interface QueryResultMeta {
     limit: number;
     offset: number;
     hasMore: boolean;
+  };
+  /** Cache outcome for agent observability. */
+  cache?: {
+    status: 'hit' | 'miss' | 'bypass';
+    ageMs?: number;
+    stale?: boolean;
   };
 }
 

--- a/plans/mcp-cloud-agent-platform-plan.md
+++ b/plans/mcp-cloud-agent-platform-plan.md
@@ -445,6 +445,15 @@ MCP client protocol test covers initialization, discovery, tool calls, and
 prompts through an injected in-memory transport and executor. No HTTP behavior
 is included.
 
+**CORE-05 implementation status:** Implemented on the joined `CORE-02` and
+`CORE-04` foundations. Every tool now declares an output schema, title, and
+read-only/idempotent annotations and returns structured content with compact
+text fallback. Query envelopes include row count, timing, pagination, and cache
+outcome. Stable error envelopes classify correctable input, authorization,
+stale-contract, budget, and redacted internal failures. Protocol tests exercise
+both success and error output-schema validation through a real MCP SDK client;
+SQL remains opt-in for trusted debugging.
+
 ### Deployment bridge PRs
 
 | PR | Depends on | Deliverable and merge gate |
@@ -552,9 +561,9 @@ identifiers above are the actual PR boundaries.
   from `@hypequery/datasets`.
 - [ ] **MCP-105:** Make generated schemas exact: field/operator enums, integer
   bounds, closed objects, dataset-specific limits, and at-least-one selection.
-- [ ] **MCP-106:** Return MCP `structuredContent` and declare output schemas while
+- [x] **MCP-106:** Return MCP `structuredContent` and declare output schemas while
   retaining concise text fallback for clients that need it.
-- [ ] **MCP-107:** Add MCP tool titles and read-only/idempotent annotations.
+- [x] **MCP-107:** Add MCP tool titles and read-only/idempotent annotations.
 - [ ] **DATA-101:** Add dataset metadata needed by agents: description, examples,
   synonyms, format/unit, currency, timezone, freshness, owner, sensitivity, and
   default dimensions/time grain. Verified questions are handled in `CORE-13`.
@@ -562,7 +571,7 @@ identifiers above are the actual PR boundaries.
   and named metrics instead of object spreading.
 - [ ] **MCP-108:** Split introspection into safe and trusted-debug projections;
   hide physical SQL/source/tenant details by default.
-- [ ] **MCP-109:** Normalize stable error codes and classify retryable,
+- [x] **MCP-109:** Normalize stable error codes and classify retryable,
   correctable-input, unauthorized, stale-contract, budget, and internal errors.
 - [x] **MCP-110:** Fix package version reporting, examples, test documentation,
   and the unsafe `system.numbers` quickstart.


### PR DESCRIPTION
## Summary

- converge the CORE-02 execution-budget branch with the CORE-04 transport-neutral executor branch
- add MCP structuredContent and declared output schemas for every tool while retaining compact JSON text fallback
- add tool titles plus read-only, non-destructive, idempotent, closed-world annotations
- include row count, timing, pagination, and cache outcome in query result metadata
- add stable structured errors for correctable input, authorization, stale-contract, budget, and redacted internal failures
- apply response-byte ceilings to the complete structured-plus-text MCP response
- preserve default SQL redaction in both structured and text results

## Stack

CORE-05 is the convergence point for the two MCP foundation tracks. This PR is based on CORE-04 #448 and also merges CORE-02 #446 as a required dependency.

- ARCH-01: #443
- CORE-01: #445
- CORE-02: #446
- CORE-03: #447
- CORE-04: #448
- CORE-05: this PR

The PR diff includes CORE-01/CORE-02 until both prerequisite tracks are merged or rebased onto their shared target.

## Validation

- @hypequery/datasets: lint, build, 314 tests across 13 files
- @hypequery/serve: lint, build, 533 tests across 29 files
- @hypequery/mcp: lint, type tests, build, 115 tests across 14 files
- real MCP SDK client validates structured success and error results over an injected in-memory transport
- legacy text fallback and stdio compatibility remain covered
- SQL redaction is asserted for both response formats
- git diff --check