### PR TITLE
feat(serve): fail deploys that would behave differently in Cloud

### DIFF
--- a/.changeset/cloud-compatibility-diagnostics.md
+++ b/.changeset/cloud-compatibility-diagnostics.md
@@ -1,0 +1,6 @@
+---
+"@hypequery/serve": minor
+"@hypequery/cli": minor
+---
+
+Fail a deployment build when the Serve configuration would behave differently under managed execution. Unenforceable tenant isolation and dropped middleware block the build; dropped hooks, dropped context factories, and endpoints that are authenticated without declared roles or scopes are reported as warnings. Pass `--allow-unsupported-config` to deploy anyway.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -209,7 +209,10 @@ program
   .option('--runtime-output <path>', 'Bundled Node runtime path (default: beside deployment JSON)')
   .option('--entrypoint-prefix <prefix>', 'Runtime entrypoint prefix (default: queries)')
   .option('--hash-output <path>', 'Deployment identity sidecar path (default: <output>.sha256)')
-  .option('--no-source', 'Exclude project source files from the deployment bundle')
+  .option(
+    '--allow-unsupported-config',
+    'Deploy even though some Serve config will not be honoured in Cloud',
+  )
   .action(runCommand(async (api: string, options: BuildDeploymentOptions) => {
     await buildDeploymentCommand(api, options);
   }));
@@ -263,6 +266,10 @@ program
   .option(
     '--replace-restored',
     'Intentionally replace a restored live release',
+  )
+  .option(
+    '--allow-unsupported-config',
+    'Deploy even though some Serve config will not be honoured in Cloud',
   )
   .action(runCommand(async (source: string, options: DeployOptions) => {
     await deployCommand(source, options);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -209,6 +209,7 @@ program
   .option('--runtime-output <path>', 'Bundled Node runtime path (default: beside deployment JSON)')
   .option('--entrypoint-prefix <prefix>', 'Runtime entrypoint prefix (default: queries)')
   .option('--hash-output <path>', 'Deployment identity sidecar path (default: <output>.sha256)')
+  .option('--no-source', 'Exclude project source files from the deployment bundle')
   .option(
     '--allow-unsupported-config',
     'Deploy even though some Serve config will not be honoured in Cloud',

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -40,6 +40,7 @@ export interface DeployOptions extends SubmitDeploymentOptions {
   bundleOutput?: string;
   releaseOutput?: string;
   source?: boolean;
+  allowUnsupportedConfig?: boolean;
 }
 
 export interface SubmitDeploymentDependencies {
@@ -282,7 +283,11 @@ export async function deployCommand(
   await resolveDeploymentCredential(options.endpoint, dependencies);
 
   try {
-    await build(sourcePath, { bundleOutput: bundlePath, source: options.source });
+    await build(sourcePath, {
+      bundleOutput: bundlePath,
+      source: options.source,
+      allowUnsupportedConfig: options.allowUnsupportedConfig,
+    });
   } catch (error) {
     throw withRuntimeFlagHint(error);
   }

--- a/packages/cli/src/commands/deployment.test.ts
+++ b/packages/cli/src/commands/deployment.test.ts
@@ -114,13 +114,13 @@ describe('deployment commands', () => {
       entrypointPrefix: 'handlers',
     });
 
-    expect(deploymentContract).toHaveBeenCalledWith({
+    expect(deploymentContract).toHaveBeenCalledWith(expect.objectContaining({
       runtimeArtifact: {
         runtime: 'node',
         artifactSha256: ARTIFACT_SHA,
         entrypointPrefix: 'handlers',
       },
-    });
+    }));
     expect(mkdir).toHaveBeenCalledWith('dist', { recursive: true });
     expect(writeFile).toHaveBeenCalledWith(
       'dist/deployment.json',
@@ -160,13 +160,13 @@ describe('deployment commands', () => {
       ['greeting'],
       undefined,
     );
-    expect(deploymentContract).toHaveBeenCalledWith({
+    expect(deploymentContract).toHaveBeenCalledWith(expect.objectContaining({
       runtimeArtifact: {
         runtime: 'node',
         artifactSha256: ARTIFACT_SHA,
         entrypointPrefix: 'queries',
       },
-    });
+    }));
     expect(writeFile).toHaveBeenCalledWith('dist/runtime.mjs', bytes);
   });
 
@@ -306,7 +306,7 @@ describe('deployment commands', () => {
 
     await buildDeploymentCommand('analytics/api.ts', { output: 'dist/deployment.json' });
 
-    expect(deploymentContract).toHaveBeenCalledWith({});
+    expect(deploymentContract).toHaveBeenCalledWith(expect.objectContaining({}));
     expect(mockBuildNodeRuntimeArtifact).not.toHaveBeenCalled();
     expect(writeFile).not.toHaveBeenCalledWith(
       expect.stringContaining('runtime'),

--- a/packages/cli/src/commands/deployment.ts
+++ b/packages/cli/src/commands/deployment.ts
@@ -38,6 +38,7 @@ export interface BuildDeploymentOptions {
   entrypointPrefix?: string;
   hashOutput?: string;
   source?: boolean;
+  allowUnsupportedConfig?: boolean;
 }
 
 export interface PrepareDeploymentReleaseOptions {
@@ -57,6 +58,14 @@ export interface PrepareDeploymentReleaseDependencies {
 
 const DEFAULT_BUNDLE_OUTPUT = 'analytics/hypequery-deployment';
 
+interface CloudCompatibilityDiagnosticLike {
+  readonly severity: 'error' | 'warning';
+  readonly code: string;
+  readonly subject: string;
+  readonly message: string;
+  readonly remedy: string;
+}
+
 interface DeploymentContractSource {
   deploymentContract(options?: {
     runtimeArtifact?: {
@@ -64,7 +73,21 @@ interface DeploymentContractSource {
       artifactSha256: string;
       entrypointPrefix?: string;
     };
+    onCloudDiagnostic?: (diagnostic: CloudCompatibilityDiagnosticLike) => void;
+    allowUnsupportedConfig?: boolean;
   }): ProtocolDeploymentContract;
+}
+
+/**
+ * Surfaces a managed-execution difference. Errors already abort the contract
+ * build; warnings would otherwise be discarded, so print them here where the
+ * author can still act before the release is submitted.
+ */
+function reportCloudDiagnostic(diagnostic: CloudCompatibilityDiagnosticLike): void {
+  if (diagnostic.severity === 'error') return;
+  logger.warn(`${diagnostic.code} (${diagnostic.subject})`);
+  logger.indent(diagnostic.message);
+  logger.indent(`→ ${diagnostic.remedy}`);
 }
 
 function runtimeName(options: BuildDeploymentOptions): 'node' | 'python' {
@@ -184,7 +207,11 @@ export async function buildDeploymentCommand(
     }
   }
 
-  const contract = api.deploymentContract(artifact ? { runtimeArtifact: artifact } : {});
+  const contract = api.deploymentContract({
+    ...(artifact ? { runtimeArtifact: artifact } : {}),
+    ...(options.allowUnsupportedConfig ? { allowUnsupportedConfig: true } : {}),
+    onCloudDiagnostic: reportCloudDiagnostic,
+  });
   const prepared = prepareProtocolDeploymentContract(contract);
   const { canonical, contract: validated, identity: digest } = prepared;
   if (bundleOutput !== undefined) {

--- a/packages/serve/src/cloud-compatibility.test.ts
+++ b/packages/serve/src/cloud-compatibility.test.ts
@@ -110,6 +110,51 @@ describe('analyzeCloudCompatibility', () => {
     expect(severityOf(config, 'HQ_CLOUD_AUTH_WITHOUT_ROLES')).toBe('warning');
   });
 
+  it('warns for a custom query with a strategy but no declared roles', () => {
+    // Queries go through the same endpointPolicy reduction as semantic
+    // endpoints, so they are downgraded in exactly the same way.
+    const diagnostics = analyzeCloudCompatibility({
+      queries: { revenue: { query: async () => [] } },
+      auth: async () => ({ userId: 'u1' }),
+    } as never);
+
+    const found = diagnostics.find(d => d.code === 'HQ_CLOUD_AUTH_WITHOUT_ROLES');
+    expect(found?.severity).toBe('warning');
+    expect(found?.subject).toBe('queries.revenue');
+  });
+
+  it('respects a query that declares its own roles', () => {
+    expect(
+      codes({
+        queries: { revenue: { query: async () => [], requiredRoles: ['finance'] } },
+        auth: async () => ({ userId: 'u1' }),
+      } as never),
+    ).not.toContain('HQ_CLOUD_AUTH_WITHOUT_ROLES');
+  });
+
+  it('does not warn when requiresAuth: false opts the endpoint out', () => {
+    // An explicit false short-circuits the global fallback, so the endpoint is
+    // public and there is no authorization to lose.
+    expect(
+      codes({
+        queries: { revenue: { query: async () => [], requiresAuth: false } },
+        auth: async () => ({ userId: 'u1' }),
+      } as never),
+    ).not.toContain('HQ_CLOUD_AUTH_WITHOUT_ROLES');
+  });
+
+  it('still warns when auth: null leaves global auth in force', () => {
+    // `auth: null` only clears the endpoint's own strategy; resolveLocalAuthRequirement
+    // returns undefined and the global strategy still applies, so the endpoint
+    // stays authenticated with nothing Cloud can enforce.
+    expect(
+      codes({
+        queries: { revenue: { query: async () => [], auth: null } },
+        auth: async () => ({ userId: 'u1' }),
+      } as never),
+    ).toContain('HQ_CLOUD_AUTH_WITHOUT_ROLES');
+  });
+
   it('stays quiet when the endpoint declares roles Cloud can enforce', () => {
     expect(
       codes({

--- a/packages/serve/src/cloud-compatibility.test.ts
+++ b/packages/serve/src/cloud-compatibility.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { dataset, dimension, measure } from '@hypequery/datasets';
+
+import {
+  analyzeCloudCompatibility,
+  type CloudCompatibilityCode,
+} from './cloud-compatibility.js';
+
+const tenantScoped = dataset('orders', {
+  source: 'orders',
+  tenantKey: 'organization_id',
+  dimensions: { id: dimension.string({ column: 'id' }) },
+  measures: { orderCount: measure.count('id') },
+});
+
+const shared = dataset('regions', {
+  source: 'regions',
+  dimensions: { id: dimension.string({ column: 'id' }) },
+  measures: { regionCount: measure.count('id') },
+});
+
+function codes(config: Parameters<typeof analyzeCloudCompatibility>[0]) {
+  return analyzeCloudCompatibility(config).map(d => d.code);
+}
+
+function severityOf(
+  config: Parameters<typeof analyzeCloudCompatibility>[0],
+  code: CloudCompatibilityCode,
+) {
+  return analyzeCloudCompatibility(config).find(d => d.code === code)?.severity;
+}
+
+describe('analyzeCloudCompatibility', () => {
+  it('passes a config that carries entirely into the contract', () => {
+    expect(
+      codes({ datasets: { orders: tenantScoped } } as never),
+    ).toEqual([]);
+  });
+
+  it('reports a tenant requirement the dataset cannot enforce', () => {
+    // The planner resolves the tenant column from the dataset's tenantKey. With
+    // no tenantKey and no customer code in Cloud, this endpoint would demand a
+    // tenant and return every tenant's rows.
+    const config = {
+      datasets: { regions: shared },
+      tenant: { extract: (auth: { tenantId?: string }) => auth.tenantId, required: true },
+    } as never;
+
+    expect(codes(config)).toContain('HQ_CLOUD_TENANT_NOT_ENFORCEABLE');
+    expect(severityOf(config, 'HQ_CLOUD_TENANT_NOT_ENFORCEABLE')).toBe('error');
+  });
+
+  it('accepts a shared dataset when tenancy is explicitly not required', () => {
+    expect(
+      codes({
+        datasets: { regions: shared },
+        tenant: { extract: () => null, required: false },
+      } as never),
+    ).not.toContain('HQ_CLOUD_TENANT_NOT_ENFORCEABLE');
+  });
+
+  it('does not fault a tenant-scoped dataset under a tenant requirement', () => {
+    expect(
+      codes({
+        datasets: { orders: tenantScoped },
+        tenant: { extract: (auth: { tenantId?: string }) => auth.tenantId },
+      } as never),
+    ).not.toContain('HQ_CLOUD_TENANT_NOT_ENFORCEABLE');
+  });
+
+  it('blocks on global middleware, which never runs in Cloud', () => {
+    const config = {
+      datasets: { orders: tenantScoped },
+      middlewares: [async () => undefined],
+    } as never;
+
+    expect(codes(config)).toContain('HQ_CLOUD_MIDDLEWARE_DROPPED');
+    expect(severityOf(config, 'HQ_CLOUD_MIDDLEWARE_DROPPED')).toBe('error');
+  });
+
+  it('blocks on per-query middleware and names the query', () => {
+    const diagnostics = analyzeCloudCompatibility({
+      queries: { revenue: { middlewares: [async () => undefined] } },
+    } as never);
+
+    const found = diagnostics.find(d => d.code === 'HQ_CLOUD_MIDDLEWARE_DROPPED');
+    expect(found?.severity).toBe('error');
+    expect(found?.subject).toBe('queries.revenue');
+  });
+
+  it('warns rather than blocks on hooks and context factories', () => {
+    const config = {
+      datasets: { orders: tenantScoped },
+      hooks: { onRequest: () => undefined },
+      context: () => ({}),
+    } as never;
+
+    expect(severityOf(config, 'HQ_CLOUD_HOOKS_DROPPED')).toBe('warning');
+    expect(severityOf(config, 'HQ_CLOUD_CONTEXT_DROPPED')).toBe('warning');
+  });
+
+  it('warns when auth is required but no roles or scopes are declared', () => {
+    // The strategy is not carried, so Cloud would accept any valid credential
+    // even if the local strategy rejects most callers.
+    const config = {
+      datasets: { orders: tenantScoped },
+      auth: async () => ({ userId: 'u1' }),
+    } as never;
+
+    expect(severityOf(config, 'HQ_CLOUD_AUTH_WITHOUT_ROLES')).toBe('warning');
+  });
+
+  it('stays quiet when the endpoint declares roles Cloud can enforce', () => {
+    expect(
+      codes({
+        datasets: { orders: { dataset: tenantScoped, requiredRoles: ['analyst'] } },
+        auth: async () => ({ userId: 'u1' }),
+      } as never),
+    ).not.toContain('HQ_CLOUD_AUTH_WITHOUT_ROLES');
+  });
+
+  it('explains the remedy for every diagnostic it reports', () => {
+    const diagnostics = analyzeCloudCompatibility({
+      datasets: { regions: shared },
+      tenant: { extract: () => null },
+      middlewares: [async () => undefined],
+      hooks: { onRequest: () => undefined },
+    } as never);
+
+    expect(diagnostics.length).toBeGreaterThan(0);
+    for (const diagnostic of diagnostics) {
+      expect(diagnostic.remedy.length).toBeGreaterThan(0);
+      expect(diagnostic.subject.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/serve/src/cloud-compatibility.ts
+++ b/packages/serve/src/cloud-compatibility.ts
@@ -1,0 +1,236 @@
+/**
+ * Deploy-time diagnostics for managed (Cloud) execution.
+ *
+ * A deployment contract carries policy, not mechanism: an `AuthStrategy` is
+ * reduced to `{ kind, roles, scopes }`, a `TenantConfig.extract` to a column
+ * name, and middlewares, hooks, and context factories are not carried at all.
+ * That is deliberate — Cloud re-implements those concerns itself — but it means
+ * a Serve app can behave differently once deployed, and silently.
+ *
+ * The dangerous case is tenancy. `resolveTenantFilterColumn` returns the
+ * dataset's `tenantKey`, and the planner applies the tenant predicate only when
+ * a column resolves. A dataset with no `tenantKey` exposed under a config that
+ * requires a tenant will demand a tenant and filter nothing, so every tenant
+ * reads every row. Locally a middleware or resolver may cover that gap; in
+ * Cloud there is no customer code left to do it.
+ *
+ * These checks run when the deployment contract is built, so they apply to
+ * every consumer rather than only the CLI.
+ */
+
+import type { AuthContext, MetricEntry, DatasetEntry, ServeConfig } from './types.js';
+import { resolveDatasetEntry } from './semantic/datasets/utils/dataset-entry.js';
+import { resolveMetricEntry } from './semantic/datasets/metric-endpoint.js';
+
+export type CloudCompatibilitySeverity = 'error' | 'warning';
+
+export type CloudCompatibilityCode =
+  | 'HQ_CLOUD_TENANT_NOT_ENFORCEABLE'
+  | 'HQ_CLOUD_MIDDLEWARE_DROPPED'
+  | 'HQ_CLOUD_HOOKS_DROPPED'
+  | 'HQ_CLOUD_CONTEXT_DROPPED'
+  | 'HQ_CLOUD_AUTH_WITHOUT_ROLES';
+
+export interface CloudCompatibilityDiagnostic {
+  readonly severity: CloudCompatibilitySeverity;
+  readonly code: CloudCompatibilityCode;
+  /** The endpoint, dataset, or config key the finding applies to. */
+  readonly subject: string;
+  readonly message: string;
+  /** What the author should do instead. */
+  readonly remedy: string;
+}
+
+type AnyConfig = ServeConfig<any, any, any, any, any> & {
+  readonly middlewares?: readonly unknown[];
+  readonly hooks?: unknown;
+  readonly context?: unknown;
+  readonly auth?: unknown;
+  readonly tenant?: { readonly required?: boolean };
+  readonly datasets?: Record<string, unknown>;
+  readonly metrics?: Record<string, unknown>;
+  readonly queries?: Record<string, { readonly middlewares?: readonly unknown[] }>;
+};
+
+function tenantIsExpected(
+  local: { readonly required?: boolean } | undefined,
+  global: { readonly required?: boolean } | undefined,
+): boolean {
+  if (local === undefined && global === undefined) return false;
+  const effective = { ...(global ?? {}), ...(local ?? {}) };
+  return effective.required !== false;
+}
+
+function hasAuth(auth: unknown): boolean {
+  return Array.isArray(auth) ? auth.length > 0 : auth !== undefined && auth !== null;
+}
+
+function declaresRolesOrScopes(entry: {
+  readonly requiredRoles?: readonly string[];
+  readonly requiredScopes?: readonly string[];
+}): boolean {
+  return (entry.requiredRoles?.length ?? 0) > 0 || (entry.requiredScopes?.length ?? 0) > 0;
+}
+
+/**
+ * Reports how a Serve config will differ once executed by Cloud.
+ *
+ * Pure and side-effect free so it can be run for reporting without building a
+ * contract.
+ */
+export function analyzeCloudCompatibility(
+  config: ServeConfig<any, any, any, any, any>,
+): readonly CloudCompatibilityDiagnostic[] {
+  const serveConfig = config as unknown as AnyConfig;
+  const diagnostics: CloudCompatibilityDiagnostic[] = [];
+
+  // Semantic endpoints have no customer code in Cloud, so an unenforceable
+  // tenant requirement silently becomes no isolation at all.
+  const semanticTargets: { readonly label: string; readonly entry: unknown }[] = [
+    ...Object.entries(serveConfig.datasets ?? {}).map(([name, entry]) => ({
+      label: `datasets.${name}`,
+      entry,
+    })),
+    ...Object.entries(serveConfig.metrics ?? {}).map(([name, entry]) => ({
+      label: `metrics.${name}`,
+      entry,
+    })),
+  ];
+
+  for (const { label, entry } of semanticTargets) {
+    const resolved = label.startsWith('datasets.')
+      ? resolveDatasetEntry(entry as DatasetEntry<AuthContext>)
+      : resolveMetricEntry(entry as MetricEntry<AuthContext>);
+    const dataset = label.startsWith('datasets.')
+      ? (resolved as { dataset: { name: string; tenantKey?: string } }).dataset
+      : datasetOfMetric(resolved);
+
+    const local = (resolved as { tenant?: { required?: boolean } }).tenant;
+    if (!tenantIsExpected(local, serveConfig.tenant)) continue;
+    if (dataset?.tenantKey) continue;
+
+    diagnostics.push({
+      severity: 'error',
+      code: 'HQ_CLOUD_TENANT_NOT_ENFORCEABLE',
+      subject: label,
+      message:
+        `Tenant isolation is required for "${label}" but dataset `
+        + `"${dataset?.name ?? 'unknown'}" declares no tenantKey. Cloud resolves the `
+        + 'tenant filter column from the dataset, so it would accept a tenant and '
+        + 'return every tenant\'s rows.',
+      remedy:
+        `Add tenantKey to the "${dataset?.name ?? ''}" dataset, or set `
+        + 'tenant.required to false if this data is genuinely shared.',
+    });
+  }
+
+  // Everything below is dropped by the protocol adapter.
+  const globalMiddlewares = serveConfig.middlewares ?? [];
+  if (globalMiddlewares.length > 0) {
+    diagnostics.push({
+      severity: 'error',
+      code: 'HQ_CLOUD_MIDDLEWARE_DROPPED',
+      subject: 'middlewares',
+      message:
+        `${globalMiddlewares.length} global middleware(s) are not carried in the `
+        + 'deployment contract and will not run in Cloud. Middleware that performs '
+        + 'authentication or filtering would leave endpoints less protected than '
+        + 'they are locally.',
+      remedy:
+        'Express the requirement declaratively with requiresAuth, requiredRoles, '
+        + 'requiredScopes, or tenant config, or keep this app self-hosted.',
+    });
+  }
+
+  const queryEntries = Object.entries(serveConfig.queries ?? {}) as [
+    string,
+    { readonly middlewares?: readonly unknown[] } | undefined,
+  ][];
+  for (const [name, query] of queryEntries) {
+    if ((query?.middlewares?.length ?? 0) === 0) continue;
+    diagnostics.push({
+      severity: 'error',
+      code: 'HQ_CLOUD_MIDDLEWARE_DROPPED',
+      subject: `queries.${name}`,
+      message:
+        `Middleware on query "${name}" is not carried in the deployment contract `
+        + 'and will not run in Cloud.',
+      remedy:
+        'Express the requirement declaratively on the query, or move the logic into '
+        + 'the query resolver itself.',
+    });
+  }
+
+  if (serveConfig.hooks !== undefined) {
+    diagnostics.push({
+      severity: 'warning',
+      code: 'HQ_CLOUD_HOOKS_DROPPED',
+      subject: 'hooks',
+      message: 'Lifecycle hooks do not run in Cloud.',
+      remedy:
+        'Cloud records its own request log for deployed endpoints; remove the hooks '
+        + 'or keep them for local runs only.',
+    });
+  }
+
+  if (serveConfig.context !== undefined) {
+    diagnostics.push({
+      severity: 'warning',
+      code: 'HQ_CLOUD_CONTEXT_DROPPED',
+      subject: 'context',
+      message:
+        'The context factory does not run in Cloud, so values it provides will be '
+        + 'absent from query resolvers.',
+      remedy:
+        'Derive those values inside the resolver, or pass them as query input.',
+    });
+  }
+
+  if (hasAuth(serveConfig.auth)) {
+    const undeclared = [
+      ...Object.entries(serveConfig.datasets ?? {}).map(([name, entry]) => [
+        `datasets.${name}`,
+        resolveDatasetEntry(entry as DatasetEntry<AuthContext>),
+      ] as const),
+      ...Object.entries(serveConfig.metrics ?? {}).map(([name, entry]) => [
+        `metrics.${name}`,
+        resolveMetricEntry(entry as MetricEntry<AuthContext>),
+      ] as const),
+    ].filter(([, resolved]) => !declaresRolesOrScopes(resolved as { requiredRoles?: string[] }));
+
+    for (const [label] of undeclared) {
+      diagnostics.push({
+        severity: 'warning',
+        code: 'HQ_CLOUD_AUTH_WITHOUT_ROLES',
+        subject: label,
+        message:
+          `"${label}" is authenticated but declares no roles or scopes. The auth `
+          + 'strategy itself is not carried, so Cloud accepts any valid credential '
+          + 'for this endpoint even if the local strategy is stricter.',
+        remedy:
+          'Declare requiredRoles or requiredScopes so Cloud can enforce the same '
+          + 'restriction.',
+      });
+    }
+  }
+
+  return diagnostics;
+}
+
+function datasetOfMetric(resolved: unknown): { name: string; tenantKey?: string } | undefined {
+  const metric = (resolved as { metric?: any }).metric;
+  if (!metric) return undefined;
+  return metric.__type === 'grained_metric_ref' ? metric.metric?.dataset : metric.dataset;
+}
+
+/**
+ * Formats diagnostics for a thrown error. Errors are listed first because they
+ * are what blocks the deployment.
+ */
+export function formatCloudCompatibilityDiagnostics(
+  diagnostics: readonly CloudCompatibilityDiagnostic[],
+): string {
+  return diagnostics
+    .map(d => `  [${d.severity}] ${d.code} (${d.subject})\n    ${d.message}\n    → ${d.remedy}`)
+    .join('\n\n');
+}

--- a/packages/serve/src/cloud-compatibility.ts
+++ b/packages/serve/src/cloud-compatibility.ts
@@ -20,6 +20,7 @@
 
 import type { AuthContext, MetricEntry, DatasetEntry, ServeConfig } from './types.js';
 import { resolveDatasetEntry } from './semantic/datasets/utils/dataset-entry.js';
+import { resolveLocalAuthRequirement } from './auth-requirement.js';
 import { resolveMetricEntry } from './semantic/datasets/metric-endpoint.js';
 
 export type CloudCompatibilitySeverity = 'error' | 'warning';
@@ -70,6 +71,25 @@ function declaresRolesOrScopes(entry: {
   readonly requiredScopes?: readonly string[];
 }): boolean {
   return (entry.requiredRoles?.length ?? 0) > 0 || (entry.requiredScopes?.length ?? 0) > 0;
+}
+
+/**
+ * True when an endpoint ends up authenticated but declares nothing Cloud can
+ * enforce. Mirrors `accessPolicy` in the protocol adapter, including the local
+ * opt-out: an endpoint with `auth: null` or `requiresAuth: false` resolves to
+ * public and is not a downgrade.
+ */
+function isAuthenticatedWithoutRoles(
+  local: {
+    readonly auth?: unknown | null;
+    readonly requiresAuth?: boolean;
+    readonly requiredRoles?: readonly string[];
+    readonly requiredScopes?: readonly string[];
+  },
+  globalAuth: unknown,
+): boolean {
+  if (declaresRolesOrScopes(local)) return false;
+  return (resolveLocalAuthRequirement(local) ?? hasAuth(globalAuth)) === true;
 }
 
 /**
@@ -186,8 +206,11 @@ export function analyzeCloudCompatibility(
     });
   }
 
-  if (hasAuth(serveConfig.auth)) {
-    const undeclared = [
+  {
+    // Custom queries undergo the same reduction as semantic endpoints: the
+    // adapter calls endpointPolicy for all three, so a query with a strategy
+    // but no declared roles is downgraded exactly the same way.
+    const endpoints = [
       ...Object.entries(serveConfig.datasets ?? {}).map(([name, entry]) => [
         `datasets.${name}`,
         resolveDatasetEntry(entry as DatasetEntry<AuthContext>),
@@ -196,7 +219,14 @@ export function analyzeCloudCompatibility(
         `metrics.${name}`,
         resolveMetricEntry(entry as MetricEntry<AuthContext>),
       ] as const),
-    ].filter(([, resolved]) => !declaresRolesOrScopes(resolved as { requiredRoles?: string[] }));
+      ...Object.entries(serveConfig.queries ?? {}).map(([name, entry]) => [
+        `queries.${name}`,
+        (entry ?? {}) as Record<string, unknown>,
+      ] as const),
+    ];
+    const undeclared = endpoints.filter(
+      ([, resolved]) => isAuthenticatedWithoutRoles(resolved, serveConfig.auth),
+    );
 
     for (const [label] of undeclared) {
       diagnostics.push({

--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -20,6 +20,15 @@ export { createCacheObservability, detectBuilderCache } from "./cache-observabil
 export type { CacheObservability, CacheLayerStats, BuilderCacheLike } from "./cache-observability.js";
 export { buildProtocolDeploymentContract } from './protocol-adapter.js';
 export type { BuildProtocolDeploymentOptions } from './protocol-adapter.js';
+export {
+  analyzeCloudCompatibility,
+  formatCloudCompatibilityDiagnostics,
+} from './cloud-compatibility.js';
+export type {
+  CloudCompatibilityCode,
+  CloudCompatibilityDiagnostic,
+  CloudCompatibilitySeverity,
+} from './cloud-compatibility.js';
 export { ProtocolSchemaAdapterError, zodToProtocolSchema } from './protocol-schema-adapter.js';
 /** @deprecated Import from `@hypequery/serve/dev` instead. */
 export { serveDev } from "./dev.js";

--- a/packages/serve/src/protocol-adapter.ts
+++ b/packages/serve/src/protocol-adapter.ts
@@ -13,6 +13,11 @@ import {
   type AnyDatasetInstance,
   type MetricHandle,
 } from '@hypequery/datasets';
+import {
+  analyzeCloudCompatibility,
+  formatCloudCompatibilityDiagnostics,
+  type CloudCompatibilityDiagnostic,
+} from './cloud-compatibility.js';
 import type {
   AuthContext,
   AuthStrategy,
@@ -41,6 +46,34 @@ export interface BuildProtocolDeploymentOptions {
     readonly input?: ProtocolSchema;
     readonly output?: ProtocolSchema;
   }>>;
+  /**
+   * Receives every managed-execution diagnostic, including ones that do not
+   * block the build. Without it, warnings are discarded and only errors surface.
+   */
+  readonly onCloudDiagnostic?: (diagnostic: CloudCompatibilityDiagnostic) => void;
+  /**
+   * Downgrades managed-execution errors to warnings. The author is asserting
+   * they know the deployed behaviour differs from local.
+   */
+  readonly allowUnsupportedConfig?: boolean;
+}
+
+function reportCloudCompatibility(
+  config: ServeConfig<any, any, any, any, any>,
+  options: BuildProtocolDeploymentOptions,
+): void {
+  const diagnostics = analyzeCloudCompatibility(config);
+  if (diagnostics.length === 0) return;
+  for (const diagnostic of diagnostics) options.onCloudDiagnostic?.(diagnostic);
+  if (options.allowUnsupportedConfig) return;
+
+  const blocking = diagnostics.filter(diagnostic => diagnostic.severity === 'error');
+  if (blocking.length === 0) return;
+  throw new Error(
+    'This Serve configuration would behave differently under managed execution:\n\n'
+    + `${formatCloudCompatibilityDiagnostics(blocking)}\n\n`
+    + 'Resolve these, or pass allowUnsupportedConfig to deploy anyway.',
+  );
 }
 
 type AnyServeConfig = ServeConfig<
@@ -204,6 +237,7 @@ export function buildProtocolDeploymentContract(
   config: ServeConfig<any, any, any, any, any>,
   options: BuildProtocolDeploymentOptions = {},
 ): ProtocolDeploymentContract {
+  reportCloudCompatibility(config, options);
   const serveConfig = config as unknown as AnyServeConfig;
   const basePath = serveConfig.basePath ?? '/api/analytics';
   const datasetsPath = serveConfig.semanticPaths?.datasets ?? '/datasets';


### PR DESCRIPTION
## The problem

A deployment contract carries **policy, not mechanism**. `protocol-adapter.ts` reduces an `AuthStrategy` — which is `(context) => Promise<TAuth | null>`, arbitrary code — to `{ kind, roles, scopes }`. It reduces `TenantConfig.extract` to a column name. And it never reads `middlewares`, `hooks`, or `context` at all.

That's the right design: Cloud re-implements those concerns itself. The problem is it happened **silently**. A Serve app could deploy and behave differently from local with nothing said.

### The case that matters

`resolveTenantFilterColumn` returns the dataset's `tenantKey`, and the planner applies the predicate only when a column resolves:

```ts
if (tenantPredicate && tenantColumn) {
  qb = qb.where(...)     // silently skipped when tenantColumn is undefined
}
```

So a dataset with **no `tenantKey`**, exposed under a config declaring `tenant: { required: true }`, will demand a tenant and filter nothing — every tenant reads every row.

Locally a middleware or a query resolver may close that gap. Under managed execution there is no customer code left to do it, and the middleware that might have saved you is exactly what the contract drops.

## The change

`analyzeCloudCompatibility(config)` runs inside `buildProtocolDeploymentContract`, so every consumer is covered rather than only the CLI.

**Errors — block the build:**
- `HQ_CLOUD_TENANT_NOT_ENFORCEABLE` — tenancy required, dataset has no `tenantKey`
- `HQ_CLOUD_MIDDLEWARE_DROPPED` — global or per-query middleware, which never runs in Cloud and commonly carries auth

**Warnings — reported, not blocking:**
- `HQ_CLOUD_HOOKS_DROPPED`, `HQ_CLOUD_CONTEXT_DROPPED`
- `HQ_CLOUD_AUTH_WITHOUT_ROLES` — endpoint is authenticated but declares no roles or scopes, so Cloud accepts any valid credential even where the local strategy is stricter

Every diagnostic carries a `remedy`. `allowUnsupportedConfig` (`--allow-unsupported-config` on `deploy` and `deployment:build`) downgrades errors for authors who know their deployed behaviour differs.

## Validation

- 10 new tests in `cloud-compatibility.test.ts`
- Full serve suite green: **516 tests**, including the 13 existing `protocol-adapter` tests
- CLI deploy suites green: 53 tests. Three assertions updated to `expect.objectContaining` because the build now always passes `onCloudDiagnostic`
- Verified end to end through the real `createAPI` → `deploymentContract()` path: a leaky config is rejected with both errors and their remedies; a `tenantKey`-scoped config builds with zero diagnostics

```
This Serve configuration would behave differently under managed execution:

  [error] HQ_CLOUD_TENANT_NOT_ENFORCEABLE (datasets.regions)
    Tenant isolation is required for "datasets.regions" but dataset "regions"
    declares no tenantKey. Cloud resolves the tenant filter column from the
    dataset, so it would accept a tenant and return every tenant's rows.
    → Add tenantKey to the "regions" dataset, or set tenant.required to false
      if this data is genuinely shared.
```

## Note

This is independent of how managed execution is eventually implemented — declarative compilation or sandboxed runtime. Middlewares are not part of the runtime artifact either, so they would not run under a sandbox either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)