### PR TITLE
fix(clickhouse): type CTE aliases and keep their parameters bound

### DIFF
--- a/.changeset/tidy-cte-typing.md
+++ b/.changeset/tidy-cte-typing.md
@@ -1,0 +1,19 @@
+---
+"@hypequery/clickhouse": minor
+---
+
+Fix two long-standing CTE gaps in the query builder.
+
+CTE aliases are now typed join targets. `withCTE('alias', builder)` derives the
+alias's columns from the builder passed in, and `withCTE('alias', sql, columns)`
+takes a column declaration for a raw SQL body. Joining the alias, selecting
+`alias.column`, and filtering on it are all checked, and the column types flow
+through to the result row. A raw CTE with no declared columns behaves as before:
+it renders, but its alias is not a typed join target. Joining a CTE does not
+accept the trailing table-alias argument, which resolves through the schema.
+
+CTE values also stay bound. `withCTE` previously rendered a builder subquery with
+`toSQL()`, escaping its values into the CTE string while the rest of the query
+used bound parameters. The CTE body now keeps its placeholders and contributes
+its parameters ahead of the outer query's. Rendered SQL is unchanged, as is the
+`ctes` array on the deprecated `getConfig()`.

--- a/packages/clickhouse/src/core/dialects/clickhouse-dialect.ts
+++ b/packages/clickhouse/src/core/dialects/clickhouse-dialect.ts
@@ -12,7 +12,10 @@ export class ClickHouseDialect implements SqlDialect {
     const parameters: unknown[] = [];
 
     if (query.ctes?.length) {
-      parts.push(`WITH ${this.formatter.formatCtes(query)}`);
+      // CTE parameters lead the positional list because WITH renders first.
+      const compiled = this.formatter.compileCtes(query);
+      parts.push(`WITH ${compiled.query}`);
+      parameters.push(...compiled.parameters);
     }
 
     parts.push(`SELECT ${this.formatter.formatSelect(query)}`);

--- a/packages/clickhouse/src/core/features/analytics.ts
+++ b/packages/clickhouse/src/core/features/analytics.ts
@@ -4,6 +4,7 @@ import { QueryBuilder } from '../query-builder.js';
 import type { SqlDialect } from '../dialects/sql-dialect.js';
 import type { PredicateExpression } from '../utils/predicate-builder.js';
 import { substituteParameters } from '../utils.js';
+import { renderCteBody } from '../utils/cte-fragments.js';
 import { terminateTrailingLineComment } from '../utils/sql-parens.js';
 import type { SelectQueryNode } from '../../types/index.js';
 
@@ -15,10 +16,26 @@ export class AnalyticsFeature<
 
   addCTE(alias: string, subquery: QueryBuilder<any, AnyBuilderState> | string): SelectQueryNode<State['output'], Schema> {
     const query = this.builder.getQueryNode();
-    const cte = typeof subquery === 'string' ? subquery : subquery.toSQL();
+    // A builder subquery is compiled with its placeholders intact so its values
+    // stay bound. `expression` keeps the rendered form the node carried before,
+    // using the same rendering path `toSQL()` takes.
+    const compiled = typeof subquery === 'string' ? undefined : subquery.toSQLWithParams();
+    const body = compiled ? compiled.sql : subquery as string;
+    const parameters = compiled ? compiled.parameters : [];
+    const rendered = compiled ? renderCteBody(body, parameters, this.builder.getAdapter()) : body;
+
     return {
       ...query,
-      ctes: [...(query.ctes || []), { kind: 'cte' as const, expression: `${alias} AS (${cte})` }]
+      ctes: [
+        ...(query.ctes || []),
+        {
+          kind: 'cte' as const,
+          name: alias,
+          body,
+          parameters,
+          expression: `${alias} AS (${rendered})`,
+        }
+      ]
     };
   }
 

--- a/packages/clickhouse/src/core/features/joins.ts
+++ b/packages/clickhouse/src/core/features/joins.ts
@@ -50,18 +50,22 @@ export class JoinFeature<
 > {
   constructor(private builder: QueryBuilder<Schema, State>) { }
 
-  addJoin<TableName extends keyof Schema>(
+  /**
+   * Join targets are plain identifiers here: the caller has already checked the
+   * table against the schema, or the CTEs declared on the query.
+   */
+  addJoin(
     type: JoinType,
-    table: TableName,
+    table: string,
     leftColumn: string,
-    rightColumn: `${TableName & string}.${keyof Schema[TableName] & string}`,
+    rightColumn: string,
     alias?: string,
     leftSource?: string,
     on?: JoinConditionInput | JoinConditionInput[],
   ): SelectQueryNode<State['output'], Schema> {
     const query = this.builder.getQueryNode();
     const renderedRightColumn = alias
-      ? rightColumn.replace(`${String(table)}.`, `${alias}.`) as typeof rightColumn
+      ? rightColumn.replace(`${table}.`, `${alias}.`)
       : rightColumn;
     const newConfig = {
       ...query,

--- a/packages/clickhouse/src/core/formatters/sql-formatter.ts
+++ b/packages/clickhouse/src/core/formatters/sql-formatter.ts
@@ -1,4 +1,5 @@
 import { FilterOperator, type CompiledQuery, type ExprNode, type SelectQueryNode, type SourceNode, type ValueNode } from '../../types/index.js';
+import { cteFragment } from '../utils/cte-fragments.js';
 import { hasTopLevelLogicalOperator, terminateTrailingLineComment } from '../utils/sql-parens.js';
 
 export class SQLFormatter {
@@ -240,9 +241,19 @@ export class SQLFormatter {
     return this.compileJoins(query).query;
   }
 
+  compileCtes(query: SelectQueryNode<any, any>): CompiledQuery {
+    if (!query.ctes?.length) return { query: '', parameters: [] };
+    return this.combineCompiledWithSeparator(
+      query.ctes.map(item => {
+        const { sql, parameters } = cteFragment(item);
+        return { query: sql, parameters: [...parameters] };
+      }),
+      ', ',
+    );
+  }
+
   formatCtes(query: SelectQueryNode<any, any>): string {
-    if (!query.ctes?.length) return '';
-    return query.ctes.map(item => item.expression).join(', ');
+    return this.compileCtes(query).query;
   }
 
   formatOrderBy(query: SelectQueryNode<any, any>): string {

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -432,6 +432,8 @@ export class QueryBuilder<
     columns: Columns
   ): QueryBuilder<Schema, AddCte<State, Alias, Columns>>;
   withCTE(alias: string, sql: string): this;
+  // Preserve callers whose body is chosen dynamically from SQL or a builder.
+  withCTE(alias: string, subquery: QueryBuilder<any, AnyBuilderState> | string): this;
   withCTE(
     alias: string,
     subquery: QueryBuilder<any, AnyBuilderState> | string,

--- a/packages/clickhouse/src/core/query-builder.ts
+++ b/packages/clickhouse/src/core/query-builder.ts
@@ -58,7 +58,12 @@ import type {
   BaseRow,
   AddAlias,
   AddScalar,
+  AddCte,
   FromSubqueryState,
+  JoinableTable,
+  JoinRightColumn,
+  JoinAliasArg,
+  JoinResultState,
 } from './types/builder-state.js';
 import {
   SelectableItem,
@@ -402,13 +407,58 @@ export class QueryBuilder<
     return next;
   }
 
-  // --- Analytics Helper: Add a CTE.
+  /**
+   * Adds a CTE to the query. The alias becomes a typed join target when its
+   * columns are known — derived from the builder passed in, or declared
+   * alongside a raw SQL body.
+   *
+   * @example
+   * ```ts
+   * const activeUsers = db.table('users').select(['id', 'user_name']).where('status', 'eq', 'active');
+   *
+   * db.table('orders')
+   *   .withCTE('active_users', activeUsers)
+   *   .innerJoin('active_users', 'user_id', 'active_users.id')
+   *   .select(['orders.id', 'active_users.user_name']);
+   * ```
+   */
+  withCTE<Alias extends string, SubqueryState extends AnyBuilderState>(
+    alias: Alias,
+    subquery: QueryBuilder<any, SubqueryState>
+  ): QueryBuilder<Schema, AddCte<State, Alias, SubqueryState['output']>>;
+  withCTE<Alias extends string, Columns extends Record<string, ColumnType>>(
+    alias: Alias,
+    sql: string,
+    columns: Columns
+  ): QueryBuilder<Schema, AddCte<State, Alias, Columns>>;
+  withCTE(alias: string, sql: string): this;
   withCTE(
     alias: string,
-    subquery: QueryBuilder<any, AnyBuilderState> | string
-  ): this {
+    subquery: QueryBuilder<any, AnyBuilderState> | string,
+    columns?: Record<string, ColumnType>
+  ): any {
     assertSafeIdentifier(alias, 'CTE alias');
-    return this.updateQuery(() => this.analytics.addCTE(alias, subquery));
+    for (const column of Object.keys(columns ?? {})) {
+      assertSafeIdentifier(column, 'CTE column');
+    }
+
+    const nextConfig = this.analytics.addCTE(alias, subquery);
+
+    // A raw body with no declared columns exposes nothing to type against, so
+    // the alias stays unregistered rather than registering an empty shape.
+    if (typeof subquery === 'string' && !columns) {
+      return this.assignQuery(this.cloneMutable(), nextConfig);
+    }
+
+    // Columns are carried by the state's type; a builder CTE takes its shape
+    // from the subquery's output type, so the runtime value stays empty.
+    const shape = columns ?? {};
+
+    const nextState = {
+      ...this.state,
+      ctes: { ...this.state.ctes, [alias]: shape },
+    };
+    return this.transition(nextState as any, nextConfig);
   }
 
   // --- Analytics Helper: Add a scalar WITH alias.
@@ -1075,32 +1125,22 @@ export class QueryBuilder<
     );
   }
 
-  innerJoin<TableName extends Extract<keyof Schema, string>, Alias extends string | undefined = undefined>(
+  innerJoin<TableName extends JoinableTable<State>, Alias extends string | undefined = undefined>(
     table: TableName,
     leftColumn: keyof BaseRow<State>,
-    rightColumn: `${TableName & string}.${keyof Schema[TableName] & string}`,
-    alias?: Alias
-  ): QueryBuilder<
-    Schema,
-    Alias extends string
-    ? AddAlias<WidenTables<State, TableName>, Alias, TableName>
-    : WidenTables<State, TableName>
-  > {
+    rightColumn: JoinRightColumn<State, TableName>,
+    alias?: JoinAliasArg<State, TableName, Alias>
+  ): QueryBuilder<Schema, JoinResultState<State, TableName, Alias>> {
     return this.applyJoin('INNER', table, leftColumn, rightColumn, alias);
   }
 
-  leftJoin<TableName extends Extract<keyof Schema, string>, Alias extends string | undefined = undefined>(
+  leftJoin<TableName extends JoinableTable<State>, Alias extends string | undefined = undefined>(
     table: TableName,
     leftColumn: keyof BaseRow<State>,
-    rightColumn: `${TableName & string}.${keyof Schema[TableName] & string}`,
-    alias?: Alias,
+    rightColumn: JoinRightColumn<State, TableName>,
+    alias?: JoinAliasArg<State, TableName, Alias>,
     on?: JoinConditionInput | JoinConditionInput[],
-  ): QueryBuilder<
-    Schema,
-    Alias extends string
-    ? AddAlias<WidenTables<State, TableName>, Alias, TableName>
-    : WidenTables<State, TableName>
-  > {
+  ): QueryBuilder<Schema, JoinResultState<State, TableName, Alias>> {
     return this.applyJoin('LEFT', table, leftColumn, rightColumn, alias, on);
   }
 
@@ -1109,64 +1149,43 @@ export class QueryBuilder<
    * right-side row per left row, so duplicate join keys never fan out the
    * result. Used by the semantic layer for to-one relationship traversal.
    */
-  leftAnyJoin<TableName extends Extract<keyof Schema, string>, Alias extends string | undefined = undefined>(
+  leftAnyJoin<TableName extends JoinableTable<State>, Alias extends string | undefined = undefined>(
     table: TableName,
     leftColumn: keyof BaseRow<State>,
-    rightColumn: `${TableName & string}.${keyof Schema[TableName] & string}`,
-    alias?: Alias,
+    rightColumn: JoinRightColumn<State, TableName>,
+    alias?: JoinAliasArg<State, TableName, Alias>,
     on?: JoinConditionInput | JoinConditionInput[],
-  ): QueryBuilder<
-    Schema,
-    Alias extends string
-    ? AddAlias<WidenTables<State, TableName>, Alias, TableName>
-    : WidenTables<State, TableName>
-  > {
+  ): QueryBuilder<Schema, JoinResultState<State, TableName, Alias>> {
     return this.applyJoin('LEFT ANY', table, leftColumn, rightColumn, alias, on);
   }
 
-  rightJoin<TableName extends Extract<keyof Schema, string>, Alias extends string | undefined = undefined>(
+  rightJoin<TableName extends JoinableTable<State>, Alias extends string | undefined = undefined>(
     table: TableName,
     leftColumn: keyof BaseRow<State>,
-    rightColumn: `${TableName & string}.${keyof Schema[TableName] & string}`,
-    alias?: Alias
-  ): QueryBuilder<
-    Schema,
-    Alias extends string
-    ? AddAlias<WidenTables<State, TableName>, Alias, TableName>
-    : WidenTables<State, TableName>
-  > {
+    rightColumn: JoinRightColumn<State, TableName>,
+    alias?: JoinAliasArg<State, TableName, Alias>
+  ): QueryBuilder<Schema, JoinResultState<State, TableName, Alias>> {
     return this.applyJoin('RIGHT', table, leftColumn, rightColumn, alias);
   }
 
-  fullJoin<TableName extends Extract<keyof Schema, string>, Alias extends string | undefined = undefined>(
+  fullJoin<TableName extends JoinableTable<State>, Alias extends string | undefined = undefined>(
     table: TableName,
     leftColumn: keyof BaseRow<State>,
-    rightColumn: `${TableName & string}.${keyof Schema[TableName] & string}`,
-    alias?: Alias
-  ): QueryBuilder<
-    Schema,
-    Alias extends string
-    ? AddAlias<WidenTables<State, TableName>, Alias, TableName>
-    : WidenTables<State, TableName>
-  > {
+    rightColumn: JoinRightColumn<State, TableName>,
+    alias?: JoinAliasArg<State, TableName, Alias>
+  ): QueryBuilder<Schema, JoinResultState<State, TableName, Alias>> {
     return this.applyJoin('FULL', table, leftColumn, rightColumn, alias);
   }
 
-  private applyJoin<TableName extends Extract<keyof Schema, string>, Alias extends string | undefined = undefined>(
+  private applyJoin<TableName extends JoinableTable<State>, Alias extends string | undefined = undefined>(
     type: JoinType,
     table: TableName,
     leftColumn: keyof BaseRow<State>,
-    rightColumn: `${TableName & string}.${keyof Schema[TableName] & string}`,
-    alias?: Alias,
+    rightColumn: JoinRightColumn<State, TableName>,
+    alias?: JoinAliasArg<State, TableName, Alias>,
     on?: JoinConditionInput | JoinConditionInput[],
-  ): QueryBuilder<
-    Schema,
-    Alias extends string
-    ? AddAlias<WidenTables<State, TableName>, Alias, TableName>
-    : WidenTables<State, TableName>
-  > {
-    type JoinedState = WidenTables<State, TableName>;
-    type NextState = Alias extends string ? AddAlias<JoinedState, Alias, TableName> : JoinedState;
+  ): QueryBuilder<Schema, JoinResultState<State, TableName, Alias>> {
+    type NextState = JoinResultState<State, TableName, Alias>;
 
     const nextAliases = (
       alias
@@ -1176,7 +1195,7 @@ export class QueryBuilder<
 
     const nextState = this.withAliasesState<NextState>(nextAliases);
 
-    const nextConfig = this.joins.addJoin(type, table, String(leftColumn), rightColumn, alias, undefined, on);
+    const nextConfig = this.joins.addJoin(type, String(table), String(leftColumn), String(rightColumn), alias, undefined, on);
     return this.transition<NextState>(nextState, nextConfig);
   }
 
@@ -1382,6 +1401,7 @@ export function createQueryBuilder<Schema extends SchemaDefinition<Schema>>(
         base: {} as SubqueryState['output'],
         aliases: {},
         scalars: {},
+        ctes: {},
       };
 
       const builder = new QueryBuilder<Schema, NextState>(

--- a/packages/clickhouse/src/core/query-node.ts
+++ b/packages/clickhouse/src/core/query-node.ts
@@ -96,7 +96,12 @@ export function createSelectQueryNode<TOutput, TSchema>(
     joins: config.joins
       ? config.joins.map(item => ({ ...item, on: cloneExprNode(item.on) }))
       : undefined,
-    ctes: config.ctes ? config.ctes.map(item => ({ ...item })) : undefined,
+    ctes: config.ctes
+      ? config.ctes.map(item => ({
+        ...item,
+        parameters: item.parameters ? [...item.parameters] : undefined,
+      }))
+      : undefined,
     unionQueries: config.unionQueries ? [...config.unionQueries] : undefined,
     settings: config.settings ? { ...config.settings } : undefined,
   };

--- a/packages/clickhouse/src/core/tests/query-builder-analytics.test.ts
+++ b/packages/clickhouse/src/core/tests/query-builder-analytics.test.ts
@@ -212,6 +212,91 @@ describe('QueryBuilder Analytics Features', () => {
         queryBuilder.withCTE('safe AS (SELECT 1) --', 'SELECT id FROM users')
       ).toThrow('Unsafe CTE alias identifier');
     });
+
+    it('should reject unsafe CTE column names', () => {
+      expect(() =>
+        queryBuilder.withCTE('summary', 'SELECT 1 AS id', { 'id, x --': 'UInt32' })
+      ).toThrow('Unsafe CTE column identifier');
+    });
+
+    it('keeps subquery values bound instead of inlining them', () => {
+      const subquery = builderUsers
+        .select(['id'])
+        .where('user_name', 'eq', "O'Brien");
+
+      const { sql, parameters } = queryBuilder
+        .withCTE('filtered_users', subquery)
+        .select(['id'])
+        .toSQLWithParams();
+
+      expect(sql).toBe(
+        'WITH filtered_users AS (SELECT id FROM users WHERE user_name = ?) SELECT id FROM test_table'
+      );
+      expect(parameters).toEqual(["O'Brien"]);
+    });
+
+    it('orders CTE parameters ahead of the outer query parameters', () => {
+      const subquery = builderUsers
+        .select(['id'])
+        .where('user_name', 'eq', 'inside');
+
+      const { sql, parameters } = queryBuilder
+        .withCTE('filtered_users', subquery)
+        .select(['id'])
+        .where('status', 'eq', 'outside')
+        .toSQLWithParams();
+
+      expect(sql).toBe(
+        'WITH filtered_users AS (SELECT id FROM users WHERE user_name = ?) ' +
+        'SELECT id FROM test_table WHERE status = ?'
+      );
+      expect(parameters).toEqual(['inside', 'outside']);
+    });
+
+    it('renders the same SQL as before once parameters are substituted', () => {
+      const subquery = builderUsers
+        .select(['id'])
+        .where('user_name', 'eq', "O'Brien");
+
+      const sql = queryBuilder
+        .withCTE('filtered_users', subquery)
+        .select(['id'])
+        .toSQL();
+
+      expect(sql).toBe(
+        "WITH filtered_users AS (SELECT id FROM users WHERE user_name = 'O''Brien') " +
+        'SELECT id FROM test_table'
+      );
+    });
+
+    it('keeps the rendered CTE string on the deprecated config surface', () => {
+      const subquery = builderUsers
+        .select(['id'])
+        .where('user_name', 'eq', "O'Brien");
+
+      const config = queryBuilder.withCTE('filtered_users', subquery).getConfig();
+
+      expect(config.ctes).toEqual([
+        "filtered_users AS (SELECT id FROM users WHERE user_name = 'O''Brien')"
+      ]);
+    });
+
+    it('joins a CTE alias declared with columns', () => {
+      const sql = queryBuilder
+        .withCTE('active_users', 'SELECT id, user_name FROM users', {
+          id: 'UInt32',
+          user_name: 'String',
+        })
+        .innerJoin('active_users', 'id', 'active_users.id')
+        .select(['test_table.id', 'active_users.user_name'])
+        .toSQL();
+
+      expect(sql).toBe(
+        'WITH active_users AS (SELECT id, user_name FROM users) ' +
+        'SELECT test_table.id, active_users.user_name FROM test_table ' +
+        'INNER JOIN active_users ON id = active_users.id'
+      );
+    });
   })
 
   describe('withScalar', () => {

--- a/packages/clickhouse/src/core/tests/test-utils.ts
+++ b/packages/clickhouse/src/core/tests/test-utils.ts
@@ -121,7 +121,8 @@ export function setupUsersBuilder(): SelectQB<TestSchema, 'users', TableRecord<T
     baseTable: 'users',
     base: TEST_SCHEMAS.users,
     aliases: {},
-    scalars: {}
+    scalars: {},
+    ctes: {}
   };
   return new QueryBuilder<TestSchema, UsersState>('users', state, createTestRuntime(), testAdapter, testDialect);
 }
@@ -134,7 +135,8 @@ export function setupTestBuilder(): SelectQB<TestSchema, 'test_table', TableReco
     baseTable: 'test_table',
     base: TEST_SCHEMAS.test_table,
     aliases: {},
-    scalars: {}
+    scalars: {},
+    ctes: {}
   };
   return new QueryBuilder<TestSchema, TestTableState>('test_table', state, createTestRuntime(), testAdapter, testDialect);
 }

--- a/packages/clickhouse/src/core/types/builder-state.ts
+++ b/packages/clickhouse/src/core/types/builder-state.ts
@@ -8,6 +8,15 @@ export type SchemaDefinition<Schema extends Record<string, any> = Record<string,
 
 export const SUBQUERY_SOURCE_TABLE = '__hypequery_internal_subquery_source__' as const;
 
+/**
+ * The columns a source exposes. Either schema-style `ColumnType` strings
+ * (`{ id: 'UUID' }`) or an already-resolved row type (`{ id: string }`), which
+ * is what a CTE built from another builder carries.
+ */
+export type ColumnShape = Record<string, unknown>;
+
+export type CteShapes = Record<string, ColumnShape>;
+
 export type BuilderState<
   Schema extends SchemaDefinition<Schema>,
   VisibleTables extends string,
@@ -15,7 +24,8 @@ export type BuilderState<
   BaseTable extends keyof Schema,
   Aliases extends Partial<Record<string, keyof Schema>> = {},
   Scalars extends Record<string, unknown> = {},
-  BaseShape extends Record<string, unknown> = Schema[BaseTable]
+  BaseShape extends Record<string, unknown> = Schema[BaseTable],
+  Ctes extends CteShapes = {}
 > = {
   schema: Schema;
   tables: VisibleTables;
@@ -24,19 +34,40 @@ export type BuilderState<
   base: BaseShape;
   aliases: Aliases;
   scalars: Scalars;
+  /**
+   * CTE aliases declared on this query, with the columns each exposes.
+   * Optional so hand-constructed states stay valid.
+   */
+  ctes?: Ctes;
 };
 
-export type AnyBuilderState = BuilderState<any, any, any, any, any, any, any>;
+export type AnyBuilderState = BuilderState<any, any, any, any, any, any, any, any>;
 
-export type BaseRow<State extends AnyBuilderState> = Simplify<{
-  [K in keyof State['base']]: State['base'][K] extends ColumnType
-  ? InferColumnType<State['base'][K]>
-  : State['base'][K];
+/**
+ * Resolves a column shape to the row type it produces. `ColumnType` strings are
+ * inferred; anything else is already a TypeScript type and passes through.
+ */
+export type RowFromShape<Shape> = Simplify<{
+  [K in keyof Shape]: Shape[K] extends ColumnType
+  ? InferColumnType<Shape[K]>
+  : Shape[K];
 }>;
+
+export type BaseRow<State extends AnyBuilderState> = RowFromShape<State['base']>;
+
+/** The CTE map, with the optionality of the state field resolved away. */
+export type StateCtes<State extends AnyBuilderState> = NonNullable<State['ctes']>;
+
+export type CteNames<State extends AnyBuilderState> = Extract<keyof StateCtes<State>, string>;
+
+/** Tables a join may target: schema tables plus CTEs declared on this query. */
+export type JoinableTable<State extends AnyBuilderState> =
+  | Extract<keyof State['schema'], string>
+  | CteNames<State>;
 
 export type WidenTables<
   State extends AnyBuilderState,
-  Table extends keyof State['schema']
+  Table extends keyof State['schema'] | CteNames<State>
 > = BuilderState<
   State['schema'],
   State['tables'] | (Table & string),
@@ -44,7 +75,8 @@ export type WidenTables<
   State['baseTable'],
   State['aliases'],
   State['scalars'],
-  State['base']
+  State['base'],
+  StateCtes<State>
 >;
 
 export type UpdateOutput<
@@ -57,7 +89,8 @@ export type UpdateOutput<
   State['baseTable'],
   State['aliases'],
   State['scalars'],
-  State['base']
+  State['base'],
+  StateCtes<State>
 >;
 
 export type InitialState<
@@ -93,7 +126,8 @@ export type AddAlias<
   State['baseTable'],
   State['aliases'] & Record<Alias, Table>,
   State['scalars'],
-  State['base']
+  State['base'],
+  StateCtes<State>
 >;
 
 export type AddScalar<
@@ -107,7 +141,51 @@ export type AddScalar<
   State['baseTable'],
   State['aliases'],
   State['scalars'] & Record<Alias, Value>,
-  State['base']
+  State['base'],
+  StateCtes<State>
+>;
+
+/** Columns accepted for a join's right-hand side, qualified by table or CTE. */
+export type JoinRightColumn<
+  State extends AnyBuilderState,
+  Table extends JoinableTable<State>
+> = `${Table}.${Extract<keyof ResolveTableSchema<State, Table>, string>}`;
+
+/**
+ * Joining a CTE cannot take a table alias: aliases resolve through the schema,
+ * and a CTE has no schema entry to resolve to.
+ */
+export type JoinAliasArg<
+  State extends AnyBuilderState,
+  Table extends JoinableTable<State>,
+  Alias
+> = Table extends CteNames<State> ? undefined : Alias;
+
+export type JoinResultState<
+  State extends AnyBuilderState,
+  Table extends JoinableTable<State>,
+  Alias
+> = Alias extends string
+  ? AddAlias<WidenTables<State, Table>, Alias, Extract<Table, keyof State['schema']>>
+  : WidenTables<State, Table>;
+
+/**
+ * Registers a CTE alias and the columns it exposes. The alias only becomes
+ * selectable once the query joins it, which mirrors SQL scoping.
+ */
+export type AddCte<
+  State extends AnyBuilderState,
+  Alias extends string,
+  Columns extends ColumnShape
+> = BuilderState<
+  State['schema'],
+  State['tables'],
+  State['output'],
+  State['baseTable'],
+  State['aliases'],
+  State['scalars'],
+  State['base'],
+  StateCtes<State> & Record<Alias, Columns>
 >;
 
 export type FromSubqueryState<
@@ -145,10 +223,16 @@ export type UpdateInsertRow<
   Row
 > = InsertState<State['schema'], State['table'], Row>;
 
+/**
+ * Resolves an identifier used in a query to the columns it exposes. CTEs are
+ * checked first because a CTE shadows a table of the same name in SQL.
+ */
 export type ResolveTableSchema<
   State extends AnyBuilderState,
   Table extends string
-> = Table extends keyof State['schema']
+> = Table extends keyof StateCtes<State>
+  ? StateCtes<State>[Table]
+  : Table extends keyof State['schema']
   ? State['schema'][Table]
   : Table extends keyof State['aliases']
   ? State['schema'][State['aliases'][Table]]

--- a/packages/clickhouse/src/core/types/builder-state.ts
+++ b/packages/clickhouse/src/core/types/builder-state.ts
@@ -171,7 +171,8 @@ export type JoinResultState<
 
 /**
  * Registers a CTE alias and the columns it exposes. The alias only becomes
- * selectable once the query joins it, which mirrors SQL scoping.
+ * selectable once the query joins it, which mirrors SQL scoping. A broad
+ * string alias remains untyped; registering it would shadow every schema table.
  */
 export type AddCte<
   State extends AnyBuilderState,
@@ -185,7 +186,7 @@ export type AddCte<
   State['aliases'],
   State['scalars'],
   State['base'],
-  StateCtes<State> & Record<Alias, Columns>
+  string extends Alias ? StateCtes<State> : StateCtes<State> & Record<Alias, Columns>
 >;
 
 export type FromSubqueryState<

--- a/packages/clickhouse/src/core/types/select-types.ts
+++ b/packages/clickhouse/src/core/types/select-types.ts
@@ -6,9 +6,9 @@ import { Simplify, UnionToIntersection } from './type-helpers.js';
 type TableIdentifiers<State extends AnyBuilderState> = State['tables'] & string;
 
 type QualifiedColumnsFor<State extends AnyBuilderState, Table extends string> =
-  ResolveTableSchema<State, Table> extends Record<string, ColumnType>
-  ? `${Table}.${Extract<keyof ResolveTableSchema<State, Table>, string>}`
-  : never;
+  [ResolveTableSchema<State, Table>] extends [never]
+  ? never
+  : `${Table}.${Extract<keyof ResolveTableSchema<State, Table>, string>}`;
 
 export type QualifiedColumnKeys<State extends AnyBuilderState> = {
   [Table in TableIdentifiers<State>]: QualifiedColumnsFor<State, Table>
@@ -38,12 +38,12 @@ export type ColumnSelectionKey<P> = P extends `${string}.${infer C}` ? C : P;
 
 type QualifiedColumnValue<State extends AnyBuilderState, P> =
   P extends `${infer Table}.${infer Column}`
-  ? ResolveTableSchema<State, Table> extends Record<string, ColumnType>
-  ? Column extends keyof ResolveTableSchema<State, Table>
+  ? [ResolveTableSchema<State, Table>] extends [never]
+  ? never
+  : Column extends keyof ResolveTableSchema<State, Table>
   ? ResolveTableSchema<State, Table>[Column] extends ColumnType
   ? InferColumnType<ResolveTableSchema<State, Table>[Column]>
-  : never
-  : never
+  : ResolveTableSchema<State, Table>[Column]
   : never
   : never;
 

--- a/packages/clickhouse/src/core/utils/cte-fragments.ts
+++ b/packages/clickhouse/src/core/utils/cte-fragments.ts
@@ -1,0 +1,28 @@
+import type { DatabaseAdapter } from '../adapters/database-adapter.js';
+import type { CteNode } from '../../types/index.js';
+import { substituteParameters } from '../utils.js';
+
+/**
+ * Renders a CTE body to a standalone string with its values inlined, following
+ * the same path `toSQL()` uses so adapter-specific rendering is preserved.
+ */
+export function renderCteBody(
+  body: string,
+  parameters: readonly unknown[],
+  adapter: DatabaseAdapter,
+): string {
+  return adapter.render
+    ? adapter.render(body, [...parameters])
+    : substituteParameters(body, parameters);
+}
+
+/**
+ * The compilable form of a CTE entry. Structured entries keep their parameters
+ * bound; entries that predate the structured fields fall back to the rendered
+ * `expression`, which has its values already inlined.
+ */
+export function cteFragment(node: CteNode): { sql: string; parameters: readonly unknown[] } {
+  return node.name !== undefined && node.body !== undefined
+    ? { sql: `${node.name} AS (${node.body})`, parameters: node.parameters ?? [] }
+    : { sql: node.expression, parameters: [] };
+}

--- a/packages/clickhouse/src/types/base.ts
+++ b/packages/clickhouse/src/types/base.ts
@@ -148,7 +148,21 @@ export interface LimitByNode {
 
 export interface CteNode {
   kind: 'cte';
+  /**
+   * The entry as a single rendered fragment, with any parameter values already
+   * substituted. Kept as the canonical field so consumers reading it keep
+   * working; compilation prefers `name`/`body` when they are present.
+   */
   expression: string;
+  /** CTE alias. Present for named CTEs, absent for `withScalar` entries. */
+  name?: string;
+  /**
+   * The CTE body with `?` placeholders left in place, so its values can stay
+   * bound instead of being escaped into `expression`.
+   */
+  body?: string;
+  /** Values for the placeholders in `body`, in order. */
+  parameters?: unknown[];
 }
 
 export interface SelectQueryNode<T, Schema> extends QueryConfig<T, Schema> {

--- a/packages/clickhouse/type-tests/query-builder-types.test.ts
+++ b/packages/clickhouse/type-tests/query-builder-types.test.ts
@@ -447,3 +447,30 @@ type AliasedSchemaJoinExpected = { id: number; user_name: string }[];
 type AssertAliasedSchemaJoin = Expect<
   Equal<AliasedSchemaJoinResult, AliasedSchemaJoinExpected>
 >;
+
+// Runtime aliases must not introduce a string index signature into CTE state.
+declare const runtimeCteAlias: string;
+const dynamicBuilderCte = builder.withCTE(runtimeCteAlias, activeUsers);
+const dynamicRawCte = builder.withCTE(runtimeCteAlias, 'SELECT id FROM users', { cte_only: 'Int32' });
+const dynamicSchemaJoin = dynamicBuilderCte
+  .innerJoin('users', 'created_by', 'users.id', 'creator')
+  .select(['id', 'creator.user_name']);
+type DynamicSchemaJoinResult = Awaited<ReturnType<typeof dynamicSchemaJoin.execute>>;
+type AssertDynamicSchemaJoin = Expect<Equal<DynamicSchemaJoinResult, { id: number; user_name: string }[]>>;
+const dynamicRawSchemaJoin = dynamicRawCte
+  .innerJoin('users', 'created_by', 'users.id', 'creator')
+  .select(['id', 'creator.user_name']);
+type DynamicRawSchemaJoinResult = Awaited<ReturnType<typeof dynamicRawSchemaJoin.execute>>;
+type AssertDynamicRawSchemaJoin = Expect<Equal<DynamicRawSchemaJoinResult, { id: number; user_name: string }[]>>;
+// @ts-expect-error - runtime aliases do not make arbitrary targets joinable
+dynamicBuilderCte.innerJoin('undeclared', 'created_by', 'undeclared.id');
+// @ts-expect-error - declared raw columns with runtime aliases cannot shadow a real table
+dynamicRawCte.innerJoin('users', 'created_by', 'users.cte_only');
+// @ts-expect-error - arbitrary targets remain invalid for raw CTEs as well
+dynamicRawCte.innerJoin('undeclared', 'created_by', 'undeclared.cte_only');
+const literalAfterDynamic = dynamicRawCte
+  .withCTE('active_users', activeUsers)
+  .innerJoin('active_users', 'created_by', 'active_users.id')
+  .select(['id', 'active_users.user_name']);
+type LiteralAfterDynamicResult = Awaited<ReturnType<typeof literalAfterDynamic.execute>>;
+type AssertLiteralAfterDynamic = Expect<Equal<LiteralAfterDynamicResult, { id: number; user_name: string }[]>>;

--- a/packages/clickhouse/type-tests/query-builder-types.test.ts
+++ b/packages/clickhouse/type-tests/query-builder-types.test.ts
@@ -474,3 +474,7 @@ const literalAfterDynamic = dynamicRawCte
   .select(['id', 'active_users.user_name']);
 type LiteralAfterDynamicResult = Awaited<ReturnType<typeof literalAfterDynamic.execute>>;
 type AssertLiteralAfterDynamic = Expect<Equal<LiteralAfterDynamicResult, { id: number; user_name: string }[]>>;
+
+// The original API accepts a body selected dynamically between SQL and a builder.
+const unionCteBody = Math.random() > 0.5 ? 'SELECT id FROM users' : activeUsers;
+builder.withCTE('dynamic_body', unionCteBody).select(['id']);

--- a/packages/clickhouse/type-tests/query-builder-types.test.ts
+++ b/packages/clickhouse/type-tests/query-builder-types.test.ts
@@ -7,6 +7,7 @@ import { rawAs } from '../src/core/utils/sql-expressions.js';
 import type { Equal, Expect } from '@type-challenges/utils';
 
 const builder = setupTestBuilder();
+const builderUsers = setupUsersBuilder();
 type BuilderStateType = typeof builder extends QueryBuilder<any, infer S> ? S : never;
 
 const db = createQueryBuilder<TestSchema>({
@@ -382,3 +383,67 @@ relationships.defineChain('invalidCreatorChain', [
     rightColumn: 'updated_by',
   },
 ] as const);
+
+// --- CTE aliases as typed join targets ---
+
+const activeUsers = builderUsers
+  .select(['id', 'user_name'])
+  .where('is_active', 'eq', true);
+
+// Columns come from the builder passed to withCTE.
+const joinedBuilderCte = builder
+  .withCTE('active_users', activeUsers)
+  .innerJoin('active_users', 'created_by', 'active_users.id')
+  .select(['id', 'active_users.user_name']);
+type JoinedBuilderCteResult = Awaited<ReturnType<typeof joinedBuilderCte.execute>>;
+type JoinedBuilderCteExpected = { id: number; user_name: string }[];
+type AssertJoinedBuilderCte = Expect<
+  Equal<JoinedBuilderCteResult, JoinedBuilderCteExpected>
+>;
+
+// Columns declared alongside a raw SQL body resolve through the schema vocabulary.
+const joinedRawCte = builder
+  .withCTE('recent_orders', 'SELECT user_id, total FROM orders', {
+    user_id: 'Int32',
+    total: 'Float64',
+  })
+  .innerJoin('recent_orders', 'created_by', 'recent_orders.user_id')
+  .select(['id', 'recent_orders.total']);
+type JoinedRawCteResult = Awaited<ReturnType<typeof joinedRawCte.execute>>;
+type JoinedRawCteExpected = { id: number; total: number }[];
+type AssertJoinedRawCte = Expect<Equal<JoinedRawCteResult, JoinedRawCteExpected>>;
+
+// A CTE column can be filtered on once the CTE is joined.
+builder
+  .withCTE('active_users', activeUsers)
+  .innerJoin('active_users', 'created_by', 'active_users.id')
+  .where('active_users.user_name', 'eq', 'ada');
+
+builder
+  .withCTE('active_users', activeUsers)
+  // @ts-expect-error - columns the CTE does not expose are rejected on the join
+  .innerJoin('active_users', 'created_by', 'active_users.missing');
+
+builder
+  .withCTE('untyped_cte', 'SELECT id FROM users')
+  // @ts-expect-error - a raw CTE with no declared columns is not a typed join target
+  .innerJoin('untyped_cte', 'created_by', 'untyped_cte.id');
+
+builder
+  .withCTE('active_users', activeUsers)
+  // @ts-expect-error - a CTE join cannot take a table alias, which resolves through the schema
+  .innerJoin('active_users', 'created_by', 'active_users.id', 'au');
+
+// @ts-expect-error - an undeclared CTE name is not joinable
+builder.innerJoin('never_declared', 'created_by', 'never_declared.id');
+
+// Schema tables keep their existing join behaviour, aliases included.
+const aliasedSchemaJoin = builder
+  .withCTE('active_users', activeUsers)
+  .innerJoin('users', 'created_by', 'users.id', 'creator')
+  .select(['id', 'creator.user_name']);
+type AliasedSchemaJoinResult = Awaited<ReturnType<typeof aliasedSchemaJoin.execute>>;
+type AliasedSchemaJoinExpected = { id: number; user_name: string }[];
+type AssertAliasedSchemaJoin = Expect<
+  Equal<AliasedSchemaJoinResult, AliasedSchemaJoinExpected>
+>;

--- a/website-next/docs/capabilities.mdx
+++ b/website-next/docs/capabilities.mdx
@@ -28,7 +28,7 @@ This page records the shipped surface of hypequery as of **21 August 2026**. It 
 | `ReplacingMergeTree` `FINAL` | Native | `final()` |
 | Array expansion | Native | `arrayJoin()`, `leftArrayJoin()` |
 | Totals and distinct results | Native | `withTotals()`, `distinct()` |
-| CTEs | Native | `withCTE()` with a builder or SQL body |
+| CTEs | Native | `withCTE()` with a builder or SQL body; the alias is a typed join target when its columns are known |
 | Subqueries in `FROM` | Native | `from(queryBuilder)` with the nested output as the outer typed column scope |
 | ClickHouse settings | Native | `settings()` |
 | Streaming | Native | `stream()`, `streamForEach()` |

--- a/website-next/docs/query-building/subqueries-ctes.mdx
+++ b/website-next/docs/query-building/subqueries-ctes.mdx
@@ -143,7 +143,8 @@ as a generated schema, and it is an assertion: nothing checks it against the SQL
 so a wrong declaration surfaces at runtime rather than at compile time.
 
 Without the third argument the CTE still works and still renders, but its alias
-stays untyped and cannot be used as a join target.
+stays untyped and cannot be used as a join target. A runtime alias typed as
+`string` also stays untyped; use a literal alias when you need typed joins.
 
 ### Multiple CTEs
 

--- a/website-next/docs/query-building/subqueries-ctes.mdx
+++ b/website-next/docs/query-building/subqueries-ctes.mdx
@@ -97,6 +97,20 @@ FROM orders
 INNER JOIN active_users ON orders.user_id = active_users.id
 ```
 
+Because the CTE was built from a query builder, hypequery knows which columns it
+exposes. The alias becomes a typed join target: `active_users.id` and
+`active_users.user_name` are checked, and `active_users.user_name` carries the
+inner query's type through to the result row.
+
+Values inside a builder CTE stay bound as query parameters rather than being
+escaped into the SQL string, exactly as they are in the outer query.
+
+<Callout type="info" title="Aliasing a CTE join">
+  A CTE join does not take the trailing table-alias argument that a schema-table
+  join accepts — aliases are resolved through the schema, and a CTE has no schema
+  entry. Reference the CTE by its own name instead.
+</Callout>
+
 ### Using Raw SQL as a CTE
 
 For more complex subqueries, you can use raw SQL strings:
@@ -108,20 +122,28 @@ const results = await db
   .table('orders')
   .withCTE(
     'monthly_totals',
-    'SELECT user_id, toStartOfMonth(created_at) as month, SUM(total) as monthly_sum FROM orders GROUP BY user_id, month'
+    'SELECT user_id, toStartOfMonth(created_at) as month, SUM(total) as monthly_sum FROM orders GROUP BY user_id, month',
+    { user_id: 'UInt64', month: 'Date', monthly_sum: 'Float64' }
   )
+  .innerJoin('monthly_totals', 'user_id', 'monthly_totals.user_id')
   .select([
     'orders.id',
     'orders.created_at',
     'monthly_totals.monthly_sum'
   ])
-  .innerJoin('monthly_totals', 'user_id', 'monthly_totals.user_id')
-  .where('orders.created_at', 'gte', 'monthly_totals.month')
   .execute();
 
 ```
 
 </CodeBlock>
+
+A raw SQL body is opaque to hypequery, so declare the columns it produces to get
+the same typing a builder CTE gets. The declaration uses the same column types
+as a generated schema, and it is an assertion: nothing checks it against the SQL,
+so a wrong declaration surfaces at runtime rather than at compile time.
+
+Without the third argument the CTE still works and still renders, but its alias
+stays untyped and cannot be used as a join target.
 
 ### Multiple CTEs
 
@@ -138,10 +160,11 @@ const results = await db
   )
   .withCTE(
     'active_users',
-    'SELECT user_id, COUNT(DISTINCT day) as active_days FROM daily_users GROUP BY user_id HAVING active_days > 7'
+    'SELECT user_id, COUNT(DISTINCT day) as active_days FROM daily_users GROUP BY user_id HAVING active_days > 7',
+    { user_id: 'UInt64', active_days: 'UInt64' }
   )
-  .select(['events.*'])
   .innerJoin('active_users', 'user_id', 'active_users.user_id')
+  .select(['events.*'])
   .execute();
 
 ```


### PR DESCRIPTION
Fixes two pre-existing defects in `withCTE`, split out of the recursive-CTE design work so that feature can be argued on its own merits.

## 1. CTE aliases were never typed

`innerJoin` and friends constrained their table argument to `keyof Schema`, so joining a CTE only compiled when its alias happened to name a real schema table. The documented example in `subqueries-ctes.mdx` was relying on that coincidence.

`BuilderState` now carries the CTEs declared on a query, and both typing paths route through `ResolveTableSchema`, so joins, qualified selects (`alias.column`) and filters are all checked and the column types reach the result row.

```ts
// columns derived from the builder's output type
const activeUsers = db.table('users').select(['id', 'user_name']).where('is_active', 'eq', true);

db.table('orders')
  .withCTE('active_users', activeUsers)
  .innerJoin('active_users', 'user_id', 'active_users.id')
  .select(['orders.id', 'active_users.user_name']);

// columns declared for a raw SQL body
db.table('orders')
  .withCTE('monthly_totals', 'SELECT user_id, SUM(total) AS monthly_sum FROM orders GROUP BY user_id', {
    user_id: 'UInt64',
    monthly_sum: 'Float64',
  })
  .innerJoin('monthly_totals', 'user_id', 'monthly_totals.user_id');
```

Two deliberate limits, both covered by `@ts-expect-error` type tests:

- A raw CTE with **no** declared columns behaves exactly as before — it renders, but its alias is not a typed join target. There is nothing to type it from.
- Joining a CTE rejects the trailing table-alias argument. Aliases resolve through the schema and a CTE has no schema entry, so supporting one would mean weakening the `Aliases` constraint for every join.

The column declaration is an assertion, not a derivation — nothing checks it against the raw SQL, same trust model as `rawAs<T, Alias>()`. Documented as such.

## 2. CTE values were escaped inline

`addCTE` rendered a builder subquery with `toSQL()`, which substitutes parameters, so CTE values were escaped into the SQL string while the rest of the query used bound parameters. The node now keeps the body's placeholders alongside its parameters, and the dialect contributes them ahead of the outer query's — correct ordering, since `WITH` renders first.

```
WITH filtered_users AS (SELECT id FROM users WHERE user_name = ?) SELECT id FROM test_table WHERE status = ?
parameters: ['inside', 'outside']
```

Rendered SQL is unchanged, and `expression` still holds the rendered entry so the deprecated `getConfig()` surface keeps its current output. Both are covered by tests.

## Compatibility

- `ctes` is **optional** on `BuilderState` — an earlier draft made it required and broke a type test that hand-constructs a state, which is a good proxy for anyone doing the same.
- `CteNode` keeps `expression` as its canonical field; `name`/`body`/`parameters` are additive.
- `withCTE`'s existing two-argument calls are unchanged at runtime and in rendered SQL.

## Not included

`withScalar` still inlines its parameters the same way. It is the same class of issue and the same machinery would fix it, but it is a separate change with its own test surface.

## Testing

- `pnpm test` — 18/18 tasks, 676 unit tests, type tests included
- `pnpm lint` — clean
- New unit tests: parameter binding, parameter ordering across `WITH` → `FROM` → `WHERE`, unchanged rendered SQL, unchanged `getConfig()` output, CTE column identifier validation, and a joined raw CTE
- New type tests: builder-derived and declared-column joins, filtering a CTE column, plus the three negative cases above

🤖 Generated with [Claude Code](https://claude.com/claude-code)