### PR TITLE
test(specs): exercise a derived metric in the vertical-slice fixture

### DIFF
--- a/packages/datasets/src/protocol-rehydrate.test.ts
+++ b/packages/datasets/src/protocol-rehydrate.test.ts
@@ -46,6 +46,45 @@ function roundTrip(
   });
 }
 
+/** Renders each builder call into readable SQL so a plan can be asserted on. */
+function renderingBuilder() {
+  const build = (table: string) => {
+    const select: string[] = [];
+    const where: string[] = [];
+    const groupBy: string[] = [];
+    const agg = (fn: string) => (column: string, alias?: string) => {
+      select.push(`${fn}(${column}) AS ${alias ?? column}`);
+      return builder;
+    };
+    const builder: Record<string, unknown> = {
+      select: (columns: string | string[]) => {
+        select.push(...(Array.isArray(columns) ? columns : [columns]));
+        return builder;
+      },
+      sum: agg('SUM'),
+      count: agg('COUNT'),
+      groupBy: (columns: string | string[]) => {
+        groupBy.push(...(Array.isArray(columns) ? columns : [columns]));
+        return builder;
+      },
+      where: (column: string, operator: string, value: unknown) => {
+        where.push(`${column} ${operator} ${JSON.stringify(value)}`);
+        return builder;
+      },
+      toSQLWithParams: () => ({
+        sql: `SELECT ${select.join(', ')} FROM ${table}`
+          + (where.length > 0 ? ` WHERE ${where.join(' AND ')}` : '')
+          + (groupBy.length > 0 ? ` GROUP BY ${groupBy.join(', ')}` : ''),
+        parameters: [],
+      }),
+    };
+    return new Proxy(builder, {
+      get: (target, property: string) => target[property] ?? (() => builder),
+    });
+  };
+  return { table: build, rawQuery: async () => [] };
+}
+
 /**
  * A dataset carrying a derived metric, authored rather than hand-written, so
  * the contract under test is the one the adapter actually emits.
@@ -109,6 +148,39 @@ describe('contract-to-catalog rehydration', () => {
     };
     const registry = rehydrateProtocolDatasets([contract, ...deployment.datasets.filter(item => item.name !== source.name)]);
     expect(roundTrip(contract, registry as never)).toEqual(contract);
+  });
+
+  it('plans the fixture\'s derived metric under the aliases it declared', () => {
+    const registry = rehydrateProtocolDatasets(deployment.datasets);
+    const client = createDatasetClient({ queryBuilder: renderingBuilder() });
+
+    const sql = client.toSQL(
+      registry.orders.metrics.averageOrderValue as never,
+      { dimensions: ['region'] } as never,
+      { runtime: { tenant: 'tenant_acme' } } as never,
+    );
+
+    // The formula, written in the aliases the contract carried, over an
+    // intermediate aggregate whose columns are those same aliases. Nothing here
+    // came from a customer module.
+    expect(sql).toContain('(revenue) / (NULLIF(orders, 0)) AS averageOrderValue');
+    expect(sql).toContain('SUM(amount) AS revenue');
+    expect(sql).toContain('COUNT(order_id) AS orders');
+    expect(sql).toContain('analytics.orders');
+    expect(sql).toContain('tenant_acme');
+  });
+
+  it('keeps a derived metric\'s formula out of the agent-safe catalog', () => {
+    const [orders] = projectAgentSafeCatalog(deployment).datasets;
+    const metric = orders.metrics.find(entry => entry.name === 'averageOrderValue');
+
+    // The formula names measure input fields and aggregations, which the safe
+    // projection exists to withhold. An agent is told the metric exists and
+    // what it can be grouped, filtered, and grained by — not how it is computed.
+    expect(metric).toBeDefined();
+    expect(JSON.stringify(metric)).not.toContain('derivation');
+    expect(JSON.stringify(metric)).not.toContain('amount');
+    expect(JSON.stringify(metric)).not.toContain('aggregate');
   });
 
   it('restores the physical mappings execution needs', () => {
@@ -330,10 +402,14 @@ describe('contract-to-catalog rehydration', () => {
   });
 
   it('fails closed on a metric with no matching measure', () => {
+    // Selected by name, not position: the fixture's metric list is ordered and
+    // may grow, and an index would quietly retarget this at another metric.
+    const source = deployment.datasets.find(item => item.name === 'orders')!;
+    const base = source.metrics.find(item => item.name === 'totalRevenue')!;
     const orphaned = {
-      ...deployment.datasets[0],
+      ...source,
       metrics: [{
-        ...deployment.datasets[0].metrics[0],
+        ...base,
         expression: { kind: 'aggregate' as const, aggregation: 'avg' as const, field: 'amount' },
       }],
     };

--- a/specs/deployment/fixtures/mcp-cloud-v1/README.md
+++ b/specs/deployment/fixtures/mcp-cloud-v1/README.md
@@ -12,7 +12,7 @@ protocol RFC and conformance process.
 
 | File | Purpose |
 | --- | --- |
-| [`deployment.json`](./deployment.json) | Valid deployment contract v1 with one tenant-scoped orders dataset and one named metric |
+| [`deployment.json`](./deployment.json) | Valid deployment contract v1 with one tenant-scoped orders dataset, one named metric, and one derived metric |
 | [`context.json`](./context.json) | Fixed target, generation, authorized principal, and server-resolved tenant used by hosted tests |
 | [`expected-safe-catalog.json`](./expected-safe-catalog.json) | Logical agent-safe projection expected from the deployment |
 | [`expected-tools.json`](./expected-tools.json) | Deterministic MCP `tools/list` result for compatibility-tool mode |
@@ -24,7 +24,7 @@ protocol RFC and conformance process.
 The canonical deployment contract identity is:
 
 ```text
-2d71d44577daffdc952ef55d640ece588a74fc6493f0857c5851325745af890a
+94ff668005c4a9496ad27dd9faddb896261001d1607278dfe8d713f7008af51e
 ```
 
 It is SHA-256 over the deployment v1 identity domain followed by the RFC 8785
@@ -44,7 +44,8 @@ compatibility tools, sorted by name:
 
 The generated schemas must:
 
-- advertise only the `orders` dataset and `totalRevenue` metric;
+- advertise only the `orders` dataset and the `averageOrderValue` and
+  `totalRevenue` metrics;
 - advertise exact logical dimensions, measures, filters, operators, grains,
   order fields, and limits;
 - require at least one dimension or measure for `query_dataset`;
@@ -59,7 +60,10 @@ The safe catalog and tool manifest must not expose:
 - mappings to physical columns such as `created_at`, `order_id`, or the internal
   non-queryable `amount` field;
 - measure input fields or aggregation implementation details;
-- runtime artifacts, SQL, credentials, roles, or scopes.
+- runtime artifacts, SQL, credentials, roles, or scopes; or
+- a derived metric's `derivation` — its inputs and formula are physical detail,
+  and the safe catalog publishes only that the metric exists and what it can be
+  grouped, filtered, and grained by.
 
 The generic dataset description in the expected safe catalog is a deterministic
 fallback because deployment contract v1 does not yet carry dataset-level
@@ -83,7 +87,10 @@ the fixture never executes the SQL.
    produce `expected-tools.json` from one catalog generator.
 2. `CORE-06` validates the safe catalog and forbidden physical fields.
 3. `CORE-12` activates the contract and executes dataset/metric calls with the
-   pinned principal, tenant, and activation revision.
+   pinned principal, tenant, and activation revision. `CORE-17` adds
+   `averageOrderValue`, whose `derivation` carries the formula under the aliases
+   it was authored with, so a rebuilt catalog emits the same SQL rather than
+   merely the same number.
 4. `CLOUD-04` runs the same calls through Streamable HTTP.
 5. `CORE-13` and `AGENT-04` replay `questions.json` through local, hosted, and
    agent paths.

--- a/specs/deployment/fixtures/mcp-cloud-v1/context.json
+++ b/specs/deployment/fixtures/mcp-cloud-v1/context.json
@@ -6,7 +6,7 @@
   "activationRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "releaseIdentity": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "bundleIdentity": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-  "deploymentIdentity": "2d71d44577daffdc952ef55d640ece588a74fc6493f0857c5851325745af890a",
+  "deploymentIdentity": "94ff668005c4a9496ad27dd9faddb896261001d1607278dfe8d713f7008af51e",
   "principal": {
     "subject": "user_ada",
     "roles": [

--- a/specs/deployment/fixtures/mcp-cloud-v1/deployment.json
+++ b/specs/deployment/fixtures/mcp-cloud-v1/deployment.json
@@ -133,6 +133,105 @@
       ],
       "metrics": [
         {
+          "name": "averageOrderValue",
+          "kind": "derived-metric",
+          "expression": {
+            "kind": "binary",
+            "operator": "divide",
+            "left": {
+              "kind": "aggregate",
+              "aggregation": "sum",
+              "field": "amount"
+            },
+            "right": {
+              "kind": "call",
+              "function": "nullIfZero",
+              "args": [
+                {
+                  "kind": "aggregate",
+                  "aggregation": "count",
+                  "field": "orderId"
+                }
+              ]
+            }
+          },
+          "derivation": {
+            "inputs": [
+              {
+                "alias": "revenue",
+                "expression": {
+                  "kind": "aggregate",
+                  "aggregation": "sum",
+                  "field": "amount"
+                }
+              },
+              {
+                "alias": "orders",
+                "expression": {
+                  "kind": "aggregate",
+                  "aggregation": "count",
+                  "field": "orderId"
+                }
+              }
+            ],
+            "expression": {
+              "kind": "binary",
+              "operator": "divide",
+              "left": {
+                "kind": "reference",
+                "name": "revenue"
+              },
+              "right": {
+                "kind": "call",
+                "function": "nullIfZero",
+                "args": [
+                  {
+                    "kind": "reference",
+                    "name": "orders"
+                  }
+                ]
+              }
+            }
+          },
+          "dimensions": [
+            "createdAt",
+            "region",
+            "status"
+          ],
+          "filters": [
+            "createdAt",
+            "region",
+            "status"
+          ],
+          "grains": [
+            "day",
+            "month",
+            "quarter",
+            "week",
+            "year"
+          ],
+          "label": "Average order value",
+          "description": "Revenue divided by order count, in USD.",
+          "endpoint": {
+            "access": {
+              "kind": "authenticated",
+              "roles": [
+                "analytics_reader"
+              ],
+              "scopes": [
+                "datasets:query"
+              ]
+            },
+            "tenant": {
+              "kind": "required",
+              "mode": "auto-inject",
+              "column": "tenant_id"
+            },
+            "maxLimit": 100,
+            "path": "/api/analytics/metrics/averageOrderValue"
+          }
+        },
+        {
           "name": "totalRevenue",
           "kind": "metric",
           "expression": {

--- a/specs/deployment/fixtures/mcp-cloud-v1/expected-safe-catalog.json
+++ b/specs/deployment/fixtures/mcp-cloud-v1/expected-safe-catalog.json
@@ -52,6 +52,28 @@
       ],
       "metrics": [
         {
+          "name": "averageOrderValue",
+          "label": "Average order value",
+          "description": "Revenue divided by order count, in USD.",
+          "dimensions": [
+            "createdAt",
+            "region",
+            "status"
+          ],
+          "filters": [
+            "createdAt",
+            "region",
+            "status"
+          ],
+          "grains": [
+            "day",
+            "month",
+            "quarter",
+            "week",
+            "year"
+          ]
+        },
+        {
           "name": "totalRevenue",
           "label": "Total revenue",
           "description": "Total order revenue in USD.",

--- a/specs/deployment/fixtures/mcp-cloud-v1/expected-tools.json
+++ b/specs/deployment/fixtures/mcp-cloud-v1/expected-tools.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "com.hypequery/activationRevision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "com.hypequery/deploymentIdentity": "2d71d44577daffdc952ef55d640ece588a74fc6493f0857c5851325745af890a",
+    "com.hypequery/deploymentIdentity": "94ff668005c4a9496ad27dd9faddb896261001d1607278dfe8d713f7008af51e",
     "com.hypequery/toolMode": "catalog"
   },
   "tools": [
@@ -558,6 +558,7 @@
           "metric": {
             "type": "string",
             "enum": [
+              "averageOrderValue",
               "totalRevenue"
             ]
           },
@@ -654,6 +655,7 @@
                 "field": {
                   "type": "string",
                   "enum": [
+                    "averageOrderValue",
                     "createdAt",
                     "period",
                     "region",

--- a/specs/deployment/fixtures/mcp-cloud-v1/questions.json
+++ b/specs/deployment/fixtures/mcp-cloud-v1/questions.json
@@ -44,6 +44,35 @@
     ]
   },
   {
+    "id": "average-order-value-by-region",
+    "question": "What is our average order value by region?",
+    "expectedTool": "query_metric",
+    "expectedArguments": {
+      "dataset": "orders",
+      "metric": "averageOrderValue",
+      "dimensions": [
+        "region"
+      ],
+      "orderBy": [
+        {
+          "field": "region",
+          "direction": "asc"
+        }
+      ],
+      "limit": 100
+    },
+    "expectedRows": [
+      {
+        "region": "eu",
+        "averageOrderValue": 62.5
+      },
+      {
+        "region": "us",
+        "averageOrderValue": 50
+      }
+    ]
+  },
+  {
     "id": "orders-by-status",
     "question": "How many orders are in each status?",
     "expectedTool": "query_dataset",


### PR DESCRIPTION
Stacked on #465. The follow-up that PR's description deferred.

## Why

`specs/deployment/fixtures/mcp-cloud-v1/` carried only a base metric, so the shared fixture never exercised the surface CORE-17 made portable, and the safe-catalog snapshot could not demonstrate what a `derivation` does and does not publish.

## The metric

`averageOrderValue` = `revenue / nullIfZero(orderCount)`, over the two measures the fixture already declares. Same dimensions, filters, and grains as `totalRevenue`, so the change is about the derivation rather than about widening the model — and so the `query_metric` schema's dimension/order-field union is unchanged apart from the metric name itself.

## Two tests read it

- It compiles to `(revenue) / (NULLIF(orders, 0)) AS averageOrderValue` over an intermediate aggregate whose columns are `SUM(amount) AS revenue` and `COUNT(order_id) AS orders` — the aliases the contract declared, from the contract alone, with no customer module loaded.
- The agent-safe projection withholds the formula. It names measure input fields and aggregations, which is exactly what that projection exists to withhold; an agent learns the metric exists and what it can be grouped, filtered, and grained by.

## Regenerated, not hand-edited

The contract identity changes, so `context.json`, the README's pinned identity, and the `_meta` block of `expected-tools.json` move to `94ff6680…`. `expected-safe-catalog.json` is reprojected from the contract by running the real projection.

One exception, called out because it is a hand edit: **`expected-tools.json` is not asserted by any test**, and no code emits catalog-mode tools yet — it is a specification of what CLOUD-03 must produce, not an artifact anything currently generates. Its two metric enums (`query_metric.metric` and `orderBy.field`) are therefore updated by hand. The diff is three lines.

## Incidental fix

`fails closed on a metric with no matching measure` selected a fixture metric by index, so it silently retargeted from `totalRevenue` to `averageOrderValue` when the list grew — and passed for the wrong reason until it didn't. It selects by name now. An ordered fixture that may grow should not be addressed positionally; the other index-based accesses in the suite are against locally-built contracts, not this one.

## Not included

The new question is grouped by region: 125/2 and 50/1 are exact under the seeded rows, where the ungrouped 175/3 is not, and I would rather not pin a rounded expectation into a fixture whose point is determinism.

No package source changed — spec fixture and tests only, so no changeset. Tests green across protocol (547), datasets (683), mcp (122), serve (550), deployment (153), and cli (602); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)