### PR TITLE
feat(cli): brand the login callback page

### DIFF
--- a/.changeset/branded-cli-callback-page.md
+++ b/.changeset/branded-cli-callback-page.md
@@ -1,0 +1,8 @@
+---
+"@hypequery/cli": patch
+---
+
+Brand the `hypequery login` browser callback page. The loopback listener now
+serves a self-contained page with distinct success and failure states, a status
+chip, retry guidance, and light/dark support, still under the existing
+`default-src 'none'` callback CSP.

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -50,12 +50,81 @@ export interface LogoutDependencies {
   readonly requestTimeoutMs?: number;
 }
 
-function callbackHtml(success: boolean) {
+/**
+ * The page the browser lands on once Cloud hands the authorization code back.
+ *
+ * Served from the loopback listener, under a `default-src 'none'` policy that
+ * only relaxes `style-src` — so everything is inline and there are no images or
+ * webfonts to fetch. Colours mirror the Cloud palette and follow the operating
+ * system's light/dark preference.
+ */
+export function callbackHtml(success: boolean) {
   const title = success ? 'CLI authorized' : 'Authorization failed';
+  const status = success ? 'Connected' : 'Failed';
+  const heading = success ? 'hypequery CLI is authorized' : 'Authorization failed';
   const message = success
     ? 'You can close this window and return to your terminal.'
     : 'Return to your terminal and run the login command again.';
-  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>${title}</title></head><body><main><h1>${title}</h1><p>${message}</p></main></body></html>`;
+  const state = success ? 'ok' : 'bad';
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${title} · hypequery</title>
+<style>
+:root{
+color-scheme:light dark;
+--bg:#faf9f7;--panel:#ffffff;--border:rgba(0,0,0,.08);
+--text:#1a1a1a;--muted:#5a5d63;--dim:#8b8d92;
+--ok:#22a06b;--ok-soft:rgba(34,160,107,.12);
+--bad:#dc2626;--bad-soft:rgba(220,38,38,.10);
+}
+@media (prefers-color-scheme:dark){:root{
+--bg:#0c0e14;--panel:#161922;--border:rgba(255,255,255,.07);
+--text:#f5f3ee;--muted:#a0a3ad;--dim:#8b8f99;
+--ok:#34d399;--ok-soft:rgba(52,211,153,.12);
+--bad:#f87171;--bad-soft:rgba(248,113,113,.12);
+}}
+*{box-sizing:border-box}
+html,body{height:100%}
+body{
+margin:0;padding:24px;background:var(--bg);color:var(--text);
+font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+display:flex;align-items:center;justify-content:center;
+-webkit-font-smoothing:antialiased;
+}
+.wordmark{
+position:fixed;top:26px;left:30px;
+font-size:14px;font-weight:700;letter-spacing:-.035em;
+}
+main{width:100%;max-width:400px;background:var(--panel);border:1px solid var(--border);padding:28px}
+.status{
+display:inline-block;padding:5px 9px;
+font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+font-size:11px;text-transform:uppercase;letter-spacing:.1em;
+color:var(--${state});background:var(--${state}-soft);
+}
+h1{margin:20px 0 0;font-size:23px;font-weight:500;letter-spacing:-.025em;line-height:1.25}
+p{margin:10px 0 0;font-size:13.5px;line-height:1.65;color:var(--muted)}
+.foot{
+margin-top:24px;padding-top:17px;border-top:1px solid var(--border);
+font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+font-size:11.5px;letter-spacing:.04em;color:var(--dim);
+}
+@media (max-width:420px){.wordmark{position:static;margin-bottom:18px}body{flex-direction:column;align-items:stretch;justify-content:flex-start;padding-top:30px}}
+</style>
+</head>
+<body>
+<div class="wordmark">hypequery</div>
+<main>
+<span class="status">${status}</span>
+<h1>${heading}</h1>
+<p>${message}</p>
+<div class="foot">${success ? 'Safe to close this tab' : 'hypequery login'}</div>
+</main>
+</body>
+</html>`;
 }
 
 async function callbackServer(state: string, timeoutMs: number) {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -13,6 +13,7 @@ import {
   saveCloudCredential,
   type StoredCloudCredential,
 } from '../utils/cloud-credential-store.js';
+import { callbackHtml } from '../utils/callback-page.js';
 import { logger } from '../utils/logger.js';
 
 const DEFAULT_CLOUD_URL = 'https://cloud.hypequery.com';
@@ -48,83 +49,6 @@ export interface LogoutDependencies {
   readonly loadCredential?: typeof loadCloudCredential;
   readonly deleteCredential?: typeof deleteCloudCredential;
   readonly requestTimeoutMs?: number;
-}
-
-/**
- * The page the browser lands on once Cloud hands the authorization code back.
- *
- * Served from the loopback listener, under a `default-src 'none'` policy that
- * only relaxes `style-src` — so everything is inline and there are no images or
- * webfonts to fetch. Colours mirror the Cloud palette and follow the operating
- * system's light/dark preference.
- */
-export function callbackHtml(success: boolean) {
-  const title = success ? 'CLI authorized' : 'Authorization failed';
-  const status = success ? 'Connected' : 'Failed';
-  const heading = success ? 'hypequery CLI is authorized' : 'Authorization failed';
-  const message = success
-    ? 'You can close this window and return to your terminal.'
-    : 'Return to your terminal and run the login command again.';
-  const state = success ? 'ok' : 'bad';
-  return `<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<title>${title} · hypequery</title>
-<style>
-:root{
-color-scheme:light dark;
---bg:#faf9f7;--panel:#ffffff;--border:rgba(0,0,0,.08);
---text:#1a1a1a;--muted:#5a5d63;--dim:#8b8d92;
---ok:#22a06b;--ok-soft:rgba(34,160,107,.12);
---bad:#dc2626;--bad-soft:rgba(220,38,38,.10);
-}
-@media (prefers-color-scheme:dark){:root{
---bg:#0c0e14;--panel:#161922;--border:rgba(255,255,255,.07);
---text:#f5f3ee;--muted:#a0a3ad;--dim:#8b8f99;
---ok:#34d399;--ok-soft:rgba(52,211,153,.12);
---bad:#f87171;--bad-soft:rgba(248,113,113,.12);
-}}
-*{box-sizing:border-box}
-html,body{height:100%}
-body{
-margin:0;padding:24px;background:var(--bg);color:var(--text);
-font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
-display:flex;align-items:center;justify-content:center;
--webkit-font-smoothing:antialiased;
-}
-.wordmark{
-position:fixed;top:26px;left:30px;
-font-size:14px;font-weight:700;letter-spacing:-.035em;
-}
-main{width:100%;max-width:400px;background:var(--panel);border:1px solid var(--border);padding:28px}
-.status{
-display:inline-block;padding:5px 9px;
-font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
-font-size:11px;text-transform:uppercase;letter-spacing:.1em;
-color:var(--${state});background:var(--${state}-soft);
-}
-h1{margin:20px 0 0;font-size:23px;font-weight:500;letter-spacing:-.025em;line-height:1.25}
-p{margin:10px 0 0;font-size:13.5px;line-height:1.65;color:var(--muted)}
-.foot{
-margin-top:24px;padding-top:17px;border-top:1px solid var(--border);
-font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
-font-size:11.5px;letter-spacing:.04em;color:var(--dim);
-}
-@media (max-width:420px){.wordmark{position:static;margin-bottom:18px}body{flex-direction:column;align-items:stretch;justify-content:flex-start;padding-top:30px}}
-</style>
-</head>
-<body>
-<div class="wordmark">hypequery</div>
-<main>
-<span class="status">${status}</span>
-<h1>${heading}</h1>
-<p>${message}</p>
-<div class="foot">${success ? 'Safe to close this tab' : 'hypequery login'}</div>
-</main>
-</body>
-</html>`;
 }
 
 async function callbackServer(state: string, timeoutMs: number) {

--- a/packages/cli/src/utils/callback-page.test.ts
+++ b/packages/cli/src/utils/callback-page.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { callbackHtml } from './callback-page.js';
+
+describe('Cloud CLI callback page', () => {
+  it('tells a successful user the CLI is authorized and the tab can be closed', () => {
+    const html = callbackHtml(true);
+
+    expect(html).toContain('<title>CLI authorized · hypequery</title>');
+    expect(html).toContain('>Connected<');
+    expect(html).toContain('hypequery CLI is authorized');
+    expect(html).toContain(
+      'You can close this window and return to your terminal.',
+    );
+    expect(html).toContain('Safe to close this tab');
+  });
+
+  it('tells a failed user to retry the login command', () => {
+    const html = callbackHtml(false);
+
+    expect(html).toContain('<title>Authorization failed · hypequery</title>');
+    expect(html).toContain('>Failed<');
+    expect(html).toContain(
+      'Return to your terminal and run the login command again.',
+    );
+    expect(html).not.toContain('Safe to close this tab');
+  });
+
+  it('never shows success wording on the failure page', () => {
+    const html = callbackHtml(false);
+
+    expect(html).not.toContain('Connected');
+    expect(html).not.toContain('authorized');
+  });
+
+  it('resolves the status colour tokens it interpolates', () => {
+    // The status chip builds `var(--ok)`/`var(--bad)` from the state, so a
+    // renamed token would silently fall back to an unstyled chip.
+    for (const [success, token] of [[true, 'ok'], [false, 'bad']] as const) {
+      const html = callbackHtml(success);
+      expect(html).toContain(`color:var(--${token});background:var(--${token}-soft)`);
+      expect(html).toContain(`--${token}:`);
+      expect(html).toContain(`--${token}-soft:`);
+    }
+  });
+
+  it('stays self-contained so the strict callback CSP can render it', () => {
+    // The listener serves this under `default-src 'none'; style-src
+    // 'unsafe-inline'`, so any external or scripted resource would be blocked.
+    for (const success of [true, false]) {
+      const html = callbackHtml(success);
+      expect(html).not.toMatch(/<script/i);
+      expect(html).not.toMatch(/<img/i);
+      expect(html).not.toMatch(/\b(?:src|href)=/i);
+      expect(html).not.toMatch(/url\(/i);
+      expect(html).not.toMatch(/https?:\/\//i);
+    }
+  });
+
+  it('declares the document shell both pages depend on', () => {
+    for (const success of [true, false]) {
+      const html = callbackHtml(success);
+      expect(html.startsWith('<!doctype html>')).toBe(true);
+      expect(html).toContain('<html lang="en">');
+      expect(html).toContain('<meta charset="utf-8">');
+      expect(html).toContain(
+        '<meta name="viewport" content="width=device-width,initial-scale=1">',
+      );
+      expect(html).toContain('color-scheme:light dark');
+      expect(html).toContain('@media (prefers-color-scheme:dark)');
+    }
+  });
+});

--- a/packages/cli/src/utils/callback-page.ts
+++ b/packages/cli/src/utils/callback-page.ts
@@ -1,0 +1,76 @@
+/**
+ * The page the browser lands on once Cloud hands the authorization code back.
+ *
+ * Served from the loopback listener, under a `default-src 'none'` policy that
+ * only relaxes `style-src` — so everything is inline and there are no images or
+ * webfonts to fetch. Colours mirror the Cloud palette and follow the operating
+ * system's light/dark preference.
+ */
+export function callbackHtml(success: boolean) {
+  const title = success ? 'CLI authorized' : 'Authorization failed';
+  const status = success ? 'Connected' : 'Failed';
+  const heading = success ? 'hypequery CLI is authorized' : 'Authorization failed';
+  const message = success
+    ? 'You can close this window and return to your terminal.'
+    : 'Return to your terminal and run the login command again.';
+  const state = success ? 'ok' : 'bad';
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${title} · hypequery</title>
+<style>
+:root{
+color-scheme:light dark;
+--bg:#faf9f7;--panel:#ffffff;--border:rgba(0,0,0,.08);
+--text:#1a1a1a;--muted:#5a5d63;--dim:#8b8d92;
+--ok:#22a06b;--ok-soft:rgba(34,160,107,.12);
+--bad:#dc2626;--bad-soft:rgba(220,38,38,.10);
+}
+@media (prefers-color-scheme:dark){:root{
+--bg:#0c0e14;--panel:#161922;--border:rgba(255,255,255,.07);
+--text:#f5f3ee;--muted:#a0a3ad;--dim:#8b8f99;
+--ok:#34d399;--ok-soft:rgba(52,211,153,.12);
+--bad:#f87171;--bad-soft:rgba(248,113,113,.12);
+}}
+*{box-sizing:border-box}
+html,body{height:100%}
+body{
+margin:0;padding:24px;background:var(--bg);color:var(--text);
+font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+display:flex;align-items:center;justify-content:center;
+-webkit-font-smoothing:antialiased;
+}
+.wordmark{
+position:fixed;top:26px;left:30px;
+font-size:14px;font-weight:700;letter-spacing:-.035em;
+}
+main{width:100%;max-width:400px;background:var(--panel);border:1px solid var(--border);padding:28px}
+.status{
+display:inline-block;padding:5px 9px;
+font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+font-size:11px;text-transform:uppercase;letter-spacing:.1em;
+color:var(--${state});background:var(--${state}-soft);
+}
+h1{margin:20px 0 0;font-size:23px;font-weight:500;letter-spacing:-.025em;line-height:1.25}
+p{margin:10px 0 0;font-size:13.5px;line-height:1.65;color:var(--muted)}
+.foot{
+margin-top:24px;padding-top:17px;border-top:1px solid var(--border);
+font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+font-size:11.5px;letter-spacing:.04em;color:var(--dim);
+}
+@media (max-width:420px){.wordmark{position:static;margin-bottom:18px}body{flex-direction:column;align-items:stretch;justify-content:flex-start;padding-top:30px}}
+</style>
+</head>
+<body>
+<div class="wordmark">hypequery</div>
+<main>
+<span class="status">${status}</span>
+<h1>${heading}</h1>
+<p>${message}</p>
+<div class="foot">${success ? 'Safe to close this tab' : 'hypequery login'}</div>
+</main>
+</body>
+</html>`;
+}


### PR DESCRIPTION
## What changed

Styles the loopback page the browser lands on at the end of `hypequery login`, for both the success and failure states.

- Cloud palette (`globals.css` tokens), squared corners, mono uppercase micro-labels — matching the Cloud authorize screen the user has just come from
- Follows the OS light/dark preference via `prefers-color-scheme`
- Failure state gets its own treatment instead of reusing the success layout, and surfaces the retry command
- `callbackHtml` is now exported so the markup can be previewed and asserted on

## Why

The page was unstyled default-serif markup — a bare `<h1>` and `<p>` on white. Landing there after a fully branded sign-in reads as a broken page at the exact moment the user is being told everything worked.

## Constraints

The listener serves this response under `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'`. So there is no external anything: no logo image, no webfonts. Styling is a single inline `<style>` block with system font stacks, and the brand is set as a text wordmark. The CSP is unchanged by this PR.

## Validation

- `vitest run src/commands/login.test.ts` — 15 passed
- `tsc` clean for `login.ts`
- Rendered both states in light and dark and reviewed them

Copy is unchanged for the success case: "You can close this window and return to your terminal."

🤖 Generated with [Claude Code](https://claude.com/claude-code)