### PR TITLE
feat(mcp): bound the tool manifest, not only the queries (MCP-102)

### DIFF
--- a/.changeset/mcp-catalog-budget.md
+++ b/.changeset/mcp-catalog-budget.md
@@ -1,0 +1,34 @@
+---
+"@hypequery/mcp": minor
+---
+
+Bound the tool manifest itself, not only the queries it describes.
+
+Every existing budget limits one call. None limited what a client is handed
+before it makes one — and that is the part that grows with the deployment:
+`query_dataset` and `query_metric` carry exact enums of every published dataset,
+dimension, measure, and filter field, so the manifest scales with the catalog
+while the tool count stays at four. A two-dataset catalog already compiles to
+roughly 13.7 KiB, nearly all of it those enums. Every client pays it on every
+connection, and a model pays it out of context before a question is asked.
+
+`MCPCatalogBudget` adds two ceilings, configurable on both
+`HypequeryMCPExecutor` and `createMCPDiscoveryExecutor`:
+
+- `maxTools` — 64 by default, 256 maximum. The local server publishes a fixed
+  four; this is for the hosted tool modes that publish one tool per dataset or
+  per verified metric, where the count follows the catalog.
+- `maxManifestBytes` — 256 KiB by default, 1 MiB maximum.
+
+A breach raises `MCPCatalogBudgetError`, classified `MCP_CATALOG_TOO_LARGE` in
+the `budget` category and not retryable: the same catalog produces the same
+manifest every time. A hosted gateway is expected to catch it and choose a
+narrower tool mode.
+
+The manifest is refused rather than truncated. A truncated manifest would show
+an agent fewer targets than the validators behind it accept, and the manifest
+hash would stop identifying the catalog it was compiled from — which is the
+property `CORE-03` exists to preserve.
+
+Discovery measures the catalog before `_meta` is attached, so the provenance a
+gateway stamps on a manifest is never what pushes it over.

--- a/packages/mcp-server/src/discovery-executor.test.ts
+++ b/packages/mcp-server/src/discovery-executor.test.ts
@@ -164,6 +164,38 @@ describe('HypequeryMCPDiscoveryExecutor', () => {
       .toEqual({ 'com.hypequery/toolMode': 'catalog' });
   });
 
+  it('refuses to advertise a manifest past its byte ceiling', async () => {
+    const executor = createMCPDiscoveryExecutor({
+      datasets: datasets(),
+      catalogBudget: { maxManifestBytes: 512 },
+    });
+
+    // A gateway is expected to catch this and pick a narrower tool mode, so it
+    // must be a typed budget failure rather than an opaque throw.
+    await expect(executor.listTools()).rejects.toMatchObject({
+      code: 'MCP_CATALOG_TOO_LARGE',
+      category: 'budget',
+      retryable: false,
+    });
+  });
+
+  it('measures the catalog, not the provenance stamped on it', async () => {
+    // `_meta` is attached after the budget runs. A gateway adding a revision
+    // and a deployment identity must not be what pushes a manifest over.
+    // Comfortably above this catalog's real manifest, which is ~13.7 KiB for
+    // two datasets — nearly all of it the field enums in the two query tools.
+    const budget = { maxManifestBytes: 32_768 } as const;
+    const bare = createMCPDiscoveryExecutor({ datasets: datasets(), catalogBudget: budget });
+    const stamped = createMCPDiscoveryExecutor({
+      datasets: datasets(),
+      catalogBudget: budget,
+      meta: { activationRevision: REVISION, deploymentIdentity: 'b'.repeat(64) },
+    });
+
+    const [withoutMeta, withMeta] = await Promise.all([bare.listTools(), stamped.listTools()]);
+    expect(withMeta.tools).toEqual(withoutMeta.tools);
+  });
+
   it('advertises only the datasets it was given', async () => {
     // The narrowing a gateway applies for one principal happens before this,
     // on the contract. Whatever reaches here is what gets advertised.

--- a/packages/mcp-server/src/discovery-executor.ts
+++ b/packages/mcp-server/src/discovery-executor.ts
@@ -35,8 +35,13 @@ import { getDatasetSchemaTool } from './tools/introspect.js';
 import { listDatasetsTool } from './tools/list-datasets.js';
 import { buildMCPToolManifest } from './tools/tool-manifest.js';
 import { buildMCPQuerySchemas } from './tools/utils/canonical-query-schemas.js';
+import {
+  assertManifestWithinBudget,
+  resolveCatalogBudget,
+  type EffectiveCatalogBudget,
+} from './tools/utils/catalog-budget.js';
 import { createMCPErrorResponse } from './tools/utils/tool-response.js';
-import type { DatasetRegistry, MCPQueryLimits } from './types.js';
+import type { DatasetRegistry, MCPCatalogBudget, MCPQueryLimits } from './types.js';
 
 /**
  * Provenance a client needs to cache a manifest and know when it went stale.
@@ -68,6 +73,16 @@ export interface MCPDiscoveryExecutorConfig {
   queryableDatasets?: readonly string[];
   /** Server-side query ceilings, so advertised schemas match what will run. */
   queryLimits?: MCPQueryLimits;
+  /**
+   * Tool-count and manifest-byte ceilings.
+   *
+   * This is where they bite. A gateway lists one manifest per authorized
+   * catalog, and a large deployment's `query_dataset` schema names every
+   * dataset, dimension, measure, and filter field it published. Exceeding the
+   * budget raises `MCPCatalogBudgetError`, which a caller is expected to catch
+   * and answer by choosing a narrower tool mode.
+   */
+  catalogBudget?: MCPCatalogBudget;
   /** Attached to `listTools`, so a client can pin what it listed. */
   meta?: MCPToolManifestMeta;
 }
@@ -94,6 +109,7 @@ function metaEntries(meta: MCPToolManifestMeta | undefined): Record<string, stri
  */
 export class HypequeryMCPDiscoveryExecutor implements MCPToolExecutor {
   private readonly querySchemas: CanonicalSemanticQuerySchemas;
+  private readonly catalogBudget: EffectiveCatalogBudget;
   private readonly meta: Record<string, string> | undefined;
 
   constructor(private readonly config: MCPDiscoveryExecutorConfig) {
@@ -104,6 +120,7 @@ export class HypequeryMCPDiscoveryExecutor implements MCPToolExecutor {
       config.queryLimits,
       config.queryableDatasets,
     );
+    this.catalogBudget = resolveCatalogBudget(config.catalogBudget);
     this.meta = metaEntries(config.meta);
   }
 
@@ -113,7 +130,12 @@ export class HypequeryMCPDiscoveryExecutor implements MCPToolExecutor {
   }
 
   async listTools(): Promise<ListToolsResult> {
-    const manifest = buildMCPToolManifest(this.querySchemas);
+    // Budgeted before `_meta` is attached, so the ceiling measures the catalog
+    // rather than the provenance a gateway chose to stamp on it.
+    const manifest = assertManifestWithinBudget(
+      buildMCPToolManifest(this.querySchemas),
+      this.catalogBudget,
+    );
     return this.meta === undefined ? manifest : { ...manifest, _meta: this.meta };
   }
 

--- a/packages/mcp-server/src/errors.ts
+++ b/packages/mcp-server/src/errors.ts
@@ -7,6 +7,7 @@ export type MCPToolErrorCode =
   | 'MCP_REQUEST_CANCELLED'
   | 'MCP_QUERY_TIMEOUT'
   | 'MCP_RESULT_TOO_LARGE'
+  | 'MCP_CATALOG_TOO_LARGE'
   | 'MCP_EXECUTION_FAILED';
 
 export type MCPToolErrorCategory =
@@ -40,8 +41,12 @@ function defaultErrorMetadata(code: MCPToolErrorCode): Omit<MCPErrorDetails, 'co
       return { category: 'unauthorized', retryable: false, correctable: false };
     case 'MCP_STALE_CONTRACT':
       return { category: 'stale_contract', retryable: true, correctable: false };
+    // `MCP_CATALOG_TOO_LARGE` is not retryable: the same catalog produces the
+    // same manifest every time. A caller fixes it by publishing fewer targets
+    // or choosing a tool mode that does not name every one of them.
     case 'MCP_REQUEST_CANCELLED':
     case 'MCP_RESULT_TOO_LARGE':
+    case 'MCP_CATALOG_TOO_LARGE':
       return { category: 'budget', retryable: false, correctable: false };
     case 'MCP_QUERY_TIMEOUT':
       return { category: 'budget', retryable: true, correctable: false };
@@ -84,6 +89,25 @@ export class MCPExecutionBudgetError extends MCPToolError {
       retryable: code === 'MCP_QUERY_TIMEOUT',
     });
     this.name = 'MCPExecutionBudgetError';
+  }
+}
+
+/**
+ * A catalog too large to advertise.
+ *
+ * Separate from `MCPExecutionBudgetError` because it is not raised by a query:
+ * it is raised while listing, before any call exists, and a hosted gateway is
+ * expected to catch it and choose a smaller tool mode rather than surface it to
+ * a client. Truncating instead would be worse — an agent would be shown fewer
+ * targets than the validators behind it accept, and the manifest hash would
+ * stop identifying the catalog it was built from.
+ */
+export class MCPCatalogBudgetError extends MCPToolError {
+  declare readonly code: 'MCP_CATALOG_TOO_LARGE';
+
+  constructor(message: string) {
+    super('MCP_CATALOG_TOO_LARGE', message, { category: 'budget', retryable: false });
+    this.name = 'MCPCatalogBudgetError';
   }
 }
 

--- a/packages/mcp-server/src/executor.ts
+++ b/packages/mcp-server/src/executor.ts
@@ -17,12 +17,22 @@ import { queryMetricTool } from './tools/query-metric.js';
 import { buildMCPToolManifest } from './tools/tool-manifest.js';
 import { buildMCPQuerySchemas } from './tools/utils/canonical-query-schemas.js';
 import {
+  assertManifestWithinBudget,
+  resolveCatalogBudget,
+  type EffectiveCatalogBudget,
+} from './tools/utils/catalog-budget.js';
+import {
   assertWithinBudget,
   resolveExecutionBudget,
   type EffectiveExecutionBudget,
 } from './tools/utils/execution-budget.js';
 import { resolveQueryLimits } from './tools/utils/query-limits.js';
-import type { DatasetRegistry, MCPExecutionBudget, MCPQueryLimits } from './types.js';
+import type {
+  DatasetRegistry,
+  MCPCatalogBudget,
+  MCPExecutionBudget,
+  MCPQueryLimits,
+} from './types.js';
 import { validateMCPServerTenantConfig } from './utils/tenant-config.js';
 import {
   createMCPErrorResponse,
@@ -42,6 +52,8 @@ export interface MCPExecutorConfig {
   queryLimits?: MCPQueryLimits;
   /** Query deadline and serialized-result byte ceilings. */
   executionBudget?: MCPExecutionBudget;
+  /** Tool-count and manifest-byte ceilings applied when listing tools. */
+  catalogBudget?: MCPCatalogBudget;
 }
 
 export interface MCPServerConfig extends MCPExecutorConfig {
@@ -73,11 +85,13 @@ export interface MCPToolExecutor {
 export class HypequeryMCPExecutor implements MCPToolExecutor {
   private readonly querySchemas: CanonicalSemanticQuerySchemas;
   private readonly executionBudget: EffectiveExecutionBudget;
+  private readonly catalogBudget: EffectiveCatalogBudget;
 
   constructor(private readonly config: MCPExecutorConfig) {
     validateMCPServerTenantConfig(config);
     resolveQueryLimits(undefined, config.queryLimits);
     this.executionBudget = resolveExecutionBudget(config.executionBudget);
+    this.catalogBudget = resolveCatalogBudget(config.catalogBudget);
     this.querySchemas = buildMCPQuerySchemas(config.datasets ?? {}, config.queryLimits);
   }
 
@@ -86,7 +100,7 @@ export class HypequeryMCPExecutor implements MCPToolExecutor {
   }
 
   async listTools(): Promise<ListToolsResult> {
-    return buildMCPToolManifest(this.querySchemas);
+    return assertManifestWithinBudget(buildMCPToolManifest(this.querySchemas), this.catalogBudget);
   }
 
   async callTool(

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -37,6 +37,7 @@ export type {
   QueryDatasetArgs,
   QueryToolOptions,
   MCPExecutionBudget,
+  MCPCatalogBudget,
   MCPQueryLimits,
   SchemaToolOptions,
   GetDatasetSchemaArgs,
@@ -51,6 +52,7 @@ export type {
   QueryResultMeta,
 } from './types.js';
 export {
+  MCPCatalogBudgetError,
   MCPExecutionBudgetError,
   MCPToolError,
   classifyMCPToolError,
@@ -72,5 +74,9 @@ export {
   MAX_QUERY_TIMEOUT_MS,
   DEFAULT_RESPONSE_BYTES,
   MAX_RESPONSE_BYTES,
+  DEFAULT_MANIFEST_TOOLS,
+  MAX_MANIFEST_TOOLS,
+  DEFAULT_MANIFEST_BYTES,
+  MAX_MANIFEST_BYTES,
 } from './types.js';
 export { MCP_PACKAGE_VERSION } from './version.js';

--- a/packages/mcp-server/src/tools/utils/catalog-budget.test.ts
+++ b/packages/mcp-server/src/tools/utils/catalog-budget.test.ts
@@ -1,0 +1,60 @@
+import type { ListToolsResult } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it } from 'vitest';
+import { classifyMCPToolError, MCPCatalogBudgetError } from '../../errors.js';
+import { assertManifestWithinBudget, resolveCatalogBudget } from './catalog-budget.js';
+
+function manifest(tools: number, descriptionBytes = 0): ListToolsResult {
+  return {
+    tools: Array.from({ length: tools }, (_, index) => ({
+      name: `tool_${index}`,
+      description: 'x'.repeat(descriptionBytes),
+      inputSchema: { type: 'object' as const, properties: {} },
+    })),
+  };
+}
+
+describe('catalog budgets', () => {
+  it('resolves bounded defaults and rejects unsafe configuration', () => {
+    expect(resolveCatalogBudget()).toEqual({
+      maxTools: 64,
+      maxManifestBytes: 262_144,
+    });
+    expect(() => resolveCatalogBudget({ maxTools: 0 }))
+      .toThrow('maxTools must be an integer between 1 and 256');
+    expect(() => resolveCatalogBudget({ maxTools: 257 }))
+      .toThrow('maxTools must be an integer between 1 and 256');
+    expect(() => resolveCatalogBudget({ maxManifestBytes: 1_048_577 }))
+      .toThrow('maxManifestBytes must be an integer between 1 and 1048576');
+    expect(() => resolveCatalogBudget({ maxManifestBytes: 1.5 }))
+      .toThrow('maxManifestBytes must be an integer between 1 and 1048576');
+  });
+
+  it('returns a manifest inside both ceilings unchanged', () => {
+    const within = manifest(4, 100);
+    expect(assertManifestWithinBudget(within, resolveCatalogBudget())).toBe(within);
+  });
+
+  it('refuses a manifest advertising too many tools', () => {
+    expect(() => assertManifestWithinBudget(manifest(9), resolveCatalogBudget({ maxTools: 8 })))
+      .toThrow('The tool manifest advertises 9 tools; maximum is 8');
+  });
+
+  // The count is the cheaper check, but a catalog is far likelier to breach on
+  // size: two query tools carrying an enum of every published field grow with
+  // the deployment while the tool count stays at four.
+  it('refuses a manifest too large in bytes even when the count is fine', () => {
+    const budget = resolveCatalogBudget({ maxManifestBytes: 1_000 });
+    expect(() => assertManifestWithinBudget(manifest(2, 800), budget))
+      .toThrow(/^The tool manifest is \d+ bytes across 2 tools; maximum is 1000 bytes$/);
+  });
+
+  it('classifies the refusal as a budget failure that retrying cannot fix', () => {
+    const error = new MCPCatalogBudgetError('too large');
+    expect(classifyMCPToolError(error)).toMatchObject({
+      code: 'MCP_CATALOG_TOO_LARGE',
+      category: 'budget',
+      retryable: false,
+      correctable: false,
+    });
+  });
+});

--- a/packages/mcp-server/src/tools/utils/catalog-budget.ts
+++ b/packages/mcp-server/src/tools/utils/catalog-budget.ts
@@ -1,0 +1,67 @@
+import { MCPCatalogBudgetError } from '../../errors.js';
+import {
+  DEFAULT_MANIFEST_BYTES,
+  DEFAULT_MANIFEST_TOOLS,
+  MAX_MANIFEST_BYTES,
+  MAX_MANIFEST_TOOLS,
+  type MCPCatalogBudget,
+} from '../../types.js';
+import type { ListToolsResult } from '@modelcontextprotocol/sdk/types.js';
+
+export interface EffectiveCatalogBudget {
+  readonly maxTools: number;
+  readonly maxManifestBytes: number;
+}
+
+function ceiling(
+  value: number | undefined,
+  fallback: number,
+  maximum: number,
+  name: string,
+): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved < 1 || resolved > maximum) {
+    throw new Error(`${name} must be an integer between 1 and ${maximum}`);
+  }
+  return resolved;
+}
+
+export function resolveCatalogBudget(
+  configured: MCPCatalogBudget = {},
+): EffectiveCatalogBudget {
+  return Object.freeze({
+    maxTools: ceiling(configured.maxTools, DEFAULT_MANIFEST_TOOLS, MAX_MANIFEST_TOOLS, 'maxTools'),
+    maxManifestBytes: ceiling(
+      configured.maxManifestBytes,
+      DEFAULT_MANIFEST_BYTES,
+      MAX_MANIFEST_BYTES,
+      'maxManifestBytes',
+    ),
+  });
+}
+
+/**
+ * Refuses a manifest too large to advertise, and says which ceiling it hit.
+ *
+ * Both counts are reported so a caller choosing a tool mode can tell a catalog
+ * with too many targets from one with a few enormous ones; the answers are
+ * different — fewer tools versus fewer enum members per tool.
+ */
+export function assertManifestWithinBudget(
+  manifest: ListToolsResult,
+  budget: EffectiveCatalogBudget,
+): ListToolsResult {
+  if (manifest.tools.length > budget.maxTools) {
+    throw new MCPCatalogBudgetError(
+      `The tool manifest advertises ${manifest.tools.length} tools; maximum is ${budget.maxTools}`,
+    );
+  }
+  const size = Buffer.byteLength(JSON.stringify(manifest), 'utf8');
+  if (size > budget.maxManifestBytes) {
+    throw new MCPCatalogBudgetError(
+      `The tool manifest is ${size} bytes across ${manifest.tools.length} tools; `
+      + `maximum is ${budget.maxManifestBytes} bytes`,
+    );
+  }
+  return manifest;
+}

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -67,6 +67,35 @@ export interface MCPExecutionBudget {
   maxResponseBytes?: number;
 }
 
+/**
+ * Ceilings on the tool manifest itself, rather than on any one call.
+ *
+ * Every other budget here bounds a query. This one bounds what a client is
+ * handed before it makes one: `query_dataset` and `query_metric` carry exact
+ * enums of every published dataset, dimension, measure, and filter field, so a
+ * large catalog produces a large manifest — paid by every client on every
+ * connection, and spent out of the model's context before a question is asked.
+ *
+ * A breach raises `MCPCatalogBudgetError`. It is not truncated: an agent shown
+ * fewer targets than the validators accept would be misled, and the manifest
+ * hash would no longer identify the catalog behind it.
+ */
+export interface MCPCatalogBudget {
+  /**
+   * Maximum tools a manifest may advertise. Defaults to 64, ceiling 256.
+   *
+   * The local server publishes a fixed four. This exists for the hosted tool
+   * modes that publish one tool per dataset or per verified metric, where the
+   * count follows the catalog and needs a stop.
+   */
+  maxTools?: number;
+  /**
+   * Maximum UTF-8 bytes in the serialized manifest. Defaults to 256 KiB,
+   * ceiling 1 MiB.
+   */
+  maxManifestBytes?: number;
+}
+
 /** Server-side ceilings applied in addition to Dataset limits. */
 export interface MCPQueryLimits {
   /** Rows used when a tool call omits `limit`. Defaults to 100. */
@@ -206,3 +235,7 @@ export const DEFAULT_QUERY_TIMEOUT_MS = 30_000;
 export const MAX_QUERY_TIMEOUT_MS = 120_000;
 export const DEFAULT_RESPONSE_BYTES = 1_048_576;
 export const MAX_RESPONSE_BYTES = 10_485_760;
+export const DEFAULT_MANIFEST_TOOLS = 64;
+export const MAX_MANIFEST_TOOLS = 256;
+export const DEFAULT_MANIFEST_BYTES = 262_144;
+export const MAX_MANIFEST_BYTES = 1_048_576;


### PR DESCRIPTION
Closes the `MCP-102` tail left open by `CORE-02`: tool-count and catalog-description byte ceilings.

## What was missing

Every budget in this package bounds one call — rows, offset, dimensions, measures, filters, order clauses, deadline, response bytes. None bounds what a client is handed *before* it makes one.

That is the part that grows with the deployment. `query_dataset` and `query_metric` carry exact enums of every published dataset, dimension, measure, and filter field — that precision is the point of `CORE-03` — so the manifest scales with the catalog while the tool count stays at four. The two-dataset fixture in this package already compiles to **~13.7 KiB**, nearly all of it those enums. Every client pays it on every connection, and a model pays it out of context before a question is asked.

## What this adds

`MCPCatalogBudget`, configurable on both `HypequeryMCPExecutor` and `createMCPDiscoveryExecutor`:

| ceiling | default | maximum |
|---|---|---|
| `maxTools` | 64 | 256 |
| `maxManifestBytes` | 256 KiB | 1 MiB |

`maxTools` is inert today — the local server publishes a fixed four. It is here because the hosted per-dataset and per-metric tool modes make the count follow the catalog, and a ceiling introduced *after* those ship is a breaking change rather than a default.

## Refused, not truncated

A breach raises `MCPCatalogBudgetError`, classified `MCP_CATALOG_TOO_LARGE` in the `budget` category and not retryable — the same catalog produces the same manifest every time.

Truncating was the alternative and is worse: an agent would be shown fewer targets than the validators behind it accept, and the manifest hash would stop identifying the catalog it was compiled from. That hash equality is what `CORE-18` asserts between discovery and execution; silently dropping tools would break it in the one direction no test would catch.

The error is typed so a hosted gateway can catch it and choose a narrower tool mode — which is exactly the decision `CLOUD-03` has to make. That is what this unblocks: there was previously no budget to select a tool mode against.

Discovery measures the catalog *before* `_meta` is attached, so the activation revision and deployment identity a gateway stamps on a manifest can never be what pushes it over. A test pins that.

## Verification

```
@hypequery/mcp   140 unit tests, type tests clean
workspace        18/18 test tasks, 9/9 lint tasks, 9/9 builds
```

Seven new tests: default resolution and rejection of unsafe configuration, both ceilings enforced independently, the error's classification, enforcement through `listTools()` on the discovery executor, and the `_meta` exclusion.

Includes a minor changeset for `@hypequery/mcp`.
