### PR TITLE
docs: resolve the semantic executor as portable native execution

### DIFF
--- a/plans/mcp-cloud-agent-platform-plan.md
+++ b/plans/mcp-cloud-agent-platform-plan.md
@@ -337,7 +337,7 @@ invalidate the security model.
 Durations are directional and assume Core and Cloud can work in parallel after
 the shared interfaces in Milestone 0 are agreed.
 
-The plan contains 31 active delivery PRs and two explicitly deferred
+The plan contains 36 active delivery PRs and two explicitly deferred
 relationship PRs. The count reflects the full local, hosted, agent, and GA
 horizon; the hosted MCP private-beta critical path does not require the agent or
 GA PRs.
@@ -369,12 +369,14 @@ Local MCP:  CORE-05 + CORE-08 -> CORE-09
 
 Deployment: CORE-03 -> CORE-10
             CORE-06 + CORE-10 -> CORE-11
-            CORE-02 + CORE-05 + CORE-11 -> CORE-12
+            CORE-03 + CORE-10 -> CORE-15 -> CORE-16 -> CORE-17
+            CORE-02 + CORE-05 + CORE-11 + CORE-16 -> CORE-12
 
 Hosted MCP: CORE-04 -> CLOUD-01 -> CLOUD-02
             CORE-06 + CORE-07 + CLOUD-02 -> CLOUD-03
             CORE-12 + CLOUD-03 -> CLOUD-04
             CLOUD-04 -> CLOUD-05 + CLOUD-06 -> CLOUD-07
+            CORE-12 -> CLOUD-08 -> CLOUD-09
             CLOUD-04 + CLOUD-06 -> CORE-14
 
 Agent:      ARCH-01 -> AGENT-01
@@ -460,8 +462,11 @@ SQL remains opt-in for trusted debugging.
 | --- | --- | --- |
 | **CORE-10 — Protocol semantic invocation types** | `ARCH-01`, `CORE-03` | Add strict dataset/metric invocation request, result, budget, and error types plus validators. Keep this PR pure: no data-plane or runtime execution. Prefer additive deployment contract v1 projection; if impossible, include an approved v2 migration document before code. |
 | **CORE-11 — Semantic data-plane policy and validation** | `CORE-06`, `CORE-10` | Add semantic invocation beside named-query execution. Resolve dataset/metric endpoint policy from the active contract and reuse authentication, roles/scopes, tenant resolution, input validation, budgets, and error categories with an injected fake executor. No runtime materialization changes. Merge with cross-tenant and forged-tenant tests. |
-| **CORE-12 — Activated runtime semantic execution** | `CORE-02`, `CORE-05`, `CORE-11` | Connect semantic data-plane requests to the activated deployment runtime/portable semantic executor, pin optional activation revision, propagate deadlines/cancellation, validate and byte-limit outputs, and cover activation/rollback races. Merge when a bundle can execute dataset and metric calls without loading a separate MCP config. |
+| **CORE-12 — Activated semantic execution** | `CORE-02`, `CORE-05`, `CORE-11`, `CORE-16` | Connect semantic data-plane requests to the portable native executor chosen in decision 0005: resolve the dataset or metric from the validated active contract, rebuild its catalog via `CORE-15`, and plan the query with the existing semantic planner. No customer module loading and no isolated runtime. Pin optional activation revision, propagate deadlines/cancellation, validate and byte-limit outputs, and cover activation/rollback races. Merge when a bundle can execute dataset and metric calls without loading a separate MCP config. |
 | **CORE-13 — Verified-question contract and local eval runner** | `CORE-07`, `CORE-12` | Define versioned verified questions with expected tool, semantic arguments, result shape, and invariant assertions. Add a local runner that can replay against local or hosted-compatible executors. No model-provider benchmarking yet. Merge with deterministic fixture evaluations. |
+| **CORE-15 — Contract-to-catalog rehydration** | `CORE-03`, `CORE-10` | Add a pure function to `@hypequery/datasets` that rebuilds an executable catalog from a protocol dataset contract: dimensions with column mappings, measures including raw SQL, filters, relationships, limits, tenant key, time key, and grains. No execution and no Cloud awareness. Merge when contract-to-catalog-to-contract is an identity across the vertical-slice fixture. |
+| **CORE-16 — Semantic SQL equality harness** | `CORE-15` | Add a query corpus and assert a rehydrated catalog emits byte-identical SQL to the authored one across dimension subsets, measure combinations, filter operators, time grains, ordering, pagination, joins, and tenant predicates. Test-only. This is the gate for decision 0005: if it cannot pass, that decision is void for the affected surface. Merge when the corpus is byte-identical or every divergence is documented and accepted. |
+| **CORE-17 — Carry the derived-metric expression** | `CORE-16`, `CORE-10` | `MetricCatalogEntry` keeps only metric shape and discards the symbolic `SemanticExpression` that `formulas.ts` produces. Carry the expression through catalog and protocol validation so derived metrics execute declaratively. Additive to deployment contract v1 where derivable without weakening validation. Merge when a derived metric round-trips and stays byte-identical under `CORE-16`. |
 | **CORE-14 — Hosted endpoint CLI UX** | `CLOUD-04`, `CLOUD-06` | Extend deploy/status output with the hosted MCP endpoint, generate supported client configuration, and add a non-destructive remote connection self-test. Authentication material must remain in the credential store and out of generated files/logs. |
 
 ### Cloud gateway PRs
@@ -477,6 +482,8 @@ versions of the Core contracts; they do not duplicate Core source.
 | **CLOUD-04 — Live hosted semantic execution** | `CLOUD-03`, `CORE-12` | Route MCP dataset/metric calls through `DeploymentHost`, preserve credentials, principal, tenant, trace, revision, cancellation, and structured result/error semantics. Merge when the vertical slice produces local/hosted parity and passes tenant-isolation tests. |
 | **CLOUD-05 — Quotas, observability, audit, and redaction** | `CLOUD-04` | Add per-principal/project concurrency and rate limits, plan/query/response budgets, request IDs, traces, metrics, audit events, usage metering, and log/result redaction. No billing UI. Merge with load, slow-backend, large-result, and client-disconnect tests. |
 | **CLOUD-06 — Deployment connection experience** | `CLOUD-04` | Add deployment-page endpoint status, copyable OAuth/token connection instructions, generated configurations for supported clients, and a connection diagnostic. Do not add the first-party agent UI. Merge after a new deployment can connect without an extra MCP config artifact. |
+| **CLOUD-08 — Executable dataset endpoints** | `CORE-12` | Replace the hardcoded `executable: false` on dataset registry entries with a real capability check, and route gateway dataset/metric execution through the deployment host rather than constructing a dataset client in the gateway. Validate input with the existing contract-derived schema, enforce endpoint and dataset limits server-side, and fail closed when a required tenant is absent. Merge when an activated dataset returns rows instead of a runtime-unavailable error. |
+| **CLOUD-09 — Rehydrated catalog cache** | `CLOUD-08` | Cache rehydrated catalogs keyed by release identity. Releases are immutable and content-addressed, so identity is an exact key with no invalidation problem. Add bounded size and eviction; comparable systems report per-tenant compiled models in the tens of megabytes. Merge with cache-hit, eviction, and activation-change tests. |
 | **CLOUD-07 — Compatibility matrix and hosted MCP private beta** | `CLOUD-05`, `CLOUD-06`, `CORE-14` | Run and document compatibility with at least three MCP clients, close beta-operability gaps, add SLO/runbook coverage, and prepare remote registry metadata. Registry submission itself remains conditional on current registry requirements and product readiness. |
 
 ### Agent harness PRs
@@ -587,7 +594,8 @@ identifiers above are the actual PR boundaries.
 
 ### Milestone 2 — Add deployment semantic execution (2–3 weeks)
 
-**Included PRs:** `CORE-10` through `CORE-12`
+**Included PRs:** `CORE-10` through `CORE-12`, plus `CORE-15` through
+`CORE-17`
 
 **Goal:** Execute dynamic dataset/metric requests through the activated Cloud
 deployment with the same guarantees as named queries.
@@ -610,6 +618,13 @@ deployment with the same guarantees as named queries.
 - [ ] **PROTOCOL-201:** Add only the minimum additive contract fields required for
   agent metadata. Preserve deployment contract v1 if this can be derived without
   weakening validation; otherwise design an explicit v2 migration.
+- [ ] **DEPLOY-208:** Rebuild an executable catalog from a protocol dataset
+  contract so execution needs no customer module. Decision 0005.
+- [ ] **DEPLOY-209:** Assert a rehydrated catalog emits byte-identical SQL to the
+  authored catalog across a query corpus. Gate for decision 0005.
+- [ ] **PROTOCOL-202:** Carry the symbolic derived-metric `SemanticExpression`
+  through catalog and protocol validation so derived metrics execute
+  declaratively.
 
 **Exit criteria**
 
@@ -619,6 +634,8 @@ deployment with the same guarantees as named queries.
   cancellation, error, trace, and activation semantics.
 - A tenant cannot be supplied or changed through MCP arguments.
 - Activation races and rollback behavior are integration-tested.
+- A rehydrated catalog emits byte-identical SQL to the authored catalog, so
+  managed execution cannot silently diverge from local development.
 
 ### Milestone 3 — Hosted MCP private beta (3–4 weeks)
 

--- a/plans/mcp-cloud-agent-platform-plan.md
+++ b/plans/mcp-cloud-agent-platform-plan.md
@@ -462,10 +462,10 @@ SQL remains opt-in for trusted debugging.
 | --- | --- | --- |
 | **CORE-10 — Protocol semantic invocation types** | `ARCH-01`, `CORE-03` | Add strict dataset/metric invocation request, result, budget, and error types plus validators. Keep this PR pure: no data-plane or runtime execution. Prefer additive deployment contract v1 projection; if impossible, include an approved v2 migration document before code. |
 | **CORE-11 — Semantic data-plane policy and validation** | `CORE-06`, `CORE-10` | Add semantic invocation beside named-query execution. Resolve dataset/metric endpoint policy from the active contract and reuse authentication, roles/scopes, tenant resolution, input validation, budgets, and error categories with an injected fake executor. No runtime materialization changes. Merge with cross-tenant and forged-tenant tests. |
-| **CORE-12 — Activated semantic execution** | `CORE-02`, `CORE-05`, `CORE-11`, `CORE-16` | Connect semantic data-plane requests to the portable native executor chosen in decision 0005: resolve the dataset or metric from the validated active contract, rebuild its catalog via `CORE-15`, and plan the query with the existing semantic planner. No customer module loading and no isolated runtime. Pin optional activation revision, propagate deadlines/cancellation, validate and byte-limit outputs, and cover activation/rollback races. Merge when a bundle can execute dataset and metric calls without loading a separate MCP config. |
+| **CORE-12 — Activated semantic execution** | `CORE-02`, `CORE-05`, `CORE-11`, `CORE-16` | Connect semantic data-plane requests to the portable native executor chosen in decision 0005: resolve the dataset or metric from the validated active contract, rebuild its catalog via `CORE-15`, and plan the query with the existing semantic planner. No customer module loading and no isolated runtime. Pin optional activation revision, propagate deadlines/cancellation, validate and byte-limit outputs, and cover activation/rollback races. Derived metrics are not executable until `CORE-17` carries their symbolic expression: until then this PR must reject a derived-metric target with an explicit unsupported-capability error rather than execute it from a formula-less catalog entry. The same rule applies to any surface `CORE-16` could not make byte-identical. Merge when a bundle can execute dataset and metric calls without loading a separate MCP config, with a test proving derived metrics fail closed. |
 | **CORE-13 — Verified-question contract and local eval runner** | `CORE-07`, `CORE-12` | Define versioned verified questions with expected tool, semantic arguments, result shape, and invariant assertions. Add a local runner that can replay against local or hosted-compatible executors. No model-provider benchmarking yet. Merge with deterministic fixture evaluations. |
 | **CORE-15 — Contract-to-catalog rehydration** | `CORE-03`, `CORE-10` | Add a pure function to `@hypequery/datasets` that rebuilds an executable catalog from a protocol dataset contract: dimensions with column mappings, measures including raw SQL, filters, relationships, limits, tenant key, time key, and grains. No execution and no Cloud awareness. Merge when contract-to-catalog-to-contract is an identity across the vertical-slice fixture. |
-| **CORE-16 — Semantic SQL equality harness** | `CORE-15` | Add a query corpus and assert a rehydrated catalog emits byte-identical SQL to the authored one across dimension subsets, measure combinations, filter operators, time grains, ordering, pagination, joins, and tenant predicates. Test-only. This is the gate for decision 0005: if it cannot pass, that decision is void for the affected surface. Merge when the corpus is byte-identical or every divergence is documented and accepted. |
+| **CORE-16 — Semantic SQL equality harness** | `CORE-15` | Add a query corpus and assert a rehydrated catalog emits byte-identical SQL to the authored one across dimension subsets, measure combinations, filter operators, time grains, ordering, pagination, joins, and tenant predicates. Test-only. This is the gate for decision 0005: if it cannot pass, that decision is void for the affected surface. Merge only when the corpus is byte-identical. A surface that cannot be made byte-identical is not "documented and accepted" — it is excluded from portable execution, and `CORE-12` must reject it with an explicit unsupported-capability error until the supervised runtime binding exists. |
 | **CORE-17 — Carry the derived-metric expression** | `CORE-16`, `CORE-10` | `MetricCatalogEntry` keeps only metric shape and discards the symbolic `SemanticExpression` that `formulas.ts` produces. Carry the expression through catalog and protocol validation so derived metrics execute declaratively. Additive to deployment contract v1 where derivable without weakening validation. Merge when a derived metric round-trips and stays byte-identical under `CORE-16`. |
 | **CORE-14 — Hosted endpoint CLI UX** | `CLOUD-04`, `CLOUD-06` | Extend deploy/status output with the hosted MCP endpoint, generate supported client configuration, and add a non-destructive remote connection self-test. Authentication material must remain in the credential store and out of generated files/logs. |
 
@@ -482,7 +482,7 @@ versions of the Core contracts; they do not duplicate Core source.
 | **CLOUD-04 — Live hosted semantic execution** | `CLOUD-03`, `CORE-12` | Route MCP dataset/metric calls through `DeploymentHost`, preserve credentials, principal, tenant, trace, revision, cancellation, and structured result/error semantics. Merge when the vertical slice produces local/hosted parity and passes tenant-isolation tests. |
 | **CLOUD-05 — Quotas, observability, audit, and redaction** | `CLOUD-04` | Add per-principal/project concurrency and rate limits, plan/query/response budgets, request IDs, traces, metrics, audit events, usage metering, and log/result redaction. No billing UI. Merge with load, slow-backend, large-result, and client-disconnect tests. |
 | **CLOUD-06 — Deployment connection experience** | `CLOUD-04` | Add deployment-page endpoint status, copyable OAuth/token connection instructions, generated configurations for supported clients, and a connection diagnostic. Do not add the first-party agent UI. Merge after a new deployment can connect without an extra MCP config artifact. |
-| **CLOUD-08 — Executable dataset endpoints** | `CORE-12` | Replace the hardcoded `executable: false` on dataset registry entries with a real capability check, and route gateway dataset/metric execution through the deployment host rather than constructing a dataset client in the gateway. Validate input with the existing contract-derived schema, enforce endpoint and dataset limits server-side, and fail closed when a required tenant is absent. Merge when an activated dataset returns rows instead of a runtime-unavailable error. |
+| **CLOUD-08 — Executable dataset endpoints** | `CORE-12` | Replace the hardcoded `executable: false` on dataset registry entries with a real capability check that reports a target as executable only when `CORE-12` can actually execute it — derived metrics stay non-executable until `CORE-17` lands, and route gateway dataset/metric execution through the deployment host rather than constructing a dataset client in the gateway. Validate input with the existing contract-derived schema, enforce endpoint and dataset limits server-side, and fail closed when a required tenant is absent. Merge when an activated dataset returns rows instead of a runtime-unavailable error. |
 | **CLOUD-09 — Rehydrated catalog cache** | `CLOUD-08` | Cache rehydrated catalogs keyed by release identity. Releases are immutable and content-addressed, so identity is an exact key with no invalidation problem. Add bounded size and eviction; comparable systems report per-tenant compiled models in the tens of megabytes. Merge with cache-hit, eviction, and activation-change tests. |
 | **CLOUD-07 — Compatibility matrix and hosted MCP private beta** | `CLOUD-05`, `CLOUD-06`, `CORE-14` | Run and document compatibility with at least three MCP clients, close beta-operability gaps, add SLO/runbook coverage, and prepare remote registry metadata. Registry submission itself remains conditional on current registry requirements and product readiness. |
 
@@ -636,10 +636,13 @@ deployment with the same guarantees as named queries.
 - Activation races and rollback behavior are integration-tested.
 - A rehydrated catalog emits byte-identical SQL to the authored catalog, so
   managed execution cannot silently diverge from local development.
+- Any target that portable execution cannot reproduce exactly — including derived
+  metrics before `PROTOCOL-202` — is rejected with an explicit
+  unsupported-capability error rather than executed.
 
 ### Milestone 3 — Hosted MCP private beta (3–4 weeks)
 
-**Included PRs:** `CLOUD-01` through `CLOUD-07`, plus `CORE-14`
+**Included PRs:** `CLOUD-01` through `CLOUD-09`, plus `CORE-14`
 
 **Goal:** A secure remote MCP endpoint created automatically from a Cloud
 deployment.
@@ -660,6 +663,11 @@ deployment.
   metrics, logs, and redaction.
 - [ ] **CLOUD-308:** Add deployment-page connection instructions and generated
   configurations for common MCP clients.
+- [ ] **CLOUD-310:** Replace the hardcoded `executable: false` on dataset registry
+  entries with a real capability check and route dataset/metric execution through
+  the deployment host instead of a gateway-constructed dataset client.
+- [ ] **CLOUD-311:** Cache rehydrated catalogs keyed by immutable release
+  identity, with bounded size and eviction.
 - [ ] **CLI-301:** Print or retrieve the hosted MCP endpoint after deployment and
   add a non-destructive connection self-test.
 - [ ] **CLOUD-309:** Submit the hosted endpoint metadata to the official MCP
@@ -673,6 +681,8 @@ deployment.
 - Gateway instances remain stateless apart from MCP protocol/session needs; the
   deployment contract and activation registry are authoritative.
 - Load tests prove configured concurrency, deadline, and response limits.
+- An activated dataset endpoint returns rows rather than a runtime-unavailable
+  error, and its rehydrated catalog is served from a bounded per-release cache.
 - At least three external MCP clients pass a documented compatibility matrix.
 
 ### Milestone 4 — Cloud agent harness private beta (3–5 weeks)

--- a/specs/deployment/decisions/0005-portable-semantic-execution.md
+++ b/specs/deployment/decisions/0005-portable-semantic-execution.md
@@ -1,0 +1,110 @@
+# Decision 0005: Portable semantic execution
+
+- Status: Proposed
+- Date: 2026-09-03
+- Owners: Hypequery Core and Cloud maintainers
+
+## Context
+
+Decision 0002 introduced first-class semantic invocation and deliberately left
+the executor open: "The semantic executor may be portable native execution or a
+supervised runtime binding. Both implement the same invocation contract and
+policy context."
+
+`CORE-12` inherits that openness by targeting "the activated deployment
+runtime/portable semantic executor", and `DEPLOY-204` already requires a
+"protocol-contract-to-semantic-executor bridge" that does "not require source
+TypeScript in the gateway". The mechanism is unnamed, so the work cannot be
+sequenced or gated.
+
+The choice is load-bearing. Portable native execution compiles a query from the
+activated contract and runs no customer code. A supervised runtime binding
+executes the deployed bundle's JavaScript in an isolated executor. They differ
+in cost, operational surface, and the kind of failure they risk.
+
+The deployment data plane currently makes only `deployment.queries` executable,
+so no dataset or metric endpoint can execute at all. Hosted MCP is blocked on
+resolving this.
+
+## Decision
+
+Semantic invocation executes through **portable native execution**. The executor
+resolves the dataset or metric from the validated active contract, rebuilds an
+executable catalog from that contract, and plans the query with the existing
+semantic planner. No customer module is loaded and no isolated runtime is
+required.
+
+The supervised runtime binding remains a valid implementation of the same
+invocation contract, as decision 0002 requires. It is not built now. It becomes
+the escape hatch for deployments that cannot be expressed declaratively.
+
+### Why the contract is sufficient
+
+A deployed dataset already carries dimensions with column mappings, measures
+with aggregation and field plus optional raw SQL, filters with operators,
+relationships, limits, tenant key, time key, and supported grains.
+`DatasetCatalog` is pure data with no functions.
+
+Derived metrics are also declarative. `formulas.ts` states that formula helpers
+"are symbolic — they build `FormulaExpr` objects that get compiled to SQL by the
+semantic query engine. They do not produce raw SQL strings directly." The
+carried value is a `SemanticExpression` of `ref | literal | binary | function`.
+`MetricCatalogEntry` currently discards it, which is an additive gap rather than
+a structural obstacle.
+
+### Rebuilt catalogs must not diverge
+
+The risk of this decision is that a catalog rebuilt from the contract produces
+different SQL from the authored one, so a deployment behaves differently in
+managed execution than in local development.
+
+This is mitigated by construction, not by review: both sides run the same
+planner over the same catalog shape. It is verified by a required equality
+harness that asserts a rebuilt catalog emits byte-identical SQL to the original
+across a query corpus covering dimension subsets, measure combinations, filter
+operators, time grains, ordering, pagination, joins, and tenant predicates.
+
+If the harness cannot be made to pass, this decision is void for the affected
+surface and the supervised runtime binding is required there.
+
+### What does not change
+
+Every guarantee in decision 0002 is unaffected. Portable execution sits behind
+the same invocation contract and therefore inherits generation pinning, the rule
+that a caller cannot supply a tenant, the requirement to fail closed when a
+required tenant cannot be enforced, secret ownership inside the hosted
+generation, and the stable failure categories.
+
+## Consequences
+
+- Dataset and metric endpoints become executable without an isolated executor,
+  removing the runtime executor from the hosted MCP critical path.
+- Customer code executes only on the author's machine at deploy time. It never
+  runs on Hypequery infrastructure.
+- Cloud gains a permanent obligation to interpret every contract version it has
+  accepted, because releases are immutable and rollback is supported. Contract
+  versioning becomes a compatibility surface with its own tests.
+- Rebuilt catalogs should be cached per release. Releases are immutable and
+  content-addressed, so release identity is an exact cache key.
+- Deployments that need genuinely dynamic behaviour are unsupported in managed
+  execution until the supervised runtime binding exists, and must be rejected
+  with a clear error rather than executed with different semantics.
+
+## Rejected alternatives
+
+- **Build the supervised runtime binding first:** rejected because it puts
+  isolated compute on the critical path for queries that carry no code, and adds
+  a permanent per-request cost and operational surface before demand is proven.
+  It also inverts the risk profile: a rebuilt-catalog defect is a wrong result
+  caught by tests, whereas an isolation defect is a cross-tenant incident.
+- **Emit `compiled-sql` for every dataset request at deploy time:** rejected for
+  the same reason decision 0002 rejected generating one named query per tool
+  call. Dataset selection is combinatorial in dimensions, measures, filters,
+  grains, and ordering, so it cannot be enumerated in advance. `compiled-sql`
+  remains appropriate for fixed-shape named queries.
+- **Execute a dataset client directly in the Cloud gateway:** already rejected by
+  decision 0002 because it bypasses deployment generation and secret ownership.
+  Portable execution lives inside the deployment host for the same reason.
+- **Leave the executor unspecified until implementation:** rejected because the
+  choice determines the infrastructure Cloud must operate, and hosted MCP cannot
+  be sequenced while it is open.

--- a/specs/deployment/decisions/README.md
+++ b/specs/deployment/decisions/README.md
@@ -15,6 +15,7 @@ canonical fixtures, and compatibility tests before it becomes normative.
 | [0002](./0002-semantic-invocation-and-activation-pinning.md) | Dataset/metric invocation and activation pinning | Proposed |
 | [0003](./0003-agent-safe-catalog-results-and-errors.md) | Safe discovery, tool manifests, results, and errors | Proposed |
 | [0004](./0004-cloud-routing-auth-and-agent-access.md) | Cloud routing, authentication, tenancy, and first-party agent access | Proposed |
+| [0005](./0005-portable-semantic-execution.md) | Portable semantic execution and the rebuilt-catalog equality gate | Proposed |
 
 The shared vertical-slice fixture referenced by these records lives in
 [`../fixtures/mcp-cloud-v1`](../fixtures/mcp-cloud-v1/README.md).


### PR DESCRIPTION
## What this settles

Decision 0002 deliberately left the executor open:

> The semantic executor may be portable native execution or a supervised runtime binding. Both implement the same invocation contract and policy context.

`CORE-12` inherited that ambiguity by targeting "the activated deployment runtime/portable semantic executor". `DEPLOY-204` already required a "protocol-contract-to-semantic-executor bridge" that does "not require source TypeScript in the gateway" — but the mechanism was never named, so the work could not be sequenced or gated.

**Decision 0005 resolves it in favour of portable native execution.** Rebuild an executable catalog from the activated contract and plan the query with the existing semantic planner. No customer module is loaded, no isolated runtime is required.

The supervised runtime binding is not cancelled. It stays valid behind the same invocation contract and becomes the escape hatch for deployments that cannot be expressed declaratively.

## Why the contract is sufficient

- A deployed dataset carries dimensions with column mappings, measures with aggregation/field plus optional raw SQL, filters with operators, relationships, limits, tenant key, time key, grains. `DatasetCatalog` is pure data with no functions.
- Derived metrics are declarative too. `formulas.ts` is explicit: the helpers "are symbolic — they build `FormulaExpr` objects that get compiled to SQL by the semantic query engine. They do not produce raw SQL strings directly." The carried value is a `SemanticExpression` of `ref | literal | binary | function`. `MetricCatalogEntry` currently discards it, which is an additive gap rather than a structural one — hence `CORE-17`.

## The gate

The real risk is a rebuilt catalog emitting *different* SQL from the authored one, so a deployment behaves differently under managed execution than in local development.

`CORE-16` makes that a gate rather than a hope: a rehydrated catalog must emit **byte-identical SQL** across a corpus covering dimension subsets, measure combinations, filter operators, time grains, ordering, pagination, joins, and tenant predicates. If it cannot pass, decision 0005 is void for the affected surface and the supervised runtime binding is required there.

It is mitigated by construction as well as by test — both sides run the same planner over the same catalog shape. The harness is worth keeping regardless as the regression test that stops Cloud and local development drifting apart.

## Changes

**New ADR** `0005-portable-semantic-execution.md`, plus its index row.

**Plan rows:**

| PR | Deliverable |
|---|---|
| `CORE-15` | Contract-to-catalog rehydration (pure) |
| `CORE-16` | Semantic SQL equality harness — **the gate** |
| `CORE-17` | Carry the derived-metric `SemanticExpression` |
| `CLOUD-08` | Executable dataset endpoints via the deployment host |
| `CLOUD-09` | Rehydrated catalog cache keyed by release identity |

`CORE-12` is retitled "Activated semantic execution", now depends on `CORE-16`, and names the mechanism. Dependency graph, Milestone 2 scope, exit criteria, backlog (`DEPLOY-208`, `DEPLOY-209`, `PROTOCOL-202`), and the PR count (31 → 36) are updated to match.

`CLOUD-08` respects decision 0002's rejection of executing a dataset client in the gateway — it routes through the deployment host.

## Consequences worth reviewing

- Cloud gains a **permanent obligation** to interpret every contract version it has accepted, since releases are immutable and rollback is supported. This is the strongest argument for the alternative and is recorded as a consequence, not hidden.
- Deployments needing genuinely dynamic behaviour are unsupported under managed execution until the runtime binding exists, and must be **rejected with a clear error** rather than executed with different semantics.

## Verified state

Confirmed against a live deployment: a dataset deploys, activates, and is fully introspectable — `runtime: ready`, `clickhouse: connected`, complete registry schemas. Execution is the only missing step; `POST` returns `HTTP 503 HQ_CLOUD_RUNTIME_UNAVAILABLE`.

Documentation only. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)