### PR TITLE
docs(specs): accept the five deployment decisions

### DIFF
--- a/specs/deployment/decisions/0001-mcp-transport-and-ownership.md
+++ b/specs/deployment/decisions/0001-mcp-transport-and-ownership.md
@@ -1,8 +1,11 @@
 # Decision 0001: MCP transport and ownership boundaries
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-31
 - Owners: Hypequery Core and Cloud maintainers
+- Accepted: 2026-09-11
+
+**Acceptance note.** Accepted 2026-09-11. Implemented by CORE-04 (#448) and delivered to a real transport by Cloud #64, which uses the SDK's `WebStandardStreamableHTTPServerTransport` behind the transport-neutral executor. The ownership split held: no second MCP server exists in Cloud.
 
 ## Context
 

--- a/specs/deployment/decisions/0002-semantic-invocation-and-activation-pinning.md
+++ b/specs/deployment/decisions/0002-semantic-invocation-and-activation-pinning.md
@@ -1,8 +1,11 @@
 # Decision 0002: Semantic invocation and activation pinning
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-31
 - Owners: Hypequery Core and Cloud maintainers
+- Accepted: 2026-09-11
+
+**Acceptance note.** Accepted 2026-09-11. Implemented by CORE-10 (#456), CORE-11 (#462), and CORE-12 (#463). The generation-pinning section below was amended before acceptance: the tool-list-changed notification is now explicitly an optimisation rather than the primary mechanism, because the gateway is stateless.
 
 ## Context
 
@@ -72,10 +75,27 @@ Discovery and execution must refer to a coherent generation:
   session/request context, not as a model-controlled tool argument.
 - The deployment host rejects the call with a stable stale-generation category
   if that revision is no longer active.
-- A capable client receives a tool-list-changed notification. Other clients get
-  a correctable stale-contract error and must relist before retrying.
+- **Every client learns of a changed tool list the same way: a correctable
+  stale-contract error on its next call, after which it relists.** A
+  server-initiated `notifications/tools/list_changed` is an optimisation a
+  transport may add, never the mechanism correctness depends on.
 - A rollback creates a new activation revision even when it selects an older
   release, so an ABA transition cannot satisfy a stale caller.
+
+The notification rule is narrower than this decision first stated, which assumed
+"a capable client receives a tool-list-changed notification" and left the error
+path for everyone else. Implementation showed that assumption does not hold: the
+Cloud gateway constructs a server per request with `sessionIdGenerator:
+undefined` (Cloud #64), so there is no session to notify and nothing that
+outlives a request to notify from. Making notification the primary path would
+have required session state whose only purpose is delivering it.
+
+The error path is also the one that cannot be removed. A client can hold a stale
+revision across a disconnect, a gateway restart, or a rollback it was never
+connected for, so the stale-contract response has to be correct regardless.
+Requiring it of everyone removes a second mechanism without removing any
+capability. A future session-bearing transport may notify in addition, which
+shortens the window but does not change what a client must handle.
 
 Calls already admitted to a generation follow the existing drain rules. New
 calls never cross from schemas/policy in one generation to execution in

--- a/specs/deployment/decisions/0003-agent-safe-catalog-results-and-errors.md
+++ b/specs/deployment/decisions/0003-agent-safe-catalog-results-and-errors.md
@@ -1,8 +1,11 @@
 # Decision 0003: Agent-safe catalog, results, and errors
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-31
 - Owners: Hypequery Core and Cloud maintainers
+- Accepted: 2026-09-11
+
+**Acceptance note.** Accepted 2026-09-11. Implemented by CORE-05 (#449), CORE-06 (#453), and CORE-07 (#454), with the catalog's own ceilings added by MCP-102 (#470). `getTrustedDatasetSchema` is the separately authorised debug projection.
 
 ## Context
 

--- a/specs/deployment/decisions/0004-cloud-routing-auth-and-agent-access.md
+++ b/specs/deployment/decisions/0004-cloud-routing-auth-and-agent-access.md
@@ -1,8 +1,11 @@
 # Decision 0004: Cloud routing, authentication, and agent access
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-31
 - Owners: Hypequery Cloud and Core maintainers
+- Accepted: 2026-09-11
+
+**Acceptance note.** Accepted 2026-09-11, with one part unimplemented and knowingly so. Cloud #64 and #66 deliver routing, scoped API tokens, the `mcp:invoke` scope, server-resolved tenancy, and RFC 9728 metadata. Interactive OAuth does not exist: Cloud has no authorization server, so `authorization_servers` is absent from the published metadata and the endpoint is token-only. That gap is a prerequisite for CLOUD-07's client compatibility matrix, not a change to this decision.
 
 ## Context
 

--- a/specs/deployment/decisions/0005-portable-semantic-execution.md
+++ b/specs/deployment/decisions/0005-portable-semantic-execution.md
@@ -1,8 +1,11 @@
 # Decision 0005: Portable semantic execution
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-09-03
 - Owners: Hypequery Core and Cloud maintainers
+- Accepted: 2026-09-11
+
+**Acceptance note.** Accepted 2026-09-11. Its stated gate has been met: CORE-16 (#459) asserts a rehydrated catalog emits byte-identical SQL to the authored one across the query corpus, and CORE-17 (#465) carried the derived-metric expression so those metrics are executable rather than refused. The decision is therefore live rather than void for every surface in the corpus.
 
 ## Context
 

--- a/specs/deployment/decisions/README.md
+++ b/specs/deployment/decisions/README.md
@@ -11,11 +11,11 @@ canonical fixtures, and compatibility tests before it becomes normative.
 
 | Decision | Subject | Status |
 | --- | --- | --- |
-| [0001](./0001-mcp-transport-and-ownership.md) | MCP transport and package ownership | Proposed |
-| [0002](./0002-semantic-invocation-and-activation-pinning.md) | Dataset/metric invocation and activation pinning | Proposed |
-| [0003](./0003-agent-safe-catalog-results-and-errors.md) | Safe discovery, tool manifests, results, and errors | Proposed |
-| [0004](./0004-cloud-routing-auth-and-agent-access.md) | Cloud routing, authentication, tenancy, and first-party agent access | Proposed |
-| [0005](./0005-portable-semantic-execution.md) | Portable semantic execution and the rebuilt-catalog equality gate | Proposed |
+| [0001](./0001-mcp-transport-and-ownership.md) | MCP transport and package ownership | Accepted |
+| [0002](./0002-semantic-invocation-and-activation-pinning.md) | Dataset/metric invocation and activation pinning | Accepted |
+| [0003](./0003-agent-safe-catalog-results-and-errors.md) | Safe discovery, tool manifests, results, and errors | Accepted |
+| [0004](./0004-cloud-routing-auth-and-agent-access.md) | Cloud routing, authentication, tenancy, and first-party agent access | Accepted |
+| [0005](./0005-portable-semantic-execution.md) | Portable semantic execution and the rebuilt-catalog equality gate | Accepted |
 
 The shared vertical-slice fixture referenced by these records lives in
 [`../fixtures/mcp-cloud-v1`](../fixtures/mcp-cloud-v1/README.md).


### PR DESCRIPTION
Moves the five deployment decisions from Proposed to Accepted, and amends two of them where implementation proved the original text wrong.

All five have shipped. Decision 0005's own gate — a rehydrated catalog emitting byte-identical SQL — passed in #459 two weeks ago. A record that says "proposed" about work already published to npm teaches the next reader to distrust the record, and these are the documents the Cloud gateway is being built against.

Each decision gains an acceptance note naming what implemented it, so the claim is checkable rather than asserted.

## 0002 is amended, and it settles CLOUD-03's open question

The generation-pinning section said:

> A capable client receives a tool-list-changed notification. Other clients get a correctable stale-contract error and must relist before retrying.

That is backwards for the gateway that was actually built. Cloud #64 constructs a server per request with `sessionIdGenerator: undefined` — there is no session to notify, and nothing that outlives a request to notify from. Making notification the primary path would mean introducing session state whose only purpose is delivering it.

So the rule inverts: **every client learns the same way, through a correctable stale-contract error on its next call**, and `notifications/tools/list_changed` becomes an optimisation a transport may add.

This is not a concession to the implementation. The error path cannot be removed under any design — a client can hold a stale revision across a disconnect, a gateway restart, or a rollback it was never connected for, so the stale-contract response has to be correct regardless. Requiring it of everyone removes a second mechanism without removing a capability. A session-bearing transport may later notify *in addition*, which shortens the window but changes nothing a client must handle.

This was the one open design question in front of `CLOUD-03`, so it is answered here rather than left for whoever opens that PR to decide implicitly.

## 0004 is accepted with a gap recorded, not hidden

Routing, scoped API tokens, the `mcp:invoke` scope, server-resolved tenancy, and RFC 9728 metadata all shipped in Cloud #64 and #66.

Interactive OAuth did not. Cloud has no authorization server, so `authorization_servers` is deliberately absent from the published metadata and the endpoint is token-only. The acceptance note says so. It is a prerequisite for `CLOUD-07`'s three-client compatibility matrix — several MCP clients discover auth through OAuth — and better surfaced now than at the compatibility gate.

## The rest

- **0001** — implemented by CORE-04 (#448), delivered to a real transport by Cloud #64. The ownership split held: there is no second MCP server in Cloud.
- **0003** — implemented by CORE-05 (#449), CORE-06 (#453), CORE-07 (#454), with the catalog's own ceilings added by #470. `getTrustedDatasetSchema` is the separately authorised debug projection.
- **0005** — gate met by CORE-16 (#459); CORE-17 (#465) carried the derived-metric expression so those metrics execute rather than being refused.

## Verification

Documentation only. `@hypequery/protocol` — 547 tests — passes unchanged; nothing in the conformance fixtures or `specs/security-protocol/` is touched.
